### PR TITLE
Show that Pi preserves all h-levels

### DIFF
--- a/Cubical/Basics/Function.agda
+++ b/Cubical/Basics/Function.agda
@@ -1,0 +1,29 @@
+{-# OPTIONS --cubical #-}
+
+module Cubical.Basics.Function where
+
+open import Cubical.Core.Everything
+
+-- Function extensionality is an equivalence.
+module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} where
+  private
+    appl : f ≡ g → ∀ x → f x ≡ g x
+    appl eq x i = eq i x
+
+    fib : (p : f ≡ g) → fiber (funExt B) p
+    fib p = (appl p , refl)
+
+    funExt-fiber-isContr
+      : (p : f ≡ g)
+      → (fi : fiber (funExt B) p)
+      → fib p ≡ fi
+    funExt-fiber-isContr p (h , eq) i = (appl (eq (~ i)) , λ j → eq (~ i ∨ j))
+
+  funExt-isEquiv : isEquiv (funExt B)
+  equiv-proof funExt-isEquiv p = (fib p , funExt-fiber-isContr p)
+
+  funExtEquiv : (∀ x → f x ≡ g x) ≃ (f ≡ g)
+  funExtEquiv = (funExt B , funExt-isEquiv)
+
+  funExtPath : (∀ x → f x ≡ g x) ≡ (f ≡ g)
+  funExtPath = ua funExtEquiv

--- a/Cubical/Basics/NTypes.agda
+++ b/Cubical/Basics/NTypes.agda
@@ -13,6 +13,7 @@ module Cubical.Basics.NTypes where
 open import Cubical.Core.Everything
 
 open import Cubical.Basics.Empty
+open import Cubical.Basics.Function
 
 isOfHLevel : ∀ {ℓ} → ℕ → Set ℓ → Set ℓ
 isOfHLevel zero A = isContr A

--- a/Cubical/Basics/NTypes.agda
+++ b/Cubical/Basics/NTypes.agda
@@ -93,6 +93,15 @@ module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
   isPropSigma : isProp A → ((x : A) → isProp (B x)) → isProp (Σ[ x ∈ A ] B x)
   isPropSigma pA pB t u = subtypeEquality pB t u (pA (t .fst) (u .fst))
 
+hLevelPi
+  : ∀{ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} n
+  → ((x : A) → isOfHLevel n (B x))
+  → isOfHLevel n ((x : A) → B x)
+hLevelPi 0 h = (λ x → fst (h x)) , λ f i y → snd (h y) (f y) i
+hLevelPi (suc n) h f g = subst (isOfHLevel n) funExtPath sub-lemma
+  where
+  sub-lemma : isOfHLevel n (∀ x → f x ≡ g x)
+  sub-lemma = hLevelPi n λ x → h x (f x) (g x)
 
 -- Proof of Hedberg's theorem:
 -- TODO: upstream

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -123,3 +123,26 @@ EquivContr {ℓ} A =
   , λ w i → let f : PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
                 f = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }
             in ( Glue A f , unglueEquiv _ _ f) )
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} where
+  private
+    appl : f ≡ g → ∀ x → f x ≡ g x
+    appl eq x i = eq i x
+
+    fib : (p : f ≡ g) → fiber (funExt B) p
+    fib p = (appl p , refl)
+
+    funExt-fiber-isContr
+      : (p : f ≡ g)
+      → (fi : fiber (funExt B) p)
+      → fib p ≡ fi
+    funExt-fiber-isContr p (h , eq) i = (appl (eq (~ i)) , λ j → eq (~ i ∨ j))
+
+  funExt-isEquiv : isEquiv (funExt B)
+  equiv-proof funExt-isEquiv p = (fib p , funExt-fiber-isContr p)
+
+  funExtEquiv : (∀ x → f x ≡ g x) ≃ (f ≡ g)
+  funExtEquiv = (funExt B , funExt-isEquiv)
+
+  funExtPath : (∀ x → f x ≡ g x) ≡ (f ≡ g)
+  funExtPath = ua funExtEquiv

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -123,26 +123,3 @@ EquivContr {ℓ} A =
   , λ w i → let f : PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
                 f = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }
             in ( Glue A f , unglueEquiv _ _ f) )
-
-module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} where
-  private
-    appl : f ≡ g → ∀ x → f x ≡ g x
-    appl eq x i = eq i x
-
-    fib : (p : f ≡ g) → fiber (funExt B) p
-    fib p = (appl p , refl)
-
-    funExt-fiber-isContr
-      : (p : f ≡ g)
-      → (fi : fiber (funExt B) p)
-      → fib p ≡ fi
-    funExt-fiber-isContr p (h , eq) i = (appl (eq (~ i)) , λ j → eq (~ i ∨ j))
-
-  funExt-isEquiv : isEquiv (funExt B)
-  equiv-proof funExt-isEquiv p = (fib p , funExt-fiber-isContr p)
-
-  funExtEquiv : (∀ x → f x ≡ g x) ≃ (f ≡ g)
-  funExtEquiv = (funExt B , funExt-isEquiv)
-
-  funExtPath : (∀ x → f x ≡ g x) ≡ (f ≡ g)
-  funExtPath = ua funExtEquiv


### PR DESCRIPTION
- Includes a used lemma that funExt is an equivalence/path