### PR TITLE
Make the formula in unglue explicit

### DIFF
--- a/Cubical/Basics/BinNat.agda
+++ b/Cubical/Basics/BinNat.agda
@@ -205,7 +205,7 @@ private
                 -- the glue to be well-formed
                 (hcomp (λ j → λ { (i = i0) → suc x
                                 ; (i = i1) → Binℕ→ℕsuc x j })
-                       (suc (unglue {φ = i ∨ ~ i} x)))
+                       (suc (unglue (i ∨ ~ i) x)))
 
   -- Using the equality between the two NatImplementations we can then
   -- transport oddBinℕSuc to unary numbers
@@ -282,7 +282,7 @@ private
                   ; (i = i1) → doubleℕ x })
                (hcomp (λ j → λ { (i = i0) → Binℕ→ℕdouble x j
                                ; (i = i1) → doubleℕ x })
-                      (doubleℕ (unglue {φ = i ∨ ~ i} x)))
+                      (doubleℕ (unglue (i ∨ ~ i) x)))
   elt (DoubleBinℕ≡Doubleℕ i) = transp (λ j → Binℕ≡ℕ (i ∨ ~ j)) i (Doubleℕ .elt)
 
   -- We can now use transport to prove a property that is too slow to
@@ -399,7 +399,7 @@ module _ where
   s (NatImplℕ≡NatImplbinnat i) =
     λ x → glue (λ { (i = i0) → suc x
                   ; (i = i1) → suc-binnat x })
-               (suc-binnat (unglue {φ = i ∨ ~ i} x))
+               (suc-binnat (unglue (i ∨ ~ i) x))
 
   oddSuc : (n : binnat) → oddbinnat n ≡ not (oddbinnat (suc-binnat n))
   oddSuc zero         = refl

--- a/Cubical/Basics/Univalence.agda
+++ b/Cubical/Basics/Univalence.agda
@@ -18,9 +18,9 @@ open import Cubical.Basics.NTypes
 open import Cubical.Basics.Equiv
 
 -- Give detailed type to unglue, mainly for documentation purposes
-unglueua : ∀ {A B : Set} → (e : A ≃ B) → (i : I) (x : ua e i) →
-           B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → x }) ]
-unglueua e i x = inc (unglue {φ = i ∨ ~ i} x)
+unglueua : ∀ {A B : Set} → (e : A ≃ B) → (i : I) (x : ua e i)
+           → B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → x }) ]
+unglueua e i x = inc (unglue (i ∨ ~ i) x)
 
 
 contrSinglEquiv : ∀ {ℓ} {A B : Set ℓ} (e : A ≃ B) → (B , idEquiv B) ≡ (A , e)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -16,31 +16,29 @@ module Cubical.Core.Glue where
 
 open import Cubical.Core.Prelude
 open import Agda.Builtin.Cubical.Glue public
