### PR TITLE
Reasoning with paths

### DIFF
--- a/Cubical/Core/Prelude.agda
+++ b/Cubical/Core/Prelude.agda
@@ -88,6 +88,12 @@ compPathP p q j = compPathP-filler p q j i1
 _≡⟨_⟩_ : (x : A) → x ≡ y → y ≡ z → x ≡ z
 _ ≡⟨ x≡y ⟩ y≡z = x≡y ∙ y≡z
 
+
+≡⟨⟩-syntax : (x : A) → x ≡ y → y ≡ z → x ≡ z
+≡⟨⟩-syntax = _≡⟨_⟩_
+infixr 2 ≡⟨⟩-syntax
+syntax ≡⟨⟩-syntax x (λ i → B) y = x ≡[ i ]⟨ B ⟩ y
+
 _∎ : (x : A) → x ≡ x
 _ ∎ = refl
 

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -72,12 +72,12 @@ or-comm true y =
 or-assoc     : ∀ x y z → x or (y or z) ≡ (x or y) or z
 or-assoc false y z =
   false or (y or z)   ≡⟨ or-identityˡ _ ⟩
-  y or z              ≡⟨ cong (_or z) (sym (or-identityˡ _)) ⟩
+  y or z              ≡[ i ]⟨ or-identityˡ y (~ i) or z ⟩
   ((false or y) or z) ∎ 
 or-assoc true y z  =
  true or (y or z)  ≡⟨ zeroˡ _ ⟩
   true             ≡⟨ sym (zeroˡ _) ⟩
-  true or z        ≡⟨ cong (_or z) (sym (zeroˡ _)) ⟩
+  true or z        ≡[ i ]⟨ zeroˡ y (~ i) or z ⟩
   (true or y) or z ∎
   
 or-idem      : ∀ x → x or x ≡ x

--- a/Cubical/Data/DiffInt/Properties.agda
+++ b/Cubical/Data/DiffInt/Properties.agda
@@ -26,15 +26,15 @@ relIsEquiv = EquivRel {A = ℕ ×Σ ℕ} relIsRefl relIsSym relIsTrans
     relIsTrans : isTrans rel
     relIsTrans (a0 , a1) (b0 , b1) (c0 , c1) p0 p1 =
       inj-m+ {m = (b0 + b1)} ((b0 + b1) + (a0 + c1) ≡⟨ +-assoc (b0 + b1) a0 c1  ⟩
-            ((b0 + b1) + a0) + c1 ≡⟨ cong (λ x → x + a0 + c1) (+-comm b0 b1)⟩
-            ((b1 + b0) + a0) + c1 ≡⟨ cong (λ x → x + c1) (+-comm (b1 + b0) a0) ⟩
-            (a0 + (b1 + b0)) + c1 ≡⟨ cong (λ x → x + c1) (+-assoc a0 b1 b0) ⟩
+            ((b0 + b1) + a0) + c1 ≡[ i ]⟨ +-comm b0 b1 i + a0   + c1 ⟩
+            ((b1 + b0) + a0) + c1 ≡[ i ]⟨ +-comm (b1 + b0) a0 i + c1 ⟩
+            (a0 + (b1 + b0)) + c1 ≡[ i ]⟨ +-assoc a0 b1 b0 i    + c1 ⟩
             (a0 + b1) + b0 + c1 ≡⟨ sym (+-assoc (a0 + b1) b0 c1) ⟩
             (a0 + b1) + (b0 + c1) ≡⟨ cong (λ p → p . fst + p .snd) (transport (ua Σ≡) (p0 , p1))⟩
             (b0 + a1) + (c0 + b1) ≡⟨ sym (+-assoc b0 a1 (c0 + b1))⟩
-            b0 + (a1 + (c0 + b1)) ≡⟨ cong (λ x → b0 + (a1 + x)) (+-comm c0 b1)⟩
-            b0 + (a1 + (b1 + c0)) ≡⟨ cong (λ x → b0 + x) (+-comm a1 (b1 + c0)) ⟩
-            b0 + ((b1 + c0) + a1) ≡⟨ cong (λ x → b0 + x) (sym (+-assoc b1 c0 a1))⟩
+            b0 + (a1 + (c0 + b1)) ≡[ i ]⟨ b0 + (a1 + +-comm c0 b1 i) ⟩
+            b0 + (a1 + (b1 + c0)) ≡[ i ]⟨ b0 + +-comm a1 (b1 + c0) i ⟩
+            b0 + ((b1 + c0) + a1) ≡[ i ]⟨ b0 + +-assoc b1 c0 a1 (~ i) ⟩
             b0 + (b1 + (c0 + a1)) ≡⟨ +-assoc b0 b1 (c0 + a1)⟩
             (b0 + b1) + (c0 + a1) ∎ )
 

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -134,14 +134,14 @@ predInt+negsuc (suc n) m = cong predInt (predInt+negsuc n m)
 sucInt+negsuc : ∀ n m → sucInt (m +negsuc n) ≡ (sucInt m) +negsuc n
 sucInt+negsuc zero m = (sucPred _) ∙ (sym (predSuc _))
 sucInt+negsuc (suc n) m =      _ ≡⟨ sucPred _ ⟩
