### PR TITLE
Derive some of the cartesian coe operations using transp

### DIFF
--- a/Cubical/Basics/CartesianKanOps.agda
+++ b/Cubical/Basics/CartesianKanOps.agda
@@ -18,7 +18,6 @@ coe0→i1 A a = refl
 coe0→i0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coe0→i A i0 a ≡ a
 coe0→i0 A a = refl
 
-
 -- coe backwards
 coe1→0 : ∀ {ℓ} (A : I → Set ℓ) → A i1 → A i0
 coe1→0 A a = transp (λ i → A (~ i)) i0 a
@@ -34,18 +33,6 @@ coe1→i0 A a = refl
 coe1→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i1 a ≡ a
 coe1→i1 A a = refl
 
-
--- "squeeze"
-coei→1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i1
-coei→1 A i a = transp (λ j → A (i ∨ j)) i a
-
-coei0→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→1 A i0 a ≡ coe0→1 A a
-coei0→1 A a = refl
-
-coei1→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→1 A i1 a ≡ a
-coei1→1 A a = refl
-
-
 -- "squeezeNeg"
 coei→0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i0
 coei→0 A i a = transp (λ j → A (i ∧ ~ j)) (~ i) a
@@ -56,43 +43,77 @@ coei0→0 A a = refl
 coei1→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
 coei1→0 A a = refl
 
-
--- "super coe"... Without boolean algebra structure it doesn't seem
--- possible to define. The problem is that interpolation is not
--- working properly as we don't have the boolean equations.
+-- "master coe"
+-- defined as the filler of coei→0, coe0→i, and coe1→i
+-- unlike in cartesian cubes, we don't get coei→i = id definitionally
 coei→j : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
-coei→j A i j a = transp (λ k → A ((i ∧ ~ k) ∨ (j ∧ k))) (~ i ∧ ~ j) a
+coei→j A i j a =
+  fill A
+    (λ j → λ { (i = i0) → coe0→i A j a
+             ; (i = i1) → coe1→i A j a
+             })
+    (inc (coei→0 A i a))
+    j
 
--- We only get the two equations for i0:
+-- "squeeze"
+-- this is just defined as the composite face of the master coe
+coei→1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i1
+coei→1 A i a = coei→j A i i1 a
 
+coei0→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→1 A i0 a ≡ coe0→1 A a
+coei0→1 A a = refl
+
+coei1→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→1 A i1 a ≡ a
+coei1→1 A a = refl
+
+-- equations for "master coe"
 coei→i0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i0 a ≡ coei→0 A i a
 coei→i0 A i a = refl
 
 coei0→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i0) → coei→j A i0 i a ≡ coe0→i A i a
 coei0→i A i a = refl
 
--- For i1 we don't get the equations definitionally:
+coei→i1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
+coei→i1 A i a = refl
 
--- coei→i1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
--- coei→i1 A i a = {!!}
+coei1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j A i1 i a ≡ coe1→i A i a
+coei1→i A i a = refl
 
--- coei1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j A i1 i a ≡ coe1→i A i a
--- coei1→i A i a = {!!}
+-- only non-definitional equation
+coei→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i a ≡ a
+coei→i A i = coe0→i (λ i → (a : A i) → coei→j A i i a ≡ a) i (λ _ → refl)
 
+-- We can reconstruct fill from hfill, coei→j, and the path coei→i ≡ id.
+-- The definition does not rely on the computational content of the coei→i path.
 
--- We can also get the equations for i1, but then not for i0
+-- * Note: the definition of fill' below DOES use fill, but only under the constraint φ ∨ ~i, where it will
+-- reduce either to the cap or the tube. We only have to do this because of technical limitations of cubical
+-- Agda; where we write
+--
+--   λ j _ → coei→i A i (fill A u u0 i) j
+--
+-- what we really want to write is
+--
+--   "λ j → λ {φ → coei→i A i (u i); (i = i0) → coei→i A i (ouc u0)}"
+--
+-- but this is (apparently?) not possible.
 
