### PR TITLE
Change comp to the builtin one

### DIFF
--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -26,9 +26,9 @@ module Helpers where
   compPathD F {A = A} P Q {x} p q i =
      comp (\ j → F (hfill (λ j → \ { (i = i0) → A ; (i = i1) → Q j })
                           (inS (P i))
-                          j))
+                          j)) _
           (λ j → \ { (i = i0) → x; (i = i1) → q j })
-          (inS (p i))
+          (p i)
 
 open Helpers
 

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -17,7 +17,7 @@ open import Agda.Primitive.Cubical public
            ; primIMax       to _∨_  -- I → I → I
            ; primINeg       to ~_   -- I → I
            ; isOneEmpty     to empty
-           ; primComp       to compCCHM  -- This should not be used
+           ; primComp       to comp
            ; primHComp      to hcomp
            ; primTransp     to transp
            ; itIsOne        to 1=1 )
@@ -169,16 +169,18 @@ hfill {φ = φ} u u0 i =
                  ; (i = i0) → outS u0 })
         (outS u0)
 
--- Heterogeneous composition defined as in CHM
-comp : (A : ∀ i → Type (ℓ′ i))
-       {φ : I}
-       (u : ∀ i → Partial φ (A i))
-       (u0 : A i0 [ φ ↦ u i0 ])
-     → ---------------------------
-       A i1
-comp A {φ = φ} u u0 =
-  hcomp (λ i → λ { (φ = i1) → transp (λ j → A (i ∨ j)) i (u _ 1=1) })
-        (transp A i0 (outS u0))
+-- Heterogeneous composition can defined as in CHM, however we use the
+-- builtin one as it doesn't require u0 to be a cubical subtype. This
+-- reduces the number of inS's a lot.
+-- comp : (A : ∀ i → Type (ℓ′ i))
+--        {φ : I}
+--        (u : ∀ i → Partial φ (A i))
+--        (u0 : A i0 [ φ ↦ u i0 ])
+--      → ---------------------------
+--        A i1
+-- comp A {φ = φ} u u0 =
+--   hcomp (λ i → λ { (φ = i1) → transp (λ j → A (i ∨ j)) i (u _ 1=1) })
+--         (transp A i0 (outS u0))
 
 -- Heterogeneous filling defined using comp
 fill : (A : ∀ i → Type (ℓ′ i))
@@ -189,21 +191,10 @@ fill : (A : ∀ i → Type (ℓ′ i))
        (i : I) → A i
 fill A {φ = φ} u u0 i =
   comp (λ j → A (i ∧ j))
+       _
        (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
                 ; (i = i0) → outS u0 })