-  using ( isEquiv       -- isEquiv {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ ⊔ ℓ')
+  using ( isEquiv       -- isEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) → Set (ℓ ⊔ ℓ')
 
         ; _≃_           -- ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
 
         ; equivFun      -- ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
 
-        ; equivProof    -- ∀ {la lt} (T : Set la) (A : Set lt) → (w : T ≃ A) → (a : A)
-                        -- → ∀ ψ → (Partial ψ (fiber (equivFun w) a)) → fiber (equivFun w) a
+        ; equivProof    -- ∀ {ℓ ℓ'} (T : Set ℓ) (A : Set ℓ') (w : T ≃ A) (a : A) φ →
+                        -- Partial φ (fiber (equivFun w) a) → fiber (equivFun w) a
 
-        ; primGlue      -- ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I}
-                        -- → (T : Partial φ (Set ℓ')) → (e : PartialP φ (λ o → T o ≃ A))
-                        -- → Set ℓ'
+        ; primGlue      -- ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I} (T : Partial φ (Set ℓ'))
+                        -- → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
 
-        -- Needed for transp in Glue.
-        ; primFaceForall -- (I → I) → I
+        ; prim^unglue   -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+                        -- → {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
+
+        -- The ∀ operation on I. This is commented out as it is not currently used for anything
+        -- ; primFaceForall -- (I → I) → I
         )
-  renaming ( prim^glue   to glue         -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
-                                         -- → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
+  renaming ( prim^glue   to glue         -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+                                         -- → {e : PartialP φ (λ o → T o ≃ A)}
                                          -- → PartialP φ T → A → primGlue A T e
 
-           ; prim^unglue to unglue       -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I}
-                                         -- → {T : Partial φ (Set ℓ')} → {e : PartialP φ (λ o → T o ≃ A)}
-                                         -- → primGlue A T e → A
-
-           ; pathToEquiv to lineToEquiv  -- {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) → P i0 ≃ P i1
+           ; pathToEquiv to lineToEquiv  -- ∀ {ℓ : → Level} (P : (i : I) → Set (ℓ i)) → P i0 ≃ P i1
            )
 
 open isEquiv public
@@ -62,43 +60,48 @@ equivCtrPath : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) (y : B) →
   (v : fiber (equivFun e) y) → Path _ (equivCtr e y) v
 equivCtrPath e y = e .snd .equiv-proof y .snd
 
-
--- We uncurry Glue to make it a bit more pleasant to use
+-- Uncurry Glue to make it more pleasant to use
 Glue : ∀ (A : Set ℓ) {φ : I}
        → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
        → Set ℓ'
 Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
+
+-- Make the φ argument of prim^unglue explicit
+unglue : ∀ {A : Set ℓ} (φ : I) {T : Partial φ (Set ℓ')}
+           {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
+unglue φ = prim^unglue {φ = φ}
 
 -- The identity equivalence
 idfun : ∀ {ℓ} → (A : Set ℓ) → A → A
 idfun _ x = x
 
 idIsEquiv : ∀ (A : Set ℓ) → isEquiv (idfun A)
-equiv-proof (idIsEquiv A) y = (y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j)
+equiv-proof (idIsEquiv A) y =
+  ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
 
 idEquiv : ∀ (A : Set ℓ) → A ≃ A
-idEquiv A = idfun A , idIsEquiv A
+idEquiv A = (idfun A , idIsEquiv A)
 
 -- The ua constant
 ua : ∀ {A B : Set ℓ} → A ≃ B → A ≡ B
-ua {A = A} {B = B} e i =
-  Glue B (λ { (i = i0) → (A , e)
-            ; (i = i1) → (B , idEquiv B) })
+ua {A = A} {B = B} e i = Glue B (λ { (i = i0) → (A , e)
+                                   ; (i = i1) → (B , idEquiv B) })
+
 
 -- Proof of univalence using that unglue is an equivalence:
 
 -- unglue is an equivalence
 unglueIsEquiv : ∀ (A : Set ℓ) (φ : I)
                 (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
-                isEquiv {A = Glue A f} (unglue {φ = φ})
+                isEquiv {A = Glue A f} (unglue φ)
 equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
   let u : I → Partial φ A
       u i = λ{ (φ = i1) → equivCtr (f 1=1 .snd) b .snd (~ i) }
-      ctr : fiber (unglue {φ = φ}) b
+      ctr : fiber (unglue φ) b
       ctr = ( glue (λ { (φ = i1) → equivCtr (f 1=1 .snd) b .fst }) (hcomp u b)
             , λ j → hfill u (inc b) (~ j))
   in ( ctr
-     , λ (v : fiber (unglue {φ = φ}) b) i →
+     , λ (v : fiber (unglue φ) b) i →
          let u' : I → Partial (φ ∨ ~ i ∨ i) A
              u' j = λ { (φ = i1) → equivCtrPath (f 1=1 .snd) b v i .snd (~ j)
                       ; (i = i0) → hfill u (inc b) j
@@ -111,7 +114,7 @@ equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
 unglueEquiv : ∀ (A : Set ℓ) (φ : I)
               (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
               (Glue A f) ≃ A
-unglueEquiv A φ f = ( unglue {φ = φ} , unglueIsEquiv A φ f )
+unglueEquiv A φ f = ( unglue φ , unglueIsEquiv A φ f )
 
 
 -- The following is a formulation of univalence proposed by Martín Escardó:

--- a/Cubical/HITs/S1.agda
+++ b/Cubical/HITs/S1.agda
@@ -60,7 +60,7 @@ decode : (x : S¹) → helix x → base ≡ x
 decode base         = intLoop
 decode (loop i) y j =
   let n : Int
-      n = unglue {φ = i ∨ ~ i} y
+      n = unglue (i ∨ ~ i) y
   in hcomp (λ k → λ { (i = i0) → intLoop (predSuc y k) j
                     ; (i = i1) → intLoop y j
                     ; (j = i0) → base


### PR DESCRIPTION
I noticed that I always had to tell Agda what φ in unglue was, so I made it into an explicit argument