### PR TITLE
Two small examples of generic programming using univalence

### DIFF
--- a/Cubical/Data/Prod.agda
+++ b/Cubical/Data/Prod.agda
@@ -2,3 +2,4 @@
 module Cubical.Data.Prod where
 
 open import Cubical.Data.Prod.Base public
+open import Cubical.Data.Prod.Properties public

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -3,7 +3,19 @@ module Cubical.Data.Prod.Base where
 
 open import Cubical.Core.Everything
 
+-- If × is defined using Σ then transp/hcomp will be compute
+-- "negatively", that is, they won't reduce unless we project out the
+-- first of second component. This is not always what we want so the
+-- default implementation is done using a datatype which computes
+-- positively.
+
+data _×_ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+  _,_ : A → B → A × B
+
 infixr 5 _×_
 
-_×_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
-A × B = Σ A (λ _ → B)
+-- We still export the version using Σ
+_×Σ_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+A ×Σ B = Σ A (λ _ → B)
+
+infixr 5 _×Σ_

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -25,7 +25,7 @@ swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ 
 swapInv (_ , _) = refl
 
 isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
-isEquivSwap A B = isoToIsEquiv swap swap swapInv swapInv
+isEquivSwap A B = isoToIsEquiv (iso swap swap swapInv swapInv)
 
 swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
 swapEquiv A B = (swap , isEquivSwap A B)

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -1,0 +1,46 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Prod.Properties where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Prod.Base
+
+open import Cubical.Foundations.Equiv
+
+variable
+  ℓ ℓ' : Level
+
+proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
+proj₁ (x , _) = x
+
+proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
+proj₂ (_ , x) = x
+
+-- Swapping is an equivalence
+
+swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
+swap (x , y) = (y , x)
+
+swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
+swapInv (_ , _) = refl
+
+isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
+isEquivSwap A B = isoToIsEquiv swap swap swapInv swapInv
+
+swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
+swapEquiv A B = (swap , isEquivSwap A B)
+
+swapEq : (A : Set ℓ) (B : Set ℓ') → A × B ≡ B × A
+swapEq A B = ua (swapEquiv A B)
+
+private
+  open import Cubical.Data.Nat
+
+  -- As × is defined as a datatype this computes as expected
+  -- (i.e. "C-c C-n test1" reduces to (2 , 1)). If × is implemented
+  -- using Sigma this would be "transp (λ i → swapEq ℕ ℕ i) i0 (1 , 2)"
+  test : ℕ × ℕ
+  test = transp (λ i → swapEq ℕ ℕ i) i0 (1 , 2)
+
+  testrefl : test ≡ (2 , 1)
+  testrefl = refl

--- a/Cubical/Experiments/Everything.agda
+++ b/Cubical/Experiments/Everything.agda
@@ -1,0 +1,7 @@
+-- Export only the experiments that are expected to compile (without
+-- any holes)
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Experiments.Everything where
+
+open import Cubical.Experiments.Generic public
+open import Cubical.Experiments.Problem public

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -37,7 +37,7 @@ us = (4  , "John"  , (30 ,  5) , 1956)
    ∷ []
 
 convert : Database → Database
-convert d = transp (λ i → There (swapEq ℕ ℕ i)) i0 d
+convert d = transport (λ i → There (swapEq ℕ ℕ i)) d
 
 -- Swap the dates of the American database to get the European format
 eu : Database
@@ -105,7 +105,7 @@ genCom =
 
 -- Increase the salary for everyone by 1
 incSalary : Company Int → Company Int
-incSalary c = transp (λ i → Company (sucPathInt i)) i0 c
+incSalary c = transport (λ i → Company (sucPathInt i)) c
 
 genCom1 : Company Int
 genCom1 = incSalary genCom
@@ -113,7 +113,7 @@ genCom1 = incSalary genCom
 
 -- Increase the salary more
 incSalaryℕ : ℕ → Company Int → Company Int
-incSalaryℕ n c = transp (λ i → Company (addEq n i)) i0 c
+incSalaryℕ n c = transport (λ i → Company (addEq n i)) c
 
 genCom2 : Company Int
 genCom2 = incSalaryℕ 2 genCom

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -17,7 +17,7 @@ variable
 
 swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
 swap (x , y) = (y , x)
-  
+
 swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
 swapInv xy = refl
 
@@ -48,6 +48,23 @@ test1refl = refl
 
 -- TODO: Why is the normalization producing such complicated output?
 
+-- Answer: transp and hcomp are implemented negatively for record
+-- types, so that's the normal form, normalization doesn't eta expand.
+
+-- You can get a better normal form like this:
+
+expand : ∀ {A : Set ℓ} {B : Set ℓ'} → A × B → A × B
+expand (x , y) = x , y
+
+map : ∀ {A : Set ℓ} {B : Set ℓ'} → (A → B) → List A → List B
+map f [] = []
+map f (x ∷ xs) = f x ∷ map f xs
+
+
+test1-5 : List (ℕ × ℕ)
+test1-5 = map expand test1
+
+
 
 ------------------------------------------------------------------------------
 --
@@ -64,9 +81,9 @@ db : Database
 db = (4  , "John"  , (30 ,  5) , 1956)
    ∷ (8  , "Hugo"  , (29 , 12) , 1978)
    ∷ (15 , "James" , (1  ,  7) , 1968)
-   ∷ (16 , "Sayid" , (2  , 10) , 1967)   
+   ∷ (16 , "Sayid" , (2  , 10) , 1967)
    ∷ (23 , "Jack"  , (3  , 12) , 1969)
-   ∷ (42 , "Sun"   , (20 ,  3) , 1980)   
+   ∷ (42 , "Sun"   , (20 ,  3) , 1980)
    ∷ []
 
 convert : Database → Database
@@ -81,12 +98,13 @@ want : Database
 want = (4  , "John"  , (5  , 30) , 1956)
      ∷ (8  , "Hugo"  , (12 , 29) , 1978)
      ∷ (15 , "James" , (7  ,  1) , 1968)
-     ∷ (16 , "Sayid" , (10 ,  2) , 1967)   
+     ∷ (16 , "Sayid" , (10 ,  2) , 1967)
      ∷ (23 , "Jack"  , (12 ,  3) , 1969)
-     ∷ (42 , "Sun"   , (3  , 20) , 1980)   
+     ∷ (42 , "Sun"   , (3  , 20) , 1980)
      ∷ []
 
 -- TODO: This is not proved by refl... Why??
+-- Answer: I never implemented transp for String! Should be quick.
 -- test2 : eu ≡ want
 -- test2 = {!!}
 
@@ -180,7 +198,7 @@ isEquivTransportRefl {ℓ} A = isoToIsEquiv (transport refl) (transport refl) re
   rem : (x : A) → transport refl (transport refl x) ≡ x
   rem x = compPath (cong (transport refl) (λ i → transp (λ _ → A) i x))
                    (λ i → transp (λ _ → A) i x)
-  
+
 isEquivTransport : ∀ {ℓ} {A B : Set ℓ} (p : A ≡ B) → isEquiv (transport p)
 isEquivTransport {A = A} = J (λ y x → isEquiv (transport x)) (isEquivTransportRefl A)
 

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -1,3 +1,5 @@
+-- Two fun examples of generic programming using univalence
+
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Experiments.Generic where
 
@@ -12,59 +14,9 @@ open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Int
--- open import Cubical.Data.Prod
+open import Cubical.Data.Prod
 
-variable
-  ℓ ℓ' : Level
-
-data _×_ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
-  _,_ : A → B → A × B
-
-infixr 5 _×_
-
-swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
-swap (x , y) = (y , x)
-
-swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
-swapInv (_ , _) = refl
-
-isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
-isEquivSwap A B = isoToIsEquiv swap swap swapInv swapInv
-
-swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
-swapEquiv A B = (swap , isEquivSwap A B)
-
-swapEq : (A : Set ℓ) (B : Set ℓ') → A × B ≡ B × A
-swapEq A B = ua (swapEquiv A B)
-
--- First simple test:
-
-test1 : List (ℕ × ℕ)
-test1 = transp (λ i → List (swapEq ℕ ℕ i)) i0 ((1 , 2) ∷ [])
-
-test1refl : test1 ≡ ((2 , 1) ∷ [])
-test1refl = refl
-
--- TODO: Why is the normalization producing such complicated output?
-
--- Answer: transp and hcomp are implemented negatively for record
--- types, so that's the normal form, normalization doesn't eta expand.
-
--- You can get a better normal form like this:
-
-expand : ∀ {A : Set ℓ} {B : Set ℓ'} → A × B → A × B
-expand (x , y) = (x , y)
-
-map : ∀ {A : Set ℓ} {B : Set ℓ'} → (A → B) → List A → List B
-map f [] = []
-map f (x ∷ xs) = f x ∷ map f xs
-
-test1-5 : List (ℕ × ℕ)
-test1-5 = map expand test1
-
-
-
-------------------------------------------------------------------------------
+----------------------------------------------------------------------------
 --
 -- Dan Licata's example from slide 47 of:
 -- http://dlicata.web.wesleyan.edu/pubs/l13jobtalk/l13jobtalk.pdf
@@ -75,8 +27,8 @@ There X = List (ℕ × String × (X × ℕ))
 Database : Set
 Database = There (ℕ × ℕ)
 
-db : Database
-db = (4  , "John"  , (30 ,  5) , 1956)
+us : Database
+us = (4  , "John"  , (30 ,  5) , 1956)
    ∷ (8  , "Hugo"  , (29 , 12) , 1978)
    ∷ (15 , "James" , (1  ,  7) , 1968)
    ∷ (16 , "Sayid" , (2  , 10) , 1967)
@@ -87,24 +39,16 @@ db = (4  , "John"  , (30 ,  5) , 1956)
 convert : Database → Database
 convert d = transp (λ i → There (swapEq ℕ ℕ i)) i0 d
 
+-- Swap the dates of the American database to get the European format
 eu : Database
-eu = convert db
+eu = convert us
 
-eu_normal : Database
-eu_normal =
-       (4  , "John"  , (5  , 30) , 1956)
-     ∷ (8  , "Hugo"  , (12 , 29) , 1978)
-     ∷ (15 , "James" , (7  ,  1) , 1968)
-     ∷ (16 , "Sayid" , (10 ,  2) , 1967)
-     ∷ (23 , "Jack"  , (12 ,  3) , 1969)
-     ∷ (42 , "Sun"   , (3  , 20) , 1980)
-     ∷ []
-
-test2 : eu ≡ eu_normal
-test2 = refl
+-- A sanity check
+_ : us ≡ convert eu
+_ = refl
 
 
-------------------------------------------------------------------------------
+----------------------------------------------------------------------------
 --
 -- Example inspired by:
 --
@@ -129,6 +73,7 @@ data Employee (A : Set) : Set where
 Manager : Set → Set
 Manager A = Employee A
 
+-- First test of "mutual"
 mutual
   data Dept (A : Set) : Set where
     D : Name → Manager A → List (SubUnit A) → Dept A
@@ -141,7 +86,7 @@ data Company (A : Set) : Set where
   C : List (Dept A) → Company A
 
 
--- Being the example
+-- A small example
 
 anders : Employee Int
 anders = E (P "Anders" "Pittsburgh") (S (pos 2500))
@@ -158,59 +103,15 @@ genCom =
   C ( D "Research" andreas (PU anders ∷ PU andrea ∷ [])
     ∷ [])
 
--- increase the salary for everyone by 1
+-- Increase the salary for everyone by 1
 incSalary : Company Int → Company Int
 incSalary c = transp (λ i → Company (sucPathInt i)) i0 c
 
 genCom1 : Company Int
 genCom1 = incSalary genCom
 
--- The following definition of addition is very cool! We directly get
--- that it's an equivalence. I will upstream it later.
 
--- First define transport and prove that it is an equivalence
-
-transport : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A → B
-transport p a = transp (λ i → p i) i0 a
-
-isEquivTransportRefl : ∀ {ℓ} (A : Set ℓ) → isEquiv (transport {ℓ} {A} {A} refl)
-isEquivTransportRefl {ℓ} A = isoToIsEquiv (transport refl) (transport refl) rem rem
-  where
-  rem : (x : A) → transport refl (transport refl x) ≡ x
-  rem x = compPath (cong (transport refl) (λ i → transp (λ _ → A) i x))
-                   (λ i → transp (λ _ → A) i x)
-
-isEquivTransport : ∀ {ℓ} {A B : Set ℓ} (p : A ≡ B) → isEquiv (transport p)
-isEquivTransport {A = A} = J (λ y x → isEquiv (transport x)) (isEquivTransportRefl A)
-
-
--- Compose sucPathInt with itself n times. Transporting along this
--- will be addition, transporting with it backwards will be
--- subtraction.
-addEq : ℕ → Int ≡ Int
-addEq zero = refl
-addEq (suc n) = compPath sucPathInt (addEq n)
-
-subEq : ℕ → Int ≡ Int
-subEq n i = addEq n (~ i)
-
-addInt : Int → Int → Int
-addInt m (pos n) = transport (addEq n) m
-addInt m (negsuc n) = transport (subEq (suc n)) m
-
-subInt : Int → Int → Int
-subInt m (pos zero) = m
-subInt m (pos (suc n)) = addInt m (negsuc n)
-subInt m (negsuc n) = addInt m (pos (suc n))
-
--- We directly get that addition by a fixed number is an equivalence
--- without having to do any induction!
-isEquivAddInt : (m : Int) → isEquiv (λ (n : Int) → addInt n m)
-isEquivAddInt (pos n) = isEquivTransport (addEq n)
-isEquivAddInt (negsuc n) = isEquivTransport (subEq (suc n))
-
--- Let's use this to increase everyone's salary more!
-
+-- Increase the salary more
 incSalaryℕ : ℕ → Company Int → Company Int
 incSalaryℕ n c = transp (λ i → Company (addEq n i)) i0 c
 

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -1,0 +1,209 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Experiments.Generic where
+
+open import Agda.Builtin.String
+open import Agda.Builtin.List
+open import Agda.Builtin.Float
+
+open import Cubical.Core.Primitives
+open import Cubical.Core.Prelude
+open import Cubical.Core.Glue
+
+open import Cubical.Basics.Empty
+open import Cubical.Basics.Equiv
+open import Cubical.Basics.Nat
+open import Cubical.Basics.NTypes
+open import Cubical.Basics.Int
+open import Cubical.Basics.Equiv
+open import Cubical.Basics.Univalence
+
+variable
+  ℓ ℓ' : Level
+
+swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
+swap (x , y) = (y , x)
+  
+swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
+swapInv xy = refl
+
+isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
+isEquivSwap A B = isoToIsEquiv swap swap swapInv swapInv
+
+swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
+swapEquiv A B = (swap , isEquivSwap A B)
+
+swapEq : (A : Set ℓ) (B : Set ℓ') → A × B ≡ B × A
+swapEq A B = ua (swapEquiv A B)
+
+
+-- First simple test:
+
+test1 : List (ℕ × ℕ)
+test1 = transp (λ i → List (swapEq ℕ ℕ i)) i0 ((1 , 2) ∷ [])
+
+-- TODO: Running "C-c C-n test1" gives:
+--
+-- transp (λ i → Σ ℕ (λ _ → ℕ)) i0
+--   (hcomp (λ i → empty)
+--          (transp (λ i → Σ ℕ (λ _ → ℕ)) i0 (2 , 1)) ∷ []
+
+-- This works:
+test1refl : test1 ≡ ((2 , 1) ∷ [])
+test1refl = refl
+
+-- TODO: Why is the normalization producing such complicated output?
+
+
+------------------------------------------------------------------------------
+--
+-- Dan Licata's example from slide 47 of:
+-- http://dlicata.web.wesleyan.edu/pubs/l13jobtalk/l13jobtalk.pdf
+
+There : Set → Set
+There X = List (ℕ × String × (X × ℕ))
+
+Database : Set
+Database = There (ℕ × ℕ)
+
+db : Database
+db = (4  , "John"  , (30 ,  5) , 1956)
+   ∷ (8  , "Hugo"  , (29 , 12) , 1978)
+   ∷ (15 , "James" , (1  ,  7) , 1968)
+   ∷ (16 , "Sayid" , (2  , 10) , 1967)   
+   ∷ (23 , "Jack"  , (3  , 12) , 1969)
+   ∷ (42 , "Sun"   , (20 ,  3) , 1980)   
+   ∷ []
+
+convert : Database → Database
+convert d = transp (λ i → There (swapEq ℕ ℕ i)) i0 d
+
+eu : Database
+eu = convert db
+
+-- TODO: Running "C-c C-n eu" produces some very complicated output
+
+want : Database
+want = (4  , "John"  , (5  , 30) , 1956)
+     ∷ (8  , "Hugo"  , (12 , 29) , 1978)
+     ∷ (15 , "James" , (7  ,  1) , 1968)
+     ∷ (16 , "Sayid" , (10 ,  2) , 1967)   
+     ∷ (23 , "Jack"  , (12 ,  3) , 1969)
+     ∷ (42 , "Sun"   , (3  , 20) , 1980)   
+     ∷ []
+
+-- TODO: This is not proved by refl... Why??
+-- test2 : eu ≡ want
+-- test2 = {!!}
+
+-- TODO: This is also not proved by refl:
+-- test2 : db ≡ convert (convert db)
+-- test2 = {!!}
+
+
+------------------------------------------------------------------------------
+--
+-- Example inspired by:
+--
+-- Scrap Your Boilerplate: A Practical Design Pattern for Generic Programming
+-- Ralf Lämmel & Simon Peyton Jones, TLDI'03
+
+Address : Set
+Address = String
+
+Name : Set
+Name = String
+
+data Person : Set where
+  P : Name → Address → Person
+
+data Salary (A : Set) : Set where
+  S : A → Salary A
+
+data Employee (A : Set) : Set where
+  E : Person → Salary A → Employee A
+
+Manager : Set → Set
+Manager A = Employee A
+
+mutual
+  data Dept (A : Set) : Set where
+    D : Name → Manager A → List (SubUnit A) → Dept A
+
+  data SubUnit (A : Set) : Set where
+    PU : Employee A → SubUnit A
+    DU : Dept A → SubUnit A
+
+data Company (A : Set) : Set where
+  C : List (Dept A) → Company A
+
+
+-- Being the example
+
+anders : Employee Int
+anders = E (P "Anders" "Pittsburgh") (S (pos 2500))
+
+andrea : Employee Int
+andrea = E (P "Andrea" "Copenhagen") (S (pos 2000))
+
+andreas : Employee Int
+andreas = E (P "Andreas" "Gothenburg") (S (pos 3000))
+
+-- For now we have a small company
+genCom : Company Int
+genCom =
+  C ( D "Research" andreas (PU anders ∷ PU andrea ∷ [])
+    ∷ [])
+
+-- increase the salary for everyone by 1
+incSalary : Company Int → Company Int
+incSalary c = transp (λ i → Company (sucPathInt i)) i0 c
+
+-- Increase everyone's salary with 1
+genCom1 : Company Int
+genCom1 = incSalary genCom
+
+-- This works and gives us:
+-- C (D (transp (λ i → String) i0 "Research")
+--      (E (P "Andreas" "Gothenburg") (S (pos 3001)))
+--   (PU (E (P "Anders" "Pittsburgh") (S (pos 2501))) ∷
+--    PU (E (P "Andrea" "Copenhagen") (S (pos 2001))) ∷ [])
+--   ∷ [])
+
+-- TODO: why is transport for String not removed?
+
+
+-- The following definition of addition is very cool! We directly get
+-- that it's an equivalence.
+
+-- Compose sucPathInt with itself n times. Transporting along this
+-- will be addition, transporting with it backwards will be
+-- subtraction.
+addEq : ℕ → Int ≡ Int
+addEq zero = refl
+addEq (suc n) = compPath sucPathInt (addEq n)
+
+subEq : ℕ → Int ≡ Int
+subEq n i = addEq n (~ i)
+
+addInt : Int → Int → Int
+addInt m (pos n) = transp (λ i → addEq n i) i0 m
+addInt m (negsuc n) = transp (λ i → subEq (suc n) i) i0 m
+
+subInt : Int → Int → Int
+subInt m (pos zero) = m
+subInt m (pos (suc n)) = addInt m (negsuc n)
+subInt m (negsuc n) = addInt m (pos (suc n))
+
+
+-- Let's increase everyone's salary more!
+
+incSalaryℕ : ℕ → Company Int → Company Int
+incSalaryℕ n c = transp (λ i → Company (addEq n i)) i0 c
+
+-- This is quite slow
+genCom2 : Company Int
+genCom2 = incSalaryℕ 2 genCom
+
+-- This is very slow
+genCom10 : Company Int
+genCom10 = incSalaryℕ 10 genCom

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -1,4 +1,5 @@
-{-# OPTIONS --cubical #-}
+-- An example of something where normalization is surprisingly slow
+{-# OPTIONS --cubical --safe #-}
 module Cubical.Experiments.Problem where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -14,7 +14,7 @@ open import Cubical.Core.Glue
 open import Cubical.Foundations.Equiv
 
 open import Cubical.Data.Int
-open import Cubical.Data.Prod
+open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
 
 open import Cubical.HITs.S1
 

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ check: $(wildcard **/*.agda)
 	agda Cubical/Data/Everything.agda
 	agda Cubical/HITs/Everything.agda
 	agda Cubical/Relation/Everything.agda
+	agda Cubical/Experiments/Everything.agda
 
 clean:; rm -f */*agdai */*/*agdai */*/*/*agdai


### PR DESCRIPTION
This PR also redefines product types to use a datatype instead of Sigma types (i.e. a record). The reason is that reduction is more eager this way which makes some examples nicer. The old version is still exported so that the user can choose which one to use. 