### PR TITLE
Rename Set to Type

### DIFF
--- a/Cubical/Codata/Conat/Base.agda
+++ b/Cubical/Codata/Conat/Base.agda
@@ -26,7 +26,7 @@ open import Cubical.Data.Sum
 
 open import Cubical.Core.Everything
 
-record Conat : Set
+record Conat : Type₀
 Conat′ = Unit ⊎ Conat
 record Conat where
   coinductive

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -6,7 +6,7 @@ This file defines operations and properties on conatural numbers:
 
 - Proof that ∞ + 1 is equivalent to ∞.
 
-- Proof that conatural is an hSet.
+- Proof that conatural is an hType.
 
 - Bisimulation on conatural
 
@@ -39,7 +39,7 @@ open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq
 open import Cubical.Codata.Conat.Base
 
-Unwrap-prev : Conat′ -> Set
+Unwrap-prev : Conat′ → Type₀
 Unwrap-prev  zero   = Unit
 Unwrap-prev (suc _) = Conat
 
@@ -69,14 +69,14 @@ force (∞+1≡∞ _) = suc ∞
 
 -- TODO: plus for conat, ∞ + ∞ ≡ ∞
 
-conat-absurd : ∀ {y : Conat} {ℓ} {Whatever : Set ℓ} → zero ≡ suc y → Whatever
+conat-absurd : ∀ {y : Conat} {ℓ} {Whatever : Type ℓ} → zero ≡ suc y → Whatever
 conat-absurd eq = ⊥-elim (transport (cong diag eq) tt)
   where
-  diag : Conat′ → Set
+  diag : Conat′ → Type₀
   diag zero = Unit
   diag (suc _) = ⊥
 
-module IsSet where
+module IsType where
   ≡-stable  : {x y : Conat} → Stable (x ≡ y)
   ≡′-stable : {x y : Conat′} → Stable (x ≡ y)
 
@@ -87,20 +87,20 @@ module IsSet where
   ≡′-stable {zero}  {suc y} ¬¬p′ = ⊥-elim (¬¬p′ conat-absurd)
   ≡′-stable {suc x} {zero}  ¬¬p′ = ⊥-elim (¬¬p′ λ p → conat-absurd (sym p))
 
-  isSetConat : isSet Conat
-  isSetConat _ _ = Stable≡→isSet (λ _ _ → ≡-stable) _ _
+  isTypeConat : isType Conat
+  isTypeConat _ _ = Stable≡→isType (λ _ _ → ≡-stable) _ _
 
-  isSetConat′ : isSet Conat′
-  isSetConat′ m n p′ q′ = cong (cong force) (isSetConat (conat m) (conat n) p q)
+  isTypeConat′ : isType Conat′
+  isTypeConat′ m n p′ q′ = cong (cong force) (isTypeConat (conat m) (conat n) p q)
     where p = λ where i .force → p′ i
           q = λ where i .force → q′ i
 
 module Bisimulation where
-  open IsSet using (isSetConat)
+  open IsType using (isTypeConat)
 
-  record _≈_ (x y : Conat) : Set
-  data _≈′_ (x y : Conat′) : Set
-  _≈′′_ : Conat′ → Conat′ → Set
+  record _≈_ (x y : Conat) : Type₀
+  data _≈′_ (x y : Conat′) : Type₀
+  _≈′′_ : Conat′ → Conat′ → Type₀
   zero  ≈′′ zero  = Unit
   suc x ≈′′ suc y = x ≈ y
   -- So impossible proofs are preserved
@@ -144,7 +144,7 @@ module Bisimulation where
   prove (iso″ p i) = iso′ (prove p) i
 
   osi : ∀ {x y} → (p : x ≡ y) → bisim (misib p) ≡ p
-  osi p = isSetConat _ _ _ p
+  osi p = isTypeConat _ _ _ p
 
   path≃bisim : ∀ {x y} → (x ≡ y) ≃ (x ≈ y)
   path≃bisim = isoToEquiv (iso misib bisim iso″ osi)
@@ -153,4 +153,4 @@ module Bisimulation where
   path≡bisim = ua path≃bisim
 
   isProp≈ : ∀ {x y} → isProp (x ≈ y)
-  isProp≈ = subst isProp path≡bisim (isSetConat _ _)
+  isProp≈ = subst isProp path≡bisim (isTypeConat _ _)

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -6,7 +6,7 @@ This file defines operations and properties on conatural numbers:
 
 - Proof that ∞ + 1 is equivalent to ∞.
 
-- Proof that conatural is an hType.
+- Proof that conatural is an hSet.
 
 - Bisimulation on conatural
 

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -76,7 +76,7 @@ conat-absurd eq = ⊥-elim (transport (cong diag eq) tt)
   diag zero = Unit
   diag (suc _) = ⊥
 
-module IsType where
+module IsSet where
   ≡-stable  : {x y : Conat} → Stable (x ≡ y)
   ≡′-stable : {x y : Conat′} → Stable (x ≡ y)
 
@@ -87,16 +87,16 @@ module IsType where
   ≡′-stable {zero}  {suc y} ¬¬p′ = ⊥-elim (¬¬p′ conat-absurd)
   ≡′-stable {suc x} {zero}  ¬¬p′ = ⊥-elim (¬¬p′ λ p → conat-absurd (sym p))
 
-  isTypeConat : isType Conat
-  isTypeConat _ _ = Stable≡→isType (λ _ _ → ≡-stable) _ _
+  isSetConat : isSet Conat
+  isSetConat _ _ = Stable≡→isSet (λ _ _ → ≡-stable) _ _
 
-  isTypeConat′ : isType Conat′
-  isTypeConat′ m n p′ q′ = cong (cong force) (isTypeConat (conat m) (conat n) p q)
+  isSetConat′ : isSet Conat′
+  isSetConat′ m n p′ q′ = cong (cong force) (isSetConat (conat m) (conat n) p q)
     where p = λ where i .force → p′ i
           q = λ where i .force → q′ i
 
 module Bisimulation where
-  open IsType using (isTypeConat)
+  open IsSet using (isSetConat)
 
   record _≈_ (x y : Conat) : Type₀
   data _≈′_ (x y : Conat′) : Type₀
@@ -144,7 +144,7 @@ module Bisimulation where
   prove (iso″ p i) = iso′ (prove p) i
 
   osi : ∀ {x y} → (p : x ≡ y) → bisim (misib p) ≡ p
-  osi p = isTypeConat _ _ _ p
+  osi p = isSetConat _ _ _ p
 
   path≃bisim : ∀ {x y} → (x ≡ y) ≃ (x ≈ y)
   path≃bisim = isoToEquiv (iso misib bisim iso″ osi)
@@ -153,4 +153,4 @@ module Bisimulation where
   path≡bisim = ua path≃bisim
 
   isProp≈ : ∀ {x y} → isProp (x ≈ y)
-  isProp≈ = subst isProp path≡bisim (isTypeConat _ _)
+  isProp≈ = subst isProp path≡bisim (isSetConat _ _)

--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -5,23 +5,23 @@ open import Cubical.Foundations.Prelude
 
 -- TODO move
 module Helpers where
