### PR TITLE
Equality of Sigma-types, truncatedness of Sigma-types and products

### DIFF
--- a/Cubical/Data/Everything.agda
+++ b/Cubical/Data/Everything.agda
@@ -9,3 +9,4 @@ open import Cubical.Data.Int public renaming (_+_ to _+Int_ ; +-assoc to +Int-as
 open import Cubical.Data.Sum public
 open import Cubical.Data.Prod public
 open import Cubical.Data.Unit public
+open import Cubical.Data.Sigma public

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -4,8 +4,10 @@ module Cubical.Data.Prod.Properties where
 open import Cubical.Core.Everything
 
 open import Cubical.Data.Prod.Base
+open import Cubical.Data.Sigma
 
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
 
 variable
   ℓ ℓ' : Level
@@ -44,3 +46,18 @@ private
 
   testrefl : test ≡ (2 , 1)
   testrefl = refl
+
+-- equivalence between the sigma-based definition and the inductive one
+A×B≡A×ΣB : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} → A × B ≡ A ×Σ B
+A×B≡A×ΣB = isoToPath (iso (λ { (a , b) → (a , b)})
+                          (λ { (a , b) → (a , b)})
+                          (λ _ → refl)
+                          (λ { (a , b) → refl }))
+
+-- truncation for products
+hLevelProd : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} →
+                  (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)
+hLevelProd {_} {_} {A} {B} n h1 h2 =
+  let h : isOfHLevel n (A ×Σ B)
+      h = hLevelSigma n h1 (λ _ → h2)
+  in transport (λ i → isOfHLevel n (A×B≡A×ΣB {_} {_} {A} {B} (~ i))) h

--- a/Cubical/Data/Sigma.agda
+++ b/Cubical/Data/Sigma.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Sigma where
+
+open import Cubical.Data.Sigma.Base public
+
+open import Cubical.Data.Sigma.Properties public

--- a/Cubical/Data/Sigma/Base.agda
+++ b/Cubical/Data/Sigma/Base.agda
@@ -1,0 +1,8 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Sigma.Base where
+
+open import Cubical.Core.Prelude
+
+-- TODO : Sigma-types are defined in Core/Prelude.
+-- should they be moved here ?
+-- Is it ok to have something in Core depending on something in Data ?

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -1,0 +1,130 @@
+{-
+
+Basic properties about sigma-types
+
+-}
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Sigma.Properties where
+
+open import Cubical.Data.Sigma.Base
+
+open import Cubical.Core.Everything
+
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.CartesianKanOps
+
+open import Cubical.Data.Nat.Base
+
+private
+  variable
+    ℓ ℓ' : Level
+    A : Set ℓ
+    B : (a : A) → Set ℓ'
+
+-- alternative version for path in Σ-types, as in the HoTT book
+
+sigmaPath : (a b : Σ A B) → Set _
+sigmaPath {_} {_} {_} {B} a b =
+  Σ (fst a ≡ fst b) (λ p → transport (λ i → B (p i)) (snd a) ≡ snd b)
+
+_Σ≡_ : (a b : Σ A B) → Set _
+a Σ≡ b = sigmaPath a b
+
+-- now we prove that the alternative path space a Σ≡ b is equal to the usual path space a ≡ b
+
+-- foward direction
+
+private
+  pathSigma-π1 : (a b : Σ A B) → (a ≡ b) → (fst a ≡ fst b)
+  pathSigma-π1 a b p i = fst (p i)
+
+  filler-π2 : (a b : Σ A B) → (p : a ≡ b) → I → (i : I) → B (fst (p i))
+  filler-π2 {_} {_} {_} {B} a b p i =
+    fill (λ i → B (fst (p i)))
+         (λ t → λ { (i = i0) → coe0→i (λ j → B (fst (p j))) t (snd a)
+                  ; (i = i1) → snd (p t) })
+         (inc (snd a))
+
+  pathSigma-π2 : (a b : Σ A B) → (p : a ≡ b) →
+    transport (λ i → B (pathSigma-π1 a b p i)) (snd a) ≡ snd b
+  pathSigma-π2 a b p i = filler-π2 a b p i i1
+
+pathSigma→sigmaPath : (a b : Σ A B) → a ≡ b → a Σ≡ b
+pathSigma→sigmaPath a b p = (pathSigma-π1 a b p , pathSigma-π2 a b p)
+
+-- backward direction
+
+private
+  filler-comp : (a b : Σ A B) → a Σ≡ b → I → I → Σ A B
+  filler-comp {_} {_} {_} {B} a b (p , q) i =
+    hfill (λ t → λ { (i = i0) → a
+                   ; (i = i1) → (p i1 , q t) })
+          (inc (p i , coe0→i (λ j → B (p j)) i (snd a)))
+
+sigmaPath→pathSigma : (a b : Σ A B) → a Σ≡ b → (a ≡ b)
+sigmaPath→pathSigma a b x i = filler-comp a b x i i1
+
+-- first homotopy
+
+private
+  homotopy-π1 : (a b : Σ A B) →
+    ∀ x → pathSigma-π1 a b (sigmaPath→pathSigma a b x) ≡ fst x
+  homotopy-π1 a b x i j = fst (filler-comp a b x j (~ i))
+
+  homotopy-π2 : (a b : Σ A B) → (p : a Σ≡ b) → (i : I) →
+             (transport (λ j → B (fst (filler-comp a b p j i))) (snd a) ≡ snd b)
+  homotopy-π2 {_} {_} {_} {B} a b p i j =
+    comp (λ t → B (fst (filler-comp a b p t (i ∨ j))))
+         (λ t → λ { (j = i0) → coe0→i (λ t → B (fst (filler-comp a b p t i)))
+                                      t (snd a)
+                  ; (j = i1) → snd (sigmaPath→pathSigma a b p t)
+                  ; (i = i0) → snd (filler-comp a b p t j)
+                  ; (i = i1) → filler-π2 a b (sigmaPath→pathSigma a b p) j t })
+         (inc (snd a))
+
+pathSigma→sigmaPath→pathSigma : (a b : Σ A B) →
+  ∀ x → pathSigma→sigmaPath a b (sigmaPath→pathSigma a b x) ≡ x
+pathSigma→sigmaPath→pathSigma a b p i =
+  (homotopy-π1 a b p i , homotopy-π2 a b p (~ i))
+
+-- second homotopy
+
+sigmaPath→pathSigma→sigmaPath : (a b : Σ A B) →
+  ∀ x → sigmaPath→pathSigma a b (pathSigma→sigmaPath a b x) ≡ x
+sigmaPath→pathSigma→sigmaPath {_} {_} {_} {B} a b p i j =
+  hcomp (λ t → λ { (i = i1) → (fst (p j) , filler-π2 a b p t j)
+                 ; (i = i0) → filler-comp a b (pathSigma→sigmaPath a b p) j t
+                 ; (j = i0) → (fst a , snd a)
+                 ; (j = i1) → (fst b , filler-π2 a b p t i1) })
+        (fst (p j) , coe0→i (λ k → B (fst (p k))) j (snd a))
+
+pathSigma≡sigmaPath : (a b : Σ A B) → (a ≡ b) ≡ (a Σ≡ b)
+pathSigma≡sigmaPath a b = isoToPath (iso (pathSigma→sigmaPath a b)
+                               (sigmaPath→pathSigma a b)
+                               (pathSigma→sigmaPath→pathSigma a b)
+                               (sigmaPath→pathSigma→sigmaPath a b))
+
+
+-- truncatedness for Σ-types
+-- TODO : the case n=1 is superfluous but required by the new definition of isOfHLevel. Maybe
+-- we should keep both versions and have an equivalence between the two.
+
+hLevelSigma : ∀ n
+            → isOfHLevel n A
+            → ((x : A) → isOfHLevel n (B x))
+            → isOfHLevel n (Σ A B)
+hLevelSigma {_} {_} {_} {B} zero h1 h2 =
+  let center = (fst h1 , fst (h2 (fst h1))) in
+  let p : ∀ x → center ≡ x
+      p = λ x → sym (sigmaPath→pathSigma _ _ (sym (snd h1 (fst x)) , sym (snd (h2 (fst h1)) _)))
+  in (center , p)
+hLevelSigma {_} {_} {_} {B} 1 h1 h2 =
+  λ x y → sigmaPath→pathSigma x y ((h1 _ _) , (h2 _ _ _))
+hLevelSigma {_} {_} {_} {B} (suc (suc n)) h1 h2 =
+  λ x y →
+    (let h3 : isOfHLevel (suc n) (x Σ≡ y)
+         h3 = hLevelSigma (suc n)
+                          (h1 (fst x) (fst y)) λ p → h2 (p i1)
+                          (transport (λ i → B (p i)) (snd x)) (snd y)
+     in transport (λ i → isOfHLevel (suc n) (pathSigma≡sigmaPath x y (~ i))) h3)


### PR DESCRIPTION
Add an alternative equality for Sigma-types, following the HoTT Book. Use it to prove truncatedness results for Sigma-types, and specialize them to nondependent products.