-  m +negsuc n                    ≡⟨ cong (λ z → z +negsuc n) (sym (predSuc m)) ⟩
+  m +negsuc n                    ≡[ i ]⟨ predSuc m (~ i) +negsuc n ⟩
   (predInt (sucInt m)) +negsuc n ≡⟨ sym (predInt+negsuc n (sucInt m)) ⟩
   predInt (sucInt m +negsuc n) ∎
 
 predInt+pos : ∀ n m → predInt (m +pos n) ≡ (predInt m) +pos n
 predInt+pos zero m = refl
 predInt+pos (suc n) m =     _ ≡⟨ predSuc _ ⟩
-  m +pos n                    ≡⟨ cong (λ m → m +pos n) (sym (sucPred _)) ⟩
+  m +pos n                    ≡[ i ]⟨ sucPred m (~ i) + pos n ⟩
   (sucInt (predInt m)) +pos n ≡⟨ sym (sucInt+pos n (predInt m))⟩
   (predInt m) +pos (suc n)    ∎
 
@@ -183,11 +183,11 @@ ind-comm : {A : Set} (_∙_ : A → A → A) (f : ℕ → A) (g : A → A)
          → ∀ z n → z ∙ f n ≡ f n ∙ z
 ind-comm _∙_ f g p g∙ ∙g base z 0 = base z
 ind-comm _∙_ f g p g∙ ∙g base z (suc n) =
-  z ∙ f (suc n) ≡⟨ cong (_∙_ z) p ⟩
+  z ∙ f (suc n) ≡[ i ]⟨ z ∙ p {n} i ⟩
   z ∙ g (f n)   ≡⟨ sym ( ∙g z (f n)) ⟩
   g (z ∙ f n)   ≡⟨ cong g IH ⟩
   g (f n ∙ z)   ≡⟨ g∙ (f n) z ⟩
-  g (f n) ∙ z   ≡⟨ cong (λ x → x ∙ z) (sym p) ⟩
+  g (f n) ∙ z   ≡[ i ]⟨ p {n} (~ i) ∙ z ⟩
   f (suc n) ∙ z ∎
   where
   IH = ind-comm _∙_ f g p g∙ ∙g base z n
@@ -200,12 +200,12 @@ ind-assoc : {A : Set} (_·_ : A → A → A) (f : ℕ → A)
       → m · (n · (f o)) ≡ (m · n) · (f o)
 ind-assoc _·_ f g p q base m n 0 = sym (base m n)
 ind-assoc _·_ f g p q base m n (suc o) =
