### PR TITLE
Changes needed if isEquiv does not have eta.

### DIFF
--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -128,7 +128,14 @@ unglueEquiv A φ f = ( unglue φ , unglueIsEquiv A φ f )
 --
 EquivContr : ∀ (A : Set ℓ) → isContr (Σ[ T ∈ Set ℓ ] T ≃ A)
 EquivContr {ℓ = ℓ} A =
-  ( ( A , idEquiv A)
-  , λ w i → let f : PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
-                f = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }
-            in ( Glue A f , unglueEquiv _ _ f) )
+  ( (A , idEquiv A)
+  , idEquiv≡ )
+ where
+  idEquiv≡ : (y : Σ (Set ℓ) (λ T → T ≃ A)) → (A , idEquiv A) ≡ y
+  idEquiv≡ w = \ { i .fst                   → Glue A (f i)
+                 ; i .snd .fst              → unglueEquiv _ _ (f i) .fst
+                 ; i .snd .snd .equiv-proof → unglueEquiv _ _ (f i) .snd .equiv-proof
+                 }
+    where
+      f : ∀ i → PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
+      f i = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }

--- a/Cubical/Foundations/UnivalenceId.agda
+++ b/Cubical/Foundations/UnivalenceId.agda
@@ -25,9 +25,7 @@ path≡Id = isoToPath (iso pathToId idToPath idToPathToId pathToIdToPath )
 equivPathToEquivPath : ∀ {ℓ} {A : Set ℓ} {B : Set ℓ} → (p : EquivPath A B) →
                        Path _ (equivToEquivPath (equivPathToEquiv p)) p
 equivPathToEquivPath (f , p) i =
-  ( f , isPropIsEquivPath f (λ { .equiv-proof y →
-          helper2 fiberPathToFiber fiberToFiberPath fiberPathToFiberPath
-            (helper1 fiberPathToFiber fiberToFiberPath fiberToFiber (p .equiv-proof y)) }) p i )
+  ( f , isPropIsEquivPath f (equivToEquivPath (equivPathToEquiv (f , p)) .snd) p i )
 
 equivPath≡Equiv : ∀ {ℓ} {A B : Set ℓ} → Path _ (EquivPath A B) (A ≃ B)
 equivPath≡Equiv {ℓ} = isoToPath (iso (equivPathToEquiv {ℓ}) equivToEquivPath equivToEquiv equivPathToEquivPath)


### PR DESCRIPTION
These changes are fairly small and ```isEquiv``` not having eta would speed up the comparisons between uses of ```Glue``` types.

(In particular ```hcomp {A = Set}```, but for that we might be doing a further optimization.)