-coei→j' : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
-coei→j' A i j a = transp (λ k → A ((i ∧ j) ∨ (j ∧ k) ∨ (~ k ∧ i))) (i ∧ j) a 
+fill' : ∀ {ℓ} (A : I → Set ℓ)
+       {φ : I}
+       (u : ∀ i → Partial φ (A i))
+       (u0 : A i0 [ φ ↦ u i0 ])
+       ---------------------------
+       (i : I) → A i [ φ ↦ u i ]
+fill' A {φ = φ} u u0 i =
+  inc (hcomp {φ = φ ∨ ~ i} (λ j _ → coei→i A i (fill A u u0 i) j) t) --* inessential use of fill here
+  where
+  t : A i
+  t = hfill {φ = φ} (λ j v → coei→j A j i (u j v)) (inc (coe0→i A i (ouc u0))) i
 
-coei→i1' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j' A i i1 a ≡ coei→1 A i a
-coei→i1' A i a = refl
-
-coei1→i' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j' A i1 i a ≡ coe1→i A i a
-coei1→i' A i a = refl
-
--- coei→i0' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j' A i i0 a ≡ coei→0 A i a
--- coei→i0' A i a = {!!}
-
--- coei0→i' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i0) → coei→j' A i0 i a ≡ coe0→i A i a
--- coei0→i' A i a = {!!}
+fill'-cap :  ∀ {ℓ} (A : I → Set ℓ)
+             {φ : I}
+             (u : ∀ i → Partial φ (A i))
+             (u0 : A i0 [ φ ↦ u i0 ])
+             ---------------------------
+             → ouc (fill' A u u0 i0) ≡ ouc (u0)
+fill'-cap A u u0 = refl

--- a/Cubical/Basics/CartesianKanOps.agda
+++ b/Cubical/Basics/CartesianKanOps.agda
@@ -35,18 +35,7 @@ coe1→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i1 a ≡ a
 coe1→i1 A a = refl
 
 
--- squeeze
-coei→0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i0
-coei→0 A i a = transp (λ j → A (i ∧ ~ j)) (~ i) a
-
-coei0→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→0 A i0 a ≡ a
-coei0→0 A a = refl
-
-coei1→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
-coei1→0 A a = refl
-
-
--- squeezeNeg
+-- "squeeze"
 coei→1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i1
 coei→1 A i a = transp (λ j → A (i ∨ j)) i a
 
@@ -57,17 +46,38 @@ coei1→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→1 A i1 a ≡ a
 coei1→1 A a = refl
 
 
+-- "squeezeNeg"
+coei→0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i0
+coei→0 A i a = transp (λ j → A (i ∧ ~ j)) (~ i) a
+
+coei0→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→0 A i0 a ≡ a
+coei0→0 A a = refl
+
+coei1→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
+coei1→0 A a = refl
+
+
 -- "super coe"... Without boolean algebra structure it doesn't seem
 -- possible to define. The problem is that interpolation is not
 -- working properly as we don't have the boolean equations.
 coei→j : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
 coei→j A i j a = transp (λ k → A ((i ∧ ~ k) ∨ (j ∧ k))) (~ i ∧ ~ j) a
 
+-- We only get the two equations for i0:
+
 coei→i0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i0 a ≡ coei→0 A i a
 coei→i0 A i a = refl
 
--- This is not true:
+coei0→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i0) → coei→j A i0 i a ≡ coe0→i A i a
+coei0→i A i a = refl
+
+-- For i1 we don't get the equations definitionally:
+
 -- coei→i1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
 -- coei→i1 A i a = {!!}
+
+-- coei1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j A i1 i a ≡ coe1→i A i a
+-- coei1→i A i a = {!!}
+
 
 

