### PR TITLE
Change definition of fiber

### DIFF
--- a/Cubical/Basics/IsoToEquiv.agda
+++ b/Cubical/Basics/IsoToEquiv.agda
@@ -14,14 +14,14 @@ module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (g : B → A)
          (s : (y : B) → f (g y) ≡ y) (t : (x : A) → g (f x) ≡ x) where
 
   private
-    module _ (y : B) (x0 x1 : A) (p0 : y ≡ f x0) (p1 : y ≡ f x1) where
+    module _ (y : B) (x0 x1 : A) (p0 : f x0 ≡ y) (p1 : f x1 ≡ y) where
       fill0 : I → I → A
       fill0 i = hfill (λ k → λ { (i = i1) → t x0 k; (i = i0) → g y })
-                      (inc (g (p0 i)))
+                      (inc (g (p0 (~ i))))
 
       fill1 : I → I → A
       fill1 i = hfill (λ k → λ { (i = i1) → t x1 k; (i = i0) → g y })
-                      (inc (g (p1 i)))
+                      (inc (g (p1 (~ i))))
 
       fill2 : I → I → A
       fill2 i = hfill (λ k → λ { (i = i1) → fill1 k i1; (i = i0) → fill0 k i1 })
@@ -38,20 +38,20 @@ module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (g : B → A)
                      (fill2 i j)
 
       sq1 : I → I → B