-       (inS {φ = φ ∨ (~ i)} (outS {φ = φ} u0))
-
-
--- Direct definition of transport filler, note that we have to
--- explicitly tell Agda that the type is constant (like in CHM)
-transpFill : {A : Type ℓ}
-             (φ : I)
-             (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A) ])
-             (u0 : outS (A i0))
-           → --------------------------------------
-             PathP (λ i → outS (A i)) u0 (transp (λ i → outS (A i)) φ u0)
-transpFill φ A u0 i = transp (λ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
-
+       (outS u0) -- u0 -- (inS {φ = φ ∨ (~ i)} (outS {φ = φ} u0))
 
 -- Σ-types
 infix 2 Σ-syntax

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -103,13 +103,13 @@ private
   homotopy-π2 : (a b : Σ A B) → (p : a Σ≡T b) → (i : I) →
              (transport (λ j → B (fst (filler-comp a b p j i))) (snd a) ≡ snd b)
   homotopy-π2 {B = B} a b p i j =
-    comp (λ t → B (fst (filler-comp a b p t (i ∨ j))))
+    comp (λ t → B (fst (filler-comp a b p t (i ∨ j)))) _
          (λ t → λ { (j = i0) → coe0→i (λ t → B (fst (filler-comp a b p t i)))
                                       t (snd a)
                   ; (j = i1) → snd (sigmaPath→pathSigma a b p t)
                   ; (i = i0) → snd (filler-comp a b p t j)
                   ; (i = i1) → filler-π2 (sigmaPath→pathSigma a b p) j t })
-         (inS (snd a))
+         (snd a)
 
 pathSigma→sigmaPath→pathSigma : {a b : Σ A B} →
   ∀ (x : a Σ≡T b) → pathSigma→sigmaPath _ _ (sigmaPath→pathSigma a b x) ≡ x

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -94,10 +94,10 @@ fill1→i : ∀ {ℓ} (A : ∀ i → Type ℓ)
        ---------------------------
        (i : I) → A i
 fill1→i A {φ = φ} u u1 i =
-  comp (λ j → A (i ∨ ~ j))
+  comp (λ j → A (i ∨ ~ j)) _
        (λ j → λ { (φ = i1) → u (i ∨ ~ j) 1=1
                 ; (i = i1) → outS u1 })
-       (inS {φ = φ ∨ i} (outS {φ = φ} u1))
+       (outS u1)
 
 filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
@@ -107,10 +107,10 @@ filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
        ---------------------------
        → A i0
 filli→0 A {φ = φ} u i ui =
-  comp (λ j → A (i ∧ ~ j))
+  comp (λ j → A (i ∧ ~ j)) _
        (λ j → λ { (φ = i1) → u (i ∧ ~ j) 1=1
                 ; (i = i0) → outS ui })
-       (inS {φ = φ ∨ ~ i} (outS {φ = φ} ui))
+       (outS ui)
 
 filli→j : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -118,20 +118,22 @@ lUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y
   PathP (λ j → PathP (λ i → lUnit (λ i → A i) j i) x y) p (compPathP refl p)
 lUnitP {A = A} {x = x} p k i =
   comp (λ j → lUnit-filler (λ i → A i) j k i)
+       _
        (λ j → λ { (i = i0) → x
                  ; (i = i1) → p (~ k ∨ j )
                  ; (k = i0) → p i
-                 }) (inS (p (~ k ∧ i )))
+                 }) (p (~ k ∧ i ))
 
 
 rCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → rCancel (λ i → A i) j i) x x) (compPathP p (symP p)) refl
 rCancelP {A = A} {x = x} p j i =
   comp (λ k → rCancel-filler (λ i → A i) k j i)
+       _
        (λ k → λ { (i = i0) → x
                  ; (i = i1) → p (~ k ∧ ~ j)
                  ; (j = i1) → x
-                 }) (inS (p (i ∧ ~ j)))
+                 }) (p (i ∧ ~ j))
 
 lCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → lCancel (λ i → A i) j i) y y) (compPathP (symP p) p) refl
@@ -145,22 +147,23 @@ lCancelP p = rCancelP (symP p)
   PathP (λ j → PathP (λ i → 3outof4 (λ j i → A i j) P B j i) (α i1 i0) (α i1 i1)) (λ i → α i1 i) p
 3outof4P {A = A} {P} {B} α p β j i =
   comp (λ k → 3outof4-filler (λ j i → A i j) P B k j i)