-  module _ {ℓ ℓ'} {A : Set ℓ} {x : A} (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
+  module _ {ℓ ℓ'} {A : Type ℓ} {x : A} (P : ∀ y → x ≡ y → Type ℓ') (d : P x refl) where
     -- A version with y as an explicit argument can be used to make Agda
     -- infer the family P.
     J' : ∀ y (p : x ≡ y) → P y p
     J' y p = J P d p
 
-  lem-transp : {A : Set} (i : I) → (B : Set) (P : A ≡ B) → (p : P i) → PathP (\ j → P j) (transp (\ k → P (~ k ∧ i)) (~ i) p)
+  lem-transp : ∀ {ℓ} {A : Type ℓ} (i : I) → (B : Type ℓ) (P : A ≡ B) → (p : P i) → PathP (\ j → P j) (transp (\ k → P (~ k ∧ i)) (~ i) p)
                                                                                          (transp (\ k → P (k ∨ i)) i p)
-  lem-transp {A} i = J' _ (\ p j → transp (\ _ → A) ((~ j ∧ ~ i) ∨ (j ∧ i)) p )
+  lem-transp {A = A} i = J' _ (\ p j → transp (\ _ → A) ((~ j ∧ ~ i) ∨ (j ∧ i)) p )
 
-  transp-over : (A : I → Set) (i j : I) → A i → A j
+  transp-over : ∀ {ℓ} (A : I → Type ℓ) (i j : I) → A i → A j
   transp-over A i k p = transp (\ j → A ((~ j ∧ i) ∨ (j ∧ k))) (~ i ∧ ~ k) p
 
-  transp-over-1 : (A : I → Set) (i j : I) → A i → A j
+  transp-over-1 : ∀ {ℓ} (A : I → Type ℓ) (i j : I) → A i → A j
   transp-over-1 A i k p = transp (\ j → A ((j ∨ i) ∧ (~ j ∨ k))) (i ∧ k) p
 
-  compPathD : {ℓ ℓ' : _} {X : Set ℓ} (F : X → Set ℓ') {A B C : X} (P : A ≡ B) (Q : B ≡ C)
+  compPathD : {ℓ ℓ' : _} {X : Type ℓ} (F : X → Type ℓ') {A B C : X} (P : A ≡ B) (Q : B ≡ C)
               → ∀ {x y z} → (\ i → F (P i)) [ x ≡ y ] → (\ i → F (Q i)) [ y ≡ z ] → (\ i → F ((P ∙ Q) i)) [ x ≡ z ]
   compPathD F {A = A} P Q {x} p q i =
      comp (\ j → F (hfill (λ j → \ { (i = i0) → A ; (i = i1) → Q j })
@@ -32,15 +32,15 @@ module Helpers where
 
 open Helpers
 
-IxCont : Set → Set₁
-IxCont X = Σ (X → Set) \ S → ∀ x → S x → X → Set
+IxCont : Type₀ → Type₁
+IxCont X = Σ (X → Type₀) \ S → ∀ x → S x → X → Type₀
 
 
-⟦_⟧ : ∀ {X : Set} → IxCont X → (X → Set) → (X → Set)
+⟦_⟧ : ∀ {X : Type₀} → IxCont X → (X → Type₀) → (X → Type₀)
 ⟦ (S , P) ⟧ X x = Σ (S x) \ s → ∀ y → P x s y → X y
 
 
-record M {X : Set} (C : IxCont X) (x : X) : Set where
+record M {X : Type₀} (C : IxCont X) (x : X) : Type₀ where
   coinductive
   field
     head : C .fst x
@@ -48,7 +48,7 @@ record M {X : Set} (C : IxCont X) (x : X) : Set where
 
 open M public
 
-module _ {X : Set} {C : IxCont X} where
+module _ {X : Type₀} {C : IxCont X} where
 
   private
     F = ⟦ C ⟧

--- a/Cubical/Codata/M/Bisimilarity.agda
+++ b/Cubical/Codata/M/Bisimilarity.agda
@@ -8,7 +8,7 @@ open import Cubical.Foundations.Everything
 open Helpers using (J')
 
 -- Bisimilarity as a coinductive record type.
-record _≈_ {X : Set} {C : IxCont X} {x : X} (a b : M C x) : Set where
+record _≈_ {X : Type₀} {C : IxCont X} {x : X} (a b : M C x) : Type₀ where
   coinductive
   constructor _,_
   field
@@ -21,7 +21,7 @@ open _≈_ public
 
 
 
-module _ {X : Set} {C : IxCont X} where
+module _ {X : Type₀} {C : IxCont X} where
 
   -- Here we show that `a ≡ b` and `a ≈ b` are equivalent.
   --
@@ -44,11 +44,11 @@ module _ {X : Set} {C : IxCont X} where
   -- The domain is the HoTT singleton type, so contractible, while the
   -- codomain is shown to be contractible by `contr-T` below.
 
-  T : ∀ {x} → M C x → Set _
+  T : ∀ {x} → M C x → Type _
   T a = Σ (M C _) \ b → a ≈ b
 
   private
-    lemma : ∀ {A} (B : Set) (P : A ≡ B) (pa : P i0) (pb : P i1) (peq : PathP (\ i → P i) pa pb)
+    lemma : ∀ {A} (B : Type₀) (P : A ≡ B) (pa : P i0) (pb : P i1) (peq : PathP (\ i → P i) pa pb)
           → PathP (\ i → PathP (\ j → P j) (transp (\ k → P (~ k ∧ i)) (~ i) (peq i)) pb)
                   peq
                   (\ j → transp (\ k → P (~ k ∨ j)) j pb)
@@ -108,7 +108,7 @@ module _ {X : Set} {C : IxCont X} where
   contr-T-φ-snd x a u i .tails≈ y pa pb peq = let
     eqh = u 1=1 .snd .head≈
     r = contr-T-φ-snd y (a .tails y pa) (\ o → u o .fst .tails y pb , u 1=1 .snd .tails≈ y pa pb peq)
-    F : I → Set _
+    F : I → Type _
     F k = a .tails y pa
         ≈ contr-T-fst y
             (a .tails y (transp (λ j → C .snd x (eqh (k ∧ ~ j)) y) (~ k) (peq k)))

--- a/Cubical/Codata/Stream/Base.agda
+++ b/Cubical/Codata/Stream/Base.agda
@@ -3,7 +3,7 @@ module Cubical.Codata.Stream.Base where
 
 open import Cubical.Core.Everything
 
-record Stream (A : Set) : Set where
+record Stream (A : Type₀) : Type₀ where
   coinductive
   constructor _,_
   field

--- a/Cubical/Codata/Stream/Properties.agda
+++ b/Cubical/Codata/Stream/Properties.agda
@@ -39,7 +39,7 @@ Stream-η : ∀ {A} {xs : Stream A} → xs ≡ (head xs , tail xs)
 head (Stream-η {A} {xs} i) = head xs
 tail (Stream-η {A} {xs} i) = tail xs
 
-elimS : ∀ {A} (P : Stream A → Set) (c : ∀ x xs → P (x , xs)) (xs : Stream A) → P xs
+elimS : ∀ {A} (P : Stream A → Type₀) (c : ∀ x xs → P (x , xs)) (xs : Stream A) → P xs
 elimS P c xs = transp (λ i → P (Stream-η {xs = xs} (~ i))) i0
                       (c (head xs) (tail xs))
 
@@ -55,7 +55,7 @@ tail (tail (mergeEvenOdd≡id a i)) = mergeEvenOdd≡id (tail (tail a)) i
 module Equality≅Bisimulation where
 
 -- Bisimulation
-  record _≈_ {A : Set} (x y : Stream A) : Set where
+  record _≈_ {A : Type₀} (x y : Stream A) : Type₀ where
     coinductive
     field
       ≈head : head x ≡ head y
@@ -63,49 +63,49 @@ module Equality≅Bisimulation where
 
   open _≈_
 
-  bisim : {A : Set} → {x y : Stream A} → x ≈ y → x ≡ y
+  bisim : {A : Type₀} → {x y : Stream A} → x ≈ y → x ≡ y
   head (bisim x≈y i) = ≈head x≈y i
   tail (bisim x≈y i) = bisim (≈tail x≈y) i
 
-  misib : {A : Set} → {x y : Stream A} → x ≡ y → x ≈ y
+  misib : {A : Type₀} → {x y : Stream A} → x ≡ y → x ≈ y
   ≈head (misib p) = λ i → head (p i)
   ≈tail (misib p) = misib (λ i → tail (p i))
 
-  iso1 : {A : Set} → {x y : Stream A} → (p : x ≡ y) → bisim (misib p) ≡ p
+  iso1 : {A : Type₀} → {x y : Stream A} → (p : x ≡ y) → bisim (misib p) ≡ p
   head (iso1 p i j) = head (p j)
   tail (iso1 p i j) = iso1 (λ i → tail (p i)) i j
 
-  iso2 : {A : Set} → {x y : Stream A} → (p : x ≈ y) → misib (bisim p) ≡ p
+  iso2 : {A : Type₀} → {x y : Stream A} → (p : x ≈ y) → misib (bisim p) ≡ p
   ≈head (iso2 p i) = ≈head p
   ≈tail (iso2 p i) = iso2 (≈tail p) i
 
-  path≃bisim : {A : Set} → {x y : Stream A} → (x ≡ y) ≃ (x ≈ y)
+  path≃bisim : {A : Type₀} → {x y : Stream A} → (x ≡ y) ≃ (x ≈ y)
   path≃bisim = isoToEquiv (iso misib bisim iso2 iso1)
 
-  path≡bisim : {A : Set} → {x y : Stream A} → (x ≡ y) ≡ (x ≈ y)
+  path≡bisim : {A : Type₀} → {x y : Stream A} → (x ≡ y) ≡ (x ≈ y)
   path≡bisim = ua path≃bisim
 
   -- misib can be implemented by transport as well.
-  refl≈ : {A : Set} {x : Stream A} → x ≈ x
+  refl≈ : {A : Type₀} {x : Stream A} → x ≈ x
   ≈head refl≈ = refl
   ≈tail refl≈ = refl≈
 
-  cast : ∀ {A : Set} {x y : Stream A} (p : x ≡ y) → x ≈ y
+  cast : ∀ {A : Type₀} {x y : Stream A} (p : x ≡ y) → x ≈ y
   cast {x = x} p = transport (λ i → x ≈ p i) refl≈
 
-  misib-refl : ∀ {A : Set} {x : Stream A} → misib {x = x} refl ≡ refl≈
+  misib-refl : ∀ {A : Type₀} {x : Stream A} → misib {x = x} refl ≡ refl≈
   ≈head (misib-refl i) = refl
   ≈tail (misib-refl i) = misib-refl i
 
-  misibTransp : ∀ {A : Set} {x y : Stream A} (p : x ≡ y) → cast p ≡ misib p
+  misibTransp : ∀ {A : Type₀} {x y : Stream A} (p : x ≡ y) → cast p ≡ misib p
   misibTransp p = J (λ _ p → cast p ≡ misib p) ((transportRefl refl≈) ∙ (sym misib-refl)) p
 
-module Stream≅Nat→ {A : Set} where
-  lookup : {A : Set} → Stream A → ℕ → A
+module Stream≅Nat→ {A : Type₀} where
+  lookup : {A : Type₀} → Stream A → ℕ → A
   lookup xs zero = head xs
   lookup xs (suc n) = lookup (tail xs) n
 
-  tabulate : {A : Set} → (ℕ → A) → Stream A
+  tabulate : {A : Type₀} → (ℕ → A) → Stream A
   head (tabulate f) = f zero
   tail (tabulate f) = tabulate (λ n → f (suc n))
 

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -13,31 +13,31 @@ module Cubical.Core.Glue where
 open import Cubical.Core.Primitives
 
 open import Agda.Builtin.Cubical.Glue public
-  using ( isEquiv       -- ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) → Set (ℓ ⊔ ℓ')
+  using ( isEquiv       -- ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) → Type (ℓ ⊔ ℓ')
 
         ; equiv-proof   -- ∀ (y : B) → isContr (fiber f y)
 
-        ; _≃_           -- ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ ⊔ ℓ')
+        ; _≃_           -- ∀ {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') → Type (ℓ ⊔ ℓ')
 
-        ; equivFun      -- ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → A → B
+        ; equivFun      -- ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A ≃ B → A → B
 
-        ; equivProof    -- ∀ {ℓ ℓ'} (T : Set ℓ) (A : Set ℓ') (w : T ≃ A) (a : A) φ →
+        ; equivProof    -- ∀ {ℓ ℓ'} (T : Type ℓ) (A : Type ℓ') (w : T ≃ A) (a : A) φ →
                         -- Partial φ (fiber (equivFun w) a) → fiber (equivFun w) a
 
-        ; primGlue      -- ∀ {ℓ ℓ'} (A : Set ℓ) {φ : I} (T : Partial φ (Set ℓ'))
-                        -- → (e : PartialP φ (λ o → T o ≃ A)) → Set ℓ'
+        ; primGlue      -- ∀ {ℓ ℓ'} (A : Type ℓ) {φ : I} (T : Partial φ (Type ℓ'))
+                        -- → (e : PartialP φ (λ o → T o ≃ A)) → Type ℓ'
 
-        ; prim^unglue   -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+        ; prim^unglue   -- ∀ {ℓ ℓ'} {A : Type ℓ} {φ : I} {T : Partial φ (Type ℓ')}
                         -- → {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
 
         -- The ∀ operation on I. This is commented out as it is not currently used for anything
         -- ; primFaceForall -- (I → I) → I
         )
-  renaming ( prim^glue   to glue         -- ∀ {ℓ ℓ'} {A : Set ℓ} {φ : I} {T : Partial φ (Set ℓ')}
+  renaming ( prim^glue   to glue         -- ∀ {ℓ ℓ'} {A : Type ℓ} {φ : I} {T : Partial φ (Type ℓ')}
                                          -- → {e : PartialP φ (λ o → T o ≃ A)}
                                          -- → PartialP φ T → A → primGlue A T e
 
-           ; pathToEquiv to lineToEquiv  -- ∀ {ℓ : I → Level} (P : (i : I) → Set (ℓ i)) → P i0 ≃ P i1
+           ; pathToEquiv to lineToEquiv  -- ∀ {ℓ : I → Level} (P : (i : I) → Type (ℓ i)) → P i0 ≃ P i1
            )
 
 private
@@ -45,12 +45,12 @@ private
     ℓ ℓ' : Level
 
 -- Uncurry Glue to make it more pleasant to use
-Glue : (A : Set ℓ) {φ : I}
-       → (Te : Partial φ (Σ[ T ∈ Set ℓ' ] T ≃ A))
-       → Set ℓ'
+Glue : (A : Type ℓ) {φ : I}
+       → (Te : Partial φ (Σ[ T ∈ Type ℓ' ] T ≃ A))
+       → Type ℓ'
 Glue A Te = primGlue A (λ x → Te x .fst) (λ x → Te x .snd)
 
 -- Make the φ argument of prim^unglue explicit
-unglue : {A : Set ℓ} (φ : I) {T : Partial φ (Set ℓ')}
+unglue : {A : Type ℓ} (φ : I) {T : Partial φ (Type ℓ')}
          {e : PartialP φ (λ o → T o ≃ A)} → primGlue A T e → A
 unglue φ = prim^unglue {φ = φ}

--- a/Cubical/Core/Id.agda
+++ b/Cubical/Core/Id.agda
@@ -2,14 +2,16 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Core.Id where
 
+open import Cubical.Core.Primitives hiding ( _≡_ )
+
 open import Agda.Builtin.Cubical.Id public
   renaming ( conid to ⟨_,_⟩
            -- TODO: should the user really be able to access these two?
-           ; primIdFace to faceId  -- ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → I
-           ; primIdPath to pathId  -- ∀ {ℓ} {A : Set ℓ} {x y : A} → Id x y → Path A x y
+           ; primIdFace to faceId  -- ∀ {ℓ} {A : Type ℓ} {x y : A} → Id x y → I
+           ; primIdPath to pathId  -- ∀ {ℓ} {A : Type ℓ} {x y : A} → Id x y → Path A x y
 
-           ; primIdElim to elimId  -- ∀ {ℓ ℓ'} {A : Set ℓ} {x : A}
-                                   -- (P : ∀ (y : A) → x ≡ y → Set ℓ')
+           ; primIdElim to elimId  -- ∀ {ℓ ℓ'} {A : Type ℓ} {x : A}
+                                   -- (P : ∀ (y : A) → x ≡ y → Type ℓ')
                                    -- (h : ∀ (φ : I) (y : A [ φ ↦ (λ _ → x) ])
                                    --        (w : (Path _ x (outS y)) [ φ ↦ (λ { (φ = i1) → λ _ → x}) ] ) →
                                    --        P (outS y) ⟨ φ , outS w ⟩) →
@@ -18,5 +20,5 @@ open import Agda.Builtin.Cubical.Id public
   hiding ( primIdJ ) -- this should not be used as it is using compCCHM
 
 {- BUILTIN ID Id -}
-_≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+_≡_ : ∀ {ℓ} {A : Type ℓ} → A → A → Type ℓ
 _≡_ = Id

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -25,14 +25,24 @@ open import Agda.Primitive public
   using    ( Level )
   renaming ( lzero to ℓ-zero
            ; lsuc  to ℓ-suc
-           ; _⊔_   to ℓ-max )
+           ; _⊔_   to ℓ-max
+           ; Setω  to Typeω )
 open import Agda.Builtin.Sigma public
+
+Type : (ℓ : Level) → Set (ℓ-suc ℓ)
+Type ℓ = Set ℓ
+
+Type₀ : Type (ℓ-suc ℓ-zero)
+Type₀ = Type ℓ-zero
+
+Type₁ : Type (ℓ-suc (ℓ-suc ℓ-zero))
+Type₁ = Type (ℓ-suc ℓ-zero)
 
 -- This file document the Cubical Agda primitives. The primitives
 -- themselves are bound by the Agda files imported above.
 
 -- * The Interval
--- I : Setω
+-- I : Typeω
 
 -- Endpoints, Connections, Reversal
 -- i0 i1   : I
@@ -45,28 +55,28 @@ open import Agda.Builtin.Sigma public
 -- Introduced with lambda abstraction and eliminated with application,
 -- just like function types.
 
--- PathP : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+-- PathP : ∀ {ℓ} (A : I → Type ℓ) → A i0 → A i1 → Type ℓ
 
 infix 4 _[_≡_]
 
-_[_≡_] : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+_[_≡_] : ∀ {ℓ} (A : I → Type ℓ) → A i0 → A i1 → Type ℓ
 _[_≡_] = PathP
 
 
 -- Non dependent path types
 
-Path : ∀ {ℓ} (A : Set ℓ) → A → A → Set ℓ
+Path : ∀ {ℓ} (A : Type ℓ) → A → A → Type ℓ
 Path A a b = PathP (λ _ → A) a b
 
 -- PathP (λ i → A) x y gets printed as x ≡ y when A does not mention i.
---  _≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
+--  _≡_ : ∀ {ℓ} {A : Type ℓ} → A → A → Type ℓ
 --  _≡_ {A = A} = PathP (λ _ → A)
 
 
 -- * @IsOne r@ represents the constraint "r = i1".
 -- Often we will use "φ" for elements of I, when we intend to use them
 -- with IsOne (or Partial[P]).
--- IsOne : I → Setω
+-- IsOne : I → Typeω
 
 -- i1 is indeed equal to i1.
 -- 1=1 : IsOne i1
@@ -78,39 +88,39 @@ Path A a b = PathP (λ _ → A) a b
 -- extensional judgmental equality.
 -- "PartialP φ A" allows "A" to be defined only on "φ".
 
--- Partial : ∀ {ℓ} → I → Set ℓ → Setω
--- PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Set ℓ) → Setω
+-- Partial : ∀ {ℓ} → I → Type ℓ → Typeω
+-- PartialP : ∀ {ℓ} → (φ : I) → Partial φ (Type ℓ) → Typeω
 
 -- Partial elements are introduced by pattern matching with (r = i0)
 -- or (r = i1) constraints, like so:
 
 private
-  sys : ∀ i → Partial (i ∨ ~ i) Set₁
-  sys i (i = i0) = Set
-  sys i (i = i1) = Set → Set
+  sys : ∀ i → Partial (i ∨ ~ i) Type₁
+  sys i (i = i0) = Type₀
+  sys i (i = i1) = Type₀ → Type₀
 
   -- It also works with pattern matching lambdas:
   --  http://wiki.portal.chalmers.se/agda/pmwiki.php?n=ReferenceManual.PatternMatchingLambdas
-  sys' : ∀ i → Partial (i ∨ ~ i) Set₁
-  sys' i = λ { (i = i0) → Set
-             ; (i = i1) → Set → Set
+  sys' : ∀ i → Partial (i ∨ ~ i) Type₁
+  sys' i = λ { (i = i0) → Type₀
+             ; (i = i1) → Type₀ → Type₀
              }
 
   -- When the cases overlap they must agree.
-  sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Set₁
-  sys2 i j = λ { (i = i1)          → Set
-               ; (i = i1) (j = i1) → Set
+  sys2 : ∀ i j → Partial (i ∨ (i ∧ j)) Type₁
+  sys2 i j = λ { (i = i1)          → Type₀
+               ; (i = i1) (j = i1) → Type₀
                }
 
   -- (i0 = i1) is actually absurd.
-  sys3 : Partial i0 Set₁
+  sys3 : Partial i0 Type₁
   sys3 = λ { () }
 
 
 -- * There are cubical subtypes as in CCHM. Note that these are not
--- fibrant (hence in Setω):
+-- fibrant (hence in Typeω):
 
-_[_↦_] : ∀ {ℓ} (A : Set ℓ) (φ : I) (u : Partial φ A) → Agda.Primitive.Setω
+_[_↦_] : ∀ {ℓ} (A : Type ℓ) (φ : I) (u : Partial φ A) → Typeω
 A [ φ ↦ u ] = Sub A φ u
 
 infix 4 _[_↦_]
@@ -118,16 +128,16 @@ infix 4 _[_↦_]
 -- Any element u : A can be seen as an element of A [ φ ↦ u ] which
 -- agrees with u on φ:
 
--- inS : ∀ {ℓ} {A : Set ℓ} {φ} (u : A) → A [ φ ↦ (λ _ → u) ]
+-- inS : ∀ {ℓ} {A : Type ℓ} {φ} (u : A) → A [ φ ↦ (λ _ → u) ]
 
 -- One can also forget that an element agrees with u on φ:
 
--- outS : ∀ {ℓ} {A : Set ℓ} {φ : I} {u : Partial φ A} → A [ φ ↦ u ] → A
+-- outS : ∀ {ℓ} {A : Type ℓ} {φ : I} {u : Partial φ A} → A [ φ ↦ u ] → A
 
 
 -- * Composition operation according to [CCHM 18].
 -- When calling "comp A φ u a" Agda makes sure that "a" agrees with "u i0" on "φ".
--- compCCHM : ∀ {ℓ} (A : (i : I) → Set ℓ) (φ : I) (u : ∀ i → Partial φ (A i)) (a : A i0) → A i1
+-- compCCHM : ∀ {ℓ} (A : (i : I) → Type ℓ) (φ : I) (u : ∀ i → Partial φ (A i)) (a : A i0) → A i1
 
 -- Note: this is not recommended to use, instead use the CHM
 -- primitives! The reason is that these work with HITs and produce
@@ -137,10 +147,10 @@ infix 4 _[_↦_]
 -- * Generalized transport and homogeneous composition [CHM 18].
 
 -- When calling "transp A φ a" Agda makes sure that "A" is constant on "φ".
--- transp : ∀ {ℓ} (A : I → Set ℓ) (φ : I) (a : A i0) → A i1
+-- transp : ∀ {ℓ} (A : I → Type ℓ) (φ : I) (a : A i0) → A i1
 
 -- When calling "hcomp A φ u a" Agda makes sure that "a" agrees with "u i0" on "φ".
--- hcomp : ∀ {ℓ} {A : Set ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A
+-- hcomp : ∀ {ℓ} {A : Type ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A
 
 private
   variable
@@ -148,7 +158,7 @@ private
     ℓ′ : I → Level
 
 -- Homogeneous filling
-hfill : {A : Set ℓ}
+hfill : {A : Type ℓ}
         {φ : I}
         (u : ∀ i → Partial φ A)
         (u0 : A [ φ ↦ u i0 ])
@@ -160,7 +170,7 @@ hfill {φ = φ} u u0 i =
         (outS u0)
 
 -- Heterogeneous composition defined as in CHM
-comp : (A : ∀ i → Set (ℓ′ i))
+comp : (A : ∀ i → Type (ℓ′ i))
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (u0 : A i0 [ φ ↦ u i0 ])
@@ -171,7 +181,7 @@ comp A {φ = φ} u u0 =
         (transp A i0 (outS u0))
 
 -- Heterogeneous filling defined using comp
-fill : (A : ∀ i → Set (ℓ′ i))
+fill : (A : ∀ i → Type (ℓ′ i))
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (u0 : A i0 [ φ ↦ u i0 ])
@@ -186,9 +196,9 @@ fill A {φ = φ} u u0 i =
 
 -- Direct definition of transport filler, note that we have to
 -- explicitly tell Agda that the type is constant (like in CHM)
-transpFill : {A : Set ℓ}
+transpFill : {A : Type ℓ}
              (φ : I)
-             (A : (i : I) → Set ℓ [ φ ↦ (λ _ → A) ])
+             (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A) ])
              (u0 : outS (A i0))
            → --------------------------------------
              PathP (λ i → outS (A i)) u0 (transp (λ i → outS (A i)) φ u0)
@@ -198,7 +208,7 @@ transpFill φ A u0 i = transp (λ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
 -- Σ-types
 infix 2 Σ-syntax
 
-Σ-syntax : ∀ {ℓ ℓ'} (A : Set ℓ) (B : A → Set ℓ') → Set (ℓ-max ℓ ℓ')
+Σ-syntax : ∀ {ℓ ℓ'} (A : Type ℓ) (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
 Σ-syntax = Σ
 
 syntax Σ-syntax A (λ x → B) = Σ[ x ∈ A ] B

--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -75,7 +75,7 @@ open import Cubical.Data.Empty
 open import Cubical.Relation.Nullary
 
 -- Positive binary numbers
-data Pos : Set where
+data Pos : Type₀ where
   pos1 : Pos
   x0   : Pos → Pos
   x1   : Pos → Pos
@@ -90,7 +90,7 @@ Pos→ℕ pos1    = suc zero
 Pos→ℕ (x0 ps) = doubleℕ (Pos→ℕ ps)
 Pos→ℕ (x1 ps) = suc (doubleℕ (Pos→ℕ ps))
 
-posInd : {P : Pos → Set} → P pos1 → ((p : Pos) → P p → P (sucPos p)) → (p : Pos) → P p
+posInd : {P : Pos → Type₀} → P pos1 → ((p : Pos) → P p → P (sucPos p)) → (p : Pos) → P p
 posInd {P} h1 hs ps = f ps
   where
   H : (p : Pos) → P (x0 p) → P (x0 (sucPos p))
@@ -139,7 +139,7 @@ Pos→ℕ→Pos p = posInd refl hs p
   suc (suc n) ∎
 
 -- Binary numbers
-data Binℕ : Set where
+data Binℕ : Type₀ where
   binℕ0   : Binℕ
   binℕpos : Pos → Binℕ
 
@@ -273,7 +273,7 @@ addp i = transp (λ j → Binℕ≡ℕ (~ i ∨ ~ j) → Binℕ≡ℕ (~ i ∨ ~
 
 -- An implementation of natural numbers (i.e. a "natural number
 -- structure") has a zero and successor.
-record NatImpl (A : Set) : Set where
+record NatImpl (A : Type₀) : Type₀ where
   field
     z : A
     s : A → A
@@ -319,7 +319,7 @@ s (NatImplℕ≡Binℕ i) =
 -- inefficient data-structures using efficient ones.
 
 -- Doubling structures
-record Double {ℓ} (A : Set ℓ) : Set (ℓ-suc ℓ) where
+record Double {ℓ} (A : Type ℓ) : Type (ℓ-suc ℓ) where
   field
     -- doubling function computing 2 * x
     double : A → A
@@ -328,7 +328,7 @@ record Double {ℓ} (A : Set ℓ) : Set (ℓ-suc ℓ) where
 open Double
 
 -- Compute: 2^n * x
-doubles : ∀ {ℓ} {A : Set ℓ} (D : Double A) → ℕ → A → A
+doubles : ∀ {ℓ} {A : Type ℓ} (D : Double A) → ℕ → A → A
 doubles D n x = iter n (double D) x
 
 Doubleℕ : Double ℕ
@@ -376,7 +376,7 @@ elt (DoubleBinℕ≡Doubleℕ i) = transp (λ j → Binℕ≡ℕ (i ∨ ~ j)) i 
 -- We can now use transport to prove a property that is too slow to
 -- check with unary numbers. We define the property we want to check
 -- as a record so that Agda does not try to unfold it eagerly.
-record propDouble {ℓ} {A : Set ℓ} (D : Double A) : Set ℓ where
+record propDouble {ℓ} {A : Type ℓ} (D : Double A) : Type ℓ where
   field
   -- 2^20 * e = 2^5 * (2^15 * e)
     proof : doubles D 20 (elt D) ≡ doubles D 5 (doubles D 15 (elt D))
@@ -405,7 +405,7 @@ propDoubleℕ = transport (λ i → propDouble (DoubleBinℕ≡Doubleℕ i)) pro
 -- prove, but the doubling example wouldn't work as nicely as we
 -- cannot define it as an O(1) operation
 
-data binnat : Set where
+data binnat : Type₀ where
   zero     : binnat            -- 0
   consOdd  : binnat → binnat   -- 2^n + 1
   consEven : binnat → binnat   -- 2^{n+1}

--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -32,7 +32,7 @@ false and true  = false
 true  and false = false
 true  and true  = true
 
-caseBool : ∀ {ℓ} → {A : Set ℓ} → (a0 aS : A) → Bool → A
+caseBool : ∀ {ℓ} → {A : Type ℓ} → (a0 aS : A) → Bool → A
 caseBool att aff true  = att
 caseBool att aff false = aff
 
@@ -42,6 +42,6 @@ false ≟ true  = no λ p → subst (caseBool ⊥ Bool) p true
 true  ≟ false = no λ p → subst (caseBool Bool ⊥) p true
 true  ≟ true  = yes refl
 
-Dec→Bool : ∀ {ℓ} {A : Set ℓ} → Dec A → Bool
+Dec→Bool : ∀ {ℓ} {A : Type ℓ} → Dec A → Bool
 Dec→Bool (yes p) = true
 Dec→Bool (no ¬p) = false

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -36,8 +36,8 @@ private
   nfalsepath : nfalse ≡ false
   nfalsepath = refl
 
-BoolIsSet : isSet Bool
-BoolIsSet = Discrete→isSet _≟_
+BoolIsType : isType Bool
+BoolIsType = Discrete→isType _≟_
 
 true≢false : ¬ true ≡ false
 true≢false p = subst (caseBool Bool ⊥) p true

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -36,8 +36,8 @@ private
   nfalsepath : nfalse ≡ false
   nfalsepath = refl
 
-BoolIsType : isType Bool
-BoolIsType = Discrete→isType _≟_
+isSetBool : isSet Bool
+isSetBool = Discrete→isSet _≟_
 
 true≢false : ¬ true ≡ false
 true≢false p = subst (caseBool Bool ⊥) p true

--- a/Cubical/Data/DiffInt/Base.agda
+++ b/Cubical/Data/DiffInt/Base.agda
@@ -8,7 +8,7 @@ open import Cubical.HITs.SetQuotients.Base
 open import Cubical.Data.Prod
 open import Cubical.Data.Nat
 
-rel : (ℕ ×Σ ℕ) → (ℕ ×Σ ℕ) → Set
+rel : (ℕ ×Σ ℕ) → (ℕ ×Σ ℕ) → Type₀
 rel (a₀ , b₀) (a₁ , b₁) = x ≡ y
   where
     x = a₀ + b₁

--- a/Cubical/Data/DiffInt/Properties.agda
+++ b/Cubical/Data/DiffInt/Properties.agda
@@ -42,10 +42,10 @@ relIsEquiv = EquivRel {A = ℕ ×Σ ℕ} relIsRefl relIsSym relIsTrans
             (b0 + b1) + (c0 + a1) ∎ )
 
 relIsProp : BinaryRelation.isPropValued rel
-relIsProp a b x y = isSetℕ _ _ _ _
+relIsProp a b x y = isTypeℕ _ _ _ _
 
 discreteℤ : Discrete ℤ
-discreteℤ = discreteSetQuotients (discreteΣ discreteℕ λ _ → discreteℕ) relIsProp relIsEquiv (λ _ _ → discreteℕ _ _)
+discreteℤ = discreteTypeQuotients (discreteΣ discreteℕ λ _ → discreteℕ) relIsProp relIsEquiv (λ _ _ → discreteℕ _ _)
 
 private
   _ : Dec→Bool (discreteℤ [ (3 , 5) ] [ (4 , 6) ]) ≡ true

--- a/Cubical/Data/DiffInt/Properties.agda
+++ b/Cubical/Data/DiffInt/Properties.agda
@@ -42,10 +42,10 @@ relIsEquiv = EquivRel {A = ℕ ×Σ ℕ} relIsRefl relIsSym relIsTrans
             (b0 + b1) + (c0 + a1) ∎ )
 
 relIsProp : BinaryRelation.isPropValued rel
-relIsProp a b x y = isTypeℕ _ _ _ _
+relIsProp a b x y = isSetℕ _ _ _ _
 
 discreteℤ : Discrete ℤ
-discreteℤ = discreteTypeQuotients (discreteΣ discreteℕ λ _ → discreteℕ) relIsProp relIsEquiv (λ _ _ → discreteℕ _ _)
+discreteℤ = discreteSetQuotients (discreteΣ discreteℕ λ _ → discreteℕ) relIsProp relIsEquiv (λ _ _ → discreteℕ _ _)
 
 private
   _ : Dec→Bool (discreteℤ [ (3 , 5) ] [ (4 , 6) ]) ≡ true

--- a/Cubical/Data/Empty/Base.agda
+++ b/Cubical/Data/Empty/Base.agda
@@ -3,8 +3,8 @@ module Cubical.Data.Empty.Base where
 
 open import Cubical.Core.Everything
 
-data ⊥ : Set where
+data ⊥ : Type₀ where
 
-⊥-elim : ∀ {l} {A : Set l} → ⊥ → A
+⊥-elim : ∀ {ℓ} {A : Type ℓ} → ⊥ → A
 ⊥-elim ()
 

--- a/Cubical/Data/Fin/Base.agda
+++ b/Cubical/Data/Fin/Base.agda
@@ -20,7 +20,7 @@ open import Cubical.Relation.Nullary
 -- well with cubical Agda. This definition also has some more general
 -- attractive properties, of course, such as easy conversion back to
 -- ℕ.
-Fin : ℕ → Set
+Fin : ℕ → Type₀
 Fin n = Σ[ k ∈ ℕ ] k < n
 
 private
@@ -57,7 +57,7 @@ fsplit (suc k , k<sn) = inr ((k , pred-≤-pred k<sn) , toℕ-injective refl)
 
 -- The full inductive family eliminator for finite types.
 finduction
-  : ∀(P : ∀{k} → Fin k → Set ℓ)
+  : ∀(P : ∀{k} → Fin k → Type ℓ)
   → (∀{k} → P {suc k} fzero)
   → (∀{k} {fn : Fin k} → P fn → P (fsuc fn))
   → {k : ℕ} → (fn : Fin k) → P fn

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -23,7 +23,7 @@ open import Cubical.Induction.WellFounded
 private
   -- Σ is more convenient than the inductive ×, but I don't
   -- want to have to write λ_→ all over.
-  _×_ : Set → Set → Set
+  _×_ : Type₀ → Type₀ → Type₀
   A × B = Σ A λ _ → B
 
 -- Fin 0 is empty, and thus a proposition.
@@ -82,7 +82,7 @@ private
 
 -- A Residue is a family of types representing evidence that a
 -- natural is congruent to a value of a finite type.
-Residue : ℕ → ℕ → Set
+Residue : ℕ → ℕ → Type₀
 Residue k n = Σ[ tup ∈ Fin k × ℕ ] expand× tup ≡ n
 
 extract : ∀{k n} → Residue k n → Fin k

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -48,8 +48,8 @@ record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ �
 record Iso' {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
   constructor iso'
   field
-    isoType : I.Iso (Group.type G) (Group.type H)
-    isoTypeMorph : isMorph G H (I.Iso.fun isoType)
+    isoSet : I.Iso (Group.type G) (Group.type H)
+    isoSetMorph : isMorph G H (I.Iso.fun isoSet)
 
 _≃_ : ∀ {ℓ ℓ'} (A : Group {ℓ}) (B : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
 A ≃ B = Σ (morph A B) \ f → (G.isEquiv (f .fst))
@@ -66,22 +66,22 @@ Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , fu
     open Iso'
 
     fun : G → H
-    fun = I.Iso.fun (isoType i)
+    fun = I.Iso.fun (isoSet i)
 
     inv : H → G
-    inv = I.Iso.inv (isoType i)
+    inv = I.Iso.inv (isoSet i)
 
     rightInv : I.section fun inv
-    rightInv = I.Iso.rightInv (isoType i)
+    rightInv = I.Iso.rightInv (isoSet i)
 
     leftInv : I.retract fun inv
-    leftInv = I.Iso.leftInv (isoType i)
+    leftInv = I.Iso.leftInv (isoSet i)
 
     e' : G G.≃ H
     e' = E.isoToEquiv (I.iso fun inv rightInv leftInv)
 
     funMorph : isMorph G_ H_ fun
-    funMorph = isoTypeMorph i
+    funMorph = isoSetMorph i
 
     _∘_ : H → H → H
     _∘_ = isGroup.comp Hgroup

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -26,7 +26,7 @@ record Group {ℓ} : Type (ℓ-suc ℓ) where
   constructor group
   field
     type : Type ℓ
-    setStruc : isType type
+    setStruc : isSet type
     groupStruc : isGroup type
 
 isMorph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → (f : (Group.type G → Group.type H)) → Type (ℓ-max ℓ ℓ')

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -10,7 +10,7 @@ import Cubical.Foundations.Isomorphism as I
 import Cubical.Foundations.Equiv as E
 import Cubical.Foundations.HAEquiv as HAE
 
-record isGroup {ℓ} (A : Set ℓ) : Set ℓ where
+record isGroup {ℓ} (A : Type ℓ) : Type ℓ where
   constructor group-struct
   field
     id  : A
@@ -22,22 +22,22 @@ record isGroup {ℓ} (A : Set ℓ) : Set ℓ where
     lCancel  : ∀ a → comp (inv a) a ≡ id
     rCalcel : ∀ a → comp a (inv a) ≡ id
 
-record Group {ℓ} : Set (ℓ-suc ℓ) where
+record Group {ℓ} : Type (ℓ-suc ℓ) where
   constructor group
   field
-    type : Set ℓ
-    setStruc : isSet type
+    type : Type ℓ
+    setStruc : isType type
     groupStruc : isGroup type
 
-isMorph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → (f : (Group.type G → Group.type H)) → Set (ℓ-max ℓ ℓ')
+isMorph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → (f : (Group.type G → Group.type H)) → Type (ℓ-max ℓ ℓ')
 isMorph (group G Gset (group-struct _ _ _⊙_ _ _ _ _ _))
         (group H Hset (group-struct _ _ _∘_ _ _ _ _ _)) f
         = (g0 g1 : G) → f (g0 ⊙ g1) ≡ (f g0) ∘ (f g1)
 
-morph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → Set (ℓ-max ℓ ℓ')
+morph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
 morph G H = Σ (Group.type G →  Group.type H) (isMorph G H)
 
-record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Set (ℓ-max ℓ ℓ') where
+record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
   constructor iso
   field
     fun : morph G H
@@ -45,13 +45,13 @@ record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Set (ℓ-max ℓ �
     rightInv : I.section (fun .fst) (inv .fst)
     leftInv : I.retract (fun .fst) (inv .fst)
 
-record Iso' {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Set (ℓ-max ℓ ℓ') where
+record Iso' {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
   constructor iso'
   field
-    isoSet : I.Iso (Group.type G) (Group.type H)
-    isoSetMorph : isMorph G H (I.Iso.fun isoSet)
+    isoType : I.Iso (Group.type G) (Group.type H)
+    isoTypeMorph : isMorph G H (I.Iso.fun isoType)
 
-_≃_ : ∀ {ℓ ℓ'} (A : Group {ℓ}) (B : Group {ℓ'}) → Set (ℓ-max ℓ ℓ')
+_≃_ : ∀ {ℓ ℓ'} (A : Group {ℓ}) (B : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
 A ≃ B = Σ (morph A B) \ f → (G.isEquiv (f .fst))
 
 Iso'→Iso : ∀ {ℓ ℓ'} {G : Group {ℓ}} {H : Group {ℓ'}} → Iso' G  H → Iso G H
@@ -66,22 +66,22 @@ Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , fu
     open Iso'
 
     fun : G → H
-    fun = I.Iso.fun (isoSet i)
+    fun = I.Iso.fun (isoType i)
 
     inv : H → G
-    inv = I.Iso.inv (isoSet i)
+    inv = I.Iso.inv (isoType i)
 
     rightInv : I.section fun inv
-    rightInv = I.Iso.rightInv (isoSet i)
+    rightInv = I.Iso.rightInv (isoType i)
 
     leftInv : I.retract fun inv
-    leftInv = I.Iso.leftInv (isoSet i)
+    leftInv = I.Iso.leftInv (isoType i)
 
     e' : G G.≃ H
     e' = E.isoToEquiv (I.iso fun inv rightInv leftInv)
 
     funMorph : isMorph G_ H_ fun
-    funMorph = isoSetMorph i
+    funMorph = isoTypeMorph i
 
     _∘_ : H → H → H
     _∘_ = isGroup.comp Hgroup

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -36,27 +36,27 @@ Pointed {ℓ} = Σ[ A ∈ Type ℓ ] A
         e = ∣ (Ω^ n') p .snd ∣₀
 
         _⁻¹ : ∥ A ∥₀ → ∥ A ∥₀
-        _⁻¹ = elimTypeTrunc {B = λ _ → ∥ A ∥₀} (λ x → squash₀) λ a → ∣  sym a ∣₀
+        _⁻¹ = elimSetTrunc {B = λ _ → ∥ A ∥₀} (λ x → squash₀) λ a → ∣  sym a ∣₀
 
         _⊙_ : ∥ A ∥₀ → ∥ A ∥₀ → ∥ A ∥₀
-        _⊙_ = elimTypeTrunc2 (λ _ _ → squash₀) λ a₀ a₁ → ∣ a₀ ∙ a₁ ∣₀
+        _⊙_ = elimSetTrunc2 (λ _ _ → squash₀) λ a₀ a₁ → ∣ a₀ ∙ a₁ ∣₀
 
         lUnit : (a : ∥ A ∥₀) → (e ⊙ a) ≡ a
-        lUnit = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        lUnit = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.lUnit a) ))
 
         rUnit : (a : ∥ A ∥₀) → a ⊙ e ≡ a
-        rUnit = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        rUnit = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.rUnit a) ))
 
         assoc : (a b c : ∥ A ∥₀) → ((a ⊙ b) ⊙ c) ≡ (a ⊙ (b ⊙ c))
-        assoc = elimTypeTrunc3 (λ _ _ _ → isProp→isSet (squash₀ _ _))
+        assoc = elimSetTrunc3 (λ _ _ _ → isProp→isSet (squash₀ _ _))
                 (λ a b c → cong ∣_∣₀ (sym (GL.assoc _ _ _)))
 
         lCancel : (a : ∥ A ∥₀) → ((a ⁻¹) ⊙ a) ≡ e
-        lCancel = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        lCancel = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.lCancel _)
 
         rCancel : (a : ∥ A ∥₀) → (a ⊙ (a ⁻¹)) ≡ e
-        rCancel = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        rCancel = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.rCancel _)

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -10,8 +10,8 @@ open import Cubical.Data.Group.Base
 
 open import Cubical.HITs.SetTruncation
 
-Pointed : ∀ {ℓ} → Set (ℓ-suc ℓ)
-Pointed {ℓ} = Σ[ A ∈ Set ℓ ] A
+Pointed : ∀ {ℓ} → Type (ℓ-suc ℓ)
+Pointed {ℓ} = Σ[ A ∈ Type ℓ ] A
 
 Ω : ∀ {ℓ} → Pointed {ℓ} → Pointed {ℓ}
 Ω (A , a ) = ( (a ≡ a) , refl)
@@ -26,7 +26,7 @@ Pointed {ℓ} = Σ[ A ∈ Set ℓ ] A
     n' : ℕ
     n' = suc n
 
-    A : Set ℓ
+    A : Type ℓ
     A = (Ω^ n') p .fst
 
     g : isGroup ∥ A ∥₀
@@ -36,27 +36,27 @@ Pointed {ℓ} = Σ[ A ∈ Set ℓ ] A
         e = ∣ (Ω^ n') p .snd ∣₀
 
         _⁻¹ : ∥ A ∥₀ → ∥ A ∥₀
-        _⁻¹ = elimSetTrunc {B = λ _ → ∥ A ∥₀} (λ x → squash₀) λ a → ∣  sym a ∣₀
+        _⁻¹ = elimTypeTrunc {B = λ _ → ∥ A ∥₀} (λ x → squash₀) λ a → ∣  sym a ∣₀
 
         _⊙_ : ∥ A ∥₀ → ∥ A ∥₀ → ∥ A ∥₀
-        _⊙_ = elimSetTrunc2 (λ _ _ → squash₀) λ a₀ a₁ → ∣ a₀ ∙ a₁ ∣₀
+        _⊙_ = elimTypeTrunc2 (λ _ _ → squash₀) λ a₀ a₁ → ∣ a₀ ∙ a₁ ∣₀
 
         lUnit : (a : ∥ A ∥₀) → (e ⊙ a) ≡ a
-        lUnit = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        lUnit = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.lUnit a) ))
 
         rUnit : (a : ∥ A ∥₀) → a ⊙ e ≡ a
-        rUnit = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        rUnit = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.rUnit a) ))
 
         assoc : (a b c : ∥ A ∥₀) → ((a ⊙ b) ⊙ c) ≡ (a ⊙ (b ⊙ c))
-        assoc = elimSetTrunc3 (λ _ _ _ → isProp→isSet (squash₀ _ _))
+        assoc = elimTypeTrunc3 (λ _ _ _ → isProp→isType (squash₀ _ _))
                 (λ a b c → cong ∣_∣₀ (sym (GL.assoc _ _ _)))
 
         lCancel : (a : ∥ A ∥₀) → ((a ⁻¹) ⊙ a) ≡ e
-        lCancel = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        lCancel = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.lCancel _)
 
         rCancel : (a : ∥ A ∥₀) → (a ⊙ (a ⁻¹)) ≡ e
-        rCancel = elimSetTrunc (λ _ → isProp→isSet (squash₀ _ _))
+        rCancel = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.rCancel _)

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -42,21 +42,21 @@ Pointed {ℓ} = Σ[ A ∈ Type ℓ ] A
         _⊙_ = elimTypeTrunc2 (λ _ _ → squash₀) λ a₀ a₁ → ∣ a₀ ∙ a₁ ∣₀
 
         lUnit : (a : ∥ A ∥₀) → (e ⊙ a) ≡ a
-        lUnit = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
+        lUnit = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.lUnit a) ))
 
         rUnit : (a : ∥ A ∥₀) → a ⊙ e ≡ a
-        rUnit = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
+        rUnit = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
                 (λ a → cong ∣_∣₀ (sym (GL.rUnit a) ))
 
         assoc : (a b c : ∥ A ∥₀) → ((a ⊙ b) ⊙ c) ≡ (a ⊙ (b ⊙ c))
-        assoc = elimTypeTrunc3 (λ _ _ _ → isProp→isType (squash₀ _ _))
+        assoc = elimTypeTrunc3 (λ _ _ _ → isProp→isSet (squash₀ _ _))
                 (λ a b c → cong ∣_∣₀ (sym (GL.assoc _ _ _)))
 
         lCancel : (a : ∥ A ∥₀) → ((a ⁻¹) ⊙ a) ≡ e
-        lCancel = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
+        lCancel = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.lCancel _)
 
         rCancel : (a : ∥ A ∥₀) → (a ⊙ (a ⁻¹)) ≡ e
-        rCancel = elimTypeTrunc (λ _ → isProp→isType (squash₀ _ _))
+        rCancel = elimTypeTrunc (λ _ → isProp→isSet (squash₀ _ _))
                   λ a → cong ∣_∣₀ (GL.rCancel _)

--- a/Cubical/Data/Int/Base.agda
+++ b/Cubical/Data/Int/Base.agda
@@ -5,7 +5,7 @@ open import Cubical.Core.Everything
 
 open import Cubical.Data.Nat
 
-data Int : Set where
+data Int : Type₀ where
   pos    : (n : ℕ) → Int
   negsuc : (n : ℕ) → Int
 

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -8,7 +8,7 @@ sucPred : ∀ (i : Int) → sucInt (predInt i) ≡ i
 predSuc : ∀ (i : Int) → predInt (sucInt i) ≡ i
 
 discreteInt : discrete Int
-isTypeInt : isType Int
+isSetInt : isSet Int
 
 addition of Int is defined _+_ : Int → Int → Int
 

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -8,7 +8,7 @@ sucPred : ∀ (i : Int) → sucInt (predInt i) ≡ i
 predSuc : ∀ (i : Int) → predInt (sucInt i) ≡ i
 
 discreteInt : discrete Int
-isSetInt : isSet Int
+isTypeInt : isType Int
 
 addition of Int is defined _+_ : Int → Int → Int
 
@@ -59,28 +59,28 @@ predSuc (negsuc (suc n)) = refl
 injPos : ∀ {a b : ℕ} → pos a ≡ pos b → a ≡ b
 injPos {a} h = subst T h refl
   where
-  T : Int → Set
+  T : Int → Type₀
   T (pos x)    = a ≡ x
   T (negsuc _) = ⊥
 
 injNegsuc : ∀ {a b : ℕ} → negsuc a ≡ negsuc b → a ≡ b
 injNegsuc {a} h = subst T h refl
   where
-  T : Int → Set
+  T : Int → Type₀
   T (pos _) = ⊥
   T (negsuc x) = a ≡ x
 
 posNotnegsuc : ∀ (a b : ℕ) → ¬ (pos a ≡ negsuc b)
 posNotnegsuc a b h = subst T h 0
   where
-  T : Int → Set
+  T : Int → Type₀
   T (pos _)    = ℕ
   T (negsuc _) = ⊥
 
 negsucNotpos : ∀ (a b : ℕ) → ¬ (negsuc a ≡ pos b)
 negsucNotpos a b h = subst T h 0
   where
-  T : Int → Set
+  T : Int → Type₀
   T (pos _)    = ⊥
   T (negsuc _) = ℕ
 
@@ -94,8 +94,8 @@ discreteInt (negsuc n) (negsuc m) with discreteℕ n m
 ... | yes p = yes (cong negsuc p)
 ... | no p  = no (λ x → p (injNegsuc x))
 
-isSetInt : isSet Int
-isSetInt = Discrete→isSet discreteInt
+isTypeInt : isType Int
+isTypeInt = Discrete→isType discreteInt
 
 _+pos_ : Int → ℕ  → Int
 z +pos 0 = z
@@ -166,7 +166,7 @@ negsuc0+ (pos (suc n)) = (sym (sucPred (pos n))) ∙ (cong sucInt (negsuc0+ _))
 negsuc0+ (negsuc zero) = refl
 negsuc0+ (negsuc (suc n)) = cong predInt (negsuc0+ (negsuc n))
 
-ind-comm : {A : Set} (_∙_ : A → A → A) (f : ℕ → A) (g : A → A)
+ind-comm : {A : Type₀} (_∙_ : A → A → A) (f : ℕ → A) (g : A → A)
            (p : ∀ {n} → f (suc n) ≡ g (f n))
            (g∙ : ∀ a b → g (a ∙ b) ≡ g a ∙ b)
            (∙g : ∀ a b → g (a ∙ b) ≡ a ∙ g b)
@@ -183,7 +183,7 @@ ind-comm _∙_ f g p g∙ ∙g base z (suc n) =
   where
   IH = ind-comm _∙_ f g p g∙ ∙g base z n
 
-ind-assoc : {A : Set} (_·_ : A → A → A) (f : ℕ → A)
+ind-assoc : {A : Type₀} (_·_ : A → A → A) (f : ℕ → A)
         (g : A → A) (p : ∀ a b → g (a · b) ≡ a · (g b))
         (q : ∀ {c} → f (suc c) ≡ g (f c))
         (base : ∀ m n → (m · n) · (f 0) ≡ m · (n · (f 0)))

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -94,8 +94,8 @@ discreteInt (negsuc n) (negsuc m) with discreteℕ n m
 ... | yes p = yes (cong negsuc p)
 ... | no p  = no (λ x → p (injNegsuc x))
 
-isTypeInt : isType Int
-isTypeInt = Discrete→isType discreteInt
+isSetInt : isSet Int
+isSetInt = Discrete→isSet discreteInt
 
 _+pos_ : Int → ℕ  → Int
 z +pos 0 = z

--- a/Cubical/Data/Nat/Base.agda
+++ b/Cubical/Data/Nat/Base.agda
@@ -1,6 +1,8 @@
 {-# OPTIONS --cubical --no-exact-split --safe #-}
 module Cubical.Data.Nat.Base where
 
+open import Cubical.Core.Primitives
+
 open import Agda.Builtin.Nat public
   using (zero; suc; _+_; _*_)
   renaming (Nat to ℕ)
@@ -9,7 +11,7 @@ predℕ : ℕ → ℕ
 predℕ zero    = 0
 predℕ (suc n) = n
 
-caseNat : ∀ {ℓ} → {A : Set ℓ} → (a0 aS : A) → ℕ → A
+caseNat : ∀ {ℓ} → {A : Type ℓ} → (a0 aS : A) → ℕ → A
 caseNat a0 aS 0       = a0
 caseNat a0 aS (suc n) = aS
 
@@ -23,6 +25,6 @@ doublesℕ 0 m = m
 doublesℕ (suc n) m = doublesℕ n (doubleℕ m)
 
 -- iterate
-iter : ∀ {ℓ} {A : Set ℓ} → ℕ → (A → A) → A → A
+iter : ∀ {ℓ} {A : Type ℓ} → ℕ → (A → A) → A → A
 iter zero f z    = z
 iter (suc n) f z = f (iter n f z)

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -19,13 +19,13 @@ open import Cubical.Relation.Nullary
 
 infix 4 _≤_ _<_
 
-_≤_ : ℕ → ℕ → Set
+_≤_ : ℕ → ℕ → Type
 m ≤ n = Σ[ k ∈ ℕ ] k + m ≡ n
 
-_<_ : ℕ → ℕ → Set
+_<_ : ℕ → ℕ → Type
 m < n = suc m ≤ n
 
-data Trichotomy (m n : ℕ) : Set where
+data Trichotomy (m n : ℕ) : Type where
   lt : m < n → Trichotomy m n
   eq : m ≡ n → Trichotomy m n
   gt : n < m → Trichotomy m n
@@ -36,7 +36,7 @@ private
 
 private
   witness-prop : ∀ j → isProp (j + m ≡ n)
-  witness-prop {m} {n} j = isSetℕ (j + m) n
+  witness-prop {m} {n} j = isTypeℕ (j + m) n
 
 m≤n-isProp : isProp (m ≤ n)
 m≤n-isProp {m} {n} (k , p) (l , q)

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -19,13 +19,13 @@ open import Cubical.Relation.Nullary
 
 infix 4 _≤_ _<_
 
-_≤_ : ℕ → ℕ → Type
+_≤_ : ℕ → ℕ → Type₀
 m ≤ n = Σ[ k ∈ ℕ ] k + m ≡ n
 
-_<_ : ℕ → ℕ → Type
+_<_ : ℕ → ℕ → Type₀
 m < n = suc m ≤ n
 
-data Trichotomy (m n : ℕ) : Type where
+data Trichotomy (m n : ℕ) : Type₀ where
   lt : m < n → Trichotomy m n
   eq : m ≡ n → Trichotomy m n
   gt : n < m → Trichotomy m n
@@ -36,7 +36,7 @@ private
 
 private
   witness-prop : ∀ j → isProp (j + m ≡ n)
-  witness-prop {m} {n} j = isTypeℕ (j + m) n
+  witness-prop {m} {n} j = isSetℕ (j + m) n
 
 m≤n-isProp : isProp (m ≤ n)
 m≤n-isProp {m} {n} (k , p) (l , q)
@@ -171,7 +171,7 @@ private
 
 module _
     (b₀ : ℕ)
-    (P : ℕ → Set)
+    (P : ℕ → Type₀)
     (base : ∀ n → n < suc b₀ → P n)
     (step : ∀ n → P n → P (suc b₀ + n))
   where

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -17,31 +17,31 @@ private
   variable
     ℓ ℓ' : Level
 
-data _×_ (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+data _×_ (A : Type ℓ) (B : Type ℓ') : Type (ℓ-max ℓ ℓ') where
   _,_ : A → B → A × B
 
 infixr 5 _×_
 
-proj₁ : {A : Set ℓ} {B : Set ℓ'} → A × B → A
+proj₁ : {A : Type ℓ} {B : Type ℓ'} → A × B → A
 proj₁ (x , _) = x
 
-proj₂ : {A : Set ℓ} {B : Set ℓ'} → A × B → B
+proj₂ : {A : Type ℓ} {B : Type ℓ'} → A × B → B
 proj₂ (_ , x) = x
 
 -- We still export the version using Σ
-_×Σ_ : (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+_×Σ_ : (A : Type ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
 A ×Σ B = Σ A (λ _ → B)
 
 infixr 5 _×Σ_
 
 private
   variable
-    A    : Set ℓ
-    B C  : A → Set ℓ
+    A    : Type ℓ
+    B C  : A → Type ℓ
 
 intro-× : (∀ a → B a) → (∀ a → C a) → ∀ a → B a × C a
 intro-× f g a = f a , g a
 
-map-× : {B : Set ℓ} {D : B → Set ℓ'}
+map-× : {B : Type ℓ} {D : B → Type ℓ'}
    → (∀ a → C a) → (∀ b → D b) → (x : A × B) → C (proj₁ x) × D (proj₂ x)
 map-× f g = intro-× (f ∘ proj₁) (g ∘ proj₂)

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -15,7 +15,7 @@ open import Cubical.Foundations.Univalence
 private
   variable
     ℓ ℓ' : Level
-    A B  : Set ℓ
+    A B  : Type ℓ
 
 -- Swapping is an equivalence
 
@@ -25,13 +25,13 @@ swap (x , y) = (y , x)
 swap-invol : (xy : A × B) → swap (swap xy) ≡ xy
 swap-invol (_ , _) = refl
 
-isEquivSwap : (A : Set ℓ) (B : Set ℓ') → isEquiv (λ (xy : A × B) → swap xy)
+isEquivSwap : (A : Type ℓ) (B : Type ℓ') → isEquiv (λ (xy : A × B) → swap xy)
 isEquivSwap A B = isoToIsEquiv (iso swap swap swap-invol swap-invol)
 
-swapEquiv : (A : Set ℓ) (B : Set ℓ') → A × B ≃ B × A
+swapEquiv : (A : Type ℓ) (B : Type ℓ') → A × B ≃ B × A
 swapEquiv A B = (swap , isEquivSwap A B)
 
-swapEq : (A : Set ℓ) (B : Set ℓ') → A × B ≡ B × A
+swapEq : (A : Type ℓ) (B : Type ℓ') → A × B ≡ B × A
 swapEq A B = ua (swapEquiv A B)
 
 private

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -25,8 +25,8 @@ open import Cubical.Data.Nat
 private
   variable
     ℓ : Level
-    A : Set ℓ
-    B : (a : A) → Set ℓ
+    A : Type ℓ
+    B : (a : A) → Type ℓ
 
 
 ΣPathP : ∀ {x y}
@@ -52,11 +52,11 @@ private
 
 -- Alternative version for path in Σ-types, as in the HoTT book
 
-sigmaPathTransport : (a b : Σ A B) → Set _
+sigmaPathTransport : (a b : Σ A B) → Type _
 sigmaPathTransport {B = B} a b =
   Σ (fst a ≡ fst b) (λ p → transport (λ i → B (p i)) (snd a) ≡ snd b)
 
-_Σ≡T_ : (a b : Σ A B) → Set _
+_Σ≡T_ : (a b : Σ A B) → Type _
 a Σ≡T b = sigmaPathTransport a b
 
 -- now we prove that the alternative path space a Σ≡ b is equal to the usual path space a ≡ b
@@ -143,5 +143,5 @@ discreteΣ {B = B} Adis Bdis (a0 , b0) (a1 , b1) = discreteΣ' (Adis a0 a1)
         discreteΣ'' : (b1 : B a0) → Dec ((a0 , b0) ≡ (a0 , b1))
         discreteΣ'' b1 with Bdis a0 b0 b1
         ... | (yes q) = yes (transport (ua Σ≡) (refl , q))
-        ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isSet Adis a0 a0 (cong fst r) refl) (cong snd r)))
+        ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isType Adis a0 a0 (cong fst r) refl) (cong snd r)))
     discreteΣ' (no ¬p) = no (λ r → ¬p (cong fst r))

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -143,5 +143,5 @@ discreteΣ {B = B} Adis Bdis (a0 , b0) (a1 , b1) = discreteΣ' (Adis a0 a1)
         discreteΣ'' : (b1 : B a0) → Dec ((a0 , b0) ≡ (a0 , b1))
         discreteΣ'' b1 with Bdis a0 b0 b1
         ... | (yes q) = yes (transport (ua Σ≡) (refl , q))
-        ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isType Adis a0 a0 (cong fst r) refl) (cong snd r)))
+        ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isSet Adis a0 a0 (cong fst r) refl) (cong snd r)))
     discreteΣ' (no ¬p) = no (λ r → ¬p (cong fst r))

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -6,13 +6,13 @@ open import Cubical.Core.Everything
 private
   variable
     ℓ ℓ' : Level
-    A B C D : Set ℓ
+    A B C D : Type ℓ
 
-data _⊎_ (A : Set ℓ)(B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+data _⊎_ (A : Type ℓ)(B : Type ℓ') : Type (ℓ-max ℓ ℓ') where
   inl : A → A ⊎ B
   inr : B → A ⊎ B
 
-elim-⊎ : {C : A ⊎ B → Set ℓ} →  ((a : A) → C (inl a)) → ((b : B) → C (inr b))
+elim-⊎ : {C : A ⊎ B → Type ℓ} →  ((a : A) → C (inl a)) → ((b : B) → C (inr b))
        → (x : A ⊎ B) → C x
 elim-⊎ f _ (inl x) = f x
 elim-⊎ _ g (inr y) = g y

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -54,7 +54,7 @@ mapΩ³refl f p i j k = f (p i j k)
 
 PROP SET GROUPOID TWOGROUPOID : ∀ ℓ → Type (ℓ-suc ℓ)
 PROP ℓ = Σ (Type ℓ) isProp
-SET ℓ = Σ (Type ℓ) isType
+SET ℓ = Σ (Type ℓ) isSet
 GROUPOID ℓ = Σ (Type ℓ) isGroupoid
 TWOGROUPOID ℓ = Σ (Type ℓ) is2Groupoid
 
@@ -131,7 +131,7 @@ fibContrΩ³Hopf p i j k =
       ; (j = i1) → base
       ; (k = i0) → base
       ; (k = i1) →
-        isTypeΩS¹ refl refl
+        isSetΩS¹ refl refl
           (λ i j → transp (λ n → HopfS² (p i j n)) (i ∨ ~ i ∨ j ∨ ~ j) base)
           (λ _ _ → base)
           m i j
@@ -262,7 +262,7 @@ g9 : Ω pt∥ ptS¹ ∥₁ .fst → ∥ Int ∥₀
 g9 = encodeTruncS¹
 
 g10 : ∥ Int ∥₀ → Int
-g10 = elimTypeTrunc (λ _ → isTypeInt) (idfun Int)
+g10 = elimTypeTrunc (λ _ → isSetInt) (idfun Int)
 
 -- don't run me
 brunerie : Int

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -262,7 +262,7 @@ g9 : Ω pt∥ ptS¹ ∥₁ .fst → ∥ Int ∥₀
 g9 = encodeTruncS¹
 
 g10 : ∥ Int ∥₀ → Int
-g10 = elimTypeTrunc (λ _ → isSetInt) (idfun Int)
+g10 = elimSetTrunc (λ _ → isSetInt) (idfun Int)
 
 -- don't run me
 brunerie : Int

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -19,8 +19,8 @@ open import Cubical.HITs.2GroupoidTruncation
 
 -- This code is adapted from examples/brunerie3.ctt on the pi4s3_nobug branch of cubicaltt
 
-ptType : Set₁
-ptType = Σ[ A ∈ Set ] A
+ptType : Type₁
+ptType = Σ[ A ∈ Type₀ ] A
 
 pt : ∀ (A : ptType) → A .fst
 pt A = A .snd
@@ -35,7 +35,7 @@ pt∥_∥₁ pt∥_∥₂ : ptType → ptType
 pt∥ A , a ∥₁ = ∥ A ∥₁ , ∣ a ∣₁
 pt∥ A , a ∥₂ = ∥ A ∥₂ , ∣ a ∣₂
 
-ptjoin : ptType → Set → ptType
+ptjoin : ptType → Type₀ → ptType
 ptjoin (A , a) B = join A B , inl a
 
 Ω Ω² Ω³ : ptType → ptType
@@ -43,20 +43,20 @@ ptjoin (A , a) B = join A B , inl a
 Ω² A = Ω (Ω A)
 Ω³ A = Ω (Ω² A)
 
-mapΩrefl : {A : ptType} {B : Set} (f : A .fst → B) → Ω A .fst → Ω (B , f (pt A)) .fst
+mapΩrefl : {A : ptType} {B : Type₀} (f : A .fst → B) → Ω A .fst → Ω (B , f (pt A)) .fst
 mapΩrefl f p i = f (p i)
 
-mapΩ²refl : {A : ptType} {B : Set} (f : A .fst → B) → Ω² A .fst → Ω² (B , f (pt A)) .fst
+mapΩ²refl : {A : ptType} {B : Type₀} (f : A .fst → B) → Ω² A .fst → Ω² (B , f (pt A)) .fst
 mapΩ²refl f p i j = f (p i j)
 
-mapΩ³refl : {A : ptType} {B : Set} (f : A .fst → B) → Ω³ A .fst → Ω³ (B , f (pt A)) .fst
+mapΩ³refl : {A : ptType} {B : Type₀} (f : A .fst → B) → Ω³ A .fst → Ω³ (B , f (pt A)) .fst
 mapΩ³refl f p i j k = f (p i j k)
 
-PROP SET GROUPOID TWOGROUPOID : ∀ ℓ → Set (ℓ-suc ℓ)
-PROP ℓ = Σ (Set ℓ) isProp
-SET ℓ = Σ (Set ℓ) isSet
-GROUPOID ℓ = Σ (Set ℓ) isGroupoid
-TWOGROUPOID ℓ = Σ (Set ℓ) is2Groupoid
+PROP SET GROUPOID TWOGROUPOID : ∀ ℓ → Type (ℓ-suc ℓ)
+PROP ℓ = Σ (Type ℓ) isProp
+SET ℓ = Σ (Type ℓ) isType
+GROUPOID ℓ = Σ (Type ℓ) isGroupoid
+TWOGROUPOID ℓ = Σ (Type ℓ) is2Groupoid
 
 meridS² : S¹ → Path S² base base
 meridS² base _ = base
@@ -67,7 +67,7 @@ alpha (inl x) = base
 alpha (inr y) = base
 alpha (push x y i) = (meridS² y ∙ meridS² x) i
 
-connectionBoth : {A : Set} {a : A} (p : Path A a a) → PathP (λ i → Path A (p i) (p i)) p p
+connectionBoth : {A : Type₀} {a : A} (p : Path A a a) → PathP (λ i → Path A (p i) (p i)) p p
 connectionBoth {a = a} p i j =
   hcomp
     (λ k → λ
@@ -78,7 +78,7 @@ connectionBoth {a = a} p i j =
       })
     a
 
-data PostTotalHopf : Set where
+data PostTotalHopf : Type₀ where
   base : S¹ → PostTotalHopf
   loop : (x : S¹) → PathP (λ i → Path PostTotalHopf (base x) (base (rotLoop x (~ i)))) refl refl
 
@@ -109,16 +109,16 @@ tee34 (loop x i j) =
 tee : (x : S²) → HopfS² x → join S¹ S¹
 tee x y = tee34 (tee12 x y)
 
-fibΩ : {B : ptType} (P : B .fst → Set) → P (pt B) → Ω B .fst → Set
+fibΩ : {B : ptType} (P : B .fst → Type₀) → P (pt B) → Ω B .fst → Type₀
 fibΩ P f p = PathP (λ i → P (p i)) f f
 
-fibΩ² : {B : ptType} (P : B .fst → Set) → P (pt B) → Ω² B .fst → Set
+fibΩ² : {B : ptType} (P : B .fst → Type₀) → P (pt B) → Ω² B .fst → Type₀
 fibΩ² P f = fibΩ (fibΩ P f) refl
 
-fibΩ³ : {B : ptType} (P : B .fst → Set) → P (pt B) → Ω³ B .fst → Set
+fibΩ³ : {B : ptType} (P : B .fst → Type₀) → P (pt B) → Ω³ B .fst → Type₀
 fibΩ³ P f = fibΩ² (fibΩ P f) refl
 
-Ω³Hopf : Ω³ ptS² .fst → Set
+Ω³Hopf : Ω³ ptS² .fst → Type₀
 Ω³Hopf = fibΩ³ HopfS² base
 
 fibContrΩ³Hopf : ∀ p → Ω³Hopf p
@@ -131,7 +131,7 @@ fibContrΩ³Hopf p i j k =
       ; (j = i1) → base
       ; (k = i0) → base
       ; (k = i1) →
-        isSetΩS¹ refl refl
+        isTypeΩS¹ refl refl
           (λ i j → transp (λ n → HopfS² (p i j n)) (i ∨ ~ i ∨ j ∨ ~ j) base)
           (λ _ _ → base)
           m i j
@@ -200,7 +200,7 @@ multTwoEquivAux i j =
   f : I → I → ∥ S² ∥₂ → ∥ S² ∥₂
   f i j t = multTwoTildeAux t i j
 
-tHopf³ : S³ → Set
+tHopf³ : S³ → Type₀
 tHopf³ base = ∥ S² ∥₂
 tHopf³ (surf i j k) =
   Glue ∥ S² ∥₂
@@ -262,7 +262,7 @@ g9 : Ω pt∥ ptS¹ ∥₁ .fst → ∥ Int ∥₀
 g9 = encodeTruncS¹
 
 g10 : ∥ Int ∥₀ → Int
-g10 = elimSetTrunc (λ _ → isSetInt) (idfun Int)
+g10 = elimTypeTrunc (λ _ → isTypeInt) (idfun Int)
 
 -- don't run me
 brunerie : Int

--- a/Cubical/Experiments/FunExtFromUA.agda
+++ b/Cubical/Experiments/FunExtFromUA.agda
@@ -9,32 +9,32 @@ open import Cubical.Foundations.Everything
 
 variable
  ℓ ℓ' : Level
-_∼_ : {X : Set ℓ} {A : X → Set ℓ'} → (f g : (x : X) → A x) → Set (ℓ-max ℓ ℓ')
+_∼_ : {X : Type ℓ} {A : X → Type ℓ'} → (f g : (x : X) → A x) → Type (ℓ-max ℓ ℓ')
 f ∼ g = ∀ x → f x ≡ g x
 
-funext : ∀ ℓ ℓ' → Set (ℓ-suc(ℓ-max ℓ ℓ'))
-funext ℓ ℓ' = {X : Set ℓ} {Y : Set ℓ'} {f g : X → Y} → f ∼ g → f ≡ g
+funext : ∀ ℓ ℓ' → Type (ℓ-suc(ℓ-max ℓ ℓ'))
+funext ℓ ℓ' = {X : Type ℓ} {Y : Type ℓ'} {f g : X → Y} → f ∼ g → f ≡ g
 
 
-elimEquivFun' : ∀ {ℓ} (P : (A B : Set ℓ) → (A → B) → Set ℓ)
-              → (r : (B : Set ℓ) → P B B (λ x → x))
-              → (A B : Set ℓ) → (e : A ≃ B) → P A B (e .fst)
+elimEquivFun' : ∀ {ℓ} (P : (A B : Type ℓ) → (A → B) → Type ℓ)
+              → (r : (B : Type ℓ) → P B B (λ x → x))
+              → (A B : Type ℓ) → (e : A ≃ B) → P A B (e .fst)
 elimEquivFun' P r A B = elimEquivFun B (λ A → P A B) (r B) A
 
-pre-comp-is-equiv : (X Y : Set ℓ) (f : X → Y) (Z : Set ℓ)
+pre-comp-is-equiv : (X Y : Type ℓ) (f : X → Y) (Z : Type ℓ)
                   → isEquiv f
                   → isEquiv (λ (g : Y → Z) → g ∘ f)
 pre-comp-is-equiv {ℓ} X Y f Z e = elimEquivFun' P r X Y (f , e)
  where
-  P : (X Y : Set ℓ) → (X → Y) → Set ℓ
+  P : (X Y : Type ℓ) → (X → Y) → Type ℓ
   P X Y f = isEquiv (λ (g : Y → Z) → g ∘ f)
-  r : (B : Set ℓ) → P B B (λ x → x)
+  r : (B : Type ℓ) → P B B (λ x → x)
   r B = idIsEquiv (B → Z)
 
-leftCancellable : {X : Set ℓ} {Y : Set ℓ'} → (X → Y) → Set (ℓ-max ℓ ℓ')
+leftCancellable : {X : Type ℓ} {Y : Type ℓ'} → (X → Y) → Type (ℓ-max ℓ ℓ')
 leftCancellable f = ∀ {x x'} → f x ≡ f x' → x ≡ x'
 
-equivLC : {X : Set ℓ} {Y : Set ℓ'} (f : X → Y) → isEquiv f → leftCancellable f
+equivLC : {X : Type ℓ} {Y : Type ℓ'} (f : X → Y) → isEquiv f → leftCancellable f
 equivLC f e {x} {x'} p i = hcomp (λ j → \ {(i = i0) → secEq (f , e) x j ;
                                            (i = i1) → secEq (f , e) x' j})
                                  (invEq (f , e) (p i))
@@ -89,7 +89,7 @@ univalence-gives-funext {ℓ'} {ℓ} {X} {Y} {f₀} {f₁} = γ
 
 private
 
-  data ℕ : Set where
+  data ℕ : Type₀ where
    zero : ℕ
    succ : ℕ → ℕ
 

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -22,10 +22,10 @@ open import Cubical.Data.Prod
 -- Dan Licata's example from slide 47 of:
 -- http://dlicata.web.wesleyan.edu/pubs/l13jobtalk/l13jobtalk.pdf
 
-There : Set → Set
+There : Type₀ → Type₀
 There X = List (ℕ × String × (X × ℕ))
 
-Database : Set
+Database : Type₀
 Database = There (ℕ × ℕ)
 
 us : Database
@@ -56,34 +56,34 @@ _ = refl
 -- Scrap Your Boilerplate: A Practical Design Pattern for Generic Programming
 -- Ralf Lämmel & Simon Peyton Jones, TLDI'03
 
-Address : Set
+Address : Type₀
 Address = String
 
-Name : Set
+Name : Type₀
 Name = String
 
-data Person : Set where
+data Person : Type₀ where
   P : Name → Address → Person
 
-data Salary (A : Set) : Set where
+data Salary (A : Type₀) : Type₀ where
   S : A → Salary A
 
-data Employee (A : Set) : Set where
+data Employee (A : Type₀) : Type₀ where
   E : Person → Salary A → Employee A
 
-Manager : Set → Set
+Manager : Type₀ → Type₀
 Manager A = Employee A
 
 -- First test of "mutual"
 mutual
-  data Dept (A : Set) : Set where
+  data Dept (A : Type₀) : Type₀ where
     D : Name → Manager A → List (SubUnit A) → Dept A
 
-  data SubUnit (A : Set) : Set where
+  data SubUnit (A : Type₀) : Type₀ where
     PU : Employee A → SubUnit A
     DU : Dept A → SubUnit A
 
-data Company (A : Set) : Set where
+data Company (A : Type₀) : Type₀ where
   C : List (Dept A) → Company A
 
 

--- a/Cubical/Experiments/HInt.agda
+++ b/Cubical/Experiments/HInt.agda
@@ -26,7 +26,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Data.Int
 open import Cubical.Data.Nat
 
-data ℤ : Set where
+data ℤ : Type where
   zero : ℤ
   suc  : ℤ → ℤ
   pred : ℤ → ℤ
@@ -95,5 +95,5 @@ Int→ℤ→Int (negsuc (suc n)) = cong predInt (Int→ℤ→Int (negsuc n))
 Int≡ℤ : Int ≡ ℤ
 Int≡ℤ = isoToPath (iso Int→ℤ ℤ→Int ℤ→Int→ℤ Int→ℤ→Int)
 
-isSetℤ : isSet ℤ
-isSetℤ = subst isSet Int≡ℤ isSetInt
+isTypeℤ : isType ℤ
+isTypeℤ = subst isType Int≡ℤ isTypeInt

--- a/Cubical/Experiments/HInt.agda
+++ b/Cubical/Experiments/HInt.agda
@@ -26,7 +26,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Data.Int
 open import Cubical.Data.Nat
 
-data ℤ : Type where
+data ℤ : Type₀ where
   zero : ℤ
   suc  : ℤ → ℤ
   pred : ℤ → ℤ
@@ -95,5 +95,5 @@ Int→ℤ→Int (negsuc (suc n)) = cong predInt (Int→ℤ→Int (negsuc n))
 Int≡ℤ : Int ≡ ℤ
 Int≡ℤ = isoToPath (iso Int→ℤ ℤ→Int ℤ→Int→ℤ Int→ℤ→Int)
 
-isTypeℤ : isType ℤ
-isTypeℤ = subst isType Int≡ℤ isTypeInt
+isSetℤ : isSet ℤ
+isSetℤ = subst isSet Int≡ℤ isSetInt

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -14,8 +14,8 @@ open import Cubical.HITs.S3
 open import Cubical.HITs.Join
 open import Cubical.HITs.Hopf
 
-ptType : Set _
-ptType = Σ Set \ A → A
+ptType : Type _
+ptType = Σ Type₀ \ A → A
 
 pt : (A : ptType) → A .fst
 pt A = A .snd

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -6,49 +6,49 @@ open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Prelude
 
-coe0→1 : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1
+coe0→1 : ∀ {ℓ} (A : I → Type ℓ) → A i0 → A i1
 coe0→1 A a = transp A i0 a
 
 -- "coe filler"
-coe0→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i0 → A i
+coe0→i : ∀ {ℓ} (A : I → Type ℓ) (i : I) → A i0 → A i
 coe0→i A i a = transp (λ j → A (i ∧ j)) (~ i) a
 
 -- Check the equations for the coe filler
-coe0→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coe0→i A i1 a ≡ coe0→1 A a
+coe0→i1 : ∀ {ℓ} (A : I → Type ℓ) (a : A i0) → coe0→i A i1 a ≡ coe0→1 A a
 coe0→i1 A a = refl
 
-coe0→i0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coe0→i A i0 a ≡ a
+coe0→i0 : ∀ {ℓ} (A : I → Type ℓ) (a : A i0) → coe0→i A i0 a ≡ a
 coe0→i0 A a = refl
 
 -- coe backwards
-coe1→0 : ∀ {ℓ} (A : I → Set ℓ) → A i1 → A i0
+coe1→0 : ∀ {ℓ} (A : I → Type ℓ) → A i1 → A i0
 coe1→0 A a = transp (λ i → A (~ i)) i0 a
 
 -- coe backwards filler
-coe1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i1 → A i
+coe1→i : ∀ {ℓ} (A : I → Type ℓ) (i : I) → A i1 → A i
 coe1→i A i a = transp (λ j → A (i ∨ ~ j)) i a
 
 -- Check the equations for the coe backwards filler
-coe1→i0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i0 a ≡ coe1→0 A a
+coe1→i0 : ∀ {ℓ} (A : I → Type ℓ) (a : A i1) → coe1→i A i0 a ≡ coe1→0 A a
 coe1→i0 A a = refl
 
-coe1→i1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coe1→i A i1 a ≡ a
+coe1→i1 : ∀ {ℓ} (A : I → Type ℓ) (a : A i1) → coe1→i A i1 a ≡ a
 coe1→i1 A a = refl
 
 -- "squeezeNeg"
-coei→0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i0
+coei→0 : ∀ {ℓ} (A : I → Type ℓ) (i : I) → A i → A i0
 coei→0 A i a = transp (λ j → A (i ∧ ~ j)) (~ i) a
 
-coei0→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→0 A i0 a ≡ a
+coei0→0 : ∀ {ℓ} (A : I → Type ℓ) (a : A i0) → coei→0 A i0 a ≡ a
 coei0→0 A a = refl
 
-coei1→0 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
+coei1→0 : ∀ {ℓ} (A : I → Type ℓ) (a : A i1) → coei→0 A i1 a ≡ coe1→0 A a
 coei1→0 A a = refl
 
 -- "master coe"
 -- defined as the filler of coei→0, coe0→i, and coe1→i
 -- unlike in cartesian cubes, we don't get coei→i = id definitionally
-coei→j : ∀ {ℓ} (A : I → Set ℓ) (i j : I) → A i → A j
+coei→j : ∀ {ℓ} (A : I → Type ℓ) (i j : I) → A i → A j
 coei→j A i j a =
   fill A
     (λ j → λ { (i = i0) → coe0→i A j a
@@ -59,35 +59,35 @@ coei→j A i j a =
 
 -- "squeeze"
 -- this is just defined as the composite face of the master coe
-coei→1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) → A i → A i1
+coei→1 : ∀ {ℓ} (A : I → Type ℓ) (i : I) → A i → A i1
 coei→1 A i a = coei→j A i i1 a
 
-coei0→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i0) → coei→1 A i0 a ≡ coe0→1 A a
+coei0→1 : ∀ {ℓ} (A : I → Type ℓ) (a : A i0) → coei→1 A i0 a ≡ coe0→1 A a
 coei0→1 A a = refl
 
-coei1→1 : ∀ {ℓ} (A : I → Set ℓ) (a : A i1) → coei→1 A i1 a ≡ a
+coei1→1 : ∀ {ℓ} (A : I → Type ℓ) (a : A i1) → coei→1 A i1 a ≡ a
 coei1→1 A a = refl
 
 -- equations for "master coe"
-coei→i0 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i0 a ≡ coei→0 A i a
+coei→i0 : ∀ {ℓ} (A : I → Type ℓ) (i : I) (a : A i) → coei→j A i i0 a ≡ coei→0 A i a
 coei→i0 A i a = refl
 
-coei0→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i0) → coei→j A i0 i a ≡ coe0→i A i a
+coei0→i : ∀ {ℓ} (A : I → Type ℓ) (i : I) (a : A i0) → coei→j A i0 i a ≡ coe0→i A i a
 coei0→i A i a = refl
 
-coei→i1 : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
+coei→i1 : ∀ {ℓ} (A : I → Type ℓ) (i : I) (a : A i) → coei→j A i i1 a ≡ coei→1 A i a
 coei→i1 A i a = refl
 
-coei1→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i1) → coei→j A i1 i a ≡ coe1→i A i a
+coei1→i : ∀ {ℓ} (A : I → Type ℓ) (i : I) (a : A i1) → coei→j A i1 i a ≡ coe1→i A i a
 coei1→i A i a = refl
 
 -- only non-definitional equation
-coei→i : ∀ {ℓ} (A : I → Set ℓ) (i : I) (a : A i) → coei→j A i i a ≡ a
+coei→i : ∀ {ℓ} (A : I → Type ℓ) (i : I) (a : A i) → coei→j A i i a ≡ a
 coei→i A i = coe0→i (λ i → (a : A i) → coei→j A i i a ≡ a) i (λ _ → refl)
 
 -- do the same for fill
 
-fill1→i : ∀ {ℓ} (A : ∀ i → Set ℓ)
+fill1→i : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (u1 : A i1 [ φ ↦ u i1 ])
@@ -99,7 +99,7 @@ fill1→i A {φ = φ} u u1 i =
                 ; (i = i1) → outS u1 })
        (inS {φ = φ ∨ i} (outS {φ = φ} u1))
 
-filli→0 : ∀ {ℓ} (A : ∀ i → Set ℓ)
+filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (i : I)
@@ -112,7 +112,7 @@ filli→0 A {φ = φ} u i ui =
                 ; (i = i0) → outS ui })
        (inS {φ = φ ∨ ~ i} (outS {φ = φ} ui))
 
-filli→j : ∀ {ℓ} (A : ∀ i → Set ℓ)
+filli→j : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (i : I)
@@ -130,7 +130,7 @@ filli→j A {φ = φ} u i ui j =
 
 -- We can reconstruct fill from hfill, coei→j, and the path coei→i ≡ id.
 -- The definition does not rely on the computational content of the coei→i path.
-fill' : ∀ {ℓ} (A : I → Set ℓ)
+fill' : ∀ {ℓ} (A : I → Type ℓ)
        {φ : I}
        (u : ∀ i → Partial φ (A i))
        (u0 : A i0 [ φ ↦ u i0 ])
@@ -142,7 +142,7 @@ fill' A {φ = φ} u u0 i =
   t : A i
   t = hfill {φ = φ} (λ j v → coei→j A j i (u j v)) (inS (coe0→i A i (outS u0))) i
 
-fill'-cap :  ∀ {ℓ} (A : I → Set ℓ)
+fill'-cap :  ∀ {ℓ} (A : I → Type ℓ)
              {φ : I}
              (u : ∀ i → Partial φ (A i))
              (u0 : A i0 [ φ ↦ u i0 ])

--- a/Cubical/Foundations/Embedding.agda
+++ b/Cubical/Foundations/Embedding.agda
@@ -14,7 +14,7 @@ open import Cubical.Foundations.Isomorphism
 private
   variable
     ℓ : Level
-    A B : Set ℓ
+    A B : Type ℓ
     f : A → B
     w x : A
     y z : B
@@ -26,7 +26,7 @@ private
 --
 -- is not well-behaved with higher h-levels, while embeddings
 -- are.
-isEmbedding : (A → B) → Set _
+isEmbedding : (A → B) → Type _
 isEmbedding f = ∀ w x → isEquiv {A = w ≡ x} (cong f)
 
 isEmbeddingIsProp : isProp (isEmbedding f)
@@ -75,7 +75,7 @@ private
 
 -- If `f` is an embedding, we'd expect the fibers of `f` to be
 -- propositions, like an injective function.
-hasPropFibers : (A → B) → Set _
+hasPropFibers : (A → B) → Type _
 hasPropFibers f = ∀ y → isProp (fiber f y)
 
 hasPropFibersIsProp : isProp (hasPropFibers f)

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -27,27 +27,27 @@ open import Cubical.Data.Nat
 private
   variable
     ℓ ℓ'  : Level
-    A B C : Set ℓ
+    A B C : Type ℓ
 
-fiber : ∀ {A : Set ℓ} {B : Set ℓ'} (f : A → B) (y : B) → Set (ℓ-max ℓ ℓ')
+fiber : ∀ {A : Type ℓ} {B : Type ℓ'} (f : A → B) (y : B) → Type (ℓ-max ℓ ℓ')
 fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
 
-equivIsEquiv : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) → isEquiv (equivFun e)
+equivIsEquiv : ∀ {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) → isEquiv (equivFun e)
 equivIsEquiv e = snd e
 
-equivCtr : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) (y : B) → fiber (equivFun e) y
+equivCtr : ∀ {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) (y : B) → fiber (equivFun e) y
 equivCtr e y = e .snd .equiv-proof y .fst
 
-equivCtrPath : ∀ {A : Set ℓ} {B : Set ℓ'} (e : A ≃ B) (y : B) →
+equivCtrPath : ∀ {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) (y : B) →
   (v : fiber (equivFun e) y) → Path _ (equivCtr e y) v
 equivCtrPath e y = e .snd .equiv-proof y .snd
 
 -- The identity equivalence
-idIsEquiv : ∀ (A : Set ℓ) → isEquiv (idfun A)
+idIsEquiv : ∀ (A : Type ℓ) → isEquiv (idfun A)
 equiv-proof (idIsEquiv A) y =
   ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
 
-idEquiv : ∀ (A : Set ℓ) → A ≃ A
+idEquiv : ∀ (A : Type ℓ) → A ≃ A
 idEquiv A = (idfun A , idIsEquiv A)
 
 -- Proof using isPropIsContr. This is slow and the direct proof below is better
@@ -87,7 +87,7 @@ module _ (w : A ≃ B) where
   retEq : retract invEq (w .fst)
   retEq y = λ i → snd (fst (snd w .equiv-proof y)) i
 
-equivToIso : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → Iso A B
+equivToIso : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A ≃ B → Iso A B
 equivToIso {A = A} {B = B} e = iso (e .fst) (invEq e ) (retEq e) (secEq e)
 
 invEquiv : A ≃ B → B ≃ A
@@ -100,11 +100,11 @@ compEquiv f g = isoToEquiv
                        (λ y → (cong (g .fst) (retEq f (invEq g y))) ∙ (retEq g y))
                        (λ y → (cong (invEq f) (secEq g (f .fst y))) ∙ (secEq f y)))
 
-compIso : ∀ {ℓ ℓ' ℓ''} {A : Set ℓ} {B : Set ℓ'} {C : Set ℓ''} →
+compIso : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} →
             Iso A B → Iso B C → Iso A C
 compIso i j = equivToIso (compEquiv (isoToEquiv i) (isoToEquiv j))
 
--- module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'}  where
+-- module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}  where
 --   invEquivInvol : (f : A ≃ B) → invEquiv (invEquiv f) ≡ f
 --   invEquivInvol f i .fst = fst f
 --   invEquivInvol f i .snd = propIsEquiv (fst f) (snd (invEquiv (invEquiv f))) (snd f) i
@@ -125,7 +125,7 @@ homotopyNatural H p = homotopyNatural' H p ∙ □≡∙ _ _
                    ; (j = i1) → cong g p (i ∨ k) })
           (H (p i) j)
 
-Hfa≡fHa : ∀ {A : Set ℓ} (f : A → A) → (H : ∀ a → f a ≡ a) → ∀ a → H (f a) ≡ cong f (H a)
+Hfa≡fHa : ∀ {A : Type ℓ} (f : A → A) → (H : ∀ a → f a ≡ a) → ∀ a → H (f a) ≡ cong f (H a)
 Hfa≡fHa {A = A} f H a =
   H (f a)                          ≡⟨ rUnit (H (f a)) ⟩
   H (f a) ∙ refl                   ≡⟨ cong (_∙_ (H (f a))) (sym (rCancel (H a))) ⟩

--- a/Cubical/Foundations/Equiv/Fiberwise.agda
+++ b/Cubical/Foundations/Equiv/Fiberwise.agda
@@ -5,7 +5,7 @@ open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Everything
 
-module _ {a p q} {A : Set a} (P : A → Set p) (Q : A → Set q)
+module _ {a p q} {A : Type a} (P : A → Type p) (Q : A → Type q)
          (f : ∀ x → P x → Q x)
          where
   private
@@ -33,7 +33,7 @@ module _ {a p q} {A : Set a} (P : A → Set p) (Q : A → Set q)
                                                     ([tf] .equiv-proof (x , y))
 
 
-module _ {ℓ : Level} {U : Set ℓ} {ℓr} (_~_ : U → U → Set ℓr)
+module _ {ℓ : Level} {U : Type ℓ} {ℓr} (_~_ : U → U → Type ℓr)
          (idTo~ : ∀ {A B} → A ≡ B → A ~ B)
          (c : ∀ A → isContr (Σ U \ X → A ~ X))
        where

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -18,7 +18,7 @@ open import Cubical.Foundations.Id
            ; funExt        to funExtId
            ; isContr       to isContrId
            ; isProp        to isPropId
-           ; isType         to isTypeId
+           ; isSet         to isSetId
            ; isEquiv       to isEquivId
            ; equivIsEquiv  to equivIsEquivId
            ; refl           to reflId

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -18,7 +18,7 @@ open import Cubical.Foundations.Id
            ; funExt        to funExtId
            ; isContr       to isContrId
            ; isProp        to isPropId
-           ; isSet         to isSetId
+           ; isType         to isTypeId
            ; isEquiv       to isEquivId
            ; equivIsEquiv  to equivIsEquivId
            ; refl           to reflId

--- a/Cubical/Foundations/FunExtEquiv.agda
+++ b/Cubical/Foundations/FunExtEquiv.agda
@@ -9,7 +9,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence
 
 -- Function extensionality is an equivalence.
-module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} {f g : (x : A) → B x} where
+module _ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} {f g : (x : A) → B x} where
   private
     appl : f ≡ g → ∀ x → f x ≡ g x
     appl eq x i = eq i x

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -7,33 +7,33 @@ module Cubical.Foundations.Function where
 open import Cubical.Core.Everything
 
 -- The identity function