--- a/Cubical/Basics/CartesianKanOps.agda
+++ b/Cubical/Basics/CartesianKanOps.agda
@@ -1,0 +1,73 @@
+-- This file derives some of the Cartesian Kan operations using transp
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Basics.CartesianKanOps where
+
+open import Cubical.Core.Everything
+
+coe0→1 : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1
+coe0→1 A a = transp A i0 a
+
+-- "coe filler"
+coe0→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i0 → A i
+coe0→i A i a = transp (λ j → A (i ∧ j)) (~ i) a
+
+-- Check the equations for the coe filler
+coe0→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coe0→i A i1 a ≡ coe0→1 A a
+coe0→i1 A a = refl
+
+coe0→i0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coe0→i A i0 a ≡ a
+coe0→i0 A a = refl
+
+
+-- coe backwards
+coe1→0 : ∀ {ℓ} (A : I → Set ℓ) → A i1 → A i0
+coe1→0 A a = transp (λ i → A (~ i)) i0 a
+
+-- coe backwards filler
+coe1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i1 → A i
+coe1→i A i a = transp (λ j → A (i ∨ ~ j)) i a
+
+-- Check the equations for the coe backwards filler
+coe1→i0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i0 a ≡ coe1→0 A a
+coe1→i0 A a = refl
+
+coe1→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i1 a ≡ a
+coe1→i1 A a = refl
+
+
+-- squeeze
+coei→0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i0
+coei→0 A i a = transp (λ j → A (i ∧ ~ j)) (~ i) a
+
+coei0→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→0 A i0 a ≡ a
+coei0→0 A a = refl
+
+coei1→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
+coei1→0 A a = refl
+
+
+-- squeezeNeg
+coei→1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i1
+coei→1 A i a = transp (λ j → A (i ∨ j)) i a
+
+coei0→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→1 A i0 a ≡ coe0→1 A a
+coei0→1 A a = refl
+
+coei1→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→1 A i1 a ≡ a
+coei1→1 A a = refl
+
+
+-- "super coe"... Without boolean algebra structure it doesn't seem
+-- possible to define. The problem is that interpolation is not
+-- working properly as we don't have the boolean equations.
+coei→j : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
+coei→j A i j a = transp (λ k → A ((i ∧ ~ k) ∨ (j ∧ k))) (~ i ∧ ~ j) a
+
+coei→i0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i0 a ≡ coei→0 A i a
+coei→i0 A i a = refl
+
+-- This is not true:
+-- coei→i1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
+-- coei→i1 A i a = {!!}
+
+

--- a/Cubical/Basics/CartesianKanOps.agda
+++ b/Cubical/Basics/CartesianKanOps.agda
@@ -80,4 +80,19 @@ coei0→i A i a = refl
 -- coei1→i A i a = {!!}
 
 
+-- We can also get the equations for i1, but then not for i0
 
+coei→j' : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
+coei→j' A i j a = transp (λ k → A ((i ∧ j) ∨ (j ∧ k) ∨ (~ k ∧ i))) (i ∧ j) a 
+
+coei→i1' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j' A i i1 a ≡ coei→1 A i a
+coei→i1' A i a = refl
+
+coei1→i' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j' A i1 i a ≡ coe1→i A i a
+coei1→i' A i a = refl
+
+-- coei→i0' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j' A i i0 a ≡ coei→0 A i a
+-- coei→i0' A i a = {!!}
+
+-- coei0→i' : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i0) → coei→j' A i0 i a ≡ coe0→i A i a
+-- coei0→i' A i a = {!!}

--- a/Cubical/Basics/EverythingSafe.agda
+++ b/Cubical/Basics/EverythingSafe.agda
@@ -3,6 +3,7 @@ module Cubical.Basics.EverythingSafe where
 
 open import Cubical.Basics.BinNat public
 open import Cubical.Basics.Bool public
+open import Cubical.Basics.CartesianKanOps public
 open import Cubical.Basics.Empty public
 open import Cubical.Basics.Equiv public
 open import Cubical.Basics.Int public


### PR DESCRIPTION
I mainly did this for fun to clarify the connection between transp and the generalized coe operations of Cartesian Cubical Type Theory. It might be easier for some people to use the cartesian style operations instead of the transp operation as they are maybe a bit more intuitive. 