### PR TITLE
Some logic properties

### DIFF
--- a/Cubical/Core/Prelude.agda
+++ b/Cubical/Core/Prelude.agda
@@ -35,7 +35,7 @@ infixr 2 _≡⟨_⟩_
 
 private
   variable
-    ℓ ℓ' ℓ'' : Level
+    ℓ ℓ' : Level
     A : Set ℓ
     B : A → Set ℓ
     x y z : A
@@ -54,7 +54,7 @@ cong : ∀ (f : (a : A) → B a) (p : x ≡ y) →
        PathP (λ i → B (p i)) (f x) (f y)
 cong f p i = f (p i)
 
-cong₂ : ∀ {C : (a : A) → (b : B a) → Set ℓ''} →
+cong₂ : ∀ {C : (a : A) → (b : B a) → Set ℓ} →
         (f : (a : A) → (b : B a) → C a b) →
         (p : x ≡ y) →
         {u : B x} {v : B y} (q : PathP (λ i → B (p i)) u v) →
@@ -154,7 +154,7 @@ syntax Σ-syntax A (λ x → B) = Σ[ x ∈ A ] B
 
 -- Contractibility of singletons
 
-singl : {A : Set ℓ} (a : A) → Set ℓ
+singl : (a : A) → Set _
 singl {A = A} a = Σ[ x ∈ A ] (a ≡ x)
 
 contrSingl : (p : x ≡ y) → Path (singl x) (x , refl) (y , p)

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -2,6 +2,7 @@
 module Cubical.Data.Prod.Base where
 
 open import Cubical.Core.Everything
+open import Cubical.Foundations.Function
 
 -- If × is defined using Σ then transp/hcomp will be compute
 -- "negatively", that is, they won't reduce unless we project out the
@@ -9,13 +10,36 @@ open import Cubical.Core.Everything
 -- default implementation is done using a datatype which computes
 -- positively.
 