-idfun : ∀ {ℓ} → (A : Set ℓ) → A → A
+idfun : ∀ {ℓ} → (A : Type ℓ) → A → A
 idfun _ x = x
 
 infixr 9 _∘_
 
-_∘_ : ∀ {ℓ ℓ′ ℓ″} {A : Set ℓ} {B : A → Set ℓ′} {C : (a : A) → B a → Set ℓ″}
+_∘_ : ∀ {ℓ ℓ′ ℓ″} {A : Type ℓ} {B : A → Type ℓ′} {C : (a : A) → B a → Type ℓ″}
         (g : {a : A} → (b : B a) → C a b) → (f : (a : A) → B a) → (a : A) → C a (f a)
 g ∘ f = λ x → g (f x)
 
-∘-assoc : ∀ {ℓ ℓ′ ℓ″ ℓ‴} {A : Set ℓ} {B : A → Set ℓ′} {C : (a : A) → B a → Set ℓ″} {D : (a : A) (b : B a) → C a b → Set ℓ‴}
+∘-assoc : ∀ {ℓ ℓ′ ℓ″ ℓ‴} {A : Type ℓ} {B : A → Type ℓ′} {C : (a : A) → B a → Type ℓ″} {D : (a : A) (b : B a) → C a b → Type ℓ‴}
             (h : {a : A} {b : B a} → (c : C a b) → D a b c) (g : {a : A} → (b : B a) → C a b) (f : (a : A) → B a)
           → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f)
 ∘-assoc h g f i x = h (g (f x))
 
-∘-idˡ : ∀ {ℓ ℓ′} {A : Set ℓ} {B : A → Set ℓ′} (f : (a : A) → B a) → f ∘ idfun A ≡ f
+∘-idˡ : ∀ {ℓ ℓ′} {A : Type ℓ} {B : A → Type ℓ′} (f : (a : A) → B a) → f ∘ idfun A ≡ f
 ∘-idˡ f i x = f x
 
-∘-idʳ : ∀ {ℓ ℓ′} {A : Set ℓ} {B : A → Set ℓ′} (f : (a : A) → B a) → (λ {a} → idfun (B a)) ∘ f ≡ f
+∘-idʳ : ∀ {ℓ ℓ′} {A : Type ℓ} {B : A → Type ℓ′} (f : (a : A) → B a) → (λ {a} → idfun (B a)) ∘ f ≡ f
 ∘-idʳ f i x = f x
 
 
-const : ∀ {ℓ ℓ′} {A : Set ℓ} {B : Set ℓ′} → A → B → A
+const : ∀ {ℓ ℓ′} {A : Type ℓ} {B : Type ℓ′} → A → B → A
 const x = λ _ → x
 
 
-case_of_ : ∀ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} → (x : A) → (∀ x → B x) → B x
+case_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} → (x : A) → (∀ x → B x) → B x
 case x of f = f x
 
-case_return_of_ : ∀ {ℓ ℓ'} {A : Set ℓ} (x : A) (B : A → Set ℓ') → (∀ x → B x) → B x
+case_return_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} (x : A) (B : A → Type ℓ') → (∀ x → B x) → B x
 case x return P of f = f x

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -12,7 +12,7 @@ open import Cubical.Foundations.Prelude
 private
   variable
     ℓ : Level
-    A : Set ℓ
+    A : Type ℓ
     x y z w : A
 
 _⁻¹ : (x ≡ y) → (y ≡ x)
@@ -106,15 +106,15 @@ assoc p q r = 3outof4 (compPath-filler p (q ∙ r)) ((p ∙ q) ∙ r) (preassoc 
 
 -- heterogeneous groupoid laws
 
-symInvoP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
+symInvoP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
      PathP (λ j → PathP (λ i → symInvo (λ i → A i) j i) x y) p (symP (symP p))
 symInvoP p = refl
 
-rUnitP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
+rUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
   PathP (λ j → PathP (λ i → rUnit (λ i → A i) j i) x y) p (compPathP p refl)
 rUnitP p j i = compPathP-filler p refl i j
 
-lUnitP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
+lUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
   PathP (λ j → PathP (λ i → lUnit (λ i → A i) j i) x y) p (compPathP refl p)
 lUnitP {A = A} {x = x} p k i =
   comp (λ j → lUnit-filler (λ i → A i) j k i)
@@ -124,7 +124,7 @@ lUnitP {A = A} {x = x} p k i =
                  }) (inS (p (~ k ∧ i )))
 
 