+       _
        (λ k → λ { (i = i0) → α k i0
                  ; (i = i1) → α k i1
                  ; (j = i0) → α k i
                  ; (j = i1) → β k i
-                 }) (inS (α i0 i))
+                 }) (α i0 i)
 
 preassocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
   {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
   PathP (λ j → PathP (λ i → preassoc (λ i → A i) B C j i) x ((compPathP q r) j)) p (compPathP (compPathP p q) r)
 preassocP {A = A} {x = x} {B = B} {C = C} p q r j i =
-  comp (λ k → preassoc-filler (λ i → A i) B C k j i)
+  comp (λ k → preassoc-filler (λ i → A i) B C k j i) _
        (λ k → λ { (i = i0) → x
                  ; (i = i1) → compPathP-filler q r j k
                  ; (j = i0) → p i
               -- ; (j = i1) → compPathP-filler (compPathP p q) r i k
-                 }) (inS (compPathP-filler p q i j))
+                 }) (compPathP-filler p q i j)
 
 assocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
   {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -78,7 +78,8 @@ module _ {x : A} (P : ∀ (y : A) → Id x y → Type ℓ') (d : P x refl) where
   J : ∀ {y : A} (w : x ≡ y) → P y w
   J {y = y} = elimId P (λ φ y w → comp (λ i → P _ (conId (φ ∨ ~ i) (inS (outS w i))
                                                                    (inS (λ j → outS w (i ∧ j)))))
-                                       (λ i → λ { (φ = i1) → d}) (inS d)) {y = y}
+                                       _
+                                       (λ i → λ { (φ = i1) → d}) d) {y = y}
 
   -- Check that J of refl is the identity function
   Jdefeq : Path _ (J refl) d

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -12,6 +12,16 @@ open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 
+-- Direct definition of transport filler, note that we have to
+-- explicitly tell Agda that the type is constant (like in CHM)
+transpFill : ∀ {ℓ} {A : Type ℓ}
+             (φ : I)
+             (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A) ])
+             (u0 : outS (A i0))
+           → --------------------------------------
+             PathP (λ i → outS (A i)) u0 (transp (λ i → outS (A i)) φ u0)
+transpFill φ A u0 i = transp (λ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
+
 transport⁻ : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → B → A
 transport⁻ p = transport (λ i → p (~ i))
 

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -43,7 +43,7 @@ g2TruncFib {A} P {a} {b} sPb {p} {q} {r} {s} {u} {v} w
           (Lb i j k l)
   where
   L : Path (Path (b1 ≡ b1) refl refl) refl refl
-  L i j k = comp (λ l → P (w i j k l))
+  L i j k = comp (λ l → P (w i j k l)) _
                  (λ l → λ { (i = i0) → u1 j k l
                           ; (i = i1) → v1 j k l
                           ; (j = i0) → r1 k l
@@ -51,7 +51,7 @@ g2TruncFib {A} P {a} {b} sPb {p} {q} {r} {s} {u} {v} w
                           ; (k = i0) → p1 l
                           ; (k = i1) → q1 l
                           })
-                 (inS a1)
+                 a1
   Lb : PathP (λ i → PathP (λ j → PathP (λ k → PathP (λ l → P (w i j k l)) a1 (L i j k)) p1 q1) r1 s1) u1 v1
   Lb i j k l = fill (λ l → P (w i j k l))
                     (λ l → λ { (i = i0) → u1 j k l

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -38,12 +38,12 @@ groupoidTruncFib P {a} {b} sPb u {a1} {b1} {p1} {q1} r1 s1 i j k =
         (Lb i j k)
   where
   L : (i j : I) → P b
-  L i j = comp (λ k → P (u i j k))
+  L i j = comp (λ k → P (u i j k)) _
                (λ k → λ { (i = i0) → r1 j k
                         ; (i = i1) → s1 j k
                         ; (j = i0) → p1 k
                         ; (j = i1) → q1 k })
-               (inS a1)
+               a1
   Lb : PathP (λ i → PathP (λ j → PathP (λ k → P (u i j k)) a1 (L i j)) p1 q1) r1 s1
   Lb i j k = fill (λ k → P (u i j k))
                   (λ k → λ { (i = i0) → r1 j k

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -28,7 +28,7 @@ module _ where
   transpS¹ φ u0 = refl
 
   compS1 : ∀ (φ : I) (u : ∀ i → Partial φ S¹) (u0 : S¹ [ φ ↦ u i0 ]) →
-    comp (λ _ → S¹) u u0 ≡ hcomp u (outS u0)
+    comp (λ _ → S¹) _ u (outS u0) ≡ hcomp u (outS u0)
   compS1 φ u u0 = refl
 
 helix : S¹ → Type₀


### PR DESCRIPTION
This has the benefit that we need fewer `inS`. However the builtin `comp` takes the phi explicitly. 