-data _×_ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+
+private
+  variable
+    ℓ ℓ' : Level
+    
+data _×_ (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
   _,_ : A → B → A × B
 
 infixr 5 _×_
 
+proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
+proj₁ (x , _) = x
+
+proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
+proj₂ (_ , x) = x
+
 -- We still export the version using Σ
-_×Σ_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+_×Σ_ : (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
 A ×Σ B = Σ A (λ _ → B)
 
 infixr 5 _×Σ_
+
+private
+  variable
+    A    : Set ℓ
+    B C  : A → Set ℓ 
+
+elim-× : (∀ a → B a) → (∀ a → C a) → ∀ a → B a × C a
+elim-× f g a = f a , g a
+    
+map-× : {B : Set ℓ} {D : B → Set ℓ'}
+   → (∀ a → C a) → (∀ b → D b) → (x : A × B) → C (proj₁ x) × D (proj₂ x)
+map-× f g = elim-× (f ∘ proj₁) (g ∘ proj₂)

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -13,23 +13,18 @@ open import Cubical.Foundations.Isomorphism
 private
   variable
     ℓ ℓ' : Level
-
-proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
-proj₁ (x , _) = x
-
-proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
-proj₂ (_ , x) = x
+    A B  : Set ℓ 
 
 -- Swapping is an equivalence
 
-swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
+swap : A × B → B × A
 swap (x , y) = (y , x)
 
-swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
-swapInv (_ , _) = refl
+swap-invol : (xy : A × B) → swap (swap xy) ≡ xy
+swap-invol (_ , _) = refl
 
 isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
-isEquivSwap A B = isoToIsEquiv (iso swap swap swapInv swapInv)
+isEquivSwap A B = isoToIsEquiv (iso swap swap swap-invol swap-invol)
 
 swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
 swapEquiv A B = (swap , isEquivSwap A B)
@@ -50,15 +45,14 @@ private
   testrefl = refl
 
 -- equivalence between the sigma-based definition and the inductive one
-A×B≡A×ΣB : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} → A × B ≡ A ×Σ B
+A×B≡A×ΣB : A × B ≡ A ×Σ B
 A×B≡A×ΣB = isoToPath (iso (λ { (a , b) → (a , b)})
                           (λ { (a , b) → (a , b)})
                           (λ _ → refl)
                           (λ { (a , b) → refl }))
 
 -- truncation for products
-hLevelProd : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} →
-                  (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)
+hLevelProd : (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)
 hLevelProd {A = A} {B = B} n h1 h2 =
   let h : isOfHLevel n (A ×Σ B)
       h = isOfHLevelΣ n h1 (λ _ → h2)

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -3,14 +3,19 @@ module Cubical.Data.Sum.Base where
 
 open import Cubical.Core.Everything
 
-data _⊎_ {ℓ ℓ'} (P : Set ℓ) (Q : Set ℓ') : Set (ℓ-max ℓ ℓ') where
-  inl : P → P ⊎ Q
-  inr : Q → P ⊎ Q
-
 private
   variable
-    ℓ : Level
+    ℓ ℓ' : Level
     A B C D : Set ℓ
+    
+data _⊎_ (A : Set ℓ)(B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+  inl : A → A ⊎ B
+  inr : B → A ⊎ B
+
+elim-⊎ : {C : A ⊎ B → Set ℓ} →  ((a : A) → C (inl a)) → ((b : B) → C (inr b))
+       → (x : A ⊎ B) → C x
+elim-⊎ f _ (inl x) = f x
+elim-⊎ _ g (inr y) = g y
 
 map-⊎ : (A → C) → (B → D) → A ⊎ B → C ⊎ D
 map-⊎ f _ (inl x) = inl (f x)

--- a/Cubical/Data/Unit.agda
+++ b/Cubical/Data/Unit.agda
@@ -1,4 +1,5 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Data.Unit where
 
-open import Cubical.Data.Unit.Base public
+open import Cubical.Data.Unit.Base       public
+open import Cubical.Data.Unit.Properties public

--- a/Cubical/Data/Unit/Properties.agda
+++ b/Cubical/Data/Unit/Properties.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Unit.Properties where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Unit.Base
+
+isPropUnit : isProp Unit
+isPropUnit _ _ i = tt
+
+isContrUnit : isContr Unit
+isContrUnit = tt , λ {tt → refl}

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -12,8 +12,28 @@ _∘_ : ∀ {ℓ ℓ′ ℓ″} {A : Set ℓ} {B : A → Set ℓ′} {C : (a : A
         (g : {a : A} → (b : B a) → C a b) → (f : (a : A) → B a) → (a : A) → C a (f a)
 g ∘ f = λ x → g (f x)
 
-case_of_ : ∀{ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} → (x : A) → (∀ x → B x) → B x
+∘-assoc : ∀ {ℓ ℓ′ ℓ″ ℓ‴} {A : Set ℓ} {B : A → Set ℓ′} {C : (a : A) → B a → Set ℓ″} {D : (a : A) (b : B a) → C a b → Set ℓ‴}
+            (h : {a : A} {b : B a} → (c : C a b) → D a b c) (g : {a : A} → (b : B a) → C a b) (f : (a : A) → B a)
+          → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f)
+∘-assoc h g f i x = h (g (f x))
+
+
+id : ∀ {ℓ} {A : Set ℓ} → A → A
+id = λ x → x
+
+∘-idˡ : ∀ {ℓ ℓ′} {A : Set ℓ} {B : A → Set ℓ′} (f : (a : A) → B a) → f ∘ id ≡ f
+∘-idˡ f i x = f x
+
+∘-idʳ : ∀ {ℓ ℓ′} {A : Set ℓ} {B : A → Set ℓ′} (f : (a : A) → B a) → id ∘ f ≡ f
+∘-idʳ f i x = f x
+
+
+const : ∀ {ℓ ℓ′} {A : Set ℓ} {B : Set ℓ′} → A → B → A
+const x = λ _ → x
+
+
+case_of_ : ∀ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} → (x : A) → (∀ x → B x) → B x
 case x of f = f x
 
-case_return_of_ : ∀{ℓ ℓ'} {A : Set ℓ} (x : A) (B : A → Set ℓ') → (∀ x → B x) → B x
+case_return_of_ : ∀ {ℓ ℓ'} {A : Set ℓ} (x : A) (B : A → Set ℓ') → (∀ x → B x) → B x
 case x return P of f = f x

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -3,25 +3,55 @@ module Cubical.Foundations.Logic where
 
 import Cubical.Data.Everything as D
 open import Cubical.Core.Everything
-open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.HLevels     using (ΣProp≡; isPropIsProp; propPi)
 open import Cubical.Foundations.Isomorphism
 
+
+infixr 7 _⊔_
+infixr 7 _⊔′_
+infixr 7 _⊓_
+infixr 7 _⊓′_
+infixr 5 _⇒_
+infixr 4 _⇔_
+
+--------------------------------------------------------------------------------
+-- The type hProp of mere propositions 
+
+Ω : Set₁
 Ω = Σ Set isProp
 
 [_] : Ω → Set
-[ P ] = P .fst
+[_] = fst
+
+--------------------------------------------------------------------------------
+-- Logical equivalence of mere propositions
+
+Ω≡ : {a b : Ω} → [ a ] ≡ [ b ] → a ≡ b
+Ω≡ p = ΣProp≡ (\ _ → isPropIsProp) p
+
+pequivToIso : (a b : Ω) → ([ a ] → [ b ]) → ([ b ] → [ a ]) → Iso [ a ] [ b ]
+pequivToIso a b f g = iso f g (λ b₁ → b .snd (f (g b₁)) b₁) λ a₁ → a .snd (g (f a₁)) a₁
+
+pequivToPath : (a b : Ω) → ([ a ] → [ b ]) → ([ b ] → [ a ]) → [ a ] ≡ [ b ]
+pequivToPath a b f g = isoToPath (pequivToIso a b f g)
+
+--------------------------------------------------------------------------------
+-- True and False types
 
 ⊥ : Ω
 ⊥ = D.⊥ , D.isProp⊥
 
 ⊤ : Ω
-⊤ = D.Unit , λ x y i → D.tt
+⊤ = D.Unit , D.isPropUnit
+
+--------------------------------------------------------------------------------
+-- Disjunction of mere propositions
 
 _⊔′_ : Set → Set → Set
 A ⊔′ B = ∥ A D.⊎ B ∥
 
 _⊔_ : Ω → Ω → Ω
-A ⊔ B = (∥ [ A ] D.⊎ [ B ] ∥) , propTruncIsProp
+A ⊔ B = [ A ] ⊔′ [ B ] , propTruncIsProp
 
 inl : ∀ {A B} → A → A ⊔′ B
 inl x = ∣ D.inl x ∣
@@ -29,23 +59,45 @@ inl x = ∣ D.inl x ∣
 inr : ∀ {A B} → B → A ⊔′ B
 inr x = ∣ D.inr x ∣
 
-⊔-elim : ∀ {A B} (C : [ A ⊔ B ] → Ω) → (∀ a → [ C (inl a) ]) → (∀ b → [ C (inr b) ]) → (∀ x → [ C x ])
-⊔-elim C f g = (elimPropTrunc (\ x → C _ .snd)
-                             \ { (D.inl x) → f x
-                               ; (D.inr x) → g x
-                               })
+⊔-elim : ∀ A B (C : [ A ⊔ B ] → Ω) → (∀ a → [ C (inl a) ]) → (∀ b → [ C (inr b) ]) → (∀ x → [ C x ])
+⊔-elim A B C f g = elimPropTrunc (\ x → C _ .snd) (D.elim-⊎ f g)
 
-Ω≡ : ∀ {a b : Ω} → a .fst ≡ b .fst → a ≡ b
-Ω≡ p = ΣProp≡ (\ _ → isPropIsProp) p
+--------------------------------------------------------------------------------
+-- Conjunction of mere propositions
+_⊓′_ : Set → Set → Set
+A ⊓′ B = A D.× B
 
-pequivToIso : ∀ {a b : Ω} → (a .fst → b .fst) → (b .fst → a .fst) → Iso (a .fst) (b .fst)
-pequivToIso {a} {b} f g = iso f g (λ b₁ → b .snd (f (g b₁)) b₁) λ a₁ → a .snd (g (f a₁)) a₁
+_⊓_ : Ω → Ω → Ω
+A ⊓ B = [ A ] ⊓′ [ B ] , D.hLevelProd 1 (A .snd) (B .snd)
 
-pequivToPath : ∀ {a b : Ω} → (a .fst → b .fst) → (b .fst → a .fst) → (a .fst) ≡ (b .fst)
-pequivToPath {a} {b} f g = isoToPath (pequivToIso {a} {b} f g)
+⊓-elim : ∀ A (B : [ A ] → Ω) (C : [ A ] → Ω)
+       → (∀ a → [ B a ]) → (∀ a → [ C a ]) → (∀ (a : [ A ]) → [ B a ⊓ C a ] )
+⊓-elim A B C f g a = f a D., g a
+--------------------------------------------------------------------------------
+-- Pseudo-complement of mere propositions
+¬_ : Ω → Ω
+¬ A = ([ A ] → D.⊥) , propPi λ _ → D.isProp⊥
+
+--------------------------------------------------------------------------------
+-- Logical implication of mere propositions
+
+_⇒_ : Ω → Ω → Ω
+A ⇒ B = ([ A ] → [ B ]) , propPi λ _ → B .snd
+
+--------------------------------------------------------------------------------
+-- Logical bi-implication of mere propositions
+
+_⇔_ : Ω → Ω → Ω
+A ⇔ B = (A ⇒ B) ⊓ (B ⇒ A)
+
+⇔toPath : ∀ {A B} → [ A ⇔ B ] → A ≡ B
+⇔toPath {A = A} {B = B} (A⇒B D., B⇒A) = Ω≡ (pequivToPath A B A⇒B B⇒A)
+
+--------------------------------------------------------------------------------
+-- (Ω, ⊔, ⊥) is a bounded ⊔-semilattice
 
 ⊔-assoc : ∀ a b c → a ⊔ (b ⊔ c) ≡ (a ⊔ b) ⊔ c
-⊔-assoc a b c = Ω≡ (pequivToPath {a ⊔ (b ⊔ c)} {(a ⊔ b) ⊔ c} assoc1 assoc2)
+⊔-assoc a b c = ⇔toPath (assoc1 D., assoc2)
  where
    module _ {a b c : Set} where
     assoc1 : a ⊔′ (b ⊔′ c) → (a ⊔′ b) ⊔′ c
@@ -63,7 +115,32 @@ pequivToPath {a} {b} f g = isoToPath (pequivToIso {a} {b} f g)
     assoc2 (squash x y i)           = propTruncIsProp (assoc2 x) (assoc2 y) i
 
 ⊔-idem : ∀ a → a ⊔ a ≡ a
-⊔-idem a = Ω≡ (pequivToPath {a ⊔ a} {a} (⊔-elim {a} {a} (\ _ → a) (\ x → x) (\ x → x)) inl)
+⊔-idem a = ⇔toPath (⊔-elim a a (\ _ → a) (\ x → x) (\ x → x) D., inl)
 
 ⊔-comm : ∀ a b → a ⊔ b ≡ b ⊔ a
-⊔-comm a b = Ω≡ (pequivToPath {a ⊔ b} {b ⊔ a} (⊔-elim {a} {b} (\ _ → (b ⊔ a)) inr inl) (⊔-elim {b} {a} (\ _ → (a ⊔ b)) inr inl))
+⊔-comm a b = ⇔toPath (⊔-elim a b (\ _ → (b ⊔ a)) inr inl D.,  (⊔-elim b a (\ _ → (a ⊔ b)) inr inl))
+
+⊔-identityˡ : ∀ a → ⊥ ⊔ a ≡ a
+⊔-identityˡ a = ⇔toPath (⊔-elim ⊥ a (λ _ → a) D.⊥-elim (idfun _) D., inr)
+
+⊔-identityʳ : ∀ a → a ⊔ ⊥ ≡ a
+⊔-identityʳ a = ⇔toPath ((⊔-elim a ⊥ (λ _ → a) (λ x → x) D.⊥-elim) D., inl)
+  
+--------------------------------------------------------------------------------
+-- (Ω, ⊓, ⊤) is a bounded ⊓-semilattice
+
+⊓-assoc : ∀ a b c → a ⊓ b ⊓ c ≡ (a ⊓ b) ⊓ c
+⊓-assoc a b c =
+  ⇔toPath ((λ {(x D., (y D., z)) →  (x D., y) D., z}) D., λ {((x D., y) D., z) → x D., (y D., z) })
+
+⊓-comm : ∀ a b → a ⊓ b ≡ b ⊓ a
+⊓-comm a b = ⇔toPath (D.swap D., D.swap)
+
+⊓-idem : ∀ a → a ⊓ a ≡ a
+⊓-idem a = ⇔toPath (D.proj₁ D., (λ a → a D., a))
+
+⊓-identityˡ : ∀ a → ⊤ ⊓ a ≡ a 
+⊓-identityˡ a = ⇔toPath (D.proj₂ D., λ a → D.tt D., a)
+
+⊓-identityʳ : ∀ a → a ⊓ ⊤ ≡ a
+⊓-identityʳ a = ⇔toPath (D.proj₁ D., λ a → a D., D.tt)


### PR DESCRIPTION
1. Add more logic operations and their properties in Logic: 

* pseudo-complement
* conjunction
* implication
* bi-implication
* bi-implication gives a path
* (Ω, ⊓, ⊤) is a bounded ⊓-semilattice
* left and right ⊔-identities

2. Replace proofs with `Ω≡ (pequivToPath …)` by `⇔toPath`
3. Tidy up Cubical.Data.Prod.Base

* Move projections to Base from Properties
* Add elimination rules and the bifunctorial map
* Rename `swapInv` to swap-invol`

4. Add the elimination for sum type `elim-⊎`
5. Add simple facts `isPropUnit`, `isContrUnit`

This PR includes a patch from #106, so it should be merged after #106 (I guess?). Making it universe polymorphic is currently not needed to me, so I just leave it for now. 