-rCancelP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
+rCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → rCancel (λ i → A i) j i) x x) (compPathP p (symP p)) refl
 rCancelP {A = A} {x = x} p j i =
   comp (λ k → rCancel-filler (λ i → A i) k j i)
@@ -133,12 +133,12 @@ rCancelP {A = A} {x = x} p j i =
                  ; (j = i1) → x
                  }) (inS (p (i ∧ ~ j)))
 
-lCancelP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
+lCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → lCancel (λ i → A i) j i) y y) (compPathP (symP p) p) refl
 lCancelP p = rCancelP (symP p)
 
-3outof4P : {A : I → I → Set ℓ} {P : (A i0 i1) ≡ (A i1 i1)}
-  {B : PathP (λ j → Path (Set ℓ) (A i0 j) (A i1 j)) (λ i → A i i0) P}
+3outof4P : {A : I → I → Type ℓ} {P : (A i0 i1) ≡ (A i1 i1)}
+  {B : PathP (λ j → Path (Type ℓ) (A i0 j) (A i1 j)) (λ i → A i i0) P}
   (α : ∀ (i j : I) → A j i)
   (p : PathP (λ i → P i) (α i1 i0) (α i1 i1)) →
   (β : PathP (λ j → PathP (λ i → B j i) (α j i0) (α j i1)) (λ i → α i0 i) p) →
@@ -151,8 +151,8 @@ lCancelP p = rCancelP (symP p)
                  ; (j = i1) → β k i
                  }) (inS (α i0 i))
 