-      sq1 i j = hcomp (λ k → λ { (i = i1) → s (p1 j) k
-                               ; (i = i0) → s (p0 j) k
+      sq1 i j = hcomp (λ k → λ { (i = i1) → s (p1 (~ j)) k
+                               ; (i = i0) → s (p0 (~ j)) k
                                ; (j = i1) → s (f (p i)) k
                                ; (j = i0) → s y k })
                       (f (sq i j))
 
       lemIso : (x0 , p0) ≡ (x1 , p1)
       lemIso i .fst = p i
-      lemIso i .snd = λ j → sq1 i j
+      lemIso i .snd = λ j → sq1 i (~ j)
 
   isoToIsEquiv : isEquiv f
   isoToIsEquiv .equiv-proof y .fst .fst = g y
-  isoToIsEquiv .equiv-proof y .fst .snd = sym (s y)
-  isoToIsEquiv .equiv-proof y .snd z = lemIso y (g y) (fst z) (sym (s y)) (snd z)
+  isoToIsEquiv .equiv-proof y .fst .snd = s y
+  isoToIsEquiv .equiv-proof y .snd z = lemIso y (g y) (fst z) (s y) (snd z)
 
   isoToEquiv : A ≃ B
   isoToEquiv = _ , isoToIsEquiv
@@ -64,7 +64,7 @@ module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (w : A ≃ B) where
   secEq x = λ i → fst (snd (snd w .equiv-proof (fst w x)) (x , (λ j → fst w x)) i)
 
   retEq : (y : B) → fst w (invEq y) ≡ y
-  retEq y = λ i → snd (fst (snd w .equiv-proof y)) (~ i)
+  retEq y = λ i → snd (fst (snd w .equiv-proof y)) i
 
 isoToPath : ∀ {ℓ} {A B : Set ℓ} (f : A → B) (g : B → A)
   (s : (y : B) → f (g y) ≡ y) (t : (x : A) → g (f x) ≡ x) → A ≡ B

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -30,6 +30,9 @@ private
   toInternalFiber : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → fiber f y → internalFiber f y
   toInternalFiber f y (x , p) = (x , sym p)
 
+  fromInternalFiber : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} {f : A → B} {y : B} → internalFiber f y → fiber f y
+  fromInternalFiber (x , p) = (x , sym p)
+
   toInternalFiberContr : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → isContr (fiber f y) → isContr (internalFiber f y)
   toInternalFiberContr f y (c , p) = toInternalFiber f y c , \ fb → cong (toInternalFiber f y) (p (fb .fst , sym (fb .snd)))
 
@@ -96,7 +99,9 @@ open GluePrims public
 
 -- The identity equivalence
 idEquiv : ∀ {ℓ} → (A : Set ℓ) → A ≃ A
-idEquiv A = (λ a → a) , λ { .equiv-proof y → (y , refl) , \ z → contrSingl (z .snd) }
+idEquiv A = (λ a → a) , λ { .equiv-proof y → (y , refl)
+                                           , λ z i → z .snd (~ i)
+                                             , λ j → z .snd (~ i ∨ j) }
 
 -- The ua constant
 ua : ∀ {ℓ} {A B : Set ℓ} → A ≃ B → A ≡ B
@@ -115,18 +120,18 @@ unglueIsEquiv : ∀ {ℓ} (A : Set ℓ) (φ : I) (T : Partial φ (Set ℓ))
   (f : PartialP φ λ o → (T o) ≃ A) → isEquiv {A = Glue A T f} (unglue {φ = φ})
 equiv-proof (unglueIsEquiv A φ T f) = λ (b : A) →
   let u : I → Partial φ A
-      u i = λ{ (φ = i1) → equivCtr (f 1=1) b .snd i }
+      u i = λ{ (φ = i1) → equivCtr (f 1=1) b .snd (~ i) }
       ctr : fiber (unglue {φ = φ}) b
-      ctr = ( glue (λ { (φ = i1) → equivCtr (f 1=1) b .fst }) (hcomp u b)
-            , λ j → hfill u (inc b) j)
+      ctr = (glue (λ { (φ = i1) → equivCtr (f 1=1) b .fst }) (hcomp u b)
+            , λ j → hfill u (inc b) (~ j))
   in ( ctr
      , λ (v : fiber (unglue {φ = φ}) b) i →
          let u' : I → Partial (φ ∨ ~ i ∨ i) A
-             u' j = λ { (φ = i1) → equivCtrPath (f 1=1) b v i .snd j
+             u' j = λ { (φ = i1) → equivCtrPath (f 1=1) b v i .snd (~ j)
                       ; (i = i0) → hfill u (inc b) j
-                      ; (i = i1) → v .snd  j }
+                      ; (i = i1) → v .snd (~ j) }
          in ( glue (λ { (φ = i1) → equivCtrPath (f 1=1) b v i .fst }) (hcomp u' b)
-            , λ j → hfill u' (inc b) j))
+            , λ j → hfill u' (inc b) (~ j)))
 
 -- Any partial family of equivalences can be extended to a total one
 -- from Glue [ φ ↦ (T,f) ] A to A
@@ -168,16 +173,16 @@ module _ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) where
     v i y = transp (λ j → ~E ( ~ i ∧ j)) i y
 
     fiberPath : (y : B) → (xβ0 xβ1 : fiber f y) → xβ0 ≡ xβ1
-    fiberPath y (x0 , β0) (x1 , β1) k = ω , λ j → δ j where
+    fiberPath y (x0 , β0) (x1 , β1) k = ω , λ j → δ (~ j) where
       module _ (j : I) where
         private
           sys : A → ∀ i → PartialP (~ j ∨ j) (λ _ → E (~ i))
           sys x i (j = i0) = v (~ i) y
           sys x i (j = i1) = u (~ i) x
-        ω0 = comp ~E (sys x0) (inc (β0 j))
-        ω1 = comp ~E (sys x1) (inc (β1 j))
-        θ0 = fill ~E (sys x0) (inc (β0 j))
-        θ1 = fill ~E (sys x1) (inc (β1 j))
+        ω0 = comp ~E (sys x0) (inc (β0 (~ j)))
+        ω1 = comp ~E (sys x1) (inc (β1 (~ j)))
+        θ0 = fill ~E (sys x0) (inc (β0 (~ j)))
+        θ1 = fill ~E (sys x1) (inc (β1 (~ j)))
       sys = λ {j (k = i0) → ω0 j ; j (k = i1) → ω1 j}
       ω = hcomp sys (g y)
       θ = hfill sys (inc (g y))
@@ -192,7 +197,7 @@ module _ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) where
 
   pathToisEquiv : isEquiv f
   pathToisEquiv .equiv-proof y .fst .fst = g y
-  pathToisEquiv .equiv-proof y .fst .snd = γ y
+  pathToisEquiv .equiv-proof y .fst .snd = sym (γ y)
   pathToisEquiv .equiv-proof y .snd = fiberPath y _
 
   pathToEquiv : A ≃ B

--- a/Cubical/Core/Id.agda
+++ b/Cubical/Core/Id.agda
@@ -157,7 +157,7 @@ funExt p = pathToId (λ i x → idToPath (p x) i)
 -- Equivalences expressed using Id
 
 fiber : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → Set (ℓ-max ℓ ℓ')
-fiber {A = A} f y = Σ[ x ∈ A ] y ≡ f x
+fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
 
 module _ {ℓ} where
   isContr : Set ℓ → Set ℓ


### PR DESCRIPTION
Fix issue https://github.com/agda/cubical/issues/4

This is done by just changing the definition of `fiber` to be the more standard one, internally we are still using the CCHM version. 