### PR TITLE
Logic

### DIFF
--- a/Cubical/Core/Prelude.agda
+++ b/Cubical/Core/Prelude.agda
@@ -107,7 +107,7 @@ compPath'-filler {z = z} p q j i =
 _□_ : x ≡ y → y ≡ z → x ≡ z
 (p □ q) j = compPath'-filler p q i1 j
 
-□≡∙ : (p : x ≡ y) (q : y ≡ z) → p □ q ≡ p ∙ q 
+□≡∙ : (p : x ≡ y) (q : y ≡ z) → p □ q ≡ p ∙ q
 □≡∙ {x = x} {y = y} {z = z} p q i j = hcomp (λ k → \ { (i = i0) → compPath'-filler p q k j
                                              ; (i = i1) → compPath-filler p q k j
                                              ; (j = i0) → p ( ~ i ∧ ~ k)
@@ -226,4 +226,4 @@ isProp→isSet h a b p q j i =
   hcomp (λ k → λ { (i = i0) → h a a k
                  ; (i = i1) → h a b k
                  ; (j = i0) → h a (p i) k
-                 ; (j = i1) → h a (q i) k }) a 
+                 ; (j = i1) → h a (q i) k }) a

--- a/Cubical/Core/Prelude.agda
+++ b/Cubical/Core/Prelude.agda
@@ -35,7 +35,7 @@ infixr 2 _≡⟨_⟩_
 
 private
   variable
-    ℓ ℓ' ℓ'' : Level
+    ℓ ℓ' : Level
     A : Set ℓ
     B : A → Set ℓ
     x y z : A
@@ -54,7 +54,7 @@ cong : ∀ (f : (a : A) → B a) (p : x ≡ y) →
        PathP (λ i → B (p i)) (f x) (f y)
 cong f p i = f (p i)
 
-cong₂ : ∀ {C : (a : A) → (b : B a) → Set ℓ''} →
+cong₂ : ∀ {C : (a : A) → (b : B a) → Set ℓ} →
         (f : (a : A) → (b : B a) → C a b) →
         (p : x ≡ y) →
         {u : B x} {v : B y} (q : PathP (λ i → B (p i)) u v) →
@@ -160,7 +160,7 @@ syntax Σ-syntax A (λ x → B) = Σ[ x ∈ A ] B
 
 -- Contractibility of singletons
 
-singl : {A : Set ℓ} (a : A) → Set ℓ
+singl : (a : A) → Set _
 singl {A = A} a = Σ[ x ∈ A ] (a ≡ x)
 
 contrSingl : (p : x ≡ y) → Path (singl x) (x , refl) (y , p)

--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -167,7 +167,7 @@ Binℕ→ℕ→Binℕ (binℕpos p) = posInd refl (λ p _ → rem p) p
   rem : (p : Pos) → ℕ→Binℕ (Pos→ℕ (sucPos p)) ≡ binℕpos (sucPos p)
   rem p =
     ℕ→Binℕ (Pos→ℕ (sucPos p))       ≡⟨ cong ℕ→Binℕ (Pos→ℕsucPos p) ⟩
