### PR TITLE
Few more logic

### DIFF
--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -28,19 +28,19 @@ data LFSet (A : Set) : Set where
 -- We might want to avoid it, or come up with a more clever equational reasoning.
 _∈_ : A → LFSet A → hProp
 z ∈ []                  = ⊥
-z ∈ (y ∷ xs)            = (z ≡ₘ y) ⊔ (z ∈ xs)
+z ∈ (y ∷ xs)            = (z ≡ₚ y) ⊔ (z ∈ xs)
 z ∈ dup x xs i          = proof i
   where
     -- proof : z ∈ (x ∷ x ∷ xs) ≡ z ∈ (x ∷ xs)
-    proof = z ≡ₘ x  ⊔ (z ≡ₘ x ⊔ z ∈ xs) ≡⟨ ⊔-assoc (z ≡ₘ x) (z ≡ₘ x) (z ∈ xs) ⟩
-            (z ≡ₘ x ⊔ z ≡ₘ x) ⊔ z ∈ xs  ≡⟨ cong (_⊔ (z ∈ xs)) (⊔-idem (z ≡ₘ x)) ⟩
-            z ≡ₘ x            ⊔ z ∈ xs  ∎
+    proof = z ≡ₚ x  ⊔ (z ≡ₚ x ⊔ z ∈ xs) ≡⟨ ⊔-assoc (z ≡ₚ x) (z ≡ₚ x) (z ∈ xs) ⟩
+            (z ≡ₚ x ⊔ z ≡ₚ x) ⊔ z ∈ xs  ≡⟨ cong (_⊔ (z ∈ xs)) (⊔-idem (z ≡ₚ x)) ⟩
+            z ≡ₚ x            ⊔ z ∈ xs  ∎
 z ∈ comm x y xs i       = proof i
   where
     -- proof : z ∈ (x ∷ y ∷ xs) ≡ z ∈ (y ∷ x ∷ xs)
-    proof = z ≡ₘ x  ⊔ (z ≡ₘ y ⊔ z ∈ xs) ≡⟨ ⊔-assoc (z ≡ₘ x) (z ≡ₘ y) (z ∈ xs) ⟩
-            (z ≡ₘ x ⊔ z ≡ₘ y) ⊔ z ∈ xs  ≡⟨ cong (_⊔ (z ∈ xs)) (⊔-comm (z ≡ₘ x) (z ≡ₘ y)) ⟩
-            (z ≡ₘ y ⊔ z ≡ₘ x) ⊔ z ∈ xs  ≡⟨ sym (⊔-assoc (z ≡ₘ y) (z ≡ₘ x) (z ∈ xs)) ⟩
-            z ≡ₘ y  ⊔ (z ≡ₘ x ⊔ z ∈ xs) ∎
+    proof = z ≡ₚ x  ⊔ (z ≡ₚ y ⊔ z ∈ xs) ≡⟨ ⊔-assoc (z ≡ₚ x) (z ≡ₚ y) (z ∈ xs) ⟩
+            (z ≡ₚ x ⊔ z ≡ₚ y) ⊔ z ∈ xs  ≡⟨ cong (_⊔ (z ∈ xs)) (⊔-comm (z ≡ₚ x) (z ≡ₚ y)) ⟩
+            (z ≡ₚ y ⊔ z ≡ₚ x) ⊔ z ∈ xs  ≡⟨ sym (⊔-assoc (z ≡ₚ y) (z ≡ₚ x) (z ∈ xs)) ⟩
+            z ≡ₚ y  ⊔ (z ≡ₚ x ⊔ z ∈ xs) ∎
 
 x ∈ trunc xs ys p q i j = isSetHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (cong (x ∈_) q) i j


### PR DESCRIPTION
This PR is about some helper functions for conversion between hProp and Set and to fix the universe issue of the definition of bi-implication as identity. 

Also  the naming convention issue: shall we use `m` for mere proposition or `p` for proposition? The mere equality uses `m`. However it is probably more mnemonic and consistent to use `p` instead, since `p` is naturally used for some other helper functions, e.g., `∥_∥ₚ: Set ℓ → hProp` for truncating types into hProp. 