-preassocP : {A : I → Set ℓ} {x : A i0} {y : A i1} {B_i1 : Set ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
-  {C_i1 : Set ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
+preassocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
+  {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
   PathP (λ j → PathP (λ i → preassoc (λ i → A i) B C j i) x ((compPathP q r) j)) p (compPathP (compPathP p q) r)
 preassocP {A = A} {x = x} {B = B} {C = C} p q r j i =
   comp (λ k → preassoc-filler (λ i → A i) B C k j i)
@@ -162,8 +162,8 @@ preassocP {A = A} {x = x} {B = B} {C = C} p q r j i =
               -- ; (j = i1) → compPathP-filler (compPathP p q) r i k
                  }) (inS (compPathP-filler p q i j))
 
-assocP : {A : I → Set ℓ} {x : A i0} {y : A i1} {B_i1 : Set ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
-  {C_i1 : Set ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
+assocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
+  {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
   PathP (λ j → PathP (λ i → assoc (λ i → A i) B C j i) x w) (compPathP p (compPathP q r)) (compPathP (compPathP p q) r)
 assocP p q r =
   3outof4P (λ i j → compPathP-filler p (compPathP q r) j i) (compPathP (compPathP p q) r) (preassocP p q r)
@@ -175,22 +175,22 @@ assocP p q r =
 
 -- simultaneaous composition on both sides of a path
 
-doubleCompPath-filler : {ℓ : Level} {A : Set ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z →
+doubleCompPath-filler : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z →
                         I → I → A
 doubleCompPath-filler p q r i =
   hfill (λ t → λ { (i = i0) → p (~ t)
                  ; (i = i1) → r t })
         (inS (q i))
 
-doubleCompPath : {ℓ : Level} {A : Set ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
+doubleCompPath : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
 doubleCompPath p q r i = doubleCompPath-filler p q r i i1
 
-_∙∙_∙∙_ : {ℓ : Level} {A : Set ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
+_∙∙_∙∙_ : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
 p ∙∙ q ∙∙ r = doubleCompPath p q r
 
 -- some exchange law for doubleCompPath and refl
 
-rhombus-filler : {ℓ : Level} {A : Set ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → I → I → A
+rhombus-filler : {ℓ : Level} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → I → I → A
 rhombus-filler p q i j =
   hcomp (λ t → λ { (i = i0) → p (~ t ∨ j)
                  ; (i = i1) → q (t ∧ j)
@@ -198,7 +198,7 @@ rhombus-filler p q i j =
                  ; (j = i1) → q (t ∧ i) })
         (p i1)
 
-leftright : {ℓ : Level} {A : Set ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) →
+leftright : {ℓ : Level} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) →
             (refl ∙∙ p ∙∙ q) ≡ (p ∙∙ q ∙∙ refl)
 leftright p q i j =
   hcomp (λ t → λ { (j = i0) → p (i ∧ (~ t))
@@ -207,30 +207,30 @@ leftright p q i j =
 
 -- equating doubleCompPath and a succession of two compPath
 
-split-leftright : {ℓ : Level} {A : Set ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
+split-leftright : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
                   (p ∙∙ q ∙∙ r) ≡ (refl ∙∙ (p ∙∙ q ∙∙ refl) ∙∙ r)
 split-leftright p q r i j =
   hcomp (λ t → λ { (j = i0) → p (~ i ∧ ~ t)
                  ; (j = i1) → r t })
         (doubleCompPath-filler p q refl j i)
 
-split-leftright' : {ℓ : Level} {A : Set ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
+split-leftright' : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
                   (p ∙∙ q ∙∙ r) ≡ (p ∙∙ (refl ∙∙ q ∙∙ r) ∙∙ refl)
 split-leftright' p q r i j =
   hcomp (λ t → λ { (j = i0) → p (~ t)
                  ; (j = i1) → r (i ∨ t) })
         (doubleCompPath-filler refl q r j i)
 
-doubleCompPath-elim : {ℓ : Level} {A : Set ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y)
+doubleCompPath-elim : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y)
                       (r : y ≡ z) → (p ∙∙ q ∙∙ r) ≡ (p ∙ q) ∙ r
 doubleCompPath-elim p q r = (split-leftright p q r) ∙ (λ i → (leftright p q (~ i)) ∙ r)
 
-doubleCompPath-elim' : {ℓ : Level} {A : Set ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y)
+doubleCompPath-elim' : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y)
                        (r : y ≡ z) → (p ∙∙ q ∙∙ r) ≡ p ∙ (q ∙ r)
 doubleCompPath-elim' p q r = (split-leftright' p q r) ∙ (sym (leftright p (q ∙ r)))
 
 -- deducing associativity for compPath
 
--- assoc : {ℓ : Level} {A : Set ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
+-- assoc : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
 --                 (p ∙ q) ∙ r ≡ p ∙ (q ∙ r)
 -- assoc p q r = (sym (doubleCompPath-elim p q r)) ∙ (doubleCompPath-elim' p q r)

--- a/Cubical/Foundations/HAEquiv.agda
+++ b/Cubical/Foundations/HAEquiv.agda
@@ -20,21 +20,21 @@ open import Cubical.Foundations.GroupoidLaws
 
 open import Cubical.Data.Nat
 
-record isHAEquiv {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ-max ℓ ℓ') where
+record isHAEquiv {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) : Type (ℓ-max ℓ ℓ') where
   field
     g : B → A
     sec : ∀ a → g (f a) ≡ a
     ret : ∀ b → f (g b) ≡ b
     com : ∀ a → cong f (sec a) ≡ ret (f a)
 
-HAEquiv : ∀ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+HAEquiv : ∀ {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
 HAEquiv A B = Σ (A → B) λ f → isHAEquiv f
 
 private
   variable
     ℓ ℓ' : Level
-    A : Set ℓ
-    B : Set ℓ'
+    A : Type ℓ
+    B : Type ℓ'
 
 iso→HAEquiv : Iso A B → HAEquiv A B
 iso→HAEquiv {A = A} {B = B} (iso f g ε η) = f , (record { g = g ; sec = η ; ret = ret ; com = com })
@@ -59,7 +59,7 @@ iso→HAEquiv {A = A} {B = B} (iso f g ε η) = f , (record { g = g ; sec = η ;
 equiv→HAEquiv : A ≃ B → HAEquiv A B
 equiv→HAEquiv e = iso→HAEquiv (equivToIso e)
 
-congEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
+congEquiv : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
 congEquiv {A = A} {B} {x} {y} e = isoToEquiv (iso intro elim intro-elim elim-intro)
   where
     e' : HAEquiv A B

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -2,7 +2,7 @@
 
 Basic theory about h-levels/n-types:
 
-- Basic properties of isContr, isProp and isType (definitions are in Core/Prelude)
+- Basic properties of isContr, isProp and isSet (definitions are in Prelude)
 
 - Hedberg's theorem can be found in Cubical/Relation/Nullary/DecidableEq
 
@@ -136,8 +136,8 @@ isPropIsOfHLevel 1 A = isPropIsProp
 isPropIsOfHLevel (suc (suc n)) A f g i a b =
   isPropIsOfHLevel (suc n) (a ≡ b) (f a b) (g a b) i
 
-isPropIsType : isProp (isSet A)
-isPropIsType {A = A} = isPropIsOfHLevel 2 A
+isPropIsSet : isProp (isSet A)
+isPropIsSet {A = A} = isPropIsOfHLevel 2 A
 
 HLevel≡ : ∀ {A B : Type ℓ} {hA : isOfHLevel n A} {hB : isOfHLevel n B} →
           (A ≡ B) ≡ ((A , hA) ≡ (B , hB))

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -45,7 +45,7 @@ inhProp→isContr : A → isProp A → isContr A
 inhProp→isContr x h = x , h x
 
 isPropIsProp : isProp (isProp A)
-isPropIsProp f g i a b = isProp→isType f a b (f a b) (g a b) i
+isPropIsProp f g i a b = isProp→isSet f a b (f a b) (g a b) i
 
 -- A retract of a contractible type is contractible
 retractIsContr
@@ -73,7 +73,7 @@ isProp→isPropPathP {B = B} {x = x} isPropB m = J P d m where
   P : ∀ σc → x ≡ σc → _
   P _ m = ∀ g h → isProp (PathP (λ i → B (m i)) g h)
   d : P x refl
-  d = isProp→isType (isPropB x)
+  d = isProp→isSet (isPropB x)
 
 isProp→isContrPathP : (∀ a → isProp (B a))
                     → (m : x ≡ y) (g : B x) (h : B y)
@@ -82,7 +82,7 @@ isProp→isContrPathP isPropB m g h =
   inhProp→isContr (isProp→PathP isPropB m g h) (isProp→isPropPathP isPropB m g h)
 
 isProp→isContr≡ : isProp A → (x y : A) → isContr (x ≡ y)
-isProp→isContr≡ isPropA x y = inhProp→isContr (isPropA x y) (isProp→isType isPropA x y)
+isProp→isContr≡ isPropA x y = inhProp→isContr (isPropA x y) (isProp→isSet isPropA x y)
 
 isContrPath : isContr A → (x y : A) → isContr (x ≡ y)
 isContrPath cA = isProp→isContr≡ (isContr→isProp cA)
@@ -108,22 +108,22 @@ hLevelPi {B = B} 1 h f g i x = (h x) (f x) (g x) i
 hLevelPi (suc (suc n)) h f g =
   subst (isOfHLevel (suc n)) funExtPath (hLevelPi (suc n) λ x → h x (f x) (g x))
 
-isTypePi : ((x : A) → isType (B x)) → isType ((x : A) → B x)
-isTypePi Bset = hLevelPi 2 (λ a → Bset a)
+isSetPi : ((x : A) → isSet (B x)) → isSet ((x : A) → B x)
+isSetPi Bset = hLevelPi 2 (λ a → Bset a)
 
-isType→isType' : isType A → isType' A
-isType→isType' {A = A} Aset {x} {y} {z} {w} p q r s =
+isSet→isSet' : isSet A → isSet' A
+isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s =
   J (λ (z : A) (r : x ≡ z) → ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : z ≡ w) → PathP (λ i → Path A (r i) (s i) ) p q) helper r s p q
   where
     helper : ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : x ≡ w) → PathP (λ i → Path A x (s i)) p q
     helper {w} s p q = J (λ (w : A) (s : y ≡ w) → ∀ p q → PathP (λ i → Path A x (s i)) p q) (λ p q → Aset x y p q) s p q
 
-isType'→isType : isType' A → isType A
-isType'→isType {A = A} Aset' x y p q = Aset' p q refl refl
+isSet'→isSet : isSet' A → isSet A
+isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
 
 hLevelSuc : (n : ℕ) (A : Type ℓ) → isOfHLevel n A → isOfHLevel (suc n) A
 hLevelSuc 0 A = isContr→isProp
-hLevelSuc 1 A = isProp→isType
+hLevelSuc 1 A = isProp→isSet
 hLevelSuc (suc (suc n)) A h a b = hLevelSuc (suc n) (a ≡ b) (h a b)
 
 hLevelLift : (m : ℕ) (hA : isOfHLevel n A) → isOfHLevel (m + n) A
@@ -136,7 +136,7 @@ isPropIsOfHLevel 1 A = isPropIsProp
 isPropIsOfHLevel (suc (suc n)) A f g i a b =
   isPropIsOfHLevel (suc n) (a ≡ b) (f a b) (g a b) i
 
-isPropIsType : isProp (isType A)
+isPropIsType : isProp (isSet A)
 isPropIsType {A = A} = isPropIsOfHLevel 2 A
 
 HLevel≡ : ∀ {A B : Type ℓ} {hA : isOfHLevel n A} {hB : isOfHLevel n B} →
@@ -154,7 +154,7 @@ HLevel≡ {n = n} {A = A} {B = B} {hA} {hB} =
     intro-elim eq = cong ΣPathP (ΣProp≡ (λ e →
       J (λ B e →
            ∀ k → (x y : PathP (λ i → isOfHLevel n (e i)) hA k) → x ≡ y)
-        (λ k → isProp→isType (isPropIsOfHLevel n _) _ _) e hB) refl)
+        (λ k → isProp→isSet (isPropIsOfHLevel n _) _ _) e hB) refl)
 
     elim-intro : ∀ x → elim (intro x) ≡ x
     elim-intro eq = refl
@@ -223,8 +223,8 @@ hProp≡HLevel1 {ℓ} = isoToPath (iso intro elim intro-elim elim-intro)
     elim-intro : ∀ h → elim (intro h) ≡ h
     elim-intro h = ΣProp≡ (λ _ → isPropIsProp) refl
 
-isTypeHProp : isType (hProp {ℓ = ℓ})
-isTypeHProp = subst (λ X → isOfHLevel 2 X) (sym hProp≡HLevel1) (hLevelHLevelSuc 0)
+isSetHProp : isSet (hProp {ℓ = ℓ})
+isSetHProp = subst (λ X → isOfHLevel 2 X) (sym hProp≡HLevel1) (hLevelHLevelSuc 0)
 
 
 isContrPartial→isContr : ∀ {ℓ} {A : Type ℓ}

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -2,7 +2,7 @@
 
 Basic theory about h-levels/n-types:
 
-- Basic properties of isContr, isProp and isSet (definitions are in Core/Prelude)
+- Basic properties of isContr, isProp and isType (definitions are in Core/Prelude)
 
 - Hedberg's theorem can be found in Cubical/Relation/Nullary/DecidableEq
 
@@ -25,31 +25,31 @@ open import Cubical.Data.Nat    using (ℕ; zero; suc; _+_; +-comm)
 private
   variable
     ℓ ℓ' : Level
-    A : Set ℓ
-    B : A → Set ℓ
+    A : Type ℓ
+    B : A → Type ℓ
     x y : A
     n : ℕ
 
-hProp : Set (ℓ-suc ℓ)
-hProp {ℓ} = Σ (Set ℓ) isProp
+hProp : Type (ℓ-suc ℓ)
+hProp {ℓ} = Σ (Type ℓ) isProp
 
-isOfHLevel : ℕ → Set ℓ → Set ℓ
+isOfHLevel : ℕ → Type ℓ → Type ℓ
 isOfHLevel 0 A = isContr A
 isOfHLevel 1 A = isProp A
 isOfHLevel (suc n) A = (x y : A) → isOfHLevel n (x ≡ y)
 
-HLevel : ℕ → Set (ℓ-suc ℓ)
-HLevel {ℓ} n = Σ[ A ∈ Set ℓ ] (isOfHLevel n A)
+HLevel : ℕ → Type (ℓ-suc ℓ)
+HLevel {ℓ} n = Σ[ A ∈ Type ℓ ] (isOfHLevel n A)
 
 inhProp→isContr : A → isProp A → isContr A
 inhProp→isContr x h = x , h x
 
 isPropIsProp : isProp (isProp A)
-isPropIsProp f g i a b = isProp→isSet f a b (f a b) (g a b) i
+isPropIsProp f g i a b = isProp→isType f a b (f a b) (g a b) i
 
 -- A retract of a contractible type is contractible
 retractIsContr
-  : ∀ {B : Set ℓ}
+  : ∀ {B : Type ℓ}
   → (f : A → B) (g : B → A)
   → (h : (x : A) → g (f x) ≡ x)
   → (v : isContr B) → isContr A
@@ -73,7 +73,7 @@ isProp→isPropPathP {B = B} {x = x} isPropB m = J P d m where
   P : ∀ σc → x ≡ σc → _
   P _ m = ∀ g h → isProp (PathP (λ i → B (m i)) g h)
   d : P x refl
-  d = isProp→isSet (isPropB x)
+  d = isProp→isType (isPropB x)
 
 isProp→isContrPathP : (∀ a → isProp (B a))
                     → (m : x ≡ y) (g : B x) (h : B y)
@@ -82,7 +82,7 @@ isProp→isContrPathP isPropB m g h =
   inhProp→isContr (isProp→PathP isPropB m g h) (isProp→isPropPathP isPropB m g h)
 
 isProp→isContr≡ : isProp A → (x y : A) → isContr (x ≡ y)
-isProp→isContr≡ isPropA x y = inhProp→isContr (isPropA x y) (isProp→isSet isPropA x y)
+isProp→isContr≡ isPropA x y = inhProp→isContr (isPropA x y) (isProp→isType isPropA x y)
 
 isContrPath : isContr A → (x y : A) → isContr (x ≡ y)
 isContrPath cA = isProp→isContr≡ (isContr→isProp cA)
@@ -108,38 +108,38 @@ hLevelPi {B = B} 1 h f g i x = (h x) (f x) (g x) i
 hLevelPi (suc (suc n)) h f g =
   subst (isOfHLevel (suc n)) funExtPath (hLevelPi (suc n) λ x → h x (f x) (g x))
 
-isSetPi : ((x : A) → isSet (B x)) → isSet ((x : A) → B x)
-isSetPi Bset = hLevelPi 2 (λ a → Bset a)
+isTypePi : ((x : A) → isType (B x)) → isType ((x : A) → B x)
+isTypePi Bset = hLevelPi 2 (λ a → Bset a)
 
-isSet→isSet' : isSet A → isSet' A
-isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s =
+isType→isType' : isType A → isType' A
+isType→isType' {A = A} Aset {x} {y} {z} {w} p q r s =
   J (λ (z : A) (r : x ≡ z) → ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : z ≡ w) → PathP (λ i → Path A (r i) (s i) ) p q) helper r s p q
   where
     helper : ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : x ≡ w) → PathP (λ i → Path A x (s i)) p q
     helper {w} s p q = J (λ (w : A) (s : y ≡ w) → ∀ p q → PathP (λ i → Path A x (s i)) p q) (λ p q → Aset x y p q) s p q
 
-isSet'→isSet : isSet' A → isSet A
-isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
+isType'→isType : isType' A → isType A
+isType'→isType {A = A} Aset' x y p q = Aset' p q refl refl
 
-hLevelSuc : (n : ℕ) (A : Set ℓ) → isOfHLevel n A → isOfHLevel (suc n) A
+hLevelSuc : (n : ℕ) (A : Type ℓ) → isOfHLevel n A → isOfHLevel (suc n) A
 hLevelSuc 0 A = isContr→isProp
-hLevelSuc 1 A = isProp→isSet
+hLevelSuc 1 A = isProp→isType
 hLevelSuc (suc (suc n)) A h a b = hLevelSuc (suc n) (a ≡ b) (h a b)
 
 hLevelLift : (m : ℕ) (hA : isOfHLevel n A) → isOfHLevel (m + n) A
 hLevelLift zero hA = hA
 hLevelLift {A = A} (suc m) hA = hLevelSuc _ A (hLevelLift m hA)
 
-isPropIsOfHLevel : (n : ℕ) (A : Set ℓ) → isProp (isOfHLevel n A)
+isPropIsOfHLevel : (n : ℕ) (A : Type ℓ) → isProp (isOfHLevel n A)
 isPropIsOfHLevel 0 A = isPropIsContr
 isPropIsOfHLevel 1 A = isPropIsProp
 isPropIsOfHLevel (suc (suc n)) A f g i a b =
   isPropIsOfHLevel (suc n) (a ≡ b) (f a b) (g a b) i
 
-isPropIsSet : isProp (isSet A)
-isPropIsSet {A = A} = isPropIsOfHLevel 2 A
+isPropIsType : isProp (isType A)
+isPropIsType {A = A} = isPropIsOfHLevel 2 A
 
-HLevel≡ : ∀ {A B : Set ℓ} {hA : isOfHLevel n A} {hB : isOfHLevel n B} →
+HLevel≡ : ∀ {A B : Type ℓ} {hA : isOfHLevel n A} {hB : isOfHLevel n B} →
           (A ≡ B) ≡ ((A , hA) ≡ (B , hB))
 HLevel≡ {n = n} {A = A} {B = B} {hA} {hB} =
  isoToPath (iso intro elim intro-elim elim-intro)
@@ -154,7 +154,7 @@ HLevel≡ {n = n} {A = A} {B = B} {hA} {hB} =
     intro-elim eq = cong ΣPathP (ΣProp≡ (λ e →
       J (λ B e →
            ∀ k → (x y : PathP (λ i → isOfHLevel n (e i)) hA k) → x ≡ y)
-        (λ k → isProp→isSet (isPropIsOfHLevel n _) _ _) e hB) refl)
+        (λ k → isProp→isType (isPropIsOfHLevel n _) _ _) e hB) refl)
 
     elim-intro : ∀ x → elim (intro x) ≡ x
     elim-intro eq = refl
@@ -175,7 +175,7 @@ isOfHLevelΣ {B = B} (suc (suc n)) h1 h2 x y =
                        (subst B p (snd x)) (snd y)
   in transport (λ i → isOfHLevel (suc n) (pathSigma≡sigmaPath x y (~ i))) h3
 
-hLevel≃ : ∀ n → {A B : Set ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) → isOfHLevel n (A ≃ B)
+hLevel≃ : ∀ n → {A B : Type ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) → isOfHLevel n (A ≃ B)
 hLevel≃ zero {A = A} {B = B} hA hB = A≃B , contr
   where
   A≃B : A ≃ B
@@ -188,7 +188,7 @@ hLevel≃ (suc n) hA hB =
   isOfHLevelΣ (suc n) (hLevelPi (suc n) (λ _ → hB))
               (λ a → subst (λ n → isOfHLevel n (isEquiv a)) (+-comm n 1) (hLevelLift n (isPropIsEquiv a)))
 
-hLevelRespectEquiv : {A : Set ℓ} {B : Set ℓ'} → (n : ℕ) → A ≃ B → isOfHLevel n A → isOfHLevel n B
+hLevelRespectEquiv : {A : Type ℓ} {B : Type ℓ'} → (n : ℕ) → A ≃ B → isOfHLevel n A → isOfHLevel n B
 hLevelRespectEquiv 0 eq hA =
   ( fst eq (fst hA)
   , λ b → cong (fst eq) (snd hA (eq .snd .equiv-proof b .fst .fst)) ∙ eq .snd .equiv-proof b .fst .snd)
@@ -198,7 +198,7 @@ hLevelRespectEquiv 1 eq hA x y i =
 hLevelRespectEquiv {A = A} {B = B} (suc (suc n)) eq hA x y =
   hLevelRespectEquiv (suc n) (invEquiv (congEquiv (invEquiv eq))) (hA _ _)
 
-hLevel≡ : ∀ n → {A B : Set ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) →
+hLevel≡ : ∀ n → {A B : Type ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) →
   isOfHLevel n (A ≡ B)
 hLevel≡ n hA hB = hLevelRespectEquiv n (invEquiv univalence) (hLevel≃ n hA hB)
 
@@ -223,11 +223,11 @@ hProp≡HLevel1 {ℓ} = isoToPath (iso intro elim intro-elim elim-intro)
     elim-intro : ∀ h → elim (intro h) ≡ h
     elim-intro h = ΣProp≡ (λ _ → isPropIsProp) refl
 
-isSetHProp : isSet (hProp {ℓ = ℓ})
-isSetHProp = subst (λ X → isOfHLevel 2 X) (sym hProp≡HLevel1) (hLevelHLevelSuc 0)
+isTypeHProp : isType (hProp {ℓ = ℓ})
+isTypeHProp = subst (λ X → isOfHLevel 2 X) (sym hProp≡HLevel1) (hLevelHLevelSuc 0)
 
 
-isContrPartial→isContr : ∀ {ℓ} {A : Set ℓ}
+isContrPartial→isContr : ∀ {ℓ} {A : Type ℓ}
                        → (extend : ∀ φ → Partial φ A → A)
                        → (∀ u → u ≡ (extend i1 λ { _ → u}))
                        → isContr A

--- a/Cubical/Foundations/HoTT-UF.agda
+++ b/Cubical/Foundations/HoTT-UF.agda
@@ -41,7 +41,7 @@ open import Cubical.Foundations.Id public
 
            ; isProp         -- The usual notions of proposition, contractible type, set.
            ; isContr
-           ; isType
+           ; isSet
 
            ; isEquiv        -- A map with contractible fibers
                             -- (Voevodsky's version of the notion).

--- a/Cubical/Foundations/HoTT-UF.agda
+++ b/Cubical/Foundations/HoTT-UF.agda
@@ -15,6 +15,7 @@ For the moment, this requires the development version of Agda.
 
 module Cubical.Foundations.HoTT-UF where
 
+open import Cubical.Core.Primitives hiding ( _≡_ )
 open import Cubical.Core.Id public
 
 open import Cubical.Foundations.Id public
@@ -40,7 +41,7 @@ open import Cubical.Foundations.Id public
 
            ; isProp         -- The usual notions of proposition, contractible type, set.
            ; isContr
-           ; isSet
+           ; isType
 
            ; isEquiv        -- A map with contractible fibers
                             -- (Voevodsky's version of the notion).
@@ -62,7 +63,7 @@ Here is an illustration of how function extensionality computes.
 
 private
 
-  data ℕ : Set where
+  data ℕ : Type₀ where
    zero : ℕ
    succ : ℕ → ℕ
 

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -32,7 +32,7 @@ open import Cubical.Foundations.Prelude public
            ; funExt    to funExtPath
            ; isContr   to isContrPath
            ; isProp    to isPropPath
-           ; isType     to isTypePath
+           ; isSet     to isSetPath
            ; fst       to pr₁ -- as in the HoTT book
            ; snd       to pr₂
            )

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -147,8 +147,8 @@ isContr A = Σ[ x ∈ A ] (∀ y → x ≡ y)
 isProp : Type ℓ → Type ℓ
 isProp A = (x y : A) → x ≡ y
 
-isType : Type ℓ → Type ℓ
-isType A = (x y : A) → isProp (x ≡ y)
+isSet : Type ℓ → Type ℓ
+isSet A = (x y : A) → isProp (x ≡ y)
 
 record isEquiv {A : Type ℓ} {B : Type ℓ'} (f : A → B) : Type (ℓ-max ℓ ℓ') where
   field

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -19,15 +19,15 @@ private
     ℓ : Level
 
 -- Section and retract
-module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} where
-  section : (f : A → B) → (g : B → A) → Set ℓ'
+module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
+  section : (f : A → B) → (g : B → A) → Type ℓ'
   section f g = ∀ b → f (g b) ≡ b
 
   -- NB: `g` is the retraction!
-  retract : (f : A → B) → (g : B → A) → Set ℓ
+  retract : (f : A → B) → (g : B → A) → Type ℓ
   retract f g = ∀ a → g (f a) ≡ a
 
-record Iso {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+record Iso {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') : Type (ℓ-max ℓ ℓ') where
   constructor iso
   field
     fun : A → B
@@ -36,7 +36,7 @@ record Iso {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') wher
     leftInv : retract fun inv
 
 -- Any iso is an equivalence
-module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (i : Iso A B) where
+module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (i : Iso A B) where
   open Iso i renaming ( fun to f
                       ; inv to g
                       ; rightInv to s
@@ -86,7 +86,7 @@ module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (i : Iso A B) where
   isoToIsEquiv .equiv-proof y .snd z = lemIso y (g y) (fst z) (s y) (snd z)
 
 
-isoToPath : ∀ {ℓ} {A B : Set ℓ} → (Iso A B) → A ≡ B
+isoToPath : ∀ {ℓ} {A B : Type ℓ} → (Iso A B) → A ≡ B
 isoToPath {A = A} {B = B} f i =
   Glue B (λ { (i = i0) → (A , (Iso.fun f , isoToIsEquiv f))
             ; (i = i1) → (B , (λ x → x) ,

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -39,18 +39,18 @@ infix 2 ⇐∶_⇒∶_
 --------------------------------------------------------------------------------
 -- The type hProp of mere propositions
 -- the definition hProp is given in Foundations.HLevels
--- hProp {ℓ} = Σ (Set ℓ) isProp
+-- hProp {ℓ} = Σ (Type ℓ) isProp
 
 private
   variable
     ℓ ℓ' ℓ'' : Level
     P Q R : hProp {ℓ}
-    A B C : Set ℓ
+    A B C : Type ℓ
 
-[_] : hProp → Set ℓ
+[_] : hProp → Type ℓ
 [_] = fst
 
-∥_∥ₚ : Set ℓ → hProp
+∥_∥ₚ : Type ℓ → hProp
 ∥ A ∥ₚ = ∥ A ∥ , propTruncIsProp
 
 _≡ₚ_ : (x y : A) → hProp
@@ -108,7 +108,7 @@ x ≢ₚ y = ¬ x ≡ₚ y
 --------------------------------------------------------------------------------
 -- Disjunction of mere propositions
 
-_⊔′_ : Set ℓ → Set ℓ' → Set _
+_⊔′_ : Type ℓ → Type ℓ' → Type _
 A ⊔′ B = ∥ A D.⊎ B ∥
 
 _⊔_ : hProp {ℓ} → hProp {ℓ'} → hProp
@@ -126,7 +126,7 @@ inr x = ∣ D.inr x ∣
 
 --------------------------------------------------------------------------------
 -- Conjunction of mere propositions
-_⊓′_ : Set ℓ → Set ℓ' → Set _
+_⊓′_ : Type ℓ → Type ℓ' → Type _
 A ⊓′ B = A D.× B
 
 _⊓_ : hProp {ℓ} → hProp {ℓ'} → hProp
@@ -175,7 +175,7 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
 --------------------------------------------------------------------------------
 -- Negation commutes with truncation
 
-∥¬A∥≡¬∥A∥ : (A : Set ℓ) → ∥ (A → D.⊥) ∥ₚ ≡ (¬ ∥ A ∥ₚ)
+∥¬A∥≡¬∥A∥ : (A : Type ℓ) → ∥ (A → D.⊥) ∥ₚ ≡ (¬ ∥ A ∥ₚ)
 ∥¬A∥≡¬∥A∥ _ =
   ⇒∶ (λ ¬A A → elimPropTrunc (λ _ → D.isProp⊥)
     (elimPropTrunc (λ _ → propPi λ _ → D.isProp⊥) (λ ¬p p → ¬p p) ¬A) A)

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -8,9 +8,9 @@ open import Cubical.Foundations.Prelude
 private
   variable
     ℓ ℓ' : Level
-    A : Set ℓ
+    A : Type ℓ
 
 -- Less polymorphic version of `cong`, to avoid some unresolved metas
-cong′ : ∀ {B : Set ℓ'} (f : A → B) {x y : A} (p : x ≡ y)
+cong′ : ∀ {B : Type ℓ'} (f : A → B) {x y : A} (p : x ≡ y)
       → Path B (f x) (f y)
 cong′ f = cong f

--- a/Cubical/Foundations/PathSplitEquiv.agda
+++ b/Cubical/Foundations/PathSplitEquiv.agda
@@ -26,53 +26,53 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Isomorphism
 
-isEquivCong : ∀ {ℓ} {A B : Set ℓ} {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → (cong (fst e) p))
-isEquivCong e = EquivJ (λ (B' A' : Set _) (e' : A' ≃ B') →
+isEquivCong : ∀ {ℓ} {A B : Type ℓ} {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → (cong (fst e) p))
+isEquivCong e = EquivJ (λ (B' A' : Type _) (e' : A' ≃ B') →
                          (x' y' : A') → isEquiv (λ (p : x' ≡ y') → cong (fst e') p))
                        (λ _ x' y' → idIsEquiv (x' ≡ y')) _ _ e _ _
 
-congEquiv : ∀ {ℓ} {A B : Set ℓ} {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
+congEquiv : ∀ {ℓ} {A B : Type ℓ} {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
 congEquiv e = ((λ (p : _ ≡ _) → cong (fst e) p) , isEquivCong e)
 
-isEquivPreComp : ∀ {ℓ ℓ′} {A B : Set ℓ} {C : Set ℓ′} (e : A ≃ B)
+isEquivPreComp : ∀ {ℓ ℓ′} {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
   → isEquiv (λ (φ : B → C) → φ ∘ e .fst)
 isEquivPreComp {A = A} {C = C} e = EquivJ
-                  (λ (B A : Set _) (e' : A ≃ B) → isEquiv (λ (φ : B → C) → φ ∘ e' .fst))
+                  (λ (B A : Type _) (e' : A ≃ B) → isEquiv (λ (φ : B → C) → φ ∘ e' .fst))
                   (λ A → idIsEquiv (A → C)) _ _ e
 
-isEquivPostComp : ∀ {ℓ ℓ′} {A B : Set ℓ} {C : Set ℓ′} (e : A ≃ B)
+isEquivPostComp : ∀ {ℓ ℓ′} {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
   → isEquiv (λ (φ : C → A) → e .fst ∘ φ)
 isEquivPostComp {A = A} {C = C} e = EquivJ
-                  (λ (B A : Set _) (e' : A ≃ B) →  isEquiv (λ (φ : C → A) → e' .fst ∘ φ))
+                  (λ (B A : Type _) (e' : A ≃ B) →  isEquiv (λ (φ : C → A) → e' .fst ∘ φ))
                   (λ A → idIsEquiv (C → A)) _ _ e
 
-preCompEquiv : ∀ {ℓ ℓ′} {A B : Set ℓ} {C : Set ℓ′} (e : A ≃ B)
+preCompEquiv : ∀ {ℓ ℓ′} {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
              → (B → C) ≃ (A → C)
 preCompEquiv e = (λ φ x → φ (fst e x)) , isEquivPreComp e
 
-postCompEquiv : ∀ {ℓ ℓ′} {A B : Set ℓ} {C : Set ℓ′} (e : A ≃ B)
+postCompEquiv : ∀ {ℓ ℓ′} {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
              → (C → A) ≃ (C → B)
 postCompEquiv e = (λ φ x → fst e (φ x)) , isEquivPostComp e
 
 
 
-record isPathSplitEquiv {ℓ ℓ'} {A : Set  ℓ} {B : Set ℓ'} (f : A → B) : Set (ℓ-max ℓ ℓ') where
+record isPathSplitEquiv {ℓ ℓ'} {A : Type  ℓ} {B : Type ℓ'} (f : A → B) : Type (ℓ-max ℓ ℓ') where
   field
     s : B → A
     sec : section f s
     secCong : (x y : A) → Σ[ s' ∈ (f(x) ≡ f(y) → x ≡ y) ] section (cong f) s'
 
-PathSplitEquiv : ∀ {ℓ ℓ'} (A : Set  ℓ) (B : Set ℓ') → Set (ℓ-max ℓ ℓ')
+PathSplitEquiv : ∀ {ℓ ℓ'} (A : Type  ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
 PathSplitEquiv A B = Σ[ f ∈ (A → B) ] isPathSplitEquiv f
 
 open isPathSplitEquiv
 
-idIsPathSplitEquiv : ∀ {ℓ} {A : Set ℓ} → isPathSplitEquiv (λ (x : A) → x)
+idIsPathSplitEquiv : ∀ {ℓ} {A : Type ℓ} → isPathSplitEquiv (λ (x : A) → x)
 s idIsPathSplitEquiv x = x
 sec idIsPathSplitEquiv x = refl
 secCong idIsPathSplitEquiv = λ x y → (λ p → p) , λ p _ → p
 
-module _ {ℓ} {A B : Set ℓ} where
+module _ {ℓ} {A B : Type ℓ} where
   toIsEquiv : (f : A → B) → isPathSplitEquiv f → isEquiv f
   toIsEquiv f record { s = s ; sec = sec ; secCong = secCong } =
     (isoToEquiv (iso f s sec (λ x → (secCong (s (f x)) x).fst (sec (f x))))) .snd
@@ -88,7 +88,7 @@ module _ {ℓ} {A B : Set ℓ} where
   sectionOfEquiv : (f : A → B) → isEquiv f → Σ (B → A) (section f)
   sectionOfEquiv f e = sectionOfEquiv' f e , isSec f e
 
-module _ {ℓ} {A B : Set ℓ} where
+module _ {ℓ} {A B : Type ℓ} where
   abstract
     fromIsEquiv : (f : A → B) → isEquiv f → isPathSplitEquiv f
     s (fromIsEquiv f pf) = sectionOfEquiv' f pf
@@ -128,7 +128,7 @@ module _ {ℓ} {A B : Set ℓ} where
   PathSplitEquiv is a proposition and the type
   of path split equivs is equivalent to the type of equivalences
 -}
-isPropIsPathSplitEquiv : ∀ {ℓ} {A B : Set ℓ} (f : A → B)
+isPropIsPathSplitEquiv : ∀ {ℓ} {A B : Type ℓ} (f : A → B)
      → isProp (isPathSplitEquiv f)
 isPropIsPathSplitEquiv {_} {A} {B} f
   record { s = φ ; sec = sec-φ ; secCong = secCong-φ }
@@ -151,7 +151,7 @@ isPropIsPathSplitEquiv {_} {A} {B} f
                                  (λ (p : x ≡ y) → cong f p)
                                  (isEquivCong (pathSplitToEquiv (f , φ'))))
 
-module _ {ℓ} {A B : Set ℓ} where
+module _ {ℓ} {A B : Type ℓ} where
   isEquivIsPathSplitToIsEquiv : (f : A → B) → isEquiv (fromIsEquiv f)
   isEquivIsPathSplitToIsEquiv f =
     isoToIsEquiv

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -177,15 +177,15 @@ isContr A = Σ[ x ∈ A ] (∀ y → x ≡ y)
 isProp : Type ℓ → Type ℓ
 isProp A = (x y : A) → x ≡ y
 
-isType : Type ℓ → Type ℓ
-isType A = (x y : A) → isProp (x ≡ y)
+isSet : Type ℓ → Type ℓ
+isSet A = (x y : A) → isProp (x ≡ y)
 
-isType' : Type ℓ → Type ℓ
-isType' A = {x y z w : A} (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w) →
+isSet' : Type ℓ → Type ℓ
+isSet' A = {x y z w : A} (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w) →
            PathP (λ i → Path A (r i) (s i)) p q
 
 isGroupoid : Type ℓ → Type ℓ
-isGroupoid A = ∀ a b → isType (Path A a b)
+isGroupoid A = ∀ a b → isSet (Path A a b)
 
 is2Groupoid : Type ℓ → Type ℓ
 is2Groupoid A = ∀ a b → isGroupoid (Path A a b)
@@ -211,8 +211,8 @@ isContr→isProp (x , p) a b i =
   hcomp (λ j → λ { (i = i0) → p a j
                  ; (i = i1) → p b j }) x
 
-isProp→isType : isProp A → isType A
-isProp→isType h a b p q j i =
+isProp→isSet : isProp A → isSet A
+isProp→isSet h a b p q j i =
   hcomp (λ k → λ { (i = i0) → h a a k
                  ; (i = i1) → h a b k
                  ; (j = i0) → h a (p i) k

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -34,8 +34,8 @@ infixr 2 _≡⟨_⟩_
 private
   variable
     ℓ ℓ' : Level
-    A : Set ℓ
-    B : A → Set ℓ
+    A : Type ℓ
+    B : A → Type ℓ
     x y z : A
 
 refl : x ≡ x
@@ -44,7 +44,7 @@ refl {x = x} = λ _ → x
 sym : x ≡ y → y ≡ x
 sym p i = p (~ i)
 
-symP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} →
+symP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} →
        (p : PathP A x y) → PathP (λ i → A (~ i)) y x
 symP p j = p (~ j)
 
@@ -52,7 +52,7 @@ cong : ∀ (f : (a : A) → B a) (p : x ≡ y) →
        PathP (λ i → B (p i)) (f x) (f y)
 cong f p i = f (p i)
 
-cong₂ : ∀ {C : (a : A) → (b : B a) → Set ℓ} →
+cong₂ : ∀ {C : (a : A) → (b : B a) → Type ℓ} →
         (f : (a : A) → (b : B a) → C a b) →
         (p : x ≡ y) →
         {u : B x} {v : B y} (q : PathP (λ i → B (p i)) u v) →
@@ -73,14 +73,14 @@ _∙_ : x ≡ y → y ≡ z → x ≡ z
 -- The filler of heterogeneous path composition:
 -- compPathP-filler p q = PathP (λ i → PathP (λ j → (compPath-filler (λ i → A i) B i j)) x (q i)) p (compPathP p q)
 
-compPathP-filler : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Set ℓ} {B : A i1 ≡ B_i1} → {z : B i1} →
+compPathP-filler : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Type ℓ} {B : A i1 ≡ B_i1} → {z : B i1} →
   (p : PathP A x y) → (q : PathP (λ i → B i) y z) → ∀ (i j : I) → compPath-filler (λ i → A i) B j i
 compPathP-filler {A = A} {x = x} {B = B} p q i =
   fill (λ j → compPath-filler (λ i → A i) B j i)
        (λ j → λ { (i = i0) → x ;
                    (i = i1) → q j }) (inS (p i))
 
-compPathP : {A : I → Set ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Set ℓ} {B : (A i1) ≡ B_i1} → {z : B i1} →
+compPathP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} → {z : B i1} →
   (p : PathP A x y) → (q : PathP (λ i → B i) y z) → PathP (λ j → ((λ i → A i) ∙ B) j) x z
 compPathP p q j = compPathP-filler p q j i1
 
@@ -121,7 +121,7 @@ _□_ : x ≡ y → y ≡ z → x ≡ z
 -- Transport, subst and functional extensionality
 
 -- transport is a special case of transp
-transport : {A B : Set ℓ} → A ≡ B → A → B
+transport : {A B : Type ℓ} → A ≡ B → A → B
 transport p a = transp (λ i → p i) i0 a
 
 -- Transporting in a constant family is the identity function (up to a
@@ -130,7 +130,7 @@ transportRefl : (x : A) → transport refl x ≡ x
 transportRefl {A = A} x i = transp (λ _ → A) i x
 
 -- We want B to be explicit in subst
-subst : (B : A → Set ℓ') (p : x ≡ y) → B x → B y
+subst : (B : A → Type ℓ') (p : x ≡ y) → B x → B y
 subst B p pa = transport (λ i → B (p i)) pa
 
 substRefl : (px : B x) → subst B refl px ≡ px
@@ -141,7 +141,7 @@ funExt p i x = p x i
 
 -- J for paths and its computation rule
 
-module _ (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
+module _ (P : ∀ y → x ≡ y → Type ℓ') (d : P x refl) where
   J : (p : x ≡ y) → P y p
   J p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 
@@ -150,7 +150,7 @@ module _ (P : ∀ y → x ≡ y → Set ℓ') (d : P x refl) where
 
 -- Contractibility of singletons
 
-singl : (a : A) → Set _
+singl : (a : A) → Type _
 singl {A = A} a = Σ[ x ∈ A ] (a ≡ x)
 
 contrSingl : (p : x ≡ y) → Path (singl x) (x , refl) (y , p)
@@ -159,7 +159,7 @@ contrSingl p i = (p i , λ j → p (i ∧ j))
 
 -- Converting to and from a PathP
 
-module _ {A : I → Set ℓ} {x : A i0} {y : A i1} where
+module _ {A : I → Type ℓ} {x : A i0} {y : A i1} where
   toPathP : transp A i0 x ≡ y → PathP A x y
   toPathP p i = hcomp (λ j → λ { (i = i0) → x
                                ; (i = i1) → p j })
@@ -171,23 +171,23 @@ module _ {A : I → Set ℓ} {x : A i0} {y : A i1} where
 
 -- Direct definitions of lower h-levels
 
-isContr : Set ℓ → Set ℓ
+isContr : Type ℓ → Type ℓ
 isContr A = Σ[ x ∈ A ] (∀ y → x ≡ y)
 
-isProp : Set ℓ → Set ℓ
+isProp : Type ℓ → Type ℓ
 isProp A = (x y : A) → x ≡ y
 
-isSet : Set ℓ → Set ℓ
-isSet A = (x y : A) → isProp (x ≡ y)
+isType : Type ℓ → Type ℓ
+isType A = (x y : A) → isProp (x ≡ y)
 
-isSet' : Set ℓ → Set ℓ
-isSet' A = {x y z w : A} (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w) →
+isType' : Type ℓ → Type ℓ
+isType' A = {x y z w : A} (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w) →
            PathP (λ i → Path A (r i) (s i)) p q
 
-isGroupoid : Set ℓ → Set ℓ
-isGroupoid A = ∀ a b → isSet (Path A a b)
+isGroupoid : Type ℓ → Type ℓ
+isGroupoid A = ∀ a b → isType (Path A a b)
 
-is2Groupoid : Set ℓ → Set ℓ
+is2Groupoid : Type ℓ → Type ℓ
 is2Groupoid A = ∀ a b → isGroupoid (Path A a b)
 
 -- Essential consequences of isProp and isContr
@@ -211,8 +211,8 @@ isContr→isProp (x , p) a b i =
   hcomp (λ j → λ { (i = i0) → p a j
                  ; (i = i1) → p b j }) x
 
-isProp→isSet : isProp A → isSet A
-isProp→isSet h a b p q j i =
+isProp→isType : isProp A → isType A
+isProp→isType h a b p q j i =
   hcomp (λ k → λ { (i = i0) → h a a k
                  ; (i = i1) → h a b k
                  ; (j = i0) → h a (p i) k

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -12,23 +12,23 @@ open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 
-transport⁻ : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → B → A
+transport⁻ : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → B → A
 transport⁻ p = transport (λ i → p (~ i))
 
-transport⁻Transport : ∀ {ℓ} {A B : Set ℓ} → (p : A ≡ B) → (a : A) →
+transport⁻Transport : ∀ {ℓ} {A B : Type ℓ} → (p : A ≡ B) → (a : A) →
                           transport⁻ p (transport p a) ≡ a
 transport⁻Transport p a j =
   transp (λ i → p (~ i ∧ ~ j)) j (transp (λ i → p (i ∧ ~ j)) j a)
 
-transportTransport⁻ : ∀ {ℓ} {A B : Set ℓ} → (p : A ≡ B) → (b : B) →
+transportTransport⁻ : ∀ {ℓ} {A B : Type ℓ} → (p : A ≡ B) → (b : B) →
                         transport p (transport⁻ p b) ≡ b
 transportTransport⁻ p b j =
   transp (λ i → p (i ∨ j)) j (transp (λ i → p (~ i ∨ j)) j b)
 
 -- Transport is an equivalence
-isEquivTransport : ∀ {ℓ} {A B : Set ℓ} (p : A ≡ B) → isEquiv (transport p)
+isEquivTransport : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B) → isEquiv (transport p)
 isEquivTransport {A = A} {B = B} p =
   transport (λ i → isEquiv (λ x → transp (λ j → p (i ∧ j)) (~ i) x)) (idIsEquiv A)
 
-transportEquiv : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A ≃ B
+transportEquiv : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → A ≃ B
 transportEquiv p = (transport p , isEquivTransport p)

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -26,20 +26,20 @@ private
     ℓ ℓ' : Level
 
 -- The ua constant
-ua : ∀ {A B : Set ℓ} → A ≃ B → A ≡ B
+ua : ∀ {A B : Type ℓ} → A ≃ B → A ≡ B
 ua {A = A} {B = B} e i = Glue B (λ { (i = i0) → (A , e)
                                    ; (i = i1) → (B , idEquiv B) })
 
 -- Give detailed type to unglue, mainly for documentation purposes
-unglueua : ∀ {A B : Set} → (e : A ≃ B) → (i : I) (x : ua e i)
+unglueua : ∀ {A B : Type ℓ} → (e : A ≃ B) → (i : I) (x : ua e i)
            → B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → x }) ]
 unglueua e i x = inS (unglue (i ∨ ~ i) x)
 
 -- Proof of univalence using that unglue is an equivalence:
 
 -- unglue is an equivalence
-unglueIsEquiv : ∀ (A : Set ℓ) (φ : I)
-                (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
+unglueIsEquiv : ∀ (A : Type ℓ) (φ : I)
+                (f : PartialP φ (λ o → Σ[ T ∈ Type ℓ ] T ≃ A)) →
                 isEquiv {A = Glue A f} (unglue φ)
 equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
   let u : I → Partial φ A
@@ -58,8 +58,8 @@ equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
 
 -- Any partial family of equivalences can be extended to a total one
 -- from Glue [ φ ↦ (T,f) ] A to A
-unglueEquiv : ∀ (A : Set ℓ) (φ : I)
-              (f : PartialP φ (λ o → Σ[ T ∈ Set ℓ ] T ≃ A)) →
+unglueEquiv : ∀ (A : Type ℓ) (φ : I)
+              (f : PartialP φ (λ o → Σ[ T ∈ Type ℓ ] T ≃ A)) →
               (Glue A f) ≃ A
 unglueEquiv A φ f = ( unglue φ , unglueIsEquiv A φ f )
 
@@ -73,110 +73,110 @@ unglueEquiv A φ f = ( unglue φ , unglueIsEquiv A φ f )
 -- unglue is an equivalence. The standard formulation can be found in
 -- Cubical/Basics/Univalence.
 --
-EquivContr : ∀ (A : Set ℓ) → isContr (Σ[ T ∈ Set ℓ ] T ≃ A)
+EquivContr : ∀ (A : Type ℓ) → isContr (Σ[ T ∈ Type ℓ ] T ≃ A)
 EquivContr {ℓ = ℓ} A =
   ( (A , idEquiv A)
   , idEquiv≡ )
  where
-  idEquiv≡ : (y : Σ (Set ℓ) (λ T → T ≃ A)) → (A , idEquiv A) ≡ y
+  idEquiv≡ : (y : Σ (Type ℓ) (λ T → T ≃ A)) → (A , idEquiv A) ≡ y
   idEquiv≡ w = \ { i .fst                   → Glue A (f i)
                  ; i .snd .fst              → unglueEquiv _ _ (f i) .fst
                  ; i .snd .snd .equiv-proof → unglueEquiv _ _ (f i) .snd .equiv-proof
                  }
     where
-      f : ∀ i → PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Set ℓ ] T ≃ A)
+      f : ∀ i → PartialP (~ i ∨ i) (λ x → Σ[ T ∈ Type ℓ ] T ≃ A)
       f i = λ { (i = i0) → A , idEquiv A ; (i = i1) → w }
 
-contrSinglEquiv : {A B : Set ℓ} (e : A ≃ B) → (B , idEquiv B) ≡ (A , e)
+contrSinglEquiv : {A B : Type ℓ} (e : A ≃ B) → (B , idEquiv B) ≡ (A , e)
 contrSinglEquiv {A = A} {B = B} e =
   isContr→isProp (EquivContr B) (B , idEquiv B) (A , e)
 
 -- Equivalence induction
-EquivJ : (P : (A B : Set ℓ) → (e : B ≃ A) → Set ℓ')
-       → (r : (A : Set ℓ) → P A A (idEquiv A))
-       → (A B : Set ℓ) → (e : B ≃ A) → P A B e
+EquivJ : (P : (A B : Type ℓ) → (e : B ≃ A) → Type ℓ')
+       → (r : (A : Type ℓ) → P A A (idEquiv A))
+       → (A B : Type ℓ) → (e : B ≃ A) → P A B e
 EquivJ P r A B e = subst (λ x → P A (x .fst) (x .snd)) (contrSinglEquiv e) (r A)
 
 -- Eliminate equivalences by just looking at the underlying function
-elimEquivFun : (B : Set ℓ) (P : (A : Set ℓ) → (A → B) → Set ℓ')
+elimEquivFun : (B : Type ℓ) (P : (A : Type ℓ) → (A → B) → Type ℓ')
              → (r : P B (λ x → x))
-             → (A : Set ℓ) → (e : A ≃ B) → P A (e .fst)
+             → (A : Type ℓ) → (e : A ≃ B) → P A (e .fst)
 elimEquivFun B P r a e = subst (λ x → P (x .fst) (x .snd .fst)) (contrSinglEquiv e) r
 
 -- ua is defined in Cubical/Core/Glue
-uaIdEquiv : {A : Set ℓ} → ua (idEquiv A) ≡ refl
+uaIdEquiv : {A : Type ℓ} → ua (idEquiv A) ≡ refl
 uaIdEquiv {A = A} i j = Glue A {φ = i ∨ ~ j ∨ j} (λ _ → A , idEquiv A)
 
 -- Assuming that we have an inverse to ua we can easily prove univalence
-module Univalence (au : ∀ {ℓ} {A B : Set ℓ} → A ≡ B → A ≃ B)
-                  (auid : ∀ {ℓ} {A B : Set ℓ} → au refl ≡ idEquiv A) where
-  thm : ∀ {ℓ} {A B : Set ℓ} → isEquiv au
+module Univalence (au : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → A ≃ B)
+                  (auid : ∀ {ℓ} {A B : Type ℓ} → au refl ≡ idEquiv A) where
+  thm : ∀ {ℓ} {A B : Type ℓ} → isEquiv au
   thm {A = A} {B = B} =
     isoToIsEquiv {B = A ≃ B}
       (iso au ua
         (EquivJ (λ _ _ e → au (ua e) ≡ e) (λ X → (cong au uaIdEquiv) ∙ (auid {B = B})) _ _)
         (J (λ X p → ua (au p) ≡ p) ((cong ua (auid {B = B})) ∙ uaIdEquiv)))
 
-pathToEquiv : {A B : Set ℓ} → A ≡ B → A ≃ B
+pathToEquiv : {A B : Type ℓ} → A ≡ B → A ≃ B
 pathToEquiv p = lineToEquiv (λ i → p i)
 
-pathToEquivRefl : {A : Set ℓ} → pathToEquiv refl ≡ idEquiv A
+pathToEquivRefl : {A : Type ℓ} → pathToEquiv refl ≡ idEquiv A
 pathToEquivRefl {A = A} = equivEq _ _ (λ i x → transp (λ _ → A) i x)
 
 -- Univalence
-univalence : {A B : Set ℓ} → (A ≡ B) ≃ (A ≃ B)
+univalence : {A B : Type ℓ} → (A ≡ B) ≃ (A ≃ B)
 univalence = ( pathToEquiv , Univalence.thm pathToEquiv pathToEquivRefl  )
 
 -- The original map from UniMath/Foundations
-eqweqmap : {A B : Set ℓ} → A ≡ B → A ≃ B
+eqweqmap : {A B : Type ℓ} → A ≡ B → A ≃ B
 eqweqmap {A = A} e = J (λ X _ → A ≃ X) (idEquiv A) e
 
-eqweqmapid : {A : Set ℓ} → eqweqmap refl ≡ idEquiv A
+eqweqmapid : {A : Type ℓ} → eqweqmap refl ≡ idEquiv A
 eqweqmapid {A = A} = JRefl (λ X _ → A ≃ X) (idEquiv A)
 
-univalenceStatement : {A B : Set ℓ} → isEquiv (eqweqmap {ℓ} {A} {B})
+univalenceStatement : {A B : Type ℓ} → isEquiv (eqweqmap {ℓ} {A} {B})
 univalenceStatement = Univalence.thm eqweqmap eqweqmapid
 
-univalenceUAH : {A B : Set ℓ} → (A ≡ B) ≃ (A ≃ B)
+univalenceUAH : {A B : Type ℓ} → (A ≡ B) ≃ (A ≃ B)
 univalenceUAH = ( _ , univalenceStatement )
 
 -- TODO: upstream
-record Lift {i j} (A : Set i) : Set (ℓ-max i j) where
+record Lift {i j} (A : Type i) : Type (ℓ-max i j) where
   instance constructor lift
   field
     lower : A
 
 open Lift public
 
-LiftEquiv : {A : Set ℓ} → A ≃ Lift {i = ℓ} {j = ℓ'} A
+LiftEquiv : {A : Type ℓ} → A ≃ Lift {i = ℓ} {j = ℓ'} A
 LiftEquiv = isoToEquiv (iso lift lower (λ _ → refl) (λ _ → refl))
 
-univalencePath : {A B : Set ℓ} → (A ≡ B) ≡ Lift (A ≃ B)
+univalencePath : {A B : Type ℓ} → (A ≡ B) ≡ Lift (A ≃ B)
 univalencePath = ua (compEquiv univalence LiftEquiv)
 
 -- The computation rule for ua. Because of "ghcomp" it is now very
 -- simple compared to cubicaltt:
 -- https://github.com/mortberg/cubicaltt/blob/master/examples/univalence.ctt#L202
-uaβ : {A B : Set ℓ} (e : A ≃ B) (x : A) → transport (ua e) x ≡ e .fst x
+uaβ : {A B : Type ℓ} (e : A ≃ B) (x : A) → transport (ua e) x ≡ e .fst x
 uaβ e x = transportRefl (e .fst x)
 
 -- Alternative version of EquivJ that only requires a predicate on
 -- functions
-elimEquiv : {B : Set ℓ} (P : {A : Set ℓ} → (A → B) → Set ℓ') →
-            (d : P (idfun B)) → {A : Set ℓ} → (e : A ≃ B) → P (e .fst)
+elimEquiv : {B : Type ℓ} (P : {A : Type ℓ} → (A → B) → Type ℓ') →
+            (d : P (idfun B)) → {A : Type ℓ} → (e : A ≃ B) → P (e .fst)
 elimEquiv P d e = subst (λ x → P (x .snd .fst)) (contrSinglEquiv e) d
 
 -- Isomorphism induction
-elimIso : {B : Set ℓ} → (Q : {A : Set ℓ} → (A → B) → (B → A) → Set ℓ') →
-          (h : Q (idfun B) (idfun B)) → {A : Set ℓ} →
+elimIso : {B : Type ℓ} → (Q : {A : Type ℓ} → (A → B) → (B → A) → Type ℓ') →
+          (h : Q (idfun B) (idfun B)) → {A : Type ℓ} →
           (f : A → B) → (g : B → A) → section f g → retract f g → Q f g
 elimIso {ℓ} {ℓ'} {B} Q h {A} f g sfg rfg = rem1 f g sfg rfg
   where
-  P : {A : Set ℓ} → (f : A → B) → Set (ℓ-max ℓ' ℓ)
+  P : {A : Type ℓ} → (f : A → B) → Type (ℓ-max ℓ' ℓ)
   P {A} f = (g : B → A) → section f g → retract f g → Q f g
 
   rem : P (idfun B)
   rem g sfg rfg = subst (Q (idfun B)) (λ i b → (sfg b) (~ i)) h
 
-  rem1 : {A : Set ℓ} → (f : A → B) → P f
+  rem1 : {A : Type ℓ} → (f : A → B) → P f
   rem1 f g sfg rfg = elimEquiv P rem (f , isoToIsEquiv (iso f g sfg rfg)) g sfg rfg

--- a/Cubical/Foundations/UnivalenceId.agda
+++ b/Cubical/Foundations/UnivalenceId.agda
@@ -16,18 +16,18 @@ open import Cubical.Foundations.Univalence
   renaming ( EquivContr   to EquivContrPath )
 open import Cubical.Foundations.Isomorphism
 
-path≡Id : ∀ {ℓ} {A B : Set ℓ} → Path _ (Path _ A B) (Id A B)
+path≡Id : ∀ {ℓ} {A B : Type ℓ} → Path _ (Path _ A B) (Id A B)
 path≡Id = isoToPath (iso pathToId idToPath idToPathToId pathToIdToPath )
 
-equivPathToEquivPath : ∀ {ℓ} {A : Set ℓ} {B : Set ℓ} → (p : EquivPath A B) →
+equivPathToEquivPath : ∀ {ℓ} {A : Type ℓ} {B : Type ℓ} → (p : EquivPath A B) →
                        Path _ (equivToEquivPath (equivPathToEquiv p)) p
 equivPathToEquivPath (f , p) i =
   ( f , isPropIsEquivPath f (equivToEquivPath (equivPathToEquiv (f , p)) .snd) p i )
 
-equivPath≡Equiv : ∀ {ℓ} {A B : Set ℓ} → Path _ (EquivPath A B) (A ≃ B)
+equivPath≡Equiv : ∀ {ℓ} {A B : Type ℓ} → Path _ (EquivPath A B) (A ≃ B)
 equivPath≡Equiv {ℓ} = isoToPath (iso (equivPathToEquiv {ℓ}) equivToEquivPath equivToEquiv equivPathToEquivPath)
 
-univalenceId : ∀ {ℓ} {A B : Set ℓ} → (A ≡ B) ≃ (A ≃ B)
+univalenceId : ∀ {ℓ} {A B : Type ℓ} → (A ≡ B) ≃ (A ≃ B)
 univalenceId {ℓ} {A = A} {B = B} = equivPathToEquiv rem
   where
   rem0 : Path _ (Lift (EquivPath A B)) (Lift (A ≃ B))

--- a/Cubical/HITs/2GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Base.agda
@@ -12,6 +12,6 @@ open import Cubical.Foundations.Prelude
 
 -- 2-groupoid truncation as a higher inductive type:
 
-data ∥_∥₂ {ℓ} (A : Set ℓ) : Set ℓ where
+data ∥_∥₂ {ℓ} (A : Type ℓ) : Type ℓ where
   ∣_∣₂ : A → ∥ A ∥₂
   squash₂ : ∀ (x y : ∥ A ∥₂) (p q : x ≡ y) (r s : p ≡ q) (t u : r ≡ s) → t ≡ u

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -11,7 +11,7 @@ module Cubical.HITs.2GroupoidTruncation.Properties where
 open import Cubical.Foundations.Prelude
 open import Cubical.HITs.2GroupoidTruncation.Base
 
-rec2GroupoidTrunc : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (gB : is2Groupoid B) → (A → B) → (∥ A ∥₂ → B)
+rec2GroupoidTrunc : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (gB : is2Groupoid B) → (A → B) → (∥ A ∥₂ → B)
 rec2GroupoidTrunc gB f ∣ x ∣₂ = f x
 rec2GroupoidTrunc gB f (squash₂ _ _ _ _ _ _ t u i j k l) =
   gB _ _ _ _ _ _
@@ -19,7 +19,7 @@ rec2GroupoidTrunc gB f (squash₂ _ _ _ _ _ _ t u i j k l) =
     (λ m n o → rec2GroupoidTrunc gB f (u m n o))
     i j k l
 
-g2TruncFib : ∀ {ℓ ℓ'} {A : Set ℓ} (P : A → Set ℓ')
+g2TruncFib : ∀ {ℓ ℓ'} {A : Type ℓ} (P : A → Type ℓ')
              {a b : A} (sPb : is2Groupoid (P b))
              {p q : a ≡ b} {r s : p ≡ q} {u v : r ≡ s} (w : u ≡ v) {a1 : P a} {b1 : P b}
              {p1 : PathP (λ i → P (p i)) a1 b1}
@@ -63,7 +63,7 @@ g2TruncFib {A} P {a} {b} sPb {p} {q} {r} {s} {u} {v} w
                              })
                     (inS a1) l
 
-g2TruncElim : ∀ {ℓ ℓ'} (A : Set ℓ) (B : ∥ A ∥₂ → Set ℓ')
+g2TruncElim : ∀ {ℓ ℓ'} (A : Type ℓ) (B : ∥ A ∥₂ → Type ℓ')
                     (bG : (x : ∥ A ∥₂) → is2Groupoid (B x))
                     (f : (x : A) → B ∣ x ∣₂) (x : ∥ A ∥₂) → B x
 g2TruncElim A B bG f ∣ x ∣₂ = f x

--- a/Cubical/HITs/Cylinder/Base.agda
+++ b/Cubical/HITs/Cylinder/Base.agda
@@ -16,7 +16,7 @@ open import Cubical.HITs.Interval
 -- Cylinder A is a cylinder object in the category of cubical types.
 --
 --   https://ncatlab.org/nlab/show/cylinder+object
-data Cylinder {ℓ} (A : Set ℓ) : Set ℓ where
+data Cylinder {ℓ} (A : Type ℓ) : Type ℓ where
   inl : A → Cylinder A
   inr : A → Cylinder A
   cross : ∀ x → inl x ≡ inr x
@@ -24,10 +24,10 @@ data Cylinder {ℓ} (A : Set ℓ) : Set ℓ where
 -- Dual to this is the cocylinder or path space object.
 --
 --   https://ncatlab.org/nlab/show/path+space+object
-Cocylinder : ∀ {ℓ} → Set ℓ → Set ℓ
+Cocylinder : ∀ {ℓ} → Type ℓ → Type ℓ
 Cocylinder A = Interval → A
 
-module _ {ℓ} {A : Set ℓ} where
+module _ {ℓ} {A : Type ℓ} where
   -- The cylinder is part of a factorization of the obvious mapping
   -- of type A ⊎ A → A into a pair of mappings:
   --
@@ -49,7 +49,7 @@ module _ {ℓ} {A : Set ℓ} where
       i
 
   elimCyl
-    : ∀{ℓ'} {B : Cylinder A → Set ℓ'}
+    : ∀{ℓ'} {B : Cylinder A → Type ℓ'}
     → (f : (x : A) → B (inl x))
     → (g : (x : A) → B (inr x))
     → (p : ∀ x → PathP (λ i → B (cross x i)) (f x) (g x))
@@ -113,9 +113,9 @@ module Functorial where
   private
     variable
       ℓa ℓb ℓc : Level
-      A : Set ℓa
-      B : Set ℓb
-      C : Set ℓc
+      A : Type ℓa
+      B : Type ℓb
+      C : Type ℓc
 
   mapCylinder : (A → B) → Cylinder A → Cylinder B
   mapCylinder f (inl x) = inl (f x)
@@ -190,9 +190,9 @@ module IntervalEquiv where
 
   -- More generally, there is an equivalence between the cylinder
   -- over any type A and the product of A and the interval.
-  module _ {ℓ} {A : Set ℓ} where
+  module _ {ℓ} {A : Type ℓ} where
     private
-      Cyl : Set ℓ
+      Cyl : Type ℓ
       Cyl = A × Interval
 
     CylinderA→A×Interval : Cylinder A → Cyl
@@ -226,14 +226,14 @@ module IntervalEquiv where
              CylinderA→A×Interval→CylinderA)
 
 -- The cylinder is also the pushout of the identity on A with itself.
-module Push {ℓ} {A : Set ℓ} where
+module Push {ℓ} {A : Type ℓ} where
   open import Cubical.HITs.Pushout
 
   private
-    Push : Set ℓ
+    Push : Type ℓ
     Push = Pushout (λ(x : A) → x) (λ x → x)
 
-    Cyl : Set ℓ
+    Cyl : Type ℓ
     Cyl = Cylinder A
 
   Cylinder→Pushout : Cyl → Push

--- a/Cubical/HITs/Everything.agda
+++ b/Cubical/HITs/Everything.agda
@@ -21,3 +21,4 @@ open import Cubical.HITs.SetTruncation public
 open import Cubical.HITs.GroupoidTruncation public
 open import Cubical.HITs.2GroupoidTruncation public
 open import Cubical.HITs.SetQuotients public
+open import Cubical.HITs.FiniteMultiset public hiding ( _++_ ; [_] ; assoc-++ )

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -1,48 +1,48 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.FiniteMultiset.Base where
 
-open import Cubical.Core.Everything
-open import Cubical.HITs.TypeTruncation
+open import Cubical.Foundations.Prelude
+open import Cubical.HITs.SetTruncation
 
 private
   variable
-    A : Type
+    A : Type₀
 
 infixr 20 _∷_
 
-data FMType (A : Type) : Type where
-  []    : FMType A
-  _∷_   : (x : A) → (xs : FMType A) → FMType A
+data FMSet (A : Type₀) : Type₀ where
+  []    : FMSet A
+  _∷_   : (x : A) → (xs : FMSet A) → FMSet A
   comm  : ∀ x y xs → x ∷ y ∷ xs ≡ y ∷ x ∷ xs
-  trunc : isType (FMType A)
+  trunc : isSet (FMSet A)
 
 pattern [_] x = x ∷ []
 
-module FMTypeElim {ℓ} {B : FMType A → Type ℓ}
-  ([]* : B []) (_∷*_ : (x : A) {xs : FMType A} → B xs → B (x ∷ xs))
-  (comm* : (x y : A) {xs : FMType A} (b : B xs)
+module FMSetElim {ℓ} {B : FMSet A → Type ℓ}
+  ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs))
+  (comm* : (x y : A) {xs : FMSet A} (b : B xs)
          → PathP (λ i → B (comm x y xs i)) (x ∷* (y ∷* b)) (y ∷* (x ∷* b)))
-  (trunc* : (xs : FMType A) → isType (B xs)) where
+  (trunc* : (xs : FMSet A) → isSet (B xs)) where
 
-  f : (xs : FMType A) → B xs
+  f : (xs : FMSet A) → B xs
   f [] = []*
   f (x ∷ xs) = x ∷* f xs
   f (comm x y xs i) = comm* x y (f xs) i
   f (trunc xs zs p q i j) =
     elimSquash₀ trunc* (trunc xs zs p q) (f xs) (f zs) (cong f p) (cong f q) i j
 
-module FMTypeElimProp {ℓ} {B : FMType A → Type ℓ} (BProp : {xs : FMType A} → isProp (B xs))
-  ([]* : B []) (_∷*_ : (x : A) {xs : FMType A} → B xs → B (x ∷ xs)) where
+module FMSetElimProp {ℓ} {B : FMSet A → Type ℓ} (BProp : {xs : FMSet A} → isProp (B xs))
+  ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs)) where
 
-  f : (xs : FMType A) → B xs
-  f = FMTypeElim.f []* _∷*_
+  f : (xs : FMSet A) → B xs
+  f = FMSetElim.f []* _∷*_
         (λ x y {xs} b →
           toPathP (BProp (transp (λ i → B (comm x y xs i)) i0 (x ∷* (y ∷* b))) (y ∷* (x ∷* b))))
-        (λ xs → isProp→isType BProp)
+        (λ xs → isProp→isSet BProp)
 
-module FMTypeRec {ℓ} {B : Type ℓ} (BType : isType B)
+module FMSetRec {ℓ} {B : Type ℓ} (BType : isSet B)
   ([]* : B) (_∷*_ : A → B → B)
   (comm* : (x y : A) (b : B) → x ∷* (y ∷* b) ≡ y ∷* (x ∷* b)) where
 
-  f : FMType A → B
-  f = FMTypeElim.f []* (λ x b → x ∷* b) (λ x y b → comm* x y b) (λ _ → BType)
+  f : FMSet A → B
+  f = FMSetElim.f []* (λ x b → x ∷* b) (λ x y b → comm* x y b) (λ _ → BType)

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -2,47 +2,47 @@
 module Cubical.HITs.FiniteMultiset.Base where
 
 open import Cubical.Core.Everything
-open import Cubical.HITs.SetTruncation
+open import Cubical.HITs.TypeTruncation
 
 private
   variable
-    A : Set
+    A : Type
 
 infixr 20 _∷_
 
-data FMSet (A : Set) : Set where
-  []    : FMSet A
-  _∷_   : (x : A) → (xs : FMSet A) → FMSet A
+data FMType (A : Type) : Type where
+  []    : FMType A
+  _∷_   : (x : A) → (xs : FMType A) → FMType A
   comm  : ∀ x y xs → x ∷ y ∷ xs ≡ y ∷ x ∷ xs
-  trunc : isSet (FMSet A)
+  trunc : isType (FMType A)
 
 pattern [_] x = x ∷ []
 
-module FMSetElim {ℓ} {B : FMSet A → Set ℓ}
-  ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs))
-  (comm* : (x y : A) {xs : FMSet A} (b : B xs)
+module FMTypeElim {ℓ} {B : FMType A → Type ℓ}
+  ([]* : B []) (_∷*_ : (x : A) {xs : FMType A} → B xs → B (x ∷ xs))
+  (comm* : (x y : A) {xs : FMType A} (b : B xs)
          → PathP (λ i → B (comm x y xs i)) (x ∷* (y ∷* b)) (y ∷* (x ∷* b)))
-  (trunc* : (xs : FMSet A) → isSet (B xs)) where
+  (trunc* : (xs : FMType A) → isType (B xs)) where
 
-  f : (xs : FMSet A) → B xs
+  f : (xs : FMType A) → B xs
   f [] = []*
   f (x ∷ xs) = x ∷* f xs
   f (comm x y xs i) = comm* x y (f xs) i
   f (trunc xs zs p q i j) =
     elimSquash₀ trunc* (trunc xs zs p q) (f xs) (f zs) (cong f p) (cong f q) i j
 
-module FMSetElimProp {ℓ} {B : FMSet A → Set ℓ} (BProp : {xs : FMSet A} → isProp (B xs))
-  ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs)) where
+module FMTypeElimProp {ℓ} {B : FMType A → Type ℓ} (BProp : {xs : FMType A} → isProp (B xs))
+  ([]* : B []) (_∷*_ : (x : A) {xs : FMType A} → B xs → B (x ∷ xs)) where
 
-  f : (xs : FMSet A) → B xs
-  f = FMSetElim.f []* _∷*_
+  f : (xs : FMType A) → B xs
+  f = FMTypeElim.f []* _∷*_
         (λ x y {xs} b →
           toPathP (BProp (transp (λ i → B (comm x y xs i)) i0 (x ∷* (y ∷* b))) (y ∷* (x ∷* b))))
-        (λ xs → isProp→isSet BProp)
+        (λ xs → isProp→isType BProp)
 
-module FMSetRec {ℓ} {B : Set ℓ} (BSet : isSet B)
+module FMTypeRec {ℓ} {B : Type ℓ} (BType : isType B)
   ([]* : B) (_∷*_ : A → B → B)
   (comm* : (x y : A) (b : B) → x ∷* (y ∷* b) ≡ y ∷* (x ∷* b)) where
 
-  f : FMSet A → B
-  f = FMSetElim.f []* (λ x b → x ∷* b) (λ x y b → comm* x y b) (λ _ → BSet)
+  f : FMType A → B
+  f = FMTypeElim.f []* (λ x b → x ∷* b) (λ x y b → comm* x y b) (λ _ → BType)

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -1,57 +1,57 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.FiniteMultiset.Properties where
 
-open import Cubical.Core.Everything
+open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 
 open import Cubical.HITs.FiniteMultiset.Base
 
 private
   variable
-    A : Type
+    A : Type₀
 
 infixr 30 _++_
 
-_++_ : ∀ (xs ys : FMType A) → FMType A
+_++_ : ∀ (xs ys : FMSet A) → FMSet A
 [] ++ ys = ys
 (x ∷ xs) ++ ys = x ∷ xs ++ ys
 comm x y xs i ++ ys = comm x y (xs ++ ys) i
 trunc xs zs p q i j ++ ys =
   trunc (xs ++ ys) (zs ++ ys) (cong (_++ ys) p) (cong (_++ ys) q) i j
 
-unitl-++ : ∀ (xs : FMType A) → [] ++ xs ≡ xs
+unitl-++ : ∀ (xs : FMSet A) → [] ++ xs ≡ xs
 unitl-++ xs = refl
 
-unitr-++ : ∀ (xs : FMType A) → xs ++ [] ≡ xs
-unitr-++ = FMTypeElimProp.f (trunc _ _)
+unitr-++ : ∀ (xs : FMSet A) → xs ++ [] ≡ xs
+unitr-++ = FMSetElimProp.f (trunc _ _)
   refl
   (λ x p → cong (_∷_ x) p)
 
-assoc-++ : ∀ (xs ys zs : FMType A) → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
-assoc-++ = FMTypeElimProp.f (propPi (λ _ → propPi (λ _ → trunc _ _)))
+assoc-++ : ∀ (xs ys zs : FMSet A) → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+assoc-++ = FMSetElimProp.f (propPi (λ _ → propPi (λ _ → trunc _ _)))
   (λ ys zs → refl)
   (λ x p ys zs → cong (_∷_ x) (p ys zs))
 
-cons-++ : ∀ (x : A) (xs : FMType A) → x ∷ xs ≡ xs ++ [ x ]
-cons-++ x = FMTypeElimProp.f (trunc _ _)
+cons-++ : ∀ (x : A) (xs : FMSet A) → x ∷ xs ≡ xs ++ [ x ]
+cons-++ x = FMSetElimProp.f (trunc _ _)
   refl
   (λ y {xs} p → comm x y xs ∙ cong (_∷_ y) p)
 
-comm-++ : ∀ (xs ys : FMType A) → xs ++ ys ≡ ys ++ xs
-comm-++ = FMTypeElimProp.f (propPi (λ _ → trunc _ _))
+comm-++ : ∀ (xs ys : FMSet A) → xs ++ ys ≡ ys ++ xs
+comm-++ = FMSetElimProp.f (propPi (λ _ → trunc _ _))
   (λ ys → sym (unitr-++ ys))
   (λ x {xs} p ys → cong (x ∷_) (p ys)
                  ∙ cong (_++ xs) (cons-++ x ys)
                  ∙ sym (assoc-++ ys [ x ] xs))
 
-module FMTypeUniversal {ℓ} {M : Type ℓ} (MType : isType M)
+module FMSetUniversal {ℓ} {M : Type ℓ} (MType : isSet M)
   (e : M) (_⊗_ : M → M → M)
   (comm-⊗ : ∀ x y → x ⊗ y ≡ y ⊗ x) (assoc-⊗ : ∀ x y z → x ⊗ (y ⊗ z) ≡ (x ⊗ y) ⊗ z)
   (unit-⊗ : ∀ x → e ⊗ x ≡ x)
   (f : A → M) where
 
-  f-extend : FMType A → M
-  f-extend = FMTypeRec.f MType e (λ x m → f x ⊗ m)
+  f-extend : FMSet A → M
+  f-extend = FMSetRec.f MType e (λ x m → f x ⊗ m)
          (λ x y m → comm-⊗ (f x) (f y ⊗ m) ∙ sym (assoc-⊗ (f y) m (f x)) ∙ cong (f y ⊗_) (comm-⊗ m (f x)))
 
   f-extend-nil : f-extend [] ≡ e
@@ -64,14 +64,14 @@ module FMTypeUniversal {ℓ} {M : Type ℓ} (MType : isType M)
   f-extend-sing x = comm-⊗ (f x) e ∙ unit-⊗ (f x)
 
   f-extend-++ : ∀ xs ys → f-extend (xs ++ ys) ≡ f-extend xs ⊗ f-extend ys
-  f-extend-++ = FMTypeElimProp.f (propPi λ _ → MType _ _)
+  f-extend-++ = FMSetElimProp.f (propPi λ _ → MType _ _)
     (λ ys → sym (unit-⊗ (f-extend ys)))
     (λ x {xs} p ys → cong (f x ⊗_) (p ys) ∙ assoc-⊗ (f x) (f-extend xs) (f-extend ys))
 
-  module _ (h : FMType A → M) (h-nil : h [] ≡ e) (h-sing : ∀ x → h [ x ] ≡ f x)
+  module _ (h : FMSet A → M) (h-nil : h [] ≡ e) (h-sing : ∀ x → h [ x ] ≡ f x)
            (h-++ : ∀ xs ys → h (xs ++ ys) ≡ h xs ⊗ h ys) where
 
     f-extend-unique : h ≡ f-extend
-    f-extend-unique = funExt (FMTypeElimProp.f (MType _ _)
+    f-extend-unique = funExt (FMSetElimProp.f (MType _ _)
                               h-nil
                               (λ x {xs} p → (h-++ [ x ] xs) ∙ cong (_⊗ h xs) (h-sing x) ∙ cong (f x ⊗_) p))

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -8,50 +8,50 @@ open import Cubical.HITs.FiniteMultiset.Base
 
 private
   variable
-    A : Set
+    A : Type
 
 infixr 30 _++_
 
-_++_ : ∀ (xs ys : FMSet A) → FMSet A
+_++_ : ∀ (xs ys : FMType A) → FMType A
 [] ++ ys = ys
 (x ∷ xs) ++ ys = x ∷ xs ++ ys
 comm x y xs i ++ ys = comm x y (xs ++ ys) i
 trunc xs zs p q i j ++ ys =
   trunc (xs ++ ys) (zs ++ ys) (cong (_++ ys) p) (cong (_++ ys) q) i j
 
-unitl-++ : ∀ (xs : FMSet A) → [] ++ xs ≡ xs
+unitl-++ : ∀ (xs : FMType A) → [] ++ xs ≡ xs
 unitl-++ xs = refl
 
-unitr-++ : ∀ (xs : FMSet A) → xs ++ [] ≡ xs
-unitr-++ = FMSetElimProp.f (trunc _ _)
+unitr-++ : ∀ (xs : FMType A) → xs ++ [] ≡ xs
+unitr-++ = FMTypeElimProp.f (trunc _ _)
   refl
   (λ x p → cong (_∷_ x) p)
 
-assoc-++ : ∀ (xs ys zs : FMSet A) → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
-assoc-++ = FMSetElimProp.f (propPi (λ _ → propPi (λ _ → trunc _ _)))
+assoc-++ : ∀ (xs ys zs : FMType A) → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+assoc-++ = FMTypeElimProp.f (propPi (λ _ → propPi (λ _ → trunc _ _)))
   (λ ys zs → refl)
   (λ x p ys zs → cong (_∷_ x) (p ys zs))
 
-cons-++ : ∀ (x : A) (xs : FMSet A) → x ∷ xs ≡ xs ++ [ x ]
-cons-++ x = FMSetElimProp.f (trunc _ _)
+cons-++ : ∀ (x : A) (xs : FMType A) → x ∷ xs ≡ xs ++ [ x ]
+cons-++ x = FMTypeElimProp.f (trunc _ _)
   refl
   (λ y {xs} p → comm x y xs ∙ cong (_∷_ y) p)
 
-comm-++ : ∀ (xs ys : FMSet A) → xs ++ ys ≡ ys ++ xs
-comm-++ = FMSetElimProp.f (propPi (λ _ → trunc _ _))
+comm-++ : ∀ (xs ys : FMType A) → xs ++ ys ≡ ys ++ xs
+comm-++ = FMTypeElimProp.f (propPi (λ _ → trunc _ _))
   (λ ys → sym (unitr-++ ys))
   (λ x {xs} p ys → cong (x ∷_) (p ys)
                  ∙ cong (_++ xs) (cons-++ x ys)
                  ∙ sym (assoc-++ ys [ x ] xs))
 
-module FMSetUniversal {ℓ} {M : Set ℓ} (MSet : isSet M)
+module FMTypeUniversal {ℓ} {M : Type ℓ} (MType : isType M)
   (e : M) (_⊗_ : M → M → M)
   (comm-⊗ : ∀ x y → x ⊗ y ≡ y ⊗ x) (assoc-⊗ : ∀ x y z → x ⊗ (y ⊗ z) ≡ (x ⊗ y) ⊗ z)
   (unit-⊗ : ∀ x → e ⊗ x ≡ x)
   (f : A → M) where
 
-  f-extend : FMSet A → M
-  f-extend = FMSetRec.f MSet e (λ x m → f x ⊗ m)
+  f-extend : FMType A → M
+  f-extend = FMTypeRec.f MType e (λ x m → f x ⊗ m)
          (λ x y m → comm-⊗ (f x) (f y ⊗ m) ∙ sym (assoc-⊗ (f y) m (f x)) ∙ cong (f y ⊗_) (comm-⊗ m (f x)))
 
   f-extend-nil : f-extend [] ≡ e
@@ -64,14 +64,14 @@ module FMSetUniversal {ℓ} {M : Set ℓ} (MSet : isSet M)
   f-extend-sing x = comm-⊗ (f x) e ∙ unit-⊗ (f x)
 
   f-extend-++ : ∀ xs ys → f-extend (xs ++ ys) ≡ f-extend xs ⊗ f-extend ys
-  f-extend-++ = FMSetElimProp.f (propPi λ _ → MSet _ _)
+  f-extend-++ = FMTypeElimProp.f (propPi λ _ → MType _ _)
     (λ ys → sym (unit-⊗ (f-extend ys)))
     (λ x {xs} p ys → cong (f x ⊗_) (p ys) ∙ assoc-⊗ (f x) (f-extend xs) (f-extend ys))
 
-  module _ (h : FMSet A → M) (h-nil : h [] ≡ e) (h-sing : ∀ x → h [ x ] ≡ f x)
+  module _ (h : FMType A → M) (h-nil : h [] ≡ e) (h-sing : ∀ x → h [ x ] ≡ f x)
            (h-++ : ∀ xs ys → h (xs ++ ys) ≡ h xs ⊗ h ys) where
 
     f-extend-unique : h ≡ f-extend
-    f-extend-unique = funExt (FMSetElimProp.f (MSet _ _)
+    f-extend-unique = funExt (FMTypeElimProp.f (MType _ _)
                               h-nil
                               (λ x {xs} p → (h-++ [ x ] xs) ∙ cong (_⊗ h xs) (h-sing x) ∙ cong (f x ⊗_) p))

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -44,14 +44,14 @@ comm-++ = FMSetElimProp.f (propPi (λ _ → trunc _ _))
                  ∙ cong (_++ xs) (cons-++ x ys)
                  ∙ sym (assoc-++ ys [ x ] xs))
 
-module FMSetUniversal {ℓ} {M : Type ℓ} (MType : isSet M)
+module FMSetUniversal {ℓ} {M : Type ℓ} (MSet : isSet M)
   (e : M) (_⊗_ : M → M → M)
   (comm-⊗ : ∀ x y → x ⊗ y ≡ y ⊗ x) (assoc-⊗ : ∀ x y z → x ⊗ (y ⊗ z) ≡ (x ⊗ y) ⊗ z)
   (unit-⊗ : ∀ x → e ⊗ x ≡ x)
   (f : A → M) where
 
   f-extend : FMSet A → M
-  f-extend = FMSetRec.f MType e (λ x m → f x ⊗ m)
+  f-extend = FMSetRec.f MSet e (λ x m → f x ⊗ m)
          (λ x y m → comm-⊗ (f x) (f y ⊗ m) ∙ sym (assoc-⊗ (f y) m (f x)) ∙ cong (f y ⊗_) (comm-⊗ m (f x)))
 
   f-extend-nil : f-extend [] ≡ e
@@ -64,7 +64,7 @@ module FMSetUniversal {ℓ} {M : Type ℓ} (MType : isSet M)
   f-extend-sing x = comm-⊗ (f x) e ∙ unit-⊗ (f x)
 
   f-extend-++ : ∀ xs ys → f-extend (xs ++ ys) ≡ f-extend xs ⊗ f-extend ys
-  f-extend-++ = FMSetElimProp.f (propPi λ _ → MType _ _)
+  f-extend-++ = FMSetElimProp.f (propPi λ _ → MSet _ _)
     (λ ys → sym (unit-⊗ (f-extend ys)))
     (λ x {xs} p ys → cong (f x ⊗_) (p ys) ∙ assoc-⊗ (f x) (f-extend xs) (f-extend ys))
 
@@ -72,6 +72,6 @@ module FMSetUniversal {ℓ} {M : Type ℓ} (MType : isSet M)
            (h-++ : ∀ xs ys → h (xs ++ ys) ≡ h xs ⊗ h ys) where
 
     f-extend-unique : h ≡ f-extend
-    f-extend-unique = funExt (FMSetElimProp.f (MType _ _)
+    f-extend-unique = funExt (FMSetElimProp.f (MSet _ _)
                               h-nil
                               (λ x {xs} p → (h-++ [ x ] xs) ∙ cong (_⊗ h xs) (h-sing x) ∙ cong (f x ⊗_) p))

--- a/Cubical/HITs/GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/GroupoidTruncation/Base.agda
@@ -12,6 +12,6 @@ open import Cubical.Core.Primitives
 
 -- groupoid truncation as a higher inductive type:
 
-data ∥_∥₁ {ℓ} (A : Set ℓ) : Set ℓ where
+data ∥_∥₁ {ℓ} (A : Type ℓ) : Type ℓ where
   ∣_∣₁ : A → ∥ A ∥₁
   squash₁ : ∀ (x y : ∥ A ∥₁) (p q : x ≡ y) (r s : p ≡ q) → r ≡ s

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -11,7 +11,7 @@ module Cubical.HITs.GroupoidTruncation.Properties where
 open import Cubical.Foundations.Prelude
 open import Cubical.HITs.GroupoidTruncation.Base
 
-recGroupoidTrunc : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (gB : isGroupoid B) → (A → B) → (∥ A ∥₁ → B)
+recGroupoidTrunc : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (gB : isGroupoid B) → (A → B) → (∥ A ∥₁ → B)
 recGroupoidTrunc gB f ∣ x ∣₁ = f x
 recGroupoidTrunc gB f (squash₁ _ _ _ _ r s i j k) =
   gB _ _ _ _
@@ -19,7 +19,7 @@ recGroupoidTrunc gB f (squash₁ _ _ _ _ r s i j k) =
     (λ m n → recGroupoidTrunc gB f (s m n))
     i j k
 
-groupoidTruncFib : ∀ {ℓ ℓ'} {A : Set ℓ} (P : A → Set ℓ')
+groupoidTruncFib : ∀ {ℓ ℓ'} {A : Type ℓ} (P : A → Type ℓ')
               {a b : A} (sPb : isGroupoid (P b))
               {p q : a ≡ b} {r s : p ≡ q} (u : r ≡ s) {a1 : P a} {b1 : P b}
               {p1 : PathP (λ i → P (p i)) a1 b1}
@@ -52,7 +52,7 @@ groupoidTruncFib P {a} {b} sPb u {a1} {b1} {p1} {q1} r1 s1 i j k =
                            ; (j = i1) → q1 k })
                   (inS a1) k
 
-groupoidTruncElim : ∀ {ℓ ℓ'} (A : Set ℓ) (B : ∥ A ∥₁ → Set ℓ')
+groupoidTruncElim : ∀ {ℓ ℓ'} (A : Type ℓ) (B : ∥ A ∥₁ → Type ℓ')
                     (bG : (x : ∥ A ∥₁) → isGroupoid (B x))
                     (f : (x : A) → B ∣ x ∣₁) (x : ∥ A ∥₁) → B x
 groupoidTruncElim A B bG f (∣ x ∣₁) = f x

--- a/Cubical/HITs/HitInt/Base.agda
+++ b/Cubical/HITs/HitInt/Base.agda
@@ -12,17 +12,17 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Data.Int
 open import Cubical.Data.Nat
 
-data ℤ : Set where
+data ℤ : Type₀ where
   pos    : (n : ℕ) → ℤ
   neg    : (n : ℕ) → ℤ
   posneg : pos 0 ≡ neg 0
 
-recℤ : ∀ {l} {A : Set l} → (pos' neg' : ℕ → A) → pos' 0 ≡ neg' 0 → ℤ → A
+recℤ : ∀ {l} {A : Type l} → (pos' neg' : ℕ → A) → pos' 0 ≡ neg' 0 → ℤ → A
 recℤ pos' neg' eq (pos m)    = pos' m
 recℤ pos' neg' eq (neg m)    = neg' m
 recℤ pos' neg' eq (posneg i) = eq i
 
-indℤ : ∀ {l} (P : ℤ → Set l)
+indℤ : ∀ {l} (P : ℤ → Type l)
        → (pos' : ∀ n → P (pos n))
        → (neg' : ∀ n → P (neg n))
        → (λ i → P (posneg i)) [ pos' 0 ≡ neg' 0 ]
@@ -54,8 +54,8 @@ Int→ℤ→Int (negsuc n) _ = negsuc n
 Int≡ℤ : Int ≡ ℤ
 Int≡ℤ = isoToPath (iso Int→ℤ ℤ→Int ℤ→Int→ℤ Int→ℤ→Int)
 
-isSetℤ : isSet ℤ
-isSetℤ = subst isSet Int≡ℤ isSetInt
+isTypeℤ : isType ℤ
+isTypeℤ = subst isType Int≡ℤ isTypeInt
 
 sucℤ : ℤ → ℤ
 sucℤ (pos n)       = pos (suc n)
@@ -125,7 +125,7 @@ isEquiv+ℤ = subst (λ _+_ → (m : ℤ) → isEquiv (λ n → n + m)) addℤ�
 
 
 
-data Sign : Set where
+data Sign : Type₀ where
   pos neg : Sign
 
 sign : ℤ → Sign

--- a/Cubical/HITs/HitInt/Base.agda
+++ b/Cubical/HITs/HitInt/Base.agda
@@ -54,8 +54,8 @@ Int→ℤ→Int (negsuc n) _ = negsuc n
 Int≡ℤ : Int ≡ ℤ
 Int≡ℤ = isoToPath (iso Int→ℤ ℤ→Int ℤ→Int→ℤ Int→ℤ→Int)
 
-isTypeℤ : isType ℤ
-isTypeℤ = subst isType Int≡ℤ isTypeInt
+isSetℤ : isSet ℤ
+isSetℤ = subst isSet Int≡ℤ isSetInt
 
 sucℤ : ℤ → ℤ
 sucℤ (pos n)       = pos (suc n)

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -83,9 +83,9 @@ JoinS¹S¹→TotalHopf (push y x j) =
 fibInt : S¹ → S¹ → Type₀
 fibInt _ _ = Int
 
-S¹→HType : (A : Type₀) (p : isType A) (F : S¹ → A) (x : S¹) → F base ≡ F x
-S¹→HType A p F base = refl {x = F base}
-S¹→HType A p F (loop i) = f' i
+S¹→HSet : (A : Type₀) (p : isType A) (F : S¹ → A) (x : S¹) → F base ≡ F x
+S¹→HSet A p F base = refl {x = F base}
+S¹→HSet A p F (loop i) = f' i
   where
   f : PathP (λ i → F base ≡ F (loop i)) refl (cong F loop)
   f i = λ j → F (loop (i ∧ j))
@@ -100,11 +100,11 @@ constant-loop F x y = L0 ∙ L1
   p : isType (S¹ → Int)
   p = hLevelPi 2 (λ _ → isTypeInt)
   L : F base ≡ F x
-  L = S¹→HType (S¹ → Int) p F x
+  L = S¹→HSet (S¹ → Int) p F x
   L0 : F base base ≡ F x base
   L0 i = L i base
   L1 : F x base ≡ F x y
-  L1 = S¹→HType Int isTypeInt (F x) y
+  L1 = S¹→HSet Int isTypeInt (F x) y
 
 discretefib : (F : S¹ → S¹ → Type₀) → Type₀
 discretefib F = (a : (x y : S¹) → F x y) →

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -19,19 +19,19 @@ open import Cubical.HITs.Join
 open import Cubical.HITs.Interval
   renaming ( zero to I0 ; one to I1 )
 
-Border : (x : S¹) → (j : I) → Partial (j ∨ ~ j) (Σ Set (λ T → T ≃ S¹))
+Border : (x : S¹) → (j : I) → Partial (j ∨ ~ j) (Σ Type₀ (λ T → T ≃ S¹))
 Border x j (j = i0) = S¹ , rot x , rotIsEquiv x
 Border x j (j = i1) = S¹ , idEquiv S¹
 
 -- Hopf fibration using SuspS¹
-HopfSuspS¹ : SuspS¹ → Set
+HopfSuspS¹ : SuspS¹ → Type₀
 HopfSuspS¹ north = S¹
 HopfSuspS¹ south = S¹
 HopfSuspS¹ (merid x j) = Glue S¹ (Border x j)
 
 -- Hopf fibration using S²
 -- TODO : prove that it is equivalent to HopfSuspS¹
-HopfS² : S² → Set
+HopfS² : S² → Type₀
 HopfS² base = S¹
 HopfS² (surf i j) = Glue S¹ (λ { (i = i0) → _ , idEquiv S¹
                                ; (i = i1) → _ , idEquiv S¹
@@ -40,7 +40,7 @@ HopfS² (surf i j) = Glue S¹ (λ { (i = i0) → _ , idEquiv S¹
 
 -- Hopf fibration using more direct definition of the rot equivalence
 -- TODO : prove that it is equivalent to HopfSuspS¹
-HopfS²' : S² → Set
+HopfS²' : S² → Type₀
 HopfS²' base = S¹
 HopfS²' (surf i j) = Glue S¹ (λ { (i = i0) → _ , rotLoopEquiv i0
                                 ; (i = i1) → _ , rotLoopEquiv i0
@@ -48,7 +48,7 @@ HopfS²' (surf i j) = Glue S¹ (λ { (i = i0) → _ , rotLoopEquiv i0
                                 ; (j = i1) → _ , rotLoopEquiv i } )
 
 -- Total space of the fibration
-TotalHopf : Set
+TotalHopf : Type₀
 TotalHopf = Σ SuspS¹ HopfSuspS¹
 
 -- Forward direction
@@ -80,12 +80,12 @@ JoinS¹S¹→TotalHopf (push y x j) =
 
 -- this should be generalized to a constant fibration over a connected space with
 -- discrete fiber
-fibInt : S¹ → S¹ → Set
+fibInt : S¹ → S¹ → Type₀
 fibInt _ _ = Int
 
-S¹→HSet : (A : Set) (p : isSet A) (F : S¹ → A) (x : S¹) → F base ≡ F x
-S¹→HSet A p F base = refl {x = F base}
-S¹→HSet A p F (loop i) = f' i
+S¹→HType : (A : Type₀) (p : isType A) (F : S¹ → A) (x : S¹) → F base ≡ F x
+S¹→HType A p F base = refl {x = F base}
+S¹→HType A p F (loop i) = f' i
   where
   f : PathP (λ i → F base ≡ F (loop i)) refl (cong F loop)
   f i = λ j → F (loop (i ∧ j))
@@ -97,16 +97,16 @@ S¹→HSet A p F (loop i) = f' i
 constant-loop : (F : S¹ → S¹ → Int) → (x y : S¹) → F base base ≡ F x y
 constant-loop F x y = L0 ∙ L1
   where
-  p : isSet (S¹ → Int)
-  p = hLevelPi 2 (λ _ → isSetInt)
+  p : isType (S¹ → Int)
+  p = hLevelPi 2 (λ _ → isTypeInt)
   L : F base ≡ F x
-  L = S¹→HSet (S¹ → Int) p F x
+  L = S¹→HType (S¹ → Int) p F x
   L0 : F base base ≡ F x base
   L0 i = L i base
   L1 : F x base ≡ F x y
-  L1 = S¹→HSet Int isSetInt (F x) y
+  L1 = S¹→HType Int isTypeInt (F x) y
 
-discretefib : (F : S¹ → S¹ → Set) → Set
+discretefib : (F : S¹ → S¹ → Type₀) → Type₀
 discretefib F = (a : (x y : S¹) → F x y) →
         (b : (x y : S¹) → F x y) →
         (a base base ≡ b base base) →
@@ -191,7 +191,7 @@ JoinS¹S¹→TotalHopf→JoinS¹S¹ (push y x j) i = filler-3 i j y x
 -- This allows to write compositions that do not properly match at the endpoints. However,
 -- I suspect it is unnecessary. TODO : do without PseudoHopf
 
-PseudoHopf : Set
+PseudoHopf : Type₀
 PseudoHopf = (S¹ × Interval) × S¹
 
 PseudoHopf-π1 : PseudoHopf → S¹

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -83,7 +83,7 @@ JoinS¹S¹→TotalHopf (push y x j) =
 fibInt : S¹ → S¹ → Type₀
 fibInt _ _ = Int
 
-S¹→HSet : (A : Type₀) (p : isType A) (F : S¹ → A) (x : S¹) → F base ≡ F x
+S¹→HSet : (A : Type₀) (p : isSet A) (F : S¹ → A) (x : S¹) → F base ≡ F x
 S¹→HSet A p F base = refl {x = F base}
 S¹→HSet A p F (loop i) = f' i
   where
@@ -97,14 +97,14 @@ S¹→HSet A p F (loop i) = f' i
 constant-loop : (F : S¹ → S¹ → Int) → (x y : S¹) → F base base ≡ F x y
 constant-loop F x y = L0 ∙ L1
   where
-  p : isType (S¹ → Int)
-  p = hLevelPi 2 (λ _ → isTypeInt)
+  p : isSet (S¹ → Int)
+  p = hLevelPi 2 (λ _ → isSetInt)
   L : F base ≡ F x
   L = S¹→HSet (S¹ → Int) p F x
   L0 : F base base ≡ F x base
   L0 i = L i base
   L1 : F x base ≡ F x y
-  L1 = S¹→HSet Int isTypeInt (F x) y
+  L1 = S¹→HSet Int isSetInt (F x) y
 
 discretefib : (F : S¹ → S¹ → Type₀) → Type₀
 discretefib F = (a : (x y : S¹) → F x y) →

--- a/Cubical/HITs/Interval/Base.agda
+++ b/Cubical/HITs/Interval/Base.agda
@@ -5,7 +5,7 @@ open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Prelude
 
-data Interval : Set where
+data Interval : Type₀ where
   zero : Interval
   one  : Interval
   seg  : zero ≡ one
@@ -18,7 +18,7 @@ isContrInterval = (zero , (λ x → rem x))
   rem one       = seg
   rem (seg i) j = seg (i ∧ j)
 
-funExtInterval : ∀ {ℓ} (A B : Set ℓ) (f g : A → B) → ((x : A) → f x ≡ g x) → f ≡ g
+funExtInterval : ∀ {ℓ} (A B : Type ℓ) (f g : A → B) → ((x : A) → f x ≡ g x) → f ≡ g
 funExtInterval A B f g p = λ i x → hmtpy x (seg i)
   where
   hmtpy : A → Interval → B
@@ -26,14 +26,14 @@ funExtInterval A B f g p = λ i x → hmtpy x (seg i)
   hmtpy x one     = g x
   hmtpy x (seg i) = p x i
 
-intervalElim : (A : Interval → Set) (x : A zero) (y : A one)
+intervalElim : (A : Interval → Type₀) (x : A zero) (y : A one)
                (p : PathP (λ i → A (seg i)) x y) → (x : Interval) → A x
 intervalElim A x y p zero    = x
 intervalElim A x y p one     = y
 intervalElim A x y p (seg i) = p i
 
 -- Note that this is not definitional (it is not proved by refl)
-intervalEta : ∀ {A : Set} (f : Interval → A) → intervalElim _ (f zero) (f one) (λ i → f (seg i)) ≡ f
+intervalEta : ∀ {A : Type₀} (f : Interval → A) → intervalElim _ (f zero) (f one) (λ i → f (seg i)) ≡ f
 intervalEta f i zero    = f zero
 intervalEta f i one     = f one
 intervalEta f i (seg j) = f (seg j)

--- a/Cubical/HITs/Join/Base.agda
+++ b/Cubical/HITs/Join/Base.agda
@@ -10,7 +10,7 @@ open import Cubical.HITs.S3
 
 -- redtt version : https://github.com/RedPRL/redtt/blob/master/library/cool/s3-to-join.red
 
-data join {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') : Set (ℓ-max ℓ ℓ') where
+data join {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') : Type (ℓ-max ℓ ℓ') where
   inl : A → join A B
   inr : B → join A B
   push : ∀ a b → inl a ≡ inr b

--- a/Cubical/HITs/ListedFiniteSet.agda
+++ b/Cubical/HITs/ListedFiniteSet.agda
@@ -1,6 +1,5 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.ListedFiniteSet where
 
-
 open import Cubical.HITs.ListedFiniteSet.Base public
 open import Cubical.HITs.ListedFiniteSet.Properties public

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -13,12 +13,12 @@ infixr 20 _∷_
 infix 30 _∈_
 
 
-data LFType (A : Type₀) : Type₀ where
-  []    : LFType A
-  _∷_   : (x : A) → (xs : LFType A) → LFType A
+data LFSet (A : Type₀) : Type₀ where
+  []    : LFSet A
+  _∷_   : (x : A) → (xs : LFSet A) → LFSet A
   dup   : ∀ x xs   → x ∷ x ∷ xs ≡ x ∷ xs
   comm  : ∀ x y xs → x ∷ y ∷ xs ≡ y ∷ x ∷ xs
-  trunc : isType (LFType A)
+  trunc : isSet (LFSet A)
 
 
 -- Membership.
@@ -26,7 +26,7 @@ data LFType (A : Type₀) : Type₀ where
 -- Doing some proofs with equational reasoning adds an extra "_∙ refl"
 -- at the end.
 -- We might want to avoid it, or come up with a more clever equational reasoning.
-_∈_ : A → LFType A → hProp
+_∈_ : A → LFSet A → hProp
 z ∈ []                  = ⊥
 z ∈ (y ∷ xs)            = (z ≡ₚ y) ⊔ (z ∈ xs)
 z ∈ dup x xs i          = proof i
@@ -43,4 +43,4 @@ z ∈ comm x y xs i       = proof i
             (z ≡ₚ y ⊔ z ≡ₚ x) ⊔ z ∈ xs  ≡⟨ sym (⊔-assoc (z ≡ₚ y) (z ≡ₚ x) (z ∈ xs)) ⟩
             z ≡ₚ y  ⊔ (z ≡ₚ x ⊔ z ∈ xs) ∎
 
-x ∈ trunc xs ys p q i j = isTypeHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (cong (x ∈_) q) i j
+x ∈ trunc xs ys p q i j = isSetHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (cong (x ∈_) q) i j

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -7,18 +7,18 @@ open import Cubical.Foundations.Everything
 
 private
   variable
-    A : Set
+    A : Type₀
 
 infixr 20 _∷_
 infix 30 _∈_
 
 
-data LFSet (A : Set) : Set where
-  []    : LFSet A
-  _∷_   : (x : A) → (xs : LFSet A) → LFSet A
+data LFType (A : Type₀) : Type₀ where
+  []    : LFType A
+  _∷_   : (x : A) → (xs : LFType A) → LFType A
   dup   : ∀ x xs   → x ∷ x ∷ xs ≡ x ∷ xs
   comm  : ∀ x y xs → x ∷ y ∷ xs ≡ y ∷ x ∷ xs
-  trunc : isSet (LFSet A)
+  trunc : isType (LFType A)
 
 
 -- Membership.
@@ -26,7 +26,7 @@ data LFSet (A : Set) : Set where
 -- Doing some proofs with equational reasoning adds an extra "_∙ refl"
 -- at the end.
 -- We might want to avoid it, or come up with a more clever equational reasoning.
-_∈_ : A → LFSet A → hProp
+_∈_ : A → LFType A → hProp
 z ∈ []                  = ⊥
 z ∈ (y ∷ xs)            = (z ≡ₚ y) ⊔ (z ∈ xs)
 z ∈ dup x xs i          = proof i
@@ -43,4 +43,4 @@ z ∈ comm x y xs i       = proof i
             (z ≡ₚ y ⊔ z ≡ₚ x) ⊔ z ∈ xs  ≡⟨ sym (⊔-assoc (z ≡ₚ y) (z ≡ₚ x) (z ∈ xs)) ⟩
             z ≡ₚ y  ⊔ (z ≡ₚ x ⊔ z ∈ xs) ∎
 
-x ∈ trunc xs ys p q i j = isSetHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (cong (x ∈_) q) i j
+x ∈ trunc xs ys p q i j = isTypeHProp (x ∈ xs) (x ∈ ys) (cong (x ∈_) p) (cong (x ∈_) q) i j

--- a/Cubical/HITs/ListedFiniteSet/Properties.agda
+++ b/Cubical/HITs/ListedFiniteSet/Properties.agda
@@ -11,7 +11,7 @@ private
   variable
     A : Type₀
 
-_++_ : ∀ (xs ys : LFType A) → LFType A
+_++_ : ∀ (xs ys : LFSet A) → LFSet A
 []                  ++ ys = ys
 (x ∷ xs)            ++ ys = x ∷ (xs ++ ys)
 ---------------------------------------------
@@ -27,7 +27,7 @@ trunc xs zs p q i j ++ ys
   = trunc (xs ++ ys) (zs ++ ys) (cong (_++ ys) p) (cong (_++ ys) q) i j
 
 
-assoc-++ : ∀ (xs : LFType A) ys zs → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+assoc-++ : ∀ (xs : LFSet A) ys zs → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
 assoc-++ []       ys zs = refl
 assoc-++ (x ∷ xs) ys zs
   = cong (x ∷_) (assoc-++ xs ys zs)

--- a/Cubical/HITs/ListedFiniteSet/Properties.agda
+++ b/Cubical/HITs/ListedFiniteSet/Properties.agda
@@ -9,9 +9,9 @@ open import Cubical.HITs.ListedFiniteSet.Base
 
 private
   variable
-    A : Set
+    A : Type₀
 
-_++_ : ∀ (xs ys : LFSet A) → LFSet A
+_++_ : ∀ (xs ys : LFType A) → LFType A
 []                  ++ ys = ys
 (x ∷ xs)            ++ ys = x ∷ (xs ++ ys)
 ---------------------------------------------
@@ -27,7 +27,7 @@ trunc xs zs p q i j ++ ys
   = trunc (xs ++ ys) (zs ++ ys) (cong (_++ ys) p) (cong (_++ ys) q) i j
 
 
-assoc-++ : ∀ (xs : LFSet A) ys zs → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+assoc-++ : ∀ (xs : LFType A) ys zs → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
 assoc-++ []       ys zs = refl
 assoc-++ (x ∷ xs) ys zs
   = cong (x ∷_) (assoc-++ xs ys zs)

--- a/Cubical/HITs/Modulo/Base.agda
+++ b/Cubical/HITs/Modulo/Base.agda
@@ -14,7 +14,7 @@ open import Cubical.Data.Unit renaming (Unit to ⊤)
 
 open import Cubical.Relation.Nullary
 
-NonZero : ℕ → Set
+NonZero : ℕ → Type₀
 NonZero 0 = ⊥
 NonZero _ = ⊤
 
@@ -38,7 +38,7 @@ private
 -- constructor is somewhat easier to work with than truncation.
 --
 -- Note also that unlike `Fin 0`, `Modulo 0` is equivalent to the naturals.
-data Modulo (k : ℕ) : Set where
+data Modulo (k : ℕ) : Type₀ where
   embed : (n : ℕ) → Modulo k
   pre-step : NonZero k → (n : ℕ) → embed n ≡ embed (k + n)
 
@@ -53,7 +53,7 @@ ztep {suc k} n = step n
 
 -- The standard eliminator for `Modulo`.
 elim
-  : (P : ∀ k → Modulo k → Set ℓ)
+  : (P : ∀ k → Modulo k → Type ℓ)
   → (e : ∀ k n → P k (embed n))
   → (st : ∀ k n → PathP (λ i → P (suc k) (step n i)) (e (suc k) n) (e (suc k) (suc k + n)))
   → (m : Modulo k) → P k m

--- a/Cubical/HITs/Modulo/FinEquiv.agda
+++ b/Cubical/HITs/Modulo/FinEquiv.agda
@@ -22,7 +22,7 @@ module Reduction {k₀ : ℕ} where
   fembed : Fin k → Modulo k
   fembed = embed ∘ toℕ
 
-  ResiduePath : ℕ → Set
+  ResiduePath : ℕ → Type₀
   ResiduePath n =  Σ[ f ∈ Fin k ] fembed f ≡ embed n
 
   rbase : ∀ n (n<k : n < k) → ResiduePath n

--- a/Cubical/HITs/PropositionalTruncation/Base.agda
+++ b/Cubical/HITs/PropositionalTruncation/Base.agda
@@ -12,6 +12,6 @@ open import Cubical.Core.Primitives
 
 -- Propositional truncation as a higher inductive type:
 
-data ∥_∥ {ℓ} (A : Set ℓ) : Set ℓ where
+data ∥_∥ {ℓ} (A : Type ℓ) : Type ℓ where
   ∣_∣ : A → ∥ A ∥
   squash : ∀ (x y : ∥ A ∥) → x ≡ y

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -15,9 +15,9 @@ open import Cubical.HITs.PropositionalTruncation.Base
 private
   variable
     ℓ : Level
-    A : Set ℓ
+    A : Type ℓ
 
-recPropTrunc : ∀ {P : Set ℓ} → isProp P → (A → P) → ∥ A ∥ → P
+recPropTrunc : ∀ {P : Type ℓ} → isProp P → (A → P) → ∥ A ∥ → P
 recPropTrunc Pprop f ∣ x ∣          = f x
 recPropTrunc Pprop f (squash x y i) =
   Pprop (recPropTrunc Pprop f x) (recPropTrunc Pprop f y) i
@@ -25,7 +25,7 @@ recPropTrunc Pprop f (squash x y i) =
 propTruncIsProp : isProp ∥ A ∥
 propTruncIsProp x y = squash x y
 
-elimPropTrunc : ∀ {P : ∥ A ∥ → Set ℓ} → ((a : ∥ A ∥) → isProp (P a)) →
+elimPropTrunc : ∀ {P : ∥ A ∥ → Type ℓ} → ((a : ∥ A ∥) → isProp (P a)) →
                 ((x : A) → P ∣ x ∣) → (a : ∥ A ∥) → P a
 elimPropTrunc                 Pprop f ∣ x ∣          = f x
 elimPropTrunc {A = A} {P = P} Pprop f (squash x y i) =
@@ -35,7 +35,7 @@ elimPropTrunc {A = A} {P = P} Pprop f (squash x y i) =
     PpropOver {a} = J (λ b (sq : a ≡ b) → ∀ x y → PathP (λ i → P (sq i)) x y) (Pprop a)
 
 -- We could also define the eliminator using the recursor
-elimPropTrunc' : ∀ {P : ∥ A ∥ → Set ℓ} → ((a : ∥ A ∥) → isProp (P a)) →
+elimPropTrunc' : ∀ {P : ∥ A ∥ → Type ℓ} → ((a : ∥ A ∥) → isProp (P a)) →
                  ((x : A) → P ∣ x ∣) → (a : ∥ A ∥) → P a
 elimPropTrunc' {P = P} Pprop f a =
   recPropTrunc (Pprop a) (λ x → transp (λ i → P (squash ∣ x ∣ a i)) i0 (f x)) a

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -11,8 +11,8 @@ open import Cubical.Data.Unit
 
 open import Cubical.HITs.Susp
 
-data Pushout {ℓ ℓ' ℓ''} {A : Set ℓ} {B : Set ℓ'} {C : Set ℓ''}
-             (f : A → B) (g : A → C) : Set (ℓ-max ℓ (ℓ-max ℓ' ℓ'')) where
+data Pushout {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
+             (f : A → B) (g : A → C) : Type (ℓ-max ℓ (ℓ-max ℓ' ℓ'')) where
   inl : B → Pushout f g
   inr : C → Pushout f g
   push : (a : A) → inl (f a) ≡ inr (g a)
@@ -20,33 +20,33 @@ data Pushout {ℓ ℓ' ℓ''} {A : Set ℓ} {B : Set ℓ'} {C : Set ℓ''}
 
 -- Suspension defined as a pushout
 
-PushoutSusp : ∀ {ℓ} (A : Set ℓ) → Set ℓ
+PushoutSusp : ∀ {ℓ} (A : Type ℓ) → Type ℓ
 PushoutSusp A = Pushout {A = A} {B = Unit} {C = Unit} (λ _ → tt) (λ _ → tt)
 
-PushoutSusp→Susp : ∀ {ℓ} {A : Set ℓ} → PushoutSusp A → Susp A
+PushoutSusp→Susp : ∀ {ℓ} {A : Type ℓ} → PushoutSusp A → Susp A
 PushoutSusp→Susp (inl _) = north
 PushoutSusp→Susp (inr _) = south
 PushoutSusp→Susp (push a i) = merid a i
 
-Susp→PushoutSusp : ∀ {ℓ} {A : Set ℓ} → Susp A → PushoutSusp A
+Susp→PushoutSusp : ∀ {ℓ} {A : Type ℓ} → Susp A → PushoutSusp A
 Susp→PushoutSusp north = inl tt
 Susp→PushoutSusp south = inr tt
 Susp→PushoutSusp (merid a i) = push a i
 
-Susp→PushoutSusp→Susp : ∀ {ℓ} {A : Set ℓ} (x : Susp A) →
+Susp→PushoutSusp→Susp : ∀ {ℓ} {A : Type ℓ} (x : Susp A) →
                         PushoutSusp→Susp (Susp→PushoutSusp x) ≡ x
 Susp→PushoutSusp→Susp north = refl
 Susp→PushoutSusp→Susp south = refl
 Susp→PushoutSusp→Susp (merid _ _) = refl
 
-PushoutSusp→Susp→PushoutSusp : ∀ {ℓ} {A : Set ℓ} (x : PushoutSusp A) →
+PushoutSusp→Susp→PushoutSusp : ∀ {ℓ} {A : Type ℓ} (x : PushoutSusp A) →
                                Susp→PushoutSusp (PushoutSusp→Susp x) ≡ x
 PushoutSusp→Susp→PushoutSusp (inl _) = refl
 PushoutSusp→Susp→PushoutSusp (inr _) = refl
 PushoutSusp→Susp→PushoutSusp (push _ _) = refl
 
-PushoutSusp≃Susp : ∀ {ℓ} {A : Set ℓ} → PushoutSusp A ≃ Susp A
+PushoutSusp≃Susp : ∀ {ℓ} {A : Type ℓ} → PushoutSusp A ≃ Susp A
 PushoutSusp≃Susp = isoToEquiv (iso PushoutSusp→Susp Susp→PushoutSusp Susp→PushoutSusp→Susp PushoutSusp→Susp→PushoutSusp)
 
-PushoutSusp≡Susp : ∀ {ℓ} {A : Set ℓ} → PushoutSusp A ≡ Susp A
+PushoutSusp≡Susp : ∀ {ℓ} {A : Type ℓ} → PushoutSusp A ≡ Susp A
 PushoutSusp≡Susp = isoToPath (iso PushoutSusp→Susp Susp→PushoutSusp Susp→PushoutSusp→Susp PushoutSusp→Susp→PushoutSusp)

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -49,7 +49,7 @@ Then the lemma states there is an equivalence A□○ ≃ A○□.
 -}
 
 module 3x3-span
-  (A00 A02 A04 A20 A22 A24 A40 A42 A44 : Set)
+  (A00 A02 A04 A20 A22 A24 A40 A42 A44 : Type₀)
 
   (f10 : A20 → A00)
   (f12 : A22 → A02)
@@ -74,13 +74,13 @@ module 3x3-span
   where
 
   -- pushouts of the lines
-  A□0 : Set
+  A□0 : Type₀
   A□0 = Pushout f10 f30
 
-  A□2 : Set
+  A□2 : Type₀
   A□2 = Pushout f12 f32
 
-  A□4 : Set
+  A□4 : Type₀
   A□4 = Pushout f14 f34
 
   -- maps between pushouts
@@ -99,17 +99,17 @@ module 3x3-span
                    ∙∙ (λ i → inr (H33 a (~ i)))) j
 
   -- total pushout
-  A□○ : Set
+  A□○ : Type₀
   A□○ = Pushout f□1 f□3
 
   -- pushouts of the columns
-  A0□ : Set
+  A0□ : Type₀
   A0□ = Pushout f01 f03
 
-  A2□ : Set
+  A2□ : Type₀
   A2□ = Pushout f21 f23
 
-  A4□ : Set
+  A4□ : Type₀
   A4□ = Pushout f41 f43
 
   -- maps between pushouts
@@ -128,7 +128,7 @@ module 3x3-span
                    ∙∙ (λ i → inr (H33 a i))) j
 
   -- total pushout
-  A○□ : Set
+  A○□ : Type₀
   A○□ = Pushout f1□ f3□
 
   -- forward map of the equivalence A□○ ≃ A○□

--- a/Cubical/HITs/Rational/Base.agda
+++ b/Cubical/HITs/Rational/Base.agda
@@ -12,7 +12,7 @@ open import Cubical.Data.Unit
 data ℚ : Type₀ where
   con : (u : ℤ) (a : ℤ) → ¬ (a ≡ pos 0) → ℚ
   path : ∀ u a v b {p q} → (u *ℤ b) ≡ (v *ℤ a) → con u a p ≡ con v b q
-  trunc : isType ℚ
+  trunc : isSet ℚ
 
 int : ℤ → ℚ
 int z = con z (pos 1) \ p → snotz (cong abs p)

--- a/Cubical/HITs/Rational/Base.agda
+++ b/Cubical/HITs/Rational/Base.agda
@@ -9,11 +9,10 @@ open import Cubical.Data.Nat
 open import Cubical.Data.Empty
 open import Cubical.Data.Unit
 
-
-data ℚ : Set where
+data ℚ : Type₀ where
   con : (u : ℤ) (a : ℤ) → ¬ (a ≡ pos 0) → ℚ
   path : ∀ u a v b {p q} → (u *ℤ b) ≡ (v *ℤ a) → con u a p ≡ con v b q
-  trunc : isSet ℚ
+  trunc : isType ℚ
 
 int : ℤ → ℚ
 int z = con z (pos 1) \ p → snotz (cong abs p)

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -74,13 +74,13 @@ decode (loop i) y j =
 decodeEncode : (x : S¹) (p : base ≡ x) → decode x (encode x p) ≡ p
 decodeEncode x p = J (λ y q → decode y (encode y q) ≡ q) (λ x → refl) p
 
-isTypeΩS¹ : isType ΩS¹
-isTypeΩS¹ p q r s j i =
+isSetΩS¹ : isSet ΩS¹
+isSetΩS¹ p q r s j i =
   hcomp (λ k → λ { (i = i0) → decodeEncode base p k
                  ; (i = i1) → decodeEncode base q k
                  ; (j = i0) → decodeEncode base (r i) k
                  ; (j = i1) → decodeEncode base (s i) k })
-        (decode base (isTypeInt (winding p) (winding q) (cong winding r) (cong winding s) j i))
+        (decode base (isSetInt (winding p) (winding q) (cong winding r) (cong winding s) j i))
 
 -- This proof does not rely on rewriting hcomp with empty systems in
 -- Int as ghcomp has been implemented!

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -18,7 +18,7 @@ open import Cubical.Data.Nat
   hiding (_+_ ; _*_ ; +-assoc ; +-comm)
 open import Cubical.Data.Int
 
-data S¹ : Set where
+data S¹ : Type₀ where
   base : S¹
   loop : base ≡ base
 
@@ -31,11 +31,11 @@ module _ where
     comp (λ _ → S¹) u u0 ≡ hcomp u (outS u0)
   compS1 φ u u0 = refl
 
-helix : S¹ → Set
+helix : S¹ → Type₀
 helix base     = Int
 helix (loop i) = sucPathInt i
 
-ΩS¹ : Set
+ΩS¹ : Type₀
 ΩS¹ = base ≡ base
 
 encode : ∀ x → base ≡ x → helix x
@@ -74,13 +74,13 @@ decode (loop i) y j =
 decodeEncode : (x : S¹) (p : base ≡ x) → decode x (encode x p) ≡ p
 decodeEncode x p = J (λ y q → decode y (encode y q) ≡ q) (λ x → refl) p
 
-isSetΩS¹ : isSet ΩS¹
-isSetΩS¹ p q r s j i =
+isTypeΩS¹ : isType ΩS¹
+isTypeΩS¹ p q r s j i =
   hcomp (λ k → λ { (i = i0) → decodeEncode base p k
                  ; (i = i1) → decodeEncode base q k
                  ; (j = i0) → decodeEncode base (r i) k
                  ; (j = i1) → decodeEncode base (s i) k })
-        (decode base (isSetInt (winding p) (winding q) (cong winding r) (cong winding s) j i))
+        (decode base (isTypeInt (winding p) (winding q) (cong winding r) (cong winding s) j i))
 
 -- This proof does not rely on rewriting hcomp with empty systems in
 -- Int as ghcomp has been implemented!
@@ -131,7 +131,7 @@ winding-hom a b i =
 
 -- Based homotopy group
 
-basedΩS¹ : (x : S¹) → Set
+basedΩS¹ : (x : S¹) → Type₀
 basedΩS¹ x = x ≡ x
 
 -- Proof that the homotopy group is actually independent on the basepoint
@@ -289,7 +289,7 @@ filler-rot i j = hfill (λ k → λ { (i = i0) → loop (j ∨ ~ k)
                    ; (j = i0) → loop (i ∨ ~ k)
                    ; (j = i1) → loop (i ∧ k) }) (inS base)
 
-isPropFamS¹ : ∀ {ℓ} (P : S¹ → Set ℓ) (pP : (x : S¹) → isProp (P x)) (b0 : P base) →
+isPropFamS¹ : ∀ {ℓ} (P : S¹ → Type ℓ) (pP : (x : S¹) → isProp (P x)) (b0 : P base) →
               PathP (λ i → P (loop i)) b0 b0
 isPropFamS¹ P pP b0 i = pP (loop i) (transp (λ j → P (loop (i ∧ j))) (~ i) b0)
                                     (transp (λ j → P (loop (i ∨ ~ j))) i b0) i

--- a/Cubical/HITs/S2/Base.agda
+++ b/Cubical/HITs/S2/Base.agda
@@ -3,6 +3,6 @@ module Cubical.HITs.S2.Base where
 
 open import Cubical.Foundations.Prelude
 
-data S² : Set where
+data S² : Type₀ where
   base : S²
   surf : PathP (λ i → base ≡ base) refl refl

--- a/Cubical/HITs/S3/Base.agda
+++ b/Cubical/HITs/S3/Base.agda
@@ -3,7 +3,7 @@ module Cubical.HITs.S3.Base where
 
 open import Cubical.Foundations.Prelude
 
-data S³ : Set where
+data S³ : Type₀ where
   base : S³
   surf : PathP (λ j → PathP (λ i → base ≡ base) refl refl) refl refl
 

--- a/Cubical/HITs/SetQuotients/Base.agda
+++ b/Cubical/HITs/SetQuotients/Base.agda
@@ -10,7 +10,7 @@ module Cubical.HITs.SetQuotients.Base where
 
 open import Cubical.Core.Primitives
 
--- Type quotients as a higher inductive type:
+-- Set quotients as a higher inductive type:
 data _/_ {ℓ ℓ'} (A : Type ℓ) (R : A → A → Type ℓ') : Type (ℓ-max ℓ ℓ') where
   [_] : (a : A) → A / R
   eq/ : (a b : A) → (r : R a b) → [ a ] ≡ [ b ]

--- a/Cubical/HITs/SetQuotients/Base.agda
+++ b/Cubical/HITs/SetQuotients/Base.agda
@@ -10,8 +10,8 @@ module Cubical.HITs.SetQuotients.Base where
 
 open import Cubical.Core.Primitives
 
--- Set quotients as a higher inductive type:
-data _/_ {ℓ ℓ'} (A : Set ℓ) (R : A → A → Set ℓ') : Set (ℓ-max ℓ ℓ') where
+-- Type quotients as a higher inductive type:
+data _/_ {ℓ ℓ'} (A : Type ℓ) (R : A → A → Type ℓ') : Type (ℓ-max ℓ ℓ') where
   [_] : (a : A) → A / R
   eq/ : (a b : A) → (r : R a b) → [ a ] ≡ [ b ]
   squash/ : (x y : A / R) → (p q : x ≡ y) → p ≡ q

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -46,43 +46,43 @@ elimEq/ {B = B} Bprop {x = x} =
   J (λ y eq → ∀ bx by → PathP (λ i → B (eq i)) bx by) (λ bx by → Bprop x bx by)
 
 
-elimTypeQuotientsProp : ((x : A / R ) → isProp (B x)) →
+elimSetQuotientsProp : ((x : A / R ) → isProp (B x)) →
                        (f : (a : A) → B ( [ a ])) →
                        (x : A / R) → B x
-elimTypeQuotientsProp Bprop f [ x ] = f x
-elimTypeQuotientsProp Bprop f (squash/ x y p q i j) =
-  elimSquash₀ (λ x → isProp→isType (Bprop x)) (squash/ x y p q)
+elimSetQuotientsProp Bprop f [ x ] = f x
+elimSetQuotientsProp Bprop f (squash/ x y p q i j) =
+  elimSquash₀ (λ x → isProp→isSet (Bprop x)) (squash/ x y p q)
               (g x) (g y) (cong g p) (cong g q) i j
     where
-    g = elimTypeQuotientsProp Bprop f
-elimTypeQuotientsProp Bprop f (eq/ a b r i) = elimEq/ Bprop (eq/ a b r) (f a) (f b) i
+    g = elimSetQuotientsProp Bprop f
+elimSetQuotientsProp Bprop f (eq/ a b r i) = elimEq/ Bprop (eq/ a b r) (f a) (f b) i
 
 -- lemma 6.10.2 in hott book
 -- TODO: defined truncated Sigma as ∃
 []surjective : (x : A / R) → ∥ Σ[ a ∈ A ] [ a ] ≡ x ∥
-[]surjective = elimTypeQuotientsProp (λ x → squash) (λ a → ∣ a , refl ∣)
+[]surjective = elimSetQuotientsProp (λ x → squash) (λ a → ∣ a , refl ∣)
 
-elimTypeQuotients : {B : A / R → Type ℓ} →
-                   (Bset : (x : A / R) → isType (B x)) →
+elimSetQuotients : {B : A / R → Type ℓ} →
+                   (Bset : (x : A / R) → isSet (B x)) →
                    (f : (a : A) → (B [ a ])) →
                    (feq : (a b : A) (r : R a b) →
                           PathP (λ i → B (eq/ a b r i)) (f a) (f b)) →
                    (x : A / R) → B x
-elimTypeQuotients Bset f feq [ a ] = f a
-elimTypeQuotients Bset f feq (eq/ a b r i) = feq a b r i
-elimTypeQuotients Bset f feq (squash/ x y p q i j) =
+elimSetQuotients Bset f feq [ a ] = f a
+elimSetQuotients Bset f feq (eq/ a b r i) = feq a b r i
+elimSetQuotients Bset f feq (squash/ x y p q i j) =
   elimSquash₀ Bset (squash/ x y p q)
               (g x) (g y) (cong g p) (cong g q) i j
     where
-      g = elimTypeQuotients Bset f feq
+      g = elimSetQuotients Bset f feq
 
 
-setQuotUniversal : {B : Type ℓ} (Bset : isType B) →
+setQuotUniversal : {B : Type ℓ} (Bset : isSet B) →
                    (A / R → B) ≃ (Σ[ f ∈ (A → B) ] ((a b : A) → R a b → f a ≡ f b))
 setQuotUniversal Bset = isoToEquiv (iso intro elim elimRightInv elimLeftInv)
   where
   intro = λ g →  (λ a → g [ a ]) , λ a b r i → g (eq/ a b r i)
-  elim = λ h → elimTypeQuotients (λ x → Bset) (fst h) (snd h)
+  elim = λ h → elimSetQuotients (λ x → Bset) (fst h) (snd h)
 
   elimRightInv : ∀ h → intro (elim h) ≡ h
   elimRightInv h = refl
@@ -99,7 +99,7 @@ effective : (Rprop : isPropValued R) (Requiv : isEquivRel R) (a b : A) → [ a ]
 effective {A = A} {R = R} Rprop (EquivRel R/refl R/sym R/trans) a b p = transport aa≡ab (R/refl _)
   where
     helper : A / R → hProp
-    helper = elimTypeQuotients (λ _ → isTypeHProp) (λ c → (R a c , Rprop a c))
+    helper = elimSetQuotients (λ _ → isSetHProp) (λ c → (R a c , Rprop a c))
                               (λ c d cd → ΣProp≡ (λ _ → isPropIsProp)
                                                  (ua (PropEquiv→Equiv (Rprop a c) (Rprop a d)
                                                                       (λ ac → R/trans _ _ _ ac cd) (λ ad → R/trans _ _ _ ad (R/sym _ _ cd)))))
@@ -122,13 +122,13 @@ isEquivRel→isEffective {R = R} Rprop Req a b = isoToEquiv (iso intro elim intr
     elim-intro : ∀ x → elim (intro x) ≡ x
     elim-intro eq = squash/ _ _ _ _
 
-discreteTypeQuotients : Discrete A → isPropValued R → isEquivRel R → (∀ a₀ a₁ → Dec (R a₀ a₁)) → Discrete (A / R)
-discreteTypeQuotients {A = A} {R = R} Adis Rprop Req Rdec =
- elimTypeQuotients ((λ a₀ → isTypePi (λ a₁ → isProp→isType (isPropDec (squash/ a₀ a₁)))))
-                  discreteTypeQuotients' discreteTypeQuotients'-eq
+discreteSetQuotients : Discrete A → isPropValued R → isEquivRel R → (∀ a₀ a₁ → Dec (R a₀ a₁)) → Discrete (A / R)
+discreteSetQuotients {A = A} {R = R} Adis Rprop Req Rdec =
+ elimSetQuotients ((λ a₀ → isSetPi (λ a₁ → isProp→isSet (isPropDec (squash/ a₀ a₁)))))
+                  discreteSetQuotients' discreteSetQuotients'-eq
   where
-    discreteTypeQuotients' : (a : A) (y : A / R) → Dec ([ a ] ≡ y)
-    discreteTypeQuotients' a₀ = elimTypeQuotients ((λ a₁ → isProp→isType (isPropDec (squash/ [ a₀ ] a₁)))) dis dis-eq
+    discreteSetQuotients' : (a : A) (y : A / R) → Dec ([ a ] ≡ y)
+    discreteSetQuotients' a₀ = elimSetQuotients ((λ a₁ → isProp→isSet (isPropDec (squash/ [ a₀ ] a₁)))) dis dis-eq
       where
         dis : (a₁ : A) → Dec ([ a₀ ] ≡ [ a₁ ])
         dis a₁ with Rdec a₀ a₁
@@ -140,10 +140,10 @@ discreteTypeQuotients {A = A} {R = R} Adis Rprop Req Rdec =
         dis-eq a b ab = J (λ b ab → ∀ k → PathP (λ i → Dec ([ a₀ ] ≡ ab i)) (dis a) k)
                           (λ k → isPropDec (squash/ _ _) _  _) (eq/ a b ab) (dis b)
 
-    discreteTypeQuotients'-eq : (a b : A) (r : R a b) →
+    discreteSetQuotients'-eq : (a b : A) (r : R a b) →
       PathP (λ i → (y : A / R) → Dec (eq/ a b r i ≡ y))
-            (discreteTypeQuotients' a) (discreteTypeQuotients' b)
-    discreteTypeQuotients'-eq a b ab =
+            (discreteSetQuotients' a) (discreteSetQuotients' b)
+    discreteSetQuotients'-eq a b ab =
       J (λ b ab → ∀ k → PathP (λ i → (y : A / R) → Dec (ab i ≡ y))
-                              (discreteTypeQuotients' a) k)
-        (λ k → funExt (λ x → isPropDec (squash/ _ _) _ _)) (eq/ a b ab) (discreteTypeQuotients' b)
+                              (discreteSetQuotients' a) k)
+        (λ k → funExt (λ x → isPropDec (squash/ _ _) _ _)) (eq/ a b ab) (discreteSetQuotients' b)

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -1,6 +1,6 @@
 {-
 
-Type quotients:
+Set quotients:
 
 -}
 

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -1,6 +1,6 @@
 {-
 
-Set quotients:
+Type quotients:
 
 -}
 
@@ -27,14 +27,14 @@ open import Cubical.Relation.Binary.Base
 open import Cubical.HITs.PropositionalTruncation
 open import Cubical.HITs.SetTruncation
 
--- Set quotients
+-- Type quotients
 
 private
   variable
     ℓ ℓ' ℓ'' : Level
-    A : Set ℓ
-    R : A → A → Set ℓ'
-    B : A / R → Set ℓ''
+    A : Type ℓ
+    R : A → A → Type ℓ'
+    B : A / R → Type ℓ''
 
 elimEq/ : (Bprop : (x : A / R ) → isProp (B x))
           {x y : A / R}
@@ -46,43 +46,43 @@ elimEq/ {B = B} Bprop {x = x} =
   J (λ y eq → ∀ bx by → PathP (λ i → B (eq i)) bx by) (λ bx by → Bprop x bx by)
 
 
-elimSetQuotientsProp : ((x : A / R ) → isProp (B x)) →
+elimTypeQuotientsProp : ((x : A / R ) → isProp (B x)) →
                        (f : (a : A) → B ( [ a ])) →
                        (x : A / R) → B x
-elimSetQuotientsProp Bprop f [ x ] = f x
-elimSetQuotientsProp Bprop f (squash/ x y p q i j) =
-  elimSquash₀ (λ x → isProp→isSet (Bprop x)) (squash/ x y p q)
+elimTypeQuotientsProp Bprop f [ x ] = f x
+elimTypeQuotientsProp Bprop f (squash/ x y p q i j) =
+  elimSquash₀ (λ x → isProp→isType (Bprop x)) (squash/ x y p q)
               (g x) (g y) (cong g p) (cong g q) i j
     where
-    g = elimSetQuotientsProp Bprop f
-elimSetQuotientsProp Bprop f (eq/ a b r i) = elimEq/ Bprop (eq/ a b r) (f a) (f b) i
+    g = elimTypeQuotientsProp Bprop f
+elimTypeQuotientsProp Bprop f (eq/ a b r i) = elimEq/ Bprop (eq/ a b r) (f a) (f b) i
 
 -- lemma 6.10.2 in hott book
 -- TODO: defined truncated Sigma as ∃
 []surjective : (x : A / R) → ∥ Σ[ a ∈ A ] [ a ] ≡ x ∥
-[]surjective = elimSetQuotientsProp (λ x → squash) (λ a → ∣ a , refl ∣)
+[]surjective = elimTypeQuotientsProp (λ x → squash) (λ a → ∣ a , refl ∣)
 
-elimSetQuotients : {B : A / R → Set ℓ} →
-                   (Bset : (x : A / R) → isSet (B x)) →
+elimTypeQuotients : {B : A / R → Type ℓ} →
+                   (Bset : (x : A / R) → isType (B x)) →
                    (f : (a : A) → (B [ a ])) →
                    (feq : (a b : A) (r : R a b) →
                           PathP (λ i → B (eq/ a b r i)) (f a) (f b)) →
                    (x : A / R) → B x
-elimSetQuotients Bset f feq [ a ] = f a
-elimSetQuotients Bset f feq (eq/ a b r i) = feq a b r i
-elimSetQuotients Bset f feq (squash/ x y p q i j) =
+elimTypeQuotients Bset f feq [ a ] = f a
+elimTypeQuotients Bset f feq (eq/ a b r i) = feq a b r i
+elimTypeQuotients Bset f feq (squash/ x y p q i j) =
   elimSquash₀ Bset (squash/ x y p q)
               (g x) (g y) (cong g p) (cong g q) i j
     where
-      g = elimSetQuotients Bset f feq
+      g = elimTypeQuotients Bset f feq
 
 
-setQuotUniversal : {B : Set ℓ} (Bset : isSet B) →
+setQuotUniversal : {B : Type ℓ} (Bset : isType B) →
                    (A / R → B) ≃ (Σ[ f ∈ (A → B) ] ((a b : A) → R a b → f a ≡ f b))
 setQuotUniversal Bset = isoToEquiv (iso intro elim elimRightInv elimLeftInv)
   where
   intro = λ g →  (λ a → g [ a ]) , λ a b r i → g (eq/ a b r i)
-  elim = λ h → elimSetQuotients (λ x → Bset) (fst h) (snd h)
+  elim = λ h → elimTypeQuotients (λ x → Bset) (fst h) (snd h)
 
   elimRightInv : ∀ h → intro (elim h) ≡ h
   elimRightInv h = refl
@@ -99,7 +99,7 @@ effective : (Rprop : isPropValued R) (Requiv : isEquivRel R) (a b : A) → [ a ]
 effective {A = A} {R = R} Rprop (EquivRel R/refl R/sym R/trans) a b p = transport aa≡ab (R/refl _)
   where
     helper : A / R → hProp
-    helper = elimSetQuotients (λ _ → isSetHProp) (λ c → (R a c , Rprop a c))
+    helper = elimTypeQuotients (λ _ → isTypeHProp) (λ c → (R a c , Rprop a c))
                               (λ c d cd → ΣProp≡ (λ _ → isPropIsProp)
                                                  (ua (PropEquiv→Equiv (Rprop a c) (Rprop a d)
                                                                       (λ ac → R/trans _ _ _ ac cd) (λ ad → R/trans _ _ _ ad (R/sym _ _ cd)))))
@@ -122,13 +122,13 @@ isEquivRel→isEffective {R = R} Rprop Req a b = isoToEquiv (iso intro elim intr
     elim-intro : ∀ x → elim (intro x) ≡ x
     elim-intro eq = squash/ _ _ _ _
 
-discreteSetQuotients : Discrete A → isPropValued R → isEquivRel R → (∀ a₀ a₁ → Dec (R a₀ a₁)) → Discrete (A / R)
-discreteSetQuotients {A = A} {R = R} Adis Rprop Req Rdec =
- elimSetQuotients ((λ a₀ → isSetPi (λ a₁ → isProp→isSet (isPropDec (squash/ a₀ a₁)))))
-                  discreteSetQuotients' discreteSetQuotients'-eq
+discreteTypeQuotients : Discrete A → isPropValued R → isEquivRel R → (∀ a₀ a₁ → Dec (R a₀ a₁)) → Discrete (A / R)
+discreteTypeQuotients {A = A} {R = R} Adis Rprop Req Rdec =
+ elimTypeQuotients ((λ a₀ → isTypePi (λ a₁ → isProp→isType (isPropDec (squash/ a₀ a₁)))))
+                  discreteTypeQuotients' discreteTypeQuotients'-eq
   where
-    discreteSetQuotients' : (a : A) (y : A / R) → Dec ([ a ] ≡ y)
-    discreteSetQuotients' a₀ = elimSetQuotients ((λ a₁ → isProp→isSet (isPropDec (squash/ [ a₀ ] a₁)))) dis dis-eq
+    discreteTypeQuotients' : (a : A) (y : A / R) → Dec ([ a ] ≡ y)
+    discreteTypeQuotients' a₀ = elimTypeQuotients ((λ a₁ → isProp→isType (isPropDec (squash/ [ a₀ ] a₁)))) dis dis-eq
       where
         dis : (a₁ : A) → Dec ([ a₀ ] ≡ [ a₁ ])
         dis a₁ with Rdec a₀ a₁
@@ -140,10 +140,10 @@ discreteSetQuotients {A = A} {R = R} Adis Rprop Req Rdec =
         dis-eq a b ab = J (λ b ab → ∀ k → PathP (λ i → Dec ([ a₀ ] ≡ ab i)) (dis a) k)
                           (λ k → isPropDec (squash/ _ _) _  _) (eq/ a b ab) (dis b)
 
-    discreteSetQuotients'-eq : (a b : A) (r : R a b) →
+    discreteTypeQuotients'-eq : (a b : A) (r : R a b) →
       PathP (λ i → (y : A / R) → Dec (eq/ a b r i ≡ y))
-            (discreteSetQuotients' a) (discreteSetQuotients' b)
-    discreteSetQuotients'-eq a b ab =
+            (discreteTypeQuotients' a) (discreteTypeQuotients' b)
+    discreteTypeQuotients'-eq a b ab =
       J (λ b ab → ∀ k → PathP (λ i → (y : A / R) → Dec (ab i ≡ y))
-                              (discreteSetQuotients' a) k)
-        (λ k → funExt (λ x → isPropDec (squash/ _ _) _ _)) (eq/ a b ab) (discreteSetQuotients' b)
+                              (discreteTypeQuotients' a) k)
+        (λ k → funExt (λ x → isPropDec (squash/ _ _) _ _)) (eq/ a b ab) (discreteTypeQuotients' b)

--- a/Cubical/HITs/SetTruncation/Base.agda
+++ b/Cubical/HITs/SetTruncation/Base.agda
@@ -12,6 +12,6 @@ open import Cubical.Core.Primitives
 
 -- set truncation as a higher inductive type:
 
-data ∥_∥₀ {ℓ} (A : Set ℓ) : Set ℓ where
+data ∥_∥₀ {ℓ} (A : Type ℓ) : Type ℓ where
   ∣_∣₀ : A → ∥ A ∥₀
   squash₀ : ∀ (x y : ∥ A ∥₀) (p q : x ≡ y) → p ≡ q

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -23,7 +23,7 @@ private
     A : Type ℓ
 
 elimSquash₀ : {B : A → Type ℓ} →
-              (Bset : (x : A ) → isType (B x)) →
+              (Bset : (x : A ) → isSet (B x)) →
               {x y : A } {p q : x ≡ y} (sq : p ≡ q) → ∀ bx by bp bq →
               PathP (λ i → PathP (λ j → B (sq i j)) bx by) bp bq
 elimSquash₀ {A = A} {B = B} Bset {p = p} =
@@ -36,7 +36,7 @@ elimSquash₀ {A = A} {B = B} Bset {p = p} =
 
 -- lemma 6.9.1 in HoTT book
 elimTypeTrunc : {B : ∥ A ∥₀ → Type ℓ} →
-               (Bset : (x : ∥ A ∥₀) → isType (B x)) →
+               (Bset : (x : ∥ A ∥₀) → isSet (B x)) →
                (g : (a : A) → B (∣ a ∣₀)) →
                (x : ∥ A ∥₀) → B x
 elimTypeTrunc Bset g ∣ a ∣₀ = g a
@@ -44,7 +44,7 @@ elimTypeTrunc {A = A} {B = B} Bset g (squash₀ x y p q i j) =
   elimSquash₀ Bset (squash₀ x y p q) (elimTypeTrunc Bset g x) (elimTypeTrunc Bset g y)
     (cong (elimTypeTrunc Bset g) p) (cong (elimTypeTrunc Bset g) q) i j
 
-setTruncUniversal : {B : Type ℓ} → (isType B) → (∥ A ∥₀ → B) ≃ (A → B)
+setTruncUniversal : {B : Type ℓ} → (isSet B) → (∥ A ∥₀ → B) ≃ (A → B)
 setTruncUniversal Bset = isoToEquiv (iso intro elim leftInv rightInv)
   where
   intro = (λ h a → h ∣ a ∣₀)
@@ -54,18 +54,18 @@ setTruncUniversal Bset = isoToEquiv (iso intro elim leftInv rightInv)
   leftInv g = refl
 
   rightInv : ∀ h → elim (intro h) ≡ h
-  rightInv h i x = elimTypeTrunc (λ x → isProp→isType (Bset (elim (intro h) x) (h x)))
+  rightInv h i x = elimTypeTrunc (λ x → isProp→isSet (Bset (elim (intro h) x) (h x)))
                                 (λ a → refl) x i
 
 elimTypeTrunc2 : {B : ∥ A ∥₀ → ∥ A ∥₀ → Type ℓ}
-                (Bset : ((x y : ∥ A ∥₀) → isType (B x y)))
+                (Bset : ((x y : ∥ A ∥₀) → isSet (B x y)))
                 (g : (a b : A) → B ∣ a ∣₀ ∣ b ∣₀)
                 (x y : ∥ A ∥₀) → B x y
 elimTypeTrunc2 Bset g = elimTypeTrunc (λ _ → hLevelPi 2 (λ _ → Bset _ _)) (λ a →
                        elimTypeTrunc (λ _ → Bset _ _) (λ b → g a b))
 
 elimTypeTrunc3 : {B : (x y z : ∥ A ∥₀) → Type ℓ}
-                (Bset : ((x y z : ∥ A ∥₀) → isType (B x y z)))
+                (Bset : ((x y z : ∥ A ∥₀) → isSet (B x y z)))
                 (g : (a b c : A) → B ∣ a ∣₀ ∣ b ∣₀ ∣ c ∣₀)
                 (x y z : ∥ A ∥₀) → B x y z
 elimTypeTrunc3 Bset g = elimTypeTrunc2 (λ _ _ → hLevelPi 2 λ _ → Bset _ _ _) (λ a b →

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -35,38 +35,38 @@ elimSquash₀ {A = A} {B = B} Bset {p = p} =
       (bp bp' : PathP (λ i → B (p i)) bx by) → bp ≡ bp') (Bset x)
 
 -- lemma 6.9.1 in HoTT book
-elimTypeTrunc : {B : ∥ A ∥₀ → Type ℓ} →
+elimSetTrunc : {B : ∥ A ∥₀ → Type ℓ} →
                (Bset : (x : ∥ A ∥₀) → isSet (B x)) →
                (g : (a : A) → B (∣ a ∣₀)) →
                (x : ∥ A ∥₀) → B x
-elimTypeTrunc Bset g ∣ a ∣₀ = g a
-elimTypeTrunc {A = A} {B = B} Bset g (squash₀ x y p q i j) =
-  elimSquash₀ Bset (squash₀ x y p q) (elimTypeTrunc Bset g x) (elimTypeTrunc Bset g y)
-    (cong (elimTypeTrunc Bset g) p) (cong (elimTypeTrunc Bset g) q) i j
+elimSetTrunc Bset g ∣ a ∣₀ = g a
+elimSetTrunc {A = A} {B = B} Bset g (squash₀ x y p q i j) =
+  elimSquash₀ Bset (squash₀ x y p q) (elimSetTrunc Bset g x) (elimSetTrunc Bset g y)
+    (cong (elimSetTrunc Bset g) p) (cong (elimSetTrunc Bset g) q) i j
 
 setTruncUniversal : {B : Type ℓ} → (isSet B) → (∥ A ∥₀ → B) ≃ (A → B)
 setTruncUniversal Bset = isoToEquiv (iso intro elim leftInv rightInv)
   where
   intro = (λ h a → h ∣ a ∣₀)
-  elim = elimTypeTrunc (λ x → Bset)
+  elim = elimSetTrunc (λ x → Bset)
 
   leftInv : ∀ g → intro (elim g) ≡ g
   leftInv g = refl
 
   rightInv : ∀ h → elim (intro h) ≡ h
-  rightInv h i x = elimTypeTrunc (λ x → isProp→isSet (Bset (elim (intro h) x) (h x)))
+  rightInv h i x = elimSetTrunc (λ x → isProp→isSet (Bset (elim (intro h) x) (h x)))
                                 (λ a → refl) x i
 
-elimTypeTrunc2 : {B : ∥ A ∥₀ → ∥ A ∥₀ → Type ℓ}
+elimSetTrunc2 : {B : ∥ A ∥₀ → ∥ A ∥₀ → Type ℓ}
                 (Bset : ((x y : ∥ A ∥₀) → isSet (B x y)))
                 (g : (a b : A) → B ∣ a ∣₀ ∣ b ∣₀)
                 (x y : ∥ A ∥₀) → B x y
-elimTypeTrunc2 Bset g = elimTypeTrunc (λ _ → hLevelPi 2 (λ _ → Bset _ _)) (λ a →
-                       elimTypeTrunc (λ _ → Bset _ _) (λ b → g a b))
+elimSetTrunc2 Bset g = elimSetTrunc (λ _ → hLevelPi 2 (λ _ → Bset _ _)) (λ a →
+                       elimSetTrunc (λ _ → Bset _ _) (λ b → g a b))
 
-elimTypeTrunc3 : {B : (x y z : ∥ A ∥₀) → Type ℓ}
+elimSetTrunc3 : {B : (x y z : ∥ A ∥₀) → Type ℓ}
                 (Bset : ((x y z : ∥ A ∥₀) → isSet (B x y z)))
                 (g : (a b c : A) → B ∣ a ∣₀ ∣ b ∣₀ ∣ c ∣₀)
                 (x y z : ∥ A ∥₀) → B x y z
-elimTypeTrunc3 Bset g = elimTypeTrunc2 (λ _ _ → hLevelPi 2 λ _ → Bset _ _ _) (λ a b →
-                       elimTypeTrunc (λ _ → Bset _ _ _) (λ c → g a b c))
+elimSetTrunc3 Bset g = elimSetTrunc2 (λ _ _ → hLevelPi 2 λ _ → Bset _ _ _) (λ a b →
+                       elimSetTrunc (λ _ → Bset _ _ _) (λ c → g a b c))

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -20,10 +20,10 @@ open import Cubical.Foundations.HLevels
 private
   variable
     ℓ : Level
-    A : Set ℓ
+    A : Type ℓ
 
-elimSquash₀ : {B : A → Set ℓ} →
-              (Bset : (x : A ) → isSet (B x)) →
+elimSquash₀ : {B : A → Type ℓ} →
+              (Bset : (x : A ) → isType (B x)) →
               {x y : A } {p q : x ≡ y} (sq : p ≡ q) → ∀ bx by bp bq →
               PathP (λ i → PathP (λ j → B (sq i j)) bx by) bp bq
 elimSquash₀ {A = A} {B = B} Bset {p = p} =
@@ -35,38 +35,38 @@ elimSquash₀ {A = A} {B = B} Bset {p = p} =
       (bp bp' : PathP (λ i → B (p i)) bx by) → bp ≡ bp') (Bset x)
 
 -- lemma 6.9.1 in HoTT book
-elimSetTrunc : {B : ∥ A ∥₀ → Set ℓ} →
-               (Bset : (x : ∥ A ∥₀) → isSet (B x)) →
+elimTypeTrunc : {B : ∥ A ∥₀ → Type ℓ} →
+               (Bset : (x : ∥ A ∥₀) → isType (B x)) →
                (g : (a : A) → B (∣ a ∣₀)) →
                (x : ∥ A ∥₀) → B x
-elimSetTrunc Bset g ∣ a ∣₀ = g a
-elimSetTrunc {A = A} {B = B} Bset g (squash₀ x y p q i j) =
-  elimSquash₀ Bset (squash₀ x y p q) (elimSetTrunc Bset g x) (elimSetTrunc Bset g y)
-    (cong (elimSetTrunc Bset g) p) (cong (elimSetTrunc Bset g) q) i j
+elimTypeTrunc Bset g ∣ a ∣₀ = g a
+elimTypeTrunc {A = A} {B = B} Bset g (squash₀ x y p q i j) =
+  elimSquash₀ Bset (squash₀ x y p q) (elimTypeTrunc Bset g x) (elimTypeTrunc Bset g y)
+    (cong (elimTypeTrunc Bset g) p) (cong (elimTypeTrunc Bset g) q) i j
 
-setTruncUniversal : {B : Set ℓ} → (isSet B) → (∥ A ∥₀ → B) ≃ (A → B)
+setTruncUniversal : {B : Type ℓ} → (isType B) → (∥ A ∥₀ → B) ≃ (A → B)
 setTruncUniversal Bset = isoToEquiv (iso intro elim leftInv rightInv)
   where
   intro = (λ h a → h ∣ a ∣₀)
-  elim = elimSetTrunc (λ x → Bset)
+  elim = elimTypeTrunc (λ x → Bset)
 
   leftInv : ∀ g → intro (elim g) ≡ g
   leftInv g = refl
 
   rightInv : ∀ h → elim (intro h) ≡ h
-  rightInv h i x = elimSetTrunc (λ x → isProp→isSet (Bset (elim (intro h) x) (h x)))
+  rightInv h i x = elimTypeTrunc (λ x → isProp→isType (Bset (elim (intro h) x) (h x)))
                                 (λ a → refl) x i
 
-elimSetTrunc2 : {B : ∥ A ∥₀ → ∥ A ∥₀ → Set ℓ}
-                (Bset : ((x y : ∥ A ∥₀) → isSet (B x y)))
+elimTypeTrunc2 : {B : ∥ A ∥₀ → ∥ A ∥₀ → Type ℓ}
+                (Bset : ((x y : ∥ A ∥₀) → isType (B x y)))
                 (g : (a b : A) → B ∣ a ∣₀ ∣ b ∣₀)
                 (x y : ∥ A ∥₀) → B x y
-elimSetTrunc2 Bset g = elimSetTrunc (λ _ → hLevelPi 2 (λ _ → Bset _ _)) (λ a →
-                       elimSetTrunc (λ _ → Bset _ _) (λ b → g a b))
+elimTypeTrunc2 Bset g = elimTypeTrunc (λ _ → hLevelPi 2 (λ _ → Bset _ _)) (λ a →
+                       elimTypeTrunc (λ _ → Bset _ _) (λ b → g a b))
 
-elimSetTrunc3 : {B : (x y z : ∥ A ∥₀) → Set ℓ}
-                (Bset : ((x y z : ∥ A ∥₀) → isSet (B x y z)))
+elimTypeTrunc3 : {B : (x y z : ∥ A ∥₀) → Type ℓ}
+                (Bset : ((x y z : ∥ A ∥₀) → isType (B x y z)))
                 (g : (a b c : A) → B ∣ a ∣₀ ∣ b ∣₀ ∣ c ∣₀)
                 (x y z : ∥ A ∥₀) → B x y z
-elimSetTrunc3 Bset g = elimSetTrunc2 (λ _ _ → hLevelPi 2 λ _ → Bset _ _ _) (λ a b →
-                       elimSetTrunc (λ _ → Bset _ _ _) (λ c → g a b c))
+elimTypeTrunc3 Bset g = elimTypeTrunc2 (λ _ _ → hLevelPi 2 λ _ → Bset _ _ _) (λ a b →
+                       elimTypeTrunc (λ _ → Bset _ _ _) (λ c → g a b c))

--- a/Cubical/HITs/SmashProduct/Base.agda
+++ b/Cubical/HITs/SmashProduct/Base.agda
@@ -5,13 +5,13 @@ open import Cubical.Foundations.Prelude
 
 -- This should be upstreamed to Basics when we develop some theory
 -- about pointed types
-ptType : Set₁
-ptType = Σ[ A ∈ Set ] A
+ptType : Type₁
+ptType = Σ[ A ∈ Type₀ ] A
 
 pt : ∀ (A : ptType) → A .fst
 pt A = A .snd
 
-data Smash (A B : ptType) : Set where
+data Smash (A B : ptType) : Type₀ where
   basel : Smash A B
   baser : Smash A B
   proj  : (x : A .fst) → (y : B .fst) → Smash A B

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -13,12 +13,12 @@ open import Cubical.HITs.S1
 open import Cubical.HITs.S2
 open import Cubical.HITs.S3
 
-data Susp {ℓ} (A : Set ℓ) : Set ℓ where
+data Susp {ℓ} (A : Type ℓ) : Type ℓ where
   north : Susp A
   south : Susp A
   merid : (a : A) → north ≡ south
 
-SuspBool : Set
+SuspBool : Type₀
 SuspBool = Susp Bool
 
 SuspBool→S¹ : SuspBool → S¹
@@ -53,7 +53,7 @@ S¹≡SuspBool = isoToPath (iso S¹→SuspBool SuspBool→S¹ SuspBool→S¹→S
 
 -- Now the sphere
 
-SuspS¹ : Set
+SuspS¹ : Type₀
 SuspS¹ = Susp S¹
 
 SuspS¹→S² : SuspS¹ → S²
@@ -88,7 +88,7 @@ S²≡SuspS¹ = isoToPath (iso S²→SuspS¹ SuspS¹→S² SuspS¹→S²→SuspS
 
 -- And the 3-sphere
 
-SuspS² : Set
+SuspS² : Type₀
 SuspS² = Susp S²
 
 SuspS²→S³ : SuspS² → S³

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -18,7 +18,7 @@ open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
 
 open import Cubical.HITs.S1
 
-data Torus : Set where
+data Torus : Type₀ where
   point : Torus
   line1 : point ≡ point
   line2 : point ≡ point
@@ -51,18 +51,18 @@ t2c-c2t (loop _ , loop _) = refl
 Torus≡S¹×S¹ : Torus ≡ S¹ × S¹
 Torus≡S¹×S¹ = isoToPath (iso t2c c2t t2c-c2t c2t-t2c)
 
-ΩTorus : Set
+ΩTorus : Type₀
 ΩTorus = point ≡ point
 
 -- TODO: upstream
-lemPathAnd : ∀ {ℓ} {A B : Set ℓ} (t u : A × B) →
+lemPathAnd : ∀ {ℓ} {A B : Type ℓ} (t u : A × B) →
   Path _ (t ≡ u) ((t .fst ≡ u .fst) × ((t .snd) ≡ (u .snd)))
 lemPathAnd t u = isoToPath (iso (λ tu → (λ i → tu i .fst) , λ i → tu i .snd)
                                  (λ tu i → tu .fst i , tu .snd i)
                                  (λ y → refl)
                                  (λ x → refl))
 
-funDep : ∀ {ℓ} {A B : Set ℓ} (p : A ≡ B) (u0 : A) (u1 : B) →
+funDep : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B) (u0 : A) (u1 : B) →
   (Path A u0 (transport (λ i → p (~ i)) u1)) ≡ (Path B (transport p u0) u1)
 funDep p u0 u1 i = Path (p i) (transp (λ j → p (i ∧ j)) (~ i) u0) (transp (λ j → p (i ∨ ~ j)) i u1)
 

--- a/Cubical/Induction/WellFounded.agda
+++ b/Cubical/Induction/WellFounded.agda
@@ -4,21 +4,21 @@ module Cubical.Induction.WellFounded where
 
 open import Cubical.Foundations.Everything
 
-Rel : ∀{ℓ} → Set ℓ → ∀ ℓ' → Set _
-Rel A ℓ = A → A → Set ℓ
+Rel : ∀{ℓ} → Type ℓ → ∀ ℓ' → Type _
+Rel A ℓ = A → A → Type ℓ
 
-module _ {ℓ ℓ'} {A : Set ℓ} (_<_ : A → A → Set ℓ') where
-  WFRec : ∀{ℓ''} → (A → Set ℓ'') → A → Set _
+module _ {ℓ ℓ'} {A : Type ℓ} (_<_ : A → A → Type ℓ') where
+  WFRec : ∀{ℓ''} → (A → Type ℓ'') → A → Type _
   WFRec P x = ∀ y → y < x → P y
 
-  data Acc (x : A) : Set (ℓ-max ℓ ℓ') where
+  data Acc (x : A) : Type (ℓ-max ℓ ℓ') where
     acc : WFRec Acc x → Acc x
 
-  WellFounded : Set _
+  WellFounded : Type _
   WellFounded = ∀ x → Acc x
 
 
-module _ {ℓ ℓ'} {A : Set ℓ} {_<_ : A → A → Set ℓ'} where
+module _ {ℓ ℓ'} {A : Type ℓ} {_<_ : A → A → Type ℓ'} where
   isPropAcc : ∀ x → isProp (Acc _<_ x)
   isPropAcc x (acc p) (acc q)
     = λ i → acc (λ y y<x → isPropAcc y (p y y<x) (q y y<x) i)
@@ -27,14 +27,14 @@ module _ {ℓ ℓ'} {A : Set ℓ} {_<_ : A → A → Set ℓ'} where
   access (acc r) = r
 
   private
-    wfi : ∀{ℓ''} {P : A → Set ℓ''}
+    wfi : ∀{ℓ''} {P : A → Type ℓ''}
         → ∀ x → (wf : Acc _<_ x)
         → (∀ x → (∀ y → y < x → P y) → P x)
         → P x
     wfi x (acc p) e = e x λ y y<x → wfi y (p y y<x) e
 
   module WFI (wf : WellFounded _<_) where
-    module _ {ℓ''} {P : A → Set ℓ''} (e : ∀ x → (∀ y → y < x → P y) → P x) where
+    module _ {ℓ''} {P : A → Type ℓ''} (e : ∀ x → (∀ y → y < x → P y) → P x) where
       private
         wfi-compute : ∀ x ax → wfi x ax e ≡ e x (λ y _ → wfi y (wf y) e)
         wfi-compute x (acc p)

--- a/Cubical/Relation/Binary.agda
+++ b/Cubical/Relation/Binary.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Relation.Binary where
+
+open import Cubical.Relation.Binary.Base public
+open import Cubical.Relation.Binary.Properties public
+

--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -8,27 +8,27 @@ open import Cubical.Foundations.HLevels
 
 open import Cubical.HITs.SetQuotients.Base
 
-module BinaryRelation {ℓ ℓ' : Level} {A : Set ℓ} (R : A → A → Set ℓ') where
-  isRefl : Set (ℓ-max ℓ ℓ')
+module BinaryRelation {ℓ ℓ' : Level} {A : Type ℓ} (R : A → A → Type ℓ') where
+  isRefl : Type (ℓ-max ℓ ℓ')
   isRefl = (a : A) → R a a
 
-  isSym : Set (ℓ-max ℓ ℓ')
+  isSym : Type (ℓ-max ℓ ℓ')
   isSym = (a b : A) → R a b → R b a
 
-  isTrans : Set (ℓ-max ℓ ℓ')
+  isTrans : Type (ℓ-max ℓ ℓ')
   isTrans = (a b c : A)  → R a b → R b c → R a c
 
-  record isEquivRel : Set (ℓ-max ℓ ℓ') where
+  record isEquivRel : Type (ℓ-max ℓ ℓ') where
     constructor EquivRel
     field
       reflexive : isRefl
       symmetric : isSym
       transitive : isTrans
 
-  isPropValued : Set (ℓ-max ℓ ℓ')
+  isPropValued : Type (ℓ-max ℓ ℓ')
   isPropValued = (a b : A) → isProp (R a b)
 
-  isEffective : Set (ℓ-max ℓ ℓ')
+  isEffective : Type (ℓ-max ℓ ℓ')
   isEffective = (a b : A) →
     let x : A / R
         x = [ a ]

--- a/Cubical/Relation/Binary/Properties.agda
+++ b/Cubical/Relation/Binary/Properties.agda
@@ -3,8 +3,8 @@
 module Cubical.Relation.Binary.Properties where
 
 open import Cubical.Relation.Binary.Base
-open import Cubical.HITs.SetQuotients.Base
-open import Cubical.HITs.SetQuotients.Properties
+open import Cubical.HITs.TypeQuotients.Base
+open import Cubical.HITs.TypeQuotients.Properties
 open import Cubical.Core.Prelude
 open import Cubical.Core.Glue
 open import Cubical.Foundations.HLevels
@@ -14,5 +14,5 @@ open BinaryRelation
 
 
 
-module BinaryRelationProperties {ℓ ℓ' : Level} {A : Set ℓ} (R : A → A → hProp {ℓ = ℓ'}) where
+module BinaryRelationProperties {ℓ ℓ' : Level} {A : Type ℓ} (R : A → A → hProp {ℓ = ℓ'}) where
 

--- a/Cubical/Relation/Binary/Properties.agda
+++ b/Cubical/Relation/Binary/Properties.agda
@@ -1,18 +1,5 @@
 {-# OPTIONS --cubical --safe #-}
-
 module Cubical.Relation.Binary.Properties where
 
-open import Cubical.Relation.Binary.Base
-open import Cubical.HITs.TypeQuotients.Base
-open import Cubical.HITs.TypeQuotients.Properties
-open import Cubical.Core.Prelude
-open import Cubical.Core.Glue
+open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Equiv
-
-open BinaryRelation
-
-
-
-module BinaryRelationProperties {ℓ ℓ' : Level} {A : Type ℓ} (R : A → A → hProp {ℓ = ℓ'}) where
-

--- a/Cubical/Relation/Everything.agda
+++ b/Cubical/Relation/Everything.agda
@@ -3,3 +3,4 @@ module Cubical.Relation.Everything where
 
 open import Cubical.Relation.Nullary public
 open import Cubical.Relation.Nullary.DecidableEq public
+open import Cubical.Relation.Binary public

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -10,26 +10,26 @@ open import Cubical.Data.Empty
 private
   variable
     ℓ  : Level
-    A  : Set ℓ
+    A  : Type ℓ
 
 -- Negation
 infix 3 ¬_
 
-¬_ : Set ℓ → Set ℓ
+¬_ : Type ℓ → Type ℓ
 ¬ A = A → ⊥
 
-isProp¬ : (A : Set ℓ) → isProp (¬ A)
+isProp¬ : (A : Type ℓ) → isProp (¬ A)
 isProp¬ A p q i x = isProp⊥ (p x) (q x) i
 
 -- Decidable types (inspired by standard library)
-data Dec (P : Set ℓ) : Set ℓ where
+data Dec (P : Type ℓ) : Type ℓ where
   yes : ( p :   P) → Dec P
   no  : (¬p : ¬ P) → Dec P
 
-Stable : Set ℓ → Set ℓ
+Stable : Type ℓ → Type ℓ
 Stable A = ¬ ¬ A → A
 
-Discrete : Set ℓ → Set ℓ
+Discrete : Type ℓ → Type ℓ
 Discrete A = (x y : A) → Dec (x ≡ y)
 
 Stable¬ : Stable (¬ A)

--- a/Cubical/Relation/Nullary/DecidableEq.agda
+++ b/Cubical/Relation/Nullary/DecidableEq.agda
@@ -15,8 +15,8 @@ Dec→Stable : ∀ {ℓ} (A : Type ℓ) → Dec A → Stable A
 Dec→Stable A (yes x) = λ _ → x
 Dec→Stable A (no x) = λ f → ⊥-elim (f x)
 
-Stable≡→isType : ∀ {ℓ} {A : Type ℓ} → (st : ∀ (a b : A) → Stable (a ≡ b)) → isType A
-Stable≡→isType {A = A} st a b p q j i =
+Stable≡→isSet : ∀ {ℓ} {A : Type ℓ} → (st : ∀ (a b : A) → Stable (a ≡ b)) → isSet A
+Stable≡→isSet {A = A} st a b p q j i =
   let f : (x : A) → a ≡ x → a ≡ x
       f x p = st a x (λ h → h p)
       fIsConst : (x : A) → (p q : a ≡ x) → f x p ≡ f x q
@@ -29,5 +29,5 @@ Stable≡→isType {A = A} st a b p q j i =
                     ; (j = i1) → rem q i k }) a
 
 -- Hedberg's theorem
-Discrete→isType : ∀ {ℓ} {A : Type ℓ} → Discrete A → isType A
-Discrete→isType d = Stable≡→isType (λ x y → Dec→Stable (x ≡ y) (d x y))
+Discrete→isSet : ∀ {ℓ} {A : Type ℓ} → Discrete A → isSet A
+Discrete→isSet d = Stable≡→isSet (λ x y → Dec→Stable (x ≡ y) (d x y))

--- a/Cubical/Relation/Nullary/DecidableEq.agda
+++ b/Cubical/Relation/Nullary/DecidableEq.agda
@@ -11,12 +11,12 @@ open import Cubical.Relation.Nullary
 
 -- Proof of Hedberg's theorem: a type with decidable equality is an h-set
 
-Dec→Stable : ∀ {ℓ} (A : Set ℓ) → Dec A → Stable A
+Dec→Stable : ∀ {ℓ} (A : Type ℓ) → Dec A → Stable A
 Dec→Stable A (yes x) = λ _ → x
 Dec→Stable A (no x) = λ f → ⊥-elim (f x)
 
-Stable≡→isSet : ∀ {ℓ} {A : Set ℓ} → (st : ∀ (a b : A) → Stable (a ≡ b)) → isSet A
-Stable≡→isSet {A = A} st a b p q j i =
+Stable≡→isType : ∀ {ℓ} {A : Type ℓ} → (st : ∀ (a b : A) → Stable (a ≡ b)) → isType A
+Stable≡→isType {A = A} st a b p q j i =
   let f : (x : A) → a ≡ x → a ≡ x
       f x p = st a x (λ h → h p)
       fIsConst : (x : A) → (p q : a ≡ x) → f x p ≡ f x q
@@ -29,5 +29,5 @@ Stable≡→isSet {A = A} st a b p q j i =
                     ; (j = i1) → rem q i k }) a
 
 -- Hedberg's theorem
-Discrete→isSet : ∀ {ℓ} {A : Set ℓ} → Discrete A → isSet A
-Discrete→isSet d = Stable≡→isSet (λ x y → Dec→Stable (x ≡ y) (d x y))
+Discrete→isType : ∀ {ℓ} {A : Type ℓ} → Discrete A → isType A
+Discrete→isType d = Stable≡→isType (λ x y → Dec→Stable (x ≡ y) (d x y))


### PR DESCRIPTION
This resolves https://github.com/agda/cubical/issues/118 by adding:
```
Type : (ℓ : Level) → Set (ℓ-suc ℓ)
Type ℓ = Set ℓ

Type₀ : Type (ℓ-suc ℓ-zero)
Type₀ = Type ℓ-zero

Type₁ : Type (ℓ-suc (ℓ-suc ℓ-zero))
Type₁ = Type (ℓ-suc ℓ-zero)
```
to Cubical.Core.Primitives. It also renames `Setω`  to `Typeω`.

All uses of `Set ℓ` are then changed to `Type ℓ`. One drawback is that simply `Set` used to mean `Set 0`, but now it has to be `Type₀`. However this seems better to me as it is a bit clearer.

Question: can we somehow forbid the use of `Set` somehow?