-    binℕpos (ℕ→Pos (suc (Pos→ℕ p))) ≡⟨ cong binℕpos ((ℕ→PosSuc (Pos→ℕ p) (zero≠Pos→ℕ p)) ∙ 
+    binℕpos (ℕ→Pos (suc (Pos→ℕ p))) ≡⟨ cong binℕpos ((ℕ→PosSuc (Pos→ℕ p) (zero≠Pos→ℕ p)) ∙
                                                               (cong sucPos (Pos→ℕ→Pos p))) ⟩
     binℕpos (sucPos p) ∎
 

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -17,7 +17,7 @@ notnot true  = refl
 notnot false = refl
 
 notIsEquiv : isEquiv not
-notIsEquiv = isoToIsEquiv (iso not not notnot notnot) 
+notIsEquiv = isoToIsEquiv (iso not not notnot notnot)
 
 notEquiv : Bool ≃ Bool
 notEquiv = (not , notIsEquiv)
@@ -29,7 +29,7 @@ private
   -- This computes to false as expected
   nfalse : Bool
   nfalse = transp (λ i → notEq i) i0 true
-  
+
   -- Sanity check
   nfalsepath : nfalse ≡ false
   nfalsepath = refl
@@ -68,18 +68,18 @@ or-comm true y =
   true or y ≡⟨ zeroˡ y ⟩
   true      ≡⟨ sym (zeroʳ y) ⟩
   y or true ∎
-  
+
 or-assoc     : ∀ x y z → x or (y or z) ≡ (x or y) or z
 or-assoc false y z =
   false or (y or z)   ≡⟨ or-identityˡ _ ⟩
   y or z              ≡[ i ]⟨ or-identityˡ y (~ i) or z ⟩
-  ((false or y) or z) ∎ 
+  ((false or y) or z) ∎
 or-assoc true y z  =
  true or (y or z)  ≡⟨ zeroˡ _ ⟩
   true             ≡⟨ sym (zeroˡ _) ⟩
   true or z        ≡[ i ]⟨ zeroˡ y (~ i) or z ⟩
   (true or y) or z ∎
-  
+
 or-idem      : ∀ x → x or x ≡ x
 or-idem false = refl
 or-idem true  = refl

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -2,6 +2,7 @@
 module Cubical.Data.Prod.Base where
 
 open import Cubical.Core.Everything
+open import Cubical.Foundations.Function
 
 -- If × is defined using Σ then transp/hcomp will be compute
 -- "negatively", that is, they won't reduce unless we project out the
@@ -9,13 +10,36 @@ open import Cubical.Core.Everything
 -- default implementation is done using a datatype which computes
 -- positively.
 
-data _×_ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+
+private
+  variable
+    ℓ ℓ' : Level
+    
+data _×_ (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
   _,_ : A → B → A × B
 
 infixr 5 _×_
 
+proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
+proj₁ (x , _) = x
+
+proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
+proj₂ (_ , x) = x
+
 -- We still export the version using Σ
-_×Σ_ : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+_×Σ_ : (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
 A ×Σ B = Σ A (λ _ → B)
 
 infixr 5 _×Σ_
+
+private
+  variable
+    A    : Set ℓ
+    B C  : A → Set ℓ 
+
+intro-× : (∀ a → B a) → (∀ a → C a) → ∀ a → B a × C a
+intro-× f g a = f a , g a
+    
+map-× : {B : Set ℓ} {D : B → Set ℓ'}
+   → (∀ a → C a) → (∀ b → D b) → (x : A × B) → C (proj₁ x) × D (proj₂ x)
+map-× f g = intro-× (f ∘ proj₁) (g ∘ proj₂)

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -14,7 +14,7 @@ open import Cubical.Foundations.Function
 private
   variable
     ℓ ℓ' : Level
-    
+
 data _×_ (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
   _,_ : A → B → A × B
 
@@ -35,11 +35,11 @@ infixr 5 _×Σ_
 private
   variable
     A    : Set ℓ
-    B C  : A → Set ℓ 
+    B C  : A → Set ℓ
 
 intro-× : (∀ a → B a) → (∀ a → C a) → ∀ a → B a × C a
 intro-× f g a = f a , g a
-    
+
 map-× : {B : Set ℓ} {D : B → Set ℓ'}
    → (∀ a → C a) → (∀ b → D b) → (x : A × B) → C (proj₁ x) × D (proj₂ x)
 map-× f g = intro-× (f ∘ proj₁) (g ∘ proj₂)

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -13,7 +13,7 @@ open import Cubical.Foundations.Isomorphism
 private
   variable
     ℓ ℓ' : Level
-    A B  : Set ℓ 
+    A B  : Set ℓ
 
 -- Swapping is an equivalence
 

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -13,23 +13,18 @@ open import Cubical.Foundations.Isomorphism
 private
   variable
     ℓ ℓ' : Level
-
-proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
-proj₁ (x , _) = x
-
-proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
-proj₂ (_ , x) = x
+    A B  : Set ℓ 
 
 -- Swapping is an equivalence
 
-swap : {A : Set ℓ} {B : Set ℓ'} → A × B → B × A
+swap : A × B → B × A
 swap (x , y) = (y , x)
 
-swapInv : {A : Set ℓ} {B : Set ℓ'} → (xy : A × B) → swap (swap xy) ≡ xy
-swapInv (_ , _) = refl
+swap-invol : (xy : A × B) → swap (swap xy) ≡ xy
+swap-invol (_ , _) = refl
 
 isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
-isEquivSwap A B = isoToIsEquiv (iso swap swap swapInv swapInv)
+isEquivSwap A B = isoToIsEquiv (iso swap swap swap-invol swap-invol)
 
 swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
 swapEquiv A B = (swap , isEquivSwap A B)
@@ -50,15 +45,14 @@ private
   testrefl = refl
 
 -- equivalence between the sigma-based definition and the inductive one
-A×B≡A×ΣB : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} → A × B ≡ A ×Σ B
+A×B≡A×ΣB : A × B ≡ A ×Σ B
 A×B≡A×ΣB = isoToPath (iso (λ { (a , b) → (a , b)})
                           (λ { (a , b) → (a , b)})
                           (λ _ → refl)
                           (λ { (a , b) → refl }))
 
 -- truncation for products
-hLevelProd : {ℓ ℓ' : Level} {A : Set ℓ} {B : Set ℓ'} →
-                  (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)
+hLevelProd : (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)
 hLevelProd {A = A} {B = B} n h1 h2 =
   let h : isOfHLevel n (A ×Σ B)
       h = isOfHLevelΣ n h1 (λ _ → h2)

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -3,14 +3,19 @@ module Cubical.Data.Sum.Base where
 
 open import Cubical.Core.Everything
 
-data _⊎_ {ℓ ℓ'} (P : Set ℓ) (Q : Set ℓ') : Set (ℓ-max ℓ ℓ') where
-  inl : P → P ⊎ Q
-  inr : Q → P ⊎ Q
-
 private
   variable
-    ℓ : Level
+    ℓ ℓ' : Level
     A B C D : Set ℓ
+    
+data _⊎_ (A : Set ℓ)(B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+  inl : A → A ⊎ B
+  inr : B → A ⊎ B
+
+elim-⊎ : {C : A ⊎ B → Set ℓ} →  ((a : A) → C (inl a)) → ((b : B) → C (inr b))
+       → (x : A ⊎ B) → C x
+elim-⊎ f _ (inl x) = f x
+elim-⊎ _ g (inr y) = g y
 
 map-⊎ : (A → C) → (B → D) → A ⊎ B → C ⊎ D
 map-⊎ f _ (inl x) = inl (f x)

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -7,7 +7,7 @@ private
   variable
     ℓ ℓ' : Level
     A B C D : Set ℓ
-    
+
 data _⊎_ (A : Set ℓ)(B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
   inl : A → A ⊎ B
   inr : B → A ⊎ B

--- a/Cubical/Data/Unit.agda
+++ b/Cubical/Data/Unit.agda
@@ -1,4 +1,5 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Data.Unit where
 
-open import Cubical.Data.Unit.Base public
+open import Cubical.Data.Unit.Base       public
+open import Cubical.Data.Unit.Properties public

--- a/Cubical/Data/Unit/Properties.agda
+++ b/Cubical/Data/Unit/Properties.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Unit.Properties where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Unit.Base
+
+isPropUnit : isProp Unit
+isPropUnit _ _ i = tt
+
+isContrUnit : isContr Unit
+isContrUnit = tt , λ {tt → refl}

--- a/Cubical/Experiments/HInt.agda
+++ b/Cubical/Experiments/HInt.agda
@@ -14,7 +14,7 @@ For a variation that relies on a different notion of equivalence
 
 https://github.com/RedPRL/redtt/blob/master/library/cool/biinv-int.red
 
-It might be interesting to port that example one day. 
+It might be interesting to port that example one day.
 
 -}
 {-# OPTIONS --cubical #-}
@@ -90,4 +90,4 @@ Int≡ℤ : Int ≡ ℤ
 Int≡ℤ = isoToPath Int→ℤ ℤ→Int ℤ→Int→ℤ Int→ℤ→Int
 
 isSetℤ : isSet ℤ
-isSetℤ = subst isSet Int≡ℤ isSetInt 
+isSetℤ = subst isSet Int≡ℤ isSetInt

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -84,7 +84,7 @@ invEquiv f = isoToEquiv (iso (invEq f) (fst f) (secEq f) (retEq f))
 
 compEquiv : A ≃ B → B ≃ C → A ≃ C
 compEquiv f g = isoToEquiv
-                  (iso (λ x → g .fst (f .fst x)) 
+                  (iso (λ x → g .fst (f .fst x))
                        (λ x → invEq f (invEq g x))
                        (λ y → (cong (g .fst) (retEq f (invEq g y))) ∙ (retEq g y))
                        (λ y → (cong (invEq f) (secEq g (f .fst y))) ∙ (secEq f y)))

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -14,4 +14,4 @@ open import Cubical.Foundations.Univalence public
 open import Cubical.Foundations.UnivalenceId public
 open import Cubical.Foundations.GroupoidLaws public
 open import Cubical.Foundations.Isomorphism public
-open import Cubical.Foundations.Logic 
+open import Cubical.Foundations.Logic

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -99,7 +99,7 @@ isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s =
   J (λ (z : A) (r : x ≡ z) → ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : z ≡ w) → PathP (λ i → Path A (r i) (s i) ) p q) helper r s p q
   where
     helper : ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : x ≡ w) → PathP (λ i → Path A x (s i)) p q
-    helper {w} s p q = J (λ (w : A) (s : y ≡ w) → ∀ p q → PathP (λ i → Path A x (s i)) p q) (λ p q → Aset x y p q) s p q 
+    helper {w} s p q = J (λ (w : A) (s : y ≡ w) → ∀ p q → PathP (λ i → Path A x (s i)) p q) (λ p q → Aset x y p q) s p q
 
 isSet'→isSet : isSet' A → isSet A
 isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
@@ -132,7 +132,7 @@ HLevel≡ {n = n} {A = A} {B = B} {hA} {hB} =
 
     elim : (A , hA) ≡ (B , hB) → A ≡ B
     elim = cong fst
-    
+
     intro-elim : ∀ x → intro (elim x) ≡ x
     intro-elim eq = cong ΣPathP (ΣProp≡ (λ e →
       J (λ B e →
@@ -157,7 +157,7 @@ isOfHLevelΣ {B = B} (suc (suc n)) h1 h2 x y =
       h3 = isOfHLevelΣ (suc n) (h1 (fst x) (fst y)) λ p → h2 (p i1)
                        (subst B p (snd x)) (snd y)
   in transport (λ i → isOfHLevel (suc n) (pathSigma≡sigmaPath x y (~ i))) h3
-  
+
 hLevel≃ : ∀ n → {A B : Set ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) → isOfHLevel n (A ≃ B)
 hLevel≃ zero {A = A} {B = B} hA hB = A≃B , contr
   where
@@ -166,7 +166,7 @@ hLevel≃ zero {A = A} {B = B} hA hB = A≃B , contr
 
   contr : (y : A ≃ B) → A≃B ≡ y
   contr y = ΣProp≡ isPropIsEquiv (funExt (λ a → snd hB (fst y a)))
-  
+
 hLevel≃ (suc n) hA hB =
   isOfHLevelΣ (suc n) (hLevelPi (suc n) (λ _ → hB))
               (λ a → subst (λ n → isOfHLevel n (isEquiv a)) (+-comm n 1) (hLevelLift n (isPropIsEquiv a)))
@@ -180,7 +180,7 @@ hLevelRespectEquiv 1 eq hA x y i =
         (cong (eq .fst) (hA (invEquiv eq .fst x) (invEquiv eq .fst y)) i)
 hLevelRespectEquiv {A = A} {B = B} (suc (suc n)) eq hA x y =
   hLevelRespectEquiv (suc n) (invEquiv (congEquiv (invEquiv eq))) (hA _ _)
-  
+
 hLevel≡ : ∀ n → {A B : Set ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) →
   isOfHLevel n (A ≡ B)
 hLevel≡ n hA hB = hLevelRespectEquiv n (invEquiv univalence) (hLevel≃ n hA hB)
@@ -189,7 +189,7 @@ hLevelHLevel1 : isProp (HLevel {ℓ = ℓ} 0)
 hLevelHLevel1 x y = ΣProp≡ (λ _ → isPropIsContr) ((hLevel≡ 0 (x .snd) (y .snd) .fst))
 
 hLevelHLevelSuc : ∀ n → isOfHLevel (suc (suc n)) (HLevel {ℓ = ℓ} (suc n))
-hLevelHLevelSuc n x y = subst (λ e → isOfHLevel (suc n) e) HLevel≡ (hLevel≡ (suc n) (snd x) (snd y)) 
+hLevelHLevelSuc n x y = subst (λ e → isOfHLevel (suc n) e) HLevel≡ (hLevel≡ (suc n) (snd x) (snd y))
 
 hProp≡HLevel1 : hProp {ℓ} ≡ HLevel {ℓ} 1
 hProp≡HLevel1 {ℓ} = isoToPath (iso intro elim intro-elim elim-intro)

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Logic where
 
-import Cubical.Data.Everything as D 
+import Cubical.Data.Everything as D
 open import Cubical.Core.Everything
 open import Cubical.Foundations.HLevels using (hProp; ΣProp≡; isPropIsProp; propPi; isSetHProp)
 open import Cubical.Foundations.Isomorphism
@@ -15,7 +15,7 @@ infixr 5 _⇒_
 infixr 4 _⇔_
 
 --------------------------------------------------------------------------------
--- The type hProp of mere propositions 
+-- The type hProp of mere propositions
 -- the definition hProp is given in Foundations.HLevels
 -- hProp {ℓ} = Σ (Set ℓ) isProp
 
@@ -24,7 +24,7 @@ private
     ℓ ℓ' ℓ'' : Level
     P Q R : hProp {ℓ}
     A B C : Set ℓ
-    
+
 [_] : hProp → Set ℓ
 [_] = fst
 
@@ -58,7 +58,7 @@ A ⇒ B = ([ A ] → [ B ]) , propPi λ _ → B .snd
 infix 2 ⇒∶_⇐∶_
 
 ⇐∶_⇒∶_ : [ Q ⇒ P ] → [ P ⇒ Q ] → P ≡ Q
-⇐∶ g ⇒∶ f  = ⇔toPath f g 
+⇐∶ g ⇒∶ f  = ⇔toPath f g
 infix 2 ⇐∶_⇒∶_
 
 --------------------------------------------------------------------------------
@@ -116,7 +116,7 @@ A ⇔ B = (A ≡ B) , isSetHProp A B
 
 infix 2 ∀-syntax
 
-∀-syntax : (A → hProp {ℓ}) → hProp 
+∀-syntax : (A → hProp {ℓ}) → hProp
 ∀-syntax {A = A} P = (∀ x → [ P x ]) , propPi (snd ∘ P)
 
 syntax ∀-syntax {A = A} (λ a → P) = ∀[ a ∶ A ] P
@@ -169,14 +169,14 @@ syntax ∃-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
 
 ⊔-identityʳ : (P : hProp {ℓ}) → P ⊔ ⊥ ≡ P
 ⊔-identityʳ a = ⇔toPath (⊔-elim a ⊥ (λ _ → a) (λ x → x) λ ()) inl
-  
+
 --------------------------------------------------------------------------------
 -- (hProp, ⊓, ⊤) is a bounded ⊓-lattice
 
 ⊓-assoc : (P : hProp {ℓ}) (Q : hProp {ℓ'}) (R : hProp {ℓ''})
   → P ⊓ Q ⊓ R ≡ (P ⊓ Q) ⊓ R
 ⊓-assoc a b c =
-  ⇒∶ (λ {(x D., (y D., z)) →  (x D., y) D., z}) 
+  ⇒∶ (λ {(x D., (y D., z)) →  (x D., y) D., z})
   ⇐∶ (λ {((x D., y) D., z) → x D., (y D., z) })
 
 ⊓-comm : (P : hProp {ℓ}) (Q : hProp {ℓ'}) → P ⊓ Q ≡ Q ⊓ P
@@ -214,22 +214,22 @@ syntax ∃-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
   ⇒∶ (λ { (x D., a) → ⊔-elim Q R (λ _ → (P ⊓ Q) ⊔ (P ⊓ R))
         (λ y → ∣ D.inl (x D., y) ∣ )
         (λ z → ∣ D.inr (x D., z) ∣ ) a })
-        
+
   ⇐∶ ⊔-elim (P ⊓ Q) (P ⊓ R) (λ _ → P ⊓ Q ⊔ R)
        (λ y → D.proj₁ y D., inl (D.proj₂ y))
-       (λ z → D.proj₁ z D., inr (D.proj₂ z)) 
+       (λ z → D.proj₁ z D., inr (D.proj₂ z))
 
 ⊔-dist-⊓ : (P : hProp {ℓ}) (Q : hProp {ℓ'})(R : hProp {ℓ''})
   → P ⊔ (Q ⊓ R) ≡ (P ⊔ Q) ⊓ (P ⊔ R)
 ⊔-dist-⊓ P Q R =
   ⇒∶ ⊔-elim P (Q ⊓ R) (λ _ → (P ⊔ Q) ⊓ (P ⊔ R) )
     (D.intro-× inl inl) (D.map-× inr inr)
-    
+
   ⇐∶ (λ { (x D., y) → ⊔-elim P R (λ _ → P ⊔ Q ⊓ R) inl
       (λ z → ⊔-elim P Q (λ _ → P ⊔ Q ⊓ R) inl (λ y → inr (y D., z)) x) y })
 
 --------------------------------------------------------------------------------
--- Syntax experiments 
+-- Syntax experiments
 
 --------------------------------------------------------------------------------
 -- Natural deduction style
@@ -247,7 +247,7 @@ infix 2 case-syntax
      case Q ⊓ R ∶ D.map-× inr inr
      --------------------------------
      ⊢ (P ⊔ Q) ⊓ (P ⊔ R) ⊔∎
-      
+
   ⇐∶ λ { (x D., y) →
      (case P ∶ inl
       case R ∶ (λ z →

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -38,7 +38,7 @@ elimEq/ : (Bprop : (x : A / R ) → isProp (B x))
           {x y : A / R}
           (eq : x ≡ y)
           (bx : B x)
-          (by : B y) → 
+          (by : B y) →
           PathP (λ i → B (eq i)) bx by
 elimEq/ {B = B} Bprop {x = x} =
   J (λ y eq → ∀ bx by → PathP (λ i → B (eq i)) bx by) (λ bx by → Bprop x bx by)

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -58,7 +58,7 @@ Torus≡S¹×S¹ = isoToPath (iso t2c c2t t2c-c2t c2t-t2c)
 -- TODO: upstream
 lemPathAnd : ∀ {ℓ} {A B : Set ℓ} (t u : A × B) →
   Path _ (t ≡ u) ((t .fst ≡ u .fst) × ((t .snd) ≡ (u .snd)))
-lemPathAnd t u = isoToPath (iso (λ tu → (λ i → tu i .fst) , λ i → tu i .snd) 
+lemPathAnd t u = isoToPath (iso (λ tu → (λ i → tu i .fst) , λ i → tu i .snd)
                                  (λ tu i → tu .fst i , tu .snd i)
                                  (λ y → refl)
                                  (λ x → refl))

--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -3,7 +3,7 @@ module Cubical.Relation.Binary.Base where
 
 open import Cubical.Core.Everything
 
-open import Cubical.Foundations.HLevels 
+open import Cubical.Foundations.HLevels
 
 open import Cubical.HITs.SetQuotients.Base
 

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -9,7 +9,7 @@ private
   variable
     ℓ  : Level
     A  : Set ℓ
-    
+
 -- Negation
 infix 3 ¬_
 


### PR DESCRIPTION
I improve Foundations.Logic with more operations, properties, and some notations. Hope this is useful and good enough. #111 is also resolved by this PR.

I add a mixfix notation for proving bi-implication, e.g., 

```agda
⊔-comm : (P : hProp {ℓ}) (Q : hProp {ℓ'}) → P ⊔ Q ≡ Q ⊔ P
⊔-comm a b =
  ⇒∶ (⊔-elim a b (\ _ → (b ⊔ a)) inr inl)
  ⇐∶ (⊔-elim b a (\ _ → (a ⊔ b)) inr inl)
```
Both order `⇒∶_⇐∶_`  and `⇐∶_⇒∶_` are defined, since people tend to prove easy parts first or the other round. 

In the end of Logic, I put some syntax experiments, somehow inspired by #107. (I almost forgot this feature.) To show that `P ⊔ (Q ⊓ R) ⇒ (P ⊔ Q) ⊓ (P ⊔ R)`, we can use a case analysis syntax like

```agda
⊔-dist-⊓′ : (P Q R : hProp {ℓ}) → P ⊔ (Q ⊓ R) ≡ (P ⊔ Q) ⊓ (P ⊔ R)
⊔-dist-⊓′ P Q R =
  ⇒∶ case P     ∶ D.intro-× inl inl
     case Q ⊓ R ∶ D.map-× inr inr
     --------------------------------
     ⊢ (P ⊔ Q) ⊓ (P ⊔ R) ⊔∎
...
```
but I still feel unsatisfied. If you have any suggestion, please feel free to change or remove it.

Please have a look. Thanks. 

1. Add more logic operations and their properties in Logic:

* quantifiers
* pseudo-complement
* conjunction
* implication
* bi-implication
* (Ω, ⊓, ⊤) is a bounded ⊓-semilattice
* left and right ⊔-identities
* distributivity laws

2. Replace `Ω≡ (pequivToPath …)` by `⇔toPath`
3. Tidy up Cubical.Data.Prod.Base

* Move projections to Base from Properties
* Add elimination rules and the bifunctorial map
* Rename `swapInv` to `swap-invol`

4. Add the elimination for sum type `elim-⊎`
5. Add simple facts `isPropUnit`, `isContrUnit`
6. Logic is universe polymorphic
7. Rename \Omega to hProp
8. Some syntax experiments
9. Fix whitespaces