### PR TITLE
Define isOfHLevel 1 to be isProp, add hlevelsuc

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -109,7 +109,16 @@ hLevelPi 0 h = (λ x → fst (h x)) , λ f i y → snd (h y) (f y) i
 hLevelPi {B = B} 1 h f g i x = (h x) (f x) (g x) i
 hLevelPi (suc (suc n)) h f g = subst (isOfHLevel (suc n)) funExtPath (hLevelPi (suc n) λ x → h x (f x) (g x))
 
-hlevelsuc : (n : ℕ) (A : Set) → isOfHLevel n A → isOfHLevel (suc n) A
+private
+  variable
+    ℓ : Level
+
+hlevelsuc : (n : ℕ) (A : Set ℓ) → isOfHLevel n A → isOfHLevel (suc n) A
 hlevelsuc 0 A = isContr→isProp
 hlevelsuc 1 A = isProp→isSet
 hlevelsuc (suc (suc n)) A h a b =  hlevelsuc (suc n) (a ≡ b) (h a b)
+
+isPropOfHLevel : (n : ℕ) (A : Set ℓ) → isProp (isOfHLevel n A)
+isPropOfHLevel 0 A = isPropIsContr
+isPropOfHLevel 1 A = isPropIsProp
+isPropOfHLevel (suc (suc n)) A f g i a b = isPropOfHLevel (suc n) (a ≡ b) (f a b) (g a b) i

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -58,9 +58,6 @@ isPropIsContr z0 z1 j =
 isPropIsProp : ∀ {ℓ} {A : Set ℓ} → isProp (isProp A)
 isPropIsProp f g i a b = isProp→isSet f a b (f a b) (g a b) i
 
-isPropIsSet : ∀ {ℓ} {A : Set ℓ} → isProp (isSet A)
-isPropIsSet f g i a b = isPropIsProp (f a b) (g a b) i
-
 -- A retract of a contractible type is contractible
 retractIsContr : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) (g : B → A)
                  (h : (x : A) → g (f x) ≡ x) (v : isContr B) → isContr A
@@ -122,3 +119,6 @@ isPropOfHLevel : (n : ℕ) (A : Set ℓ) → isProp (isOfHLevel n A)
 isPropOfHLevel 0 A = isPropIsContr
 isPropOfHLevel 1 A = isPropIsProp
 isPropOfHLevel (suc (suc n)) A f g i a b = isPropOfHLevel (suc n) (a ≡ b) (f a b) (g a b) i
+
+isPropIsSet : ∀ {ℓ} {A : Set ℓ} → isProp (isSet A)
+isPropIsSet {A = A} = isPropOfHLevel 2 A


### PR DESCRIPTION
If we define `isOfHLevel 1` to be `isProp` and only use induction afterward then we don't need things like `isPropIsOfHLevel1` and proofs are simpler.