-    m · (n · (f (suc o))) ≡⟨ cong (_·_ m) (cong (_·_ n) q) ⟩
-    m · (n · (g (f o)))   ≡⟨ cong (_·_ m) (sym (p n (f o)))⟩
+    m · (n · (f (suc o))) ≡[ i ]⟨ m · (n · q {o} i) ⟩
+    m · (n · (g (f o)))   ≡[ i ]⟨ m · (p n (f o) (~ i)) ⟩
     m · (g (n · (f o)))   ≡⟨ sym (p m (n · (f o)))⟩
     g (m · (n · (f o)))   ≡⟨ cong g IH ⟩
     g ((m · n) · (f o))   ≡⟨ p (m · n) (f o) ⟩
-    (m · n) · (g (f o))   ≡⟨ cong (_·_ (m · n)) (sym q)⟩
+    (m · n) · (g (f o))   ≡[ i ]⟨ (m · n) · q {o} (~ i) ⟩
     (m · n) · (f (suc o)) ∎
     where
     IH = ind-assoc _·_ f g p q base m n o
@@ -263,13 +263,13 @@ minusPlus (pos zero) n = refl
 minusPlus (pos 1) = sucPred
 minusPlus (pos (suc (suc m))) n =
   sucInt ((n +negsuc (suc m)) +pos (suc m)) ≡⟨ sucInt+pos (suc m) _ ⟩
-  sucInt (n +negsuc (suc m)) +pos (suc m)   ≡⟨ cong (λ z → z +pos (suc m)) (sucPred _) ⟩
+  sucInt (n +negsuc (suc m)) +pos (suc m)   ≡[ i ]⟨ sucPred (n +negsuc m) i +pos (suc m) ⟩
   (n - pos (suc m)) +pos (suc m)            ≡⟨ minusPlus (pos (suc m)) n ⟩
   n ∎
 minusPlus (negsuc zero) = predSuc
 minusPlus (negsuc (suc m)) n =
   predInt (sucInt (sucInt (n +pos m)) +negsuc m) ≡⟨ predInt+negsuc m _ ⟩
-  predInt (sucInt (sucInt (n +pos m))) +negsuc m ≡⟨ cong (λ z → z + negsuc m) (predSuc _) ⟩
+  predInt (sucInt (sucInt (n +pos m))) +negsuc m ≡[ i ]⟨ predSuc (sucInt (n +pos m)) i +negsuc m ⟩
   sucInt (n +pos m) +negsuc m                    ≡⟨ minusPlus (negsuc m) n ⟩
   n ∎
 


### PR DESCRIPTION
Introduces a new syntax
```
syntax ≡⟨⟩-syntax x (λ i → B) y = x ≡[ i ]⟨ B ⟩ y
```
that let's one explicitly reason along one dimension of a path. This emulates the term one is reasoning about, without having to use `cong`, `sym` etc. For example:
```diff
-  m +negsuc n                    ≡⟨ cong (λ z → z +negsuc n) (sym (predSuc m)) ⟩
+  m +negsuc n                    ≡[ i ]⟨ predSuc m (~ i) +negsuc n ⟩
  (predInt (sucInt m)) +negsuc n
```

### Downsides:

Currently, agda does not unify terms at the end of paths, which - in some places - forces one to insert arguments, that could be deduced, explicitly. This can lead to more verbose (but imo still easier to follow) code. See for example

https://github.com/agda/cubical/commit/0021690ed0a5b9d48024e1efb8716dc8a662811e#diff-c8d357f7cb4918b983a46285d4d349dcL266
```diff
-   sucInt (n +negsuc (suc m)) +pos (suc m)   ≡⟨ cong (λ z → z +pos (suc m)) (sucPred _) ⟩ 
+   sucInt (n +negsuc (suc m)) +pos (suc m)   ≡[ i ]⟨ sucPred (n +negsuc m) i +pos (suc m) ⟩ 
```