### PR TITLE
Elimination of propositional truncation to higher types

### DIFF
--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -135,3 +135,16 @@ Hfa≡fHa {A = A} f H a =
   cong f (H a) ∙ H a ∙ sym (H a)   ≡⟨ cong (_∙_ (cong f (H a))) (rCancel _) ⟩
   cong f (H a) ∙ refl              ≡⟨ sym (rUnit _) ⟩
   cong f (H a) ∎
+
+equivPi
+  : ∀{F : A → Set ℓ} {G : A → Set ℓ'}
+  → ((x : A) → F x ≃ G x) → (((x : A) → F x) ≃ ((x : A) → G x))
+equivPi k .fst f x = k x .fst (f x)
+equivPi k .snd .equiv-proof f
+  .fst .fst x = equivCtr (k x) (f x) .fst
+equivPi k .snd .equiv-proof f
+  .fst .snd i x = equivCtr (k x) (f x) .snd i
+equivPi k .snd .equiv-proof f
+  .snd (g , p) i .fst x = equivCtrPath (k x) (f x) (g x , λ j → p j x) i .fst
+equivPi k .snd .equiv-proof f
+  .snd (g , p) i .snd j x = equivCtrPath (k x) (f x) (g x , λ k → p k x) i .snd j

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -6,6 +6,8 @@ module Cubical.Foundations.Function where
 
 open import Cubical.Core.Everything
 
+open import Cubical.Foundations.Prelude
+
 -- The identity function
 idfun : ∀ {ℓ} → (A : Type ℓ) → A → A
 idfun _ x = x
@@ -53,8 +55,52 @@ module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
   2-Constant : (A → B) → Type _
   2-Constant f = ∀ x y → f x ≡ f y
 
+  2-Constant-isProp : isSet B → (f : A → B) → isProp (2-Constant f)
+  2-Constant-isProp Bset f link1 link2 i x y j
+    = Bset (f x) (f y) (link1 x y) (link2 x y) i j
+
   -- 3-Constant functions are coherently constant if B is a groupoid.
-  3-Constant : (A → B) → Type _
-  3-Constant f
-    = Σ[ kf ∈ 2-Constant f ] ∀ x y z
-    → PathP (λ i → f x ≡ kf y z i) (kf x y) (kf x z)
+  record 3-Constant (f : A → B) : Type (ℓ-max ℓ ℓ') where
+    field
+      link : 2-Constant f
+      coh₁ : ∀ x y z → Square refl (link x y) (link x z) (link y z)
+
+    coh₂ : ∀ x y z → Square (link x y) (link x z) (link y z) refl
+    coh₂ x y z i j
+      = hcomp (λ k → λ
+              { (j = i0) → link x y i
+              ; (i = i0) → link x z (j ∧ k)
+              ; (j = i1) → link x z (i ∨ k)
+              ; (i = i1) → link y z j
+              })
+          (coh₁ x y z j i)
+
+    link≡refl : ∀ x → refl ≡ link x x
+    link≡refl x i j
+      = hcomp (λ k → λ
+              { (i = i0) → link x x (j ∧ ~ k)
+              ; (i = i1) → link x x j
+              ; (j = i0) → f x
+              ; (j = i1) → link x x (~ i ∧ ~ k)
+              })
+          (coh₁ x x x (~ i) j)
+
+    downleft : ∀ x y → Square refl (link x y) refl (link y x)
+    downleft x y i j
+      = hcomp (λ k → λ
+              { (i = i0) → link x y j
+              ; (i = i1) → link≡refl x (~ k) j
+              ; (j = i0) → f x
+              ; (j = i1) → link y x i
+              })
+          (coh₁ x y x i j)
+
+    link≡symlink : ∀ x y → link x y ≡ sym (link y x)
+    link≡symlink x y i j
+      = hcomp (λ k → λ
+              { (i = i0) → link x y j
+              ; (i = i1) → link y x (~ j ∨ ~ k)
+              ; (j = i0) → f x
+              ; (j = i1) → link y x (i ∧ ~ k)
+              })
+          (downleft x y i j)

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -38,6 +38,12 @@ case x of f = f x
 case_return_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} (x : A) (B : A → Type ℓ') → (∀ x → B x) → B x
 case x return P of f = f x
 
+uncurry
+  : ∀{ℓ ℓ′ ℓ″} {A : Type ℓ} {B : A → Type ℓ′} {C : (a : A) → B a → Type ℓ″}
+  → ((x : A) → (y : B x) → C x y)
+  → (p : Σ A B) → C (fst p) (snd p)
+uncurry f (x , y) = f x y
+
 module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
   -- Notions of 'coherently constant' functions for low dimensions.
   -- These are the properties of functions necessary to e.g. eliminate

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -37,3 +37,18 @@ case x of f = f x
 
 case_return_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} (x : A) (B : A → Type ℓ') → (∀ x → B x) → B x
 case x return P of f = f x
+
+module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
+  -- Notions of 'coherently constant' functions for low dimensions.
+  -- These are the properties of functions necessary to e.g. eliminate
+  -- from the propositional truncation.
+
+  -- 2-Constant functions are coherently constant if B is a set.
+  2-Constant : (A → B) → Type _
+  2-Constant f = ∀ x y → f x ≡ f y
+
+  -- 3-Constant functions are coherently constant if B is a groupoid.
+  3-Constant : (A → B) → Type _
+  3-Constant f
+    = Σ[ kf ∈ 2-Constant f ] ∀ x y z
+    → PathP (λ i → f x ≡ kf y z i) (kf x y) (kf x z)

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -234,3 +234,14 @@ doubleCompPath-elim' p q r = (split-leftright' p q r) ∙ (sym (leftright p (q �
 -- assoc : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
 --                 (p ∙ q) ∙ r ≡ p ∙ (q ∙ r)
 -- assoc p q r = (sym (doubleCompPath-elim p q r)) ∙ (doubleCompPath-elim' p q r)
+
+squeezeSq≡
+  : ∀{w x y z : A}
+  → (p : w ≡ y) (q : w ≡ x) (r : y ≡ z) (s : x ≡ z)
+  → (q ≡ p ∙∙ r ∙∙ sym s) ≡ (Square p q r s)
+squeezeSq≡ p q r s k
+  = Square
+      (λ j → p (j ∧ k))
+      q
+      (λ j → doubleCompPath-filler p r (sym s) j (~ k))
+      (λ j → s (j ∧ k))

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -13,8 +13,11 @@ module Cubical.Foundations.HLevels where
 open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.FunExtEquiv
+open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Transport
 open import Cubical.Foundations.HAEquiv      using (congEquiv)
 open import Cubical.Foundations.Equiv        using (isoToEquiv; isPropIsEquiv; retEq; invEquiv)
 open import Cubical.Foundations.Univalence   using (univalence)
@@ -111,15 +114,27 @@ hLevelPi (suc (suc n)) h f g =
 isSetPi : ((x : A) → isSet (B x)) → isSet ((x : A) → B x)
 isSetPi Bset = hLevelPi 2 (λ a → Bset a)
 
+squeezeSq≡
+  : ∀{w x y z : A}
+  → (p : w ≡ y) (q : w ≡ x) (r : y ≡ z) (s : x ≡ z)
+  → (q ≡ p ∙∙ r ∙∙ sym s) ≡ (Square p q r s)
+squeezeSq≡ p q r s k
+  = Square
+      (λ j → p (j ∧ k))
+      q
+      (λ j → doubleCompPath-filler p r (sym s) j (~ k))
+      (λ j → s (j ∧ k))
+
 isSet→isSet' : isSet A → isSet' A
-isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s =
-  J (λ (z : A) (r : x ≡ z) → ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : z ≡ w) → PathP (λ i → Path A (r i) (s i) ) p q) helper r s p q
-  where
-    helper : ∀ {w : A} (s : y ≡ w) (p : x ≡ y) (q : x ≡ w) → PathP (λ i → Path A x (s i)) p q
-    helper {w} s p q = J (λ (w : A) (s : y ≡ w) → ∀ p q → PathP (λ i → Path A x (s i)) p q) (λ p q → Aset x y p q) s p q
+isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s
+  = transport (squeezeSq≡ r p q s) (Aset _ _ p (r ∙∙ q ∙∙ sym s))
 
 isSet'→isSet : isSet' A → isSet A
 isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
+
+isGroupoid₂→isGroupoid : isGroupoid₂ A → isGroupoid A
+isGroupoid₂→isGroupoid Agpd' w x p q r s
+  = Agpd' {q = p} {r = q} {q' = p} {r' = q} refl refl refl refl r s
 
 hLevelSuc : (n : ℕ) (A : Type ℓ) → isOfHLevel n A → isOfHLevel (suc n) A
 hLevelSuc 0 A = isContr→isProp

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -132,6 +132,70 @@ isSet→isSet' {A = A} Aset {x} {y} {z} {w} p q r s
 isSet'→isSet : isSet' A → isSet A
 isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
 
+squeezeFace≡
+  : ∀{w x y z w' x' y' z' : A}
+  → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
+  → {a : w ≡ w'} {b : x ≡ x'} {c : y ≡ y'} {d : z ≡ z'}
+  → (ps : Square a p p' c) (qs : Square a q q' b)
+  → (rs : Square c r r' d) (ss : Square b s s' d)
+  → Square p q r s ≡ Square p' q' r' s'
+squeezeFace≡ ps qs rs ss k = Square (ps k) (qs k) (rs k) (ss k)
+
+squeezeCu≡
+  : ∀{w x y z w' x' y' z' : A}
+  → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
+  → {a : w ≡ w'} {b : x ≡ x'} {c : y ≡ y'} {d : z ≡ z'}
+  → (ps : Square a p p' c) (qs : Square a q q' b)
+  → (rs : Square c r r' d) (ss : Square b s s' d)
+  → (f0 : Square p q r s) (f1 : Square p' q' r' s')
+  → (f0 ≡ transport⁻ (squeezeFace≡ ps qs rs ss) f1) ≡ Cube ps qs rs ss f0 f1
+squeezeCu≡ ps qs rs ss f0 f1 τ
+  = Cube
+      (λ j → ps (j ∧ τ))
+      (λ j → qs (j ∧ τ))
+      (λ j → rs (j ∧ τ))
+      (λ j → ss (j ∧ τ))
+      f0
+      (toPathP {A = F} (transportTransport⁻ (squeezeFace≡ ps qs rs ss) f1) τ)
+  where
+  F : I → Set _
+  F k = Square (ps k) (qs k) (rs k) (ss k)
+
+transposeSq
+  : ∀{w x y z : A} {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → Square p q r s
+  → Square q p s r
+transposeSq sq i j = sq j i
+
+transposeCu
+  : ∀{w x y z w' x' y' z' : A}
+  → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
+  → {a : w ≡ w'} {b : x ≡ x'} {c : y ≡ y'} {d : z ≡ z'}
+  → {ps : Square a p p' c} {qs : Square a q q' b}
+  → {rs : Square c r r' d} {ss : Square b s s' d}
+  → {f0 : Square p q r s} {f1 : Square p' q' r' s'}
+  → Cube (transposeSq ps) f0 f1 (transposeSq ss) qs rs
+  → Cube ps qs rs ss f0 f1
+transposeCu cu i j k = cu j i k
+
+isGroupoid→isGroupoid₁ : isGroupoid A → isGroupoid₁ A
+isGroupoid→isGroupoid₁ Agpd {p = p} {p'} {s = s} {s'} pp qp rp sp f0 f1
+  = transposeCu (transport (squeezeCu≡ ppr f0 f1 spr qp rp) (Agpd _ _ _ _ _ _))
+  where
+  ppr : Square p refl refl p'
+  ppr i j = pp j i
+  spr : Square s refl refl s'
+  spr i j = sp j i
+  Rot : Set _
+  Rot = Cube ppr f0 f1 spr qp rp
+
+isGroupoid₁→isGroupoid₂ : isGroupoid₁ A → isGroupoid₂ A
+isGroupoid₁→isGroupoid₂ Agpd₁ ps qs rs ss f0 f1
+  = transport (squeezeCu≡ ps qs rs ss f0 f1) (Agpd₁ _ _ _ _ _ _)
+
 isGroupoid₂→isGroupoid : isGroupoid₂ A → isGroupoid A
 isGroupoid₂→isGroupoid Agpd' w x p q r s
   = Agpd' {q = p} {r = q} {q' = p} {r' = q} refl refl refl refl r s

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -180,12 +180,51 @@ isProp A = (x y : A) → x ≡ y
 isSet : Type ℓ → Type ℓ
 isSet A = (x y : A) → isProp (x ≡ y)
 
+Square
+  : ∀{w x y z : A}
+  → (p : w ≡ y) (q : w ≡ x) (r : y ≡ z) (s : x ≡ z)
+  → Set _
+Square p q r s = PathP (λ i → p i ≡ s i) q r
+
 isSet' : Type ℓ → Type ℓ
-isSet' A = {x y z w : A} (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w) →
-           PathP (λ i → Path A (r i) (s i)) p q
+isSet' A
+  = {x y z w : A}
+  → (p : x ≡ y) (q : z ≡ w) (r : x ≡ z) (s : y ≡ w)
+  → Square r p q s
 
 isGroupoid : Type ℓ → Type ℓ
 isGroupoid A = ∀ a b → isSet (Path A a b)
+
+Cube
+  : ∀{w x y z w' x' y' z' : A}
+  → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
+  → {a : w ≡ w'} {b : x ≡ x'} {c : y ≡ y'} {d : z ≡ z'}
+  → (ps : Square a p p' c) (qs : Square a q q' b)
+  → (rs : Square c r r' d) (ss : Square b s s' d)
+  → (f0 : Square p q r s) (f1 : Square p' q' r' s')
+  → Set _
+Cube ps qs rs ss f0 f1
+  = PathP (λ k → Square (ps k) (qs k) (rs k) (ss k)) f0 f1
+
+isGroupoid₁ : Set ℓ → Set ℓ
+isGroupoid₁ A
+  = ∀{w x y z : A}
+  → {p p' : w ≡ y} {q q' : w ≡ x} {r r' : y ≡ z} {s s' : x ≡ z}
+  → (pp : p ≡ p') (qp : q ≡ q') (rp : r ≡ r') (sp : s ≡ s')
+  → (f0 : Square p q r s) → (f1 : Square p' q' r' s')
+  → Cube pp qp rp sp f0 f1
+
+isGroupoid₂ : Set ℓ → Set ℓ
+isGroupoid₂ A
+  = ∀{w x y z w' x' y' z' : A}
+  → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
+  → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
+  → {a : w ≡ w'} {b : x ≡ x'} {c : y ≡ y'} {d : z ≡ z'}
+  → (fp : Square a p p' c) → (fq : Square a q q' b)
+  → (fr : Square c r r' d) → (fs : Square b s s' d)
+  → (f0 : Square p q r s) → (f1 : Square p' q' r' s')
+  → PathP (λ k → Square (fp k) (fq k) (fr k) (fs k)) f0 f1
 
 is2Groupoid : Type ℓ → Type ℓ
 is2Groupoid A = ∀ a b → isGroupoid (Path A a b)

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -207,16 +207,8 @@ Cube
 Cube ps qs rs ss f0 f1
   = PathP (λ k → Square (ps k) (qs k) (rs k) (ss k)) f0 f1
 
-isGroupoid₁ : Set ℓ → Set ℓ
-isGroupoid₁ A
-  = ∀{w x y z : A}
-  → {p p' : w ≡ y} {q q' : w ≡ x} {r r' : y ≡ z} {s s' : x ≡ z}
-  → (pp : p ≡ p') (qp : q ≡ q') (rp : r ≡ r') (sp : s ≡ s')
-  → (f0 : Square p q r s) → (f1 : Square p' q' r' s')
-  → Cube pp qp rp sp f0 f1
-
-isGroupoid₂ : Set ℓ → Set ℓ
-isGroupoid₂ A
+isGroupoid' : Set ℓ → Set ℓ
+isGroupoid' A
   = ∀{w x y z w' x' y' z' : A}
   → {p : w ≡ y} {q : w ≡ x} {r : y ≡ z} {s : x ≡ z}
   → {p' : w' ≡ y'} {q' : w' ≡ x'} {r' : y' ≡ z'} {s' : x' ≡ z'}
@@ -224,7 +216,7 @@ isGroupoid₂ A
   → (fp : Square a p p' c) → (fq : Square a q q' b)
   → (fr : Square c r r' d) → (fs : Square b s s' d)
   → (f0 : Square p q r s) → (f1 : Square p' q' r' s')
-  → PathP (λ k → Square (fp k) (fq k) (fr k) (fs k)) f0 f1
+  → Cube fp fq fr fs f0 f1
 
 is2Groupoid : Type ℓ → Type ℓ
 is2Groupoid A = ∀ a b → isGroupoid (Path A a b)

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -161,8 +161,8 @@ RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ 
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP
 
 module GpdElim (Bgpd : isGroupoid B) where
-  Bgpd₂ : isGroupoid₂ B
-  Bgpd₂ = isGroupoid₁→isGroupoid₂ (isGroupoid→isGroupoid₁ Bgpd)
+  Bgpd' : isGroupoid' B
+  Bgpd' = isGroupoid→isGroupoid' Bgpd
 
   module _ (f : A → B) (3kf : 3-Constant f) where
     open 3-Constant 3kf
@@ -185,7 +185,7 @@ module GpdElim (Bgpd : isGroupoid B) where
 
     triHelper₁ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₁ x y z
     triHelper₁ (squash s t i) u v
-      = Bgpd₂
+      = Bgpd'
           (λ i → refl)
           (triHelper₂ s t u)
           (triHelper₂ s t v)
@@ -193,7 +193,7 @@ module GpdElim (Bgpd : isGroupoid B) where
           (triHelper₁ s u v)
           (triHelper₁ t u v) i
     triHelper₁ ∣ x ∣ (squash t u i) v
-      = Bgpd₂
+      = Bgpd'
           (λ i → refl)
           (triHelper₁ ∣ x ∣ t u)
           (λ i → pathHelper ∣ x ∣ v)
@@ -202,7 +202,7 @@ module GpdElim (Bgpd : isGroupoid B) where
           (triHelper₁ ∣ x ∣ u v)
           i
     triHelper₁ ∣ x ∣ ∣ y ∣ (squash u v i)
-      = Bgpd₂
+      = Bgpd'
           (λ i → refl)
           (λ i → link x y)
           (triHelper₁ ∣ x ∣ u v)
@@ -213,7 +213,7 @@ module GpdElim (Bgpd : isGroupoid B) where
 
     triHelper₂ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₂ x y z
     triHelper₂ (squash s t i) u v
-      = Bgpd₂
+      = Bgpd'
           (triHelper₂ s t u)
           (triHelper₂ s t v)
           (λ i → pathHelper u v)
@@ -222,7 +222,7 @@ module GpdElim (Bgpd : isGroupoid B) where
           (triHelper₂ t u v)
           i
     triHelper₂ ∣ x ∣ (squash t u i) v
-      = Bgpd₂
+      = Bgpd'
           (triHelper₁ ∣ x ∣ t u)
           (λ i → pathHelper ∣ x ∣ v)
           (triHelper₂ t u v)
@@ -231,7 +231,7 @@ module GpdElim (Bgpd : isGroupoid B) where
           (triHelper₂ ∣ x ∣ u v)
           i
     triHelper₂ ∣ x ∣ ∣ y ∣ (squash u v i)
-      = Bgpd₂
+      = Bgpd'
           (λ i → link x y)
           (triHelper₁ ∣ x ∣ u v)
           (triHelper₁ ∣ y ∣ u v)
@@ -256,7 +256,7 @@ module GpdElim (Bgpd : isGroupoid B) where
     retr f i t .snd .link x y j
       = f (squash (squash ∣ x ∣ ∣ y ∣ j) t i) .snd .link x y j
     retr f i t .snd .coh₁ x y z
-      = Bgpd₂
+      = Bgpd'
           (λ _ → refl)
           (λ k j → f (cb i0 j k) .snd .link x y j)
           (λ k j → f (cb i1 j k) .snd .link x z j)
@@ -284,7 +284,7 @@ module GpdElim (Bgpd : isGroupoid B) where
     e-eval a₀ (g , 3kg) i .fst x = 3kg .link a₀ x i
     e-eval a₀ (g , 3kg) i .snd .link x y = λ j → 3kg .coh₁ a₀ x y j i
     e-eval a₀ (g , 3kg) i .snd .coh₁ x y z
-      = Bgpd₂
+      = Bgpd'
           (λ _ → refl)
           (λ k j → 3kg .coh₁ a₀ x y j k)
           (λ k j → 3kg .coh₁ a₀ x z j k)

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -8,14 +8,19 @@ This file contains:
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.PropositionalTruncation.Properties where
 
+open import Cubical.Core.Everything
+
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
 
 open import Cubical.HITs.PropositionalTruncation.Base
 
 private
   variable
     ℓ : Level
-    A : Type ℓ
+    A B : Type ℓ
 
 recPropTrunc : ∀ {P : Type ℓ} → isProp P → (A → P) → ∥ A ∥ → P
 recPropTrunc Pprop f ∣ x ∣          = f x
@@ -39,3 +44,59 @@ elimPropTrunc' : ∀ {P : ∥ A ∥ → Type ℓ} → ((a : ∥ A ∥) → isPro
                  ((x : A) → P ∣ x ∣) → (a : ∥ A ∥) → P a
 elimPropTrunc' {P = P} Pprop f a =
   recPropTrunc (Pprop a) (λ x → transp (λ i → P (squash ∣ x ∣ a i)) i0 (f x)) a
+
+module SetElim (Bset : isSet B) where
+  Bset' : isSet' B
+  Bset' = isSet→isSet' Bset
+
+  recPropTrunc→Set : (f : A → B) (kf : 2-Constant f) → ∥ A ∥ → B
+  helper
+    : (f : A → B) (kf : 2-Constant f) → (t u : ∥ A ∥)
+    → recPropTrunc→Set f kf t ≡ recPropTrunc→Set f kf u
+
+  recPropTrunc→Set f kf ∣ x ∣ = f x
+  recPropTrunc→Set f kf (squash t u i) = helper f kf t u i
+
+  helper f kf ∣ x ∣ ∣ y ∣ = kf x y
+  helper f kf (squash t u i) v
+    = Bset' (helper f kf t v) (helper f kf u v) (helper f kf t u) refl i
+  helper f kf t (squash u v i)
+    = Bset' (helper f kf t u) (helper f kf t v) refl (helper f kf u v) i
+
+  kcomp : ∀(f : ∥ A ∥ → B) → 2-Constant (f ∘ ∣_∣)
+  kcomp f x y = cong f (squash ∣ x ∣ ∣ y ∣)
+
+  Fset : isSet (A → B)
+  Fset = isSetPi (const Bset)
+
+  Kset : (f : A → B) → isSet (2-Constant f)
+  Kset f = isSetPi (λ _ → isSetPi (λ _ → isProp→isSet (Bset _ _)))
+
+  setRecLemma
+    : (Bset : isSet B)
+    → (f : ∥ A ∥ → B)
+    → recPropTrunc→Set (f ∘ ∣_∣) (kcomp f) ≡ f
+  setRecLemma Bset f i t
+    = elimPropTrunc {P = λ t → recPropTrunc→Set (f ∘ ∣_∣) (kcomp f) t ≡ f t}
+        (λ t → Bset _ _) (λ x → refl) t i
+
+  mkKmap : (∥ A ∥ → B) → Σ (A → B) 2-Constant
+  mkKmap f = f ∘ ∣_∣ , kcomp f
+
+  fib : (g : Σ (A → B) 2-Constant) → fiber mkKmap g
+  fib (g , kg) = recPropTrunc→Set g kg , refl
+
+  eqv : (g : Σ (A → B) 2-Constant)
+      → ∀ fi → fib g ≡ fi
+  eqv g (f , p) =
+    ΣProp≡ (λ f → isOfHLevelΣ 2 Fset Kset _ _)
+      (cong (uncurry recPropTrunc→Set) (sym p) ∙ setRecLemma Bset f)
+
+  trunc→Set≃ : (∥ A ∥ → B) ≃ (Σ (A → B) 2-Constant)
+  trunc→Set≃ .fst = mkKmap
+  trunc→Set≃ .snd .equiv-proof g = fib g , eqv g
+
+open SetElim public using (recPropTrunc→Set; trunc→Set≃)
+
+RecHProp : (P : A → hProp ℓ) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp ℓ
+RecHProp P kP = recPropTrunc→Set isSetHProp P kP

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -100,3 +100,94 @@ open SetElim public using (recPropTrunc→Set; trunc→Set≃)
 
 RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp {ℓ}
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP
+
+module GpdElim
+  (f : A → B)
+  (Bgpd₂ : isGroupoid₂ B)
+  (kf : 2-Constant f)
+  (coh₁ : ∀ x y z → Square refl (kf x y) (kf x z) (kf y z))
+  where
+
+  coh₂ : ∀ x y z → Square (kf x y) (kf x z) (kf y z) refl
+  coh₂ x y z i j
+    = hcomp (λ k → λ
+        { (j = i0) → kf x y i
+        ; (i = i0) → kf x z (j ∧ k)
+        ; (j = i1) → kf x z (i ∨ k)
+        ; (i = i1) → kf y z j
+        })
+        (coh₁ x y z j i)
+
+  recPropTrunc→Gpd : ∥ A ∥ → B
+  pathHelper : (t u : ∥ A ∥) → recPropTrunc→Gpd t ≡ recPropTrunc→Gpd u
+  triHelper₁
+    : (t u v : ∥ A ∥)
+    → Square refl (pathHelper t u) (pathHelper t v) (pathHelper u v)
+  triHelper₂
+    : (t u v : ∥ A ∥)
+    → Square (pathHelper t u) (pathHelper t v) (pathHelper u v) refl
+
+  recPropTrunc→Gpd ∣ x ∣ = f x
+  recPropTrunc→Gpd (squash t u i) = pathHelper t u i
+
+  pathHelper ∣ x ∣ ∣ y ∣ = kf x y
+  pathHelper (squash t u j) v = triHelper₂ t u v j
+  pathHelper ∣ x ∣ (squash u v j) = triHelper₁ ∣ x ∣ u v j
+
+  triHelper₁ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₁ x y z
+  triHelper₁ (squash s t i) u v
+    = Bgpd₂
+        (λ i → refl)
+        (triHelper₂ s t u)
+        (triHelper₂ s t v)
+        (λ i → pathHelper u v)
+        (triHelper₁ s u v)
+        (triHelper₁ t u v) i
+  triHelper₁ ∣ x ∣ (squash t u i) v
+    = Bgpd₂
+        (λ i → refl)
+        (triHelper₁ ∣ x ∣ t u)
+        (λ i → pathHelper ∣ x ∣ v)
+        (triHelper₂ t u v)
+        (triHelper₁ ∣ x ∣ t v)
+        (triHelper₁ ∣ x ∣ u v)
+        i
+  triHelper₁ ∣ x ∣ ∣ y ∣ (squash u v i)
+    = Bgpd₂
+        (λ i → refl)
+        (λ i → kf x y)
+        (triHelper₁ ∣ x ∣ u v)
+        (triHelper₁ ∣ y ∣ u v)
+        (triHelper₁ ∣ x ∣ ∣ y ∣ u)
+        (triHelper₁ ∣ x ∣ ∣ y ∣ v)
+        i
+
+  triHelper₂ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₂ x y z
+  triHelper₂ (squash s t i) u v
+    = Bgpd₂
+        (triHelper₂ s t u)
+        (triHelper₂ s t v)
+        (λ i → pathHelper u v)
+        (λ i → refl)
+        (triHelper₂ s u v)
+        (triHelper₂ t u v)
+        i
+  triHelper₂ ∣ x ∣ (squash t u i) v
+    = Bgpd₂
+        (triHelper₁ ∣ x ∣ t u)
+        (λ i → pathHelper ∣ x ∣ v)
+        (triHelper₂ t u v)
+        (λ i → refl)
+        (triHelper₂ ∣ x ∣ t v)
+        (triHelper₂ ∣ x ∣ u v)
+        i
+  triHelper₂ ∣ x ∣ ∣ y ∣ (squash u v i)
+    = Bgpd₂
+        (λ i → kf x y)
+        (triHelper₁ ∣ x ∣ u v)
+        (triHelper₁ ∣ y ∣ u v)
+        (λ i → refl)
+        (triHelper₂ ∣ x ∣ ∣ y ∣ u)
+        (triHelper₂ ∣ x ∣ ∣ y ∣ v)
+        i
+

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -102,11 +102,18 @@ RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ 
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP
 
 module GpdElim
+  (Bgpd : isGroupoid B)
   (f : A → B)
-  (Bgpd₂ : isGroupoid₂ B)
-  (kf : 2-Constant f)
-  (coh₁ : ∀ x y z → Square refl (kf x y) (kf x z) (kf y z))
+  (3kf : 3-Constant f)
   where
+  kf : 2-Constant f
+  kf = fst 3kf
+
+  coh₁ : ∀ x y z → Square refl (kf x y) (kf x z) (kf y z)
+  coh₁ = snd 3kf
+
+  Bgpd₂ : isGroupoid₂ B
+  Bgpd₂ = isGroupoid₁→isGroupoid₂ (isGroupoid→isGroupoid₁ Bgpd)
 
   coh₂ : ∀ x y z → Square (kf x y) (kf x z) (kf y z) refl
   coh₂ x y z i j
@@ -191,3 +198,7 @@ module GpdElim
         (triHelper₂ ∣ x ∣ ∣ y ∣ v)
         i
 
+open GpdElim using (recPropTrunc→Gpd) public
+
+RecHSet : (P : A → HLevel {ℓ} 2) → 3-Constant P → ∥ A ∥ → HLevel {ℓ} 2
+RecHSet P 3kP = recPropTrunc→Gpd (hLevelHLevelSuc 1) P 3kP

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -98,5 +98,5 @@ module SetElim (Bset : isSet B) where
 
 open SetElim public using (recPropTrunc→Set; trunc→Set≃)
 
-RecHProp : (P : A → hProp ℓ) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp ℓ
+RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp {ℓ}
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -14,6 +14,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.HITs.PropositionalTruncation.Base
 
@@ -45,6 +46,11 @@ elimPropTrunc' : ∀ {P : ∥ A ∥ → Type ℓ} → ((a : ∥ A ∥) → isPro
 elimPropTrunc' {P = P} Pprop f a =
   recPropTrunc (Pprop a) (λ x → transp (λ i → P (squash ∣ x ∣ a i)) i0 (f x)) a
 
+-- The propositional truncation can be eliminated into non-propositional
+-- types as long as the function used in the eliminator is 'coherently
+-- constant.' The details of this can be found in the following paper:
+--
+--   https://arxiv.org/pdf/1411.2682.pdf
 module SetElim (Bset : isSet B) where
   Bset' : isSet' B
   Bset' = isSet→isSet' Bset
@@ -73,10 +79,9 @@ module SetElim (Bset : isSet B) where
   Kset f = isSetPi (λ _ → isSetPi (λ _ → isProp→isSet (Bset _ _)))
 
   setRecLemma
-    : (Bset : isSet B)
-    → (f : ∥ A ∥ → B)
+    : (f : ∥ A ∥ → B)
     → recPropTrunc→Set (f ∘ ∣_∣) (kcomp f) ≡ f
-  setRecLemma Bset f i t
+  setRecLemma f i t
     = elimPropTrunc {P = λ t → recPropTrunc→Set (f ∘ ∣_∣) (kcomp f) t ≡ f t}
         (λ t → Bset _ _) (λ x → refl) t i
 
@@ -90,115 +95,214 @@ module SetElim (Bset : isSet B) where
       → ∀ fi → fib g ≡ fi
   eqv g (f , p) =
     ΣProp≡ (λ f → isOfHLevelΣ 2 Fset Kset _ _)
-      (cong (uncurry recPropTrunc→Set) (sym p) ∙ setRecLemma Bset f)
+      (cong (uncurry recPropTrunc→Set) (sym p) ∙ setRecLemma f)
 
   trunc→Set≃ : (∥ A ∥ → B) ≃ (Σ (A → B) 2-Constant)
   trunc→Set≃ .fst = mkKmap
   trunc→Set≃ .snd .equiv-proof g = fib g , eqv g
 
+  -- The strategy of this equivalence proof follows the paper more closely.
+  -- It is used further down for the groupoid version, because the above
+  -- strategy does not generalize so easily.
+  e : B → Σ (A → B) 2-Constant
+  e b = const b , λ _ _ → refl
+
+  eval : A → (γ : Σ (A → B) 2-Constant) → B
+  eval a₀ (g , _) = g a₀
+
+  e-eval : ∀ (a₀ : A) γ → e (eval a₀ γ) ≡ γ
+  e-eval a₀ (g , kg) i .fst a₁ = kg a₀ a₁ i
+  e-eval a₀ (g , kg) i .snd a₁ a₂ = Bset' refl (kg a₁ a₂) (kg a₀ a₁) (kg a₀ a₂) i
+
+  e-isEquiv : A → isEquiv (e {A = A})
+  e-isEquiv a₀ = isoToIsEquiv (iso e (eval a₀) (e-eval a₀) λ _ → refl)
+
+  preEquiv₁ : ∥ A ∥ → B ≃ Σ (A → B) 2-Constant
+  preEquiv₁ t = e , recPropTrunc (isPropIsEquiv e) e-isEquiv t
+
+  preEquiv₂ : (∥ A ∥ → Σ (A → B) 2-Constant) ≃ Σ (A → B) 2-Constant
+  preEquiv₂ = isoToEquiv (iso to const (λ _ → refl) retr)
+    where
+    to : (∥ A ∥ → Σ (A → B) 2-Constant) → Σ (A → B) 2-Constant
+    to f .fst x = f ∣ x ∣ .fst x
+    to f .snd x y i = f (squash ∣ x ∣ ∣ y ∣ i) .snd x y i
+
+    retr : retract to const
+    retr f i t .fst x = f (squash ∣ x ∣ t i) .fst x
+    retr f i t .snd x y
+      = Bset'
+          (λ j → f (squash ∣ x ∣ ∣ y ∣ j) .snd x y j)
+          (f t .snd x y)
+          (λ j → f (squash ∣ x ∣ t j) .fst x)
+          (λ j → f (squash ∣ y ∣ t j) .fst y)
+          i
+
+  trunc→Set≃₂ : (∥ A ∥ → B) ≃ Σ (A → B) 2-Constant
+  trunc→Set≃₂ = compEquiv (equivPi preEquiv₁) preEquiv₂
+
 open SetElim public using (recPropTrunc→Set; trunc→Set≃)
+
+elimPropTrunc→Set
+  : {P : ∥ A ∥ → Set ℓ}
+  → (∀ t → isSet (P t))
+  → (f : (x : A) → P ∣ x ∣)
+  → (kf : ∀ x y → PathP (λ i → P (squash ∣ x ∣ ∣ y ∣ i)) (f x) (f y))
+  → (t : ∥ A ∥) → P t
+elimPropTrunc→Set {A = A} {P = P} Pset f kf t
+  = recPropTrunc→Set (Pset t) g gk t
+  where
+  g : A → P t
+  g x = transp (λ i → P (squash ∣ x ∣ t i)) i0 (f x)
+
+  gk : 2-Constant g
+  gk x y i = transp (λ j → P (squash (squash ∣ x ∣ ∣ y ∣ i) t j)) i0 (kf x y i)
 
 RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp {ℓ}
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP
 
-module GpdElim
-  (Bgpd : isGroupoid B)
-  (f : A → B)
-  (3kf : 3-Constant f)
-  where
-  kf : 2-Constant f
-  kf = fst 3kf
-
-  coh₁ : ∀ x y z → Square refl (kf x y) (kf x z) (kf y z)
-  coh₁ = snd 3kf
-
+module GpdElim (Bgpd : isGroupoid B) where
   Bgpd₂ : isGroupoid₂ B
   Bgpd₂ = isGroupoid₁→isGroupoid₂ (isGroupoid→isGroupoid₁ Bgpd)
 
-  coh₂ : ∀ x y z → Square (kf x y) (kf x z) (kf y z) refl
-  coh₂ x y z i j
-    = hcomp (λ k → λ
-        { (j = i0) → kf x y i
-        ; (i = i0) → kf x z (j ∧ k)
-        ; (j = i1) → kf x z (i ∨ k)
-        ; (i = i1) → kf y z j
-        })
-        (coh₁ x y z j i)
+  module _ (f : A → B) (3kf : 3-Constant f) where
+    open 3-Constant 3kf
 
-  recPropTrunc→Gpd : ∥ A ∥ → B
-  pathHelper : (t u : ∥ A ∥) → recPropTrunc→Gpd t ≡ recPropTrunc→Gpd u
-  triHelper₁
-    : (t u v : ∥ A ∥)
-    → Square refl (pathHelper t u) (pathHelper t v) (pathHelper u v)
-  triHelper₂
-    : (t u v : ∥ A ∥)
-    → Square (pathHelper t u) (pathHelper t v) (pathHelper u v) refl
+    recPropTrunc→Gpd : ∥ A ∥ → B
+    pathHelper : (t u : ∥ A ∥) → recPropTrunc→Gpd t ≡ recPropTrunc→Gpd u
+    triHelper₁
+      : (t u v : ∥ A ∥)
+      → Square refl (pathHelper t u) (pathHelper t v) (pathHelper u v)
+    triHelper₂
+      : (t u v : ∥ A ∥)
+      → Square (pathHelper t u) (pathHelper t v) (pathHelper u v) refl
 
-  recPropTrunc→Gpd ∣ x ∣ = f x
-  recPropTrunc→Gpd (squash t u i) = pathHelper t u i
+    recPropTrunc→Gpd ∣ x ∣ = f x
+    recPropTrunc→Gpd (squash t u i) = pathHelper t u i
 
-  pathHelper ∣ x ∣ ∣ y ∣ = kf x y
-  pathHelper (squash t u j) v = triHelper₂ t u v j
-  pathHelper ∣ x ∣ (squash u v j) = triHelper₁ ∣ x ∣ u v j
+    pathHelper ∣ x ∣ ∣ y ∣ = link x y
+    pathHelper (squash t u j) v = triHelper₂ t u v j
+    pathHelper ∣ x ∣ (squash u v j) = triHelper₁ ∣ x ∣ u v j
 
-  triHelper₁ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₁ x y z
-  triHelper₁ (squash s t i) u v
-    = Bgpd₂
-        (λ i → refl)
-        (triHelper₂ s t u)
-        (triHelper₂ s t v)
-        (λ i → pathHelper u v)
-        (triHelper₁ s u v)
-        (triHelper₁ t u v) i
-  triHelper₁ ∣ x ∣ (squash t u i) v
-    = Bgpd₂
-        (λ i → refl)
-        (triHelper₁ ∣ x ∣ t u)
-        (λ i → pathHelper ∣ x ∣ v)
-        (triHelper₂ t u v)
-        (triHelper₁ ∣ x ∣ t v)
-        (triHelper₁ ∣ x ∣ u v)
-        i
-  triHelper₁ ∣ x ∣ ∣ y ∣ (squash u v i)
-    = Bgpd₂
-        (λ i → refl)
-        (λ i → kf x y)
-        (triHelper₁ ∣ x ∣ u v)
-        (triHelper₁ ∣ y ∣ u v)
-        (triHelper₁ ∣ x ∣ ∣ y ∣ u)
-        (triHelper₁ ∣ x ∣ ∣ y ∣ v)
-        i
+    triHelper₁ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₁ x y z
+    triHelper₁ (squash s t i) u v
+      = Bgpd₂
+          (λ i → refl)
+          (triHelper₂ s t u)
+          (triHelper₂ s t v)
+          (λ i → pathHelper u v)
+          (triHelper₁ s u v)
+          (triHelper₁ t u v) i
+    triHelper₁ ∣ x ∣ (squash t u i) v
+      = Bgpd₂
+          (λ i → refl)
+          (triHelper₁ ∣ x ∣ t u)
+          (λ i → pathHelper ∣ x ∣ v)
+          (triHelper₂ t u v)
+          (triHelper₁ ∣ x ∣ t v)
+          (triHelper₁ ∣ x ∣ u v)
+          i
+    triHelper₁ ∣ x ∣ ∣ y ∣ (squash u v i)
+      = Bgpd₂
+          (λ i → refl)
+          (λ i → link x y)
+          (triHelper₁ ∣ x ∣ u v)
+          (triHelper₁ ∣ y ∣ u v)
+          (triHelper₁ ∣ x ∣ ∣ y ∣ u)
+          (triHelper₁ ∣ x ∣ ∣ y ∣ v)
+          i
 
-  triHelper₂ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₂ x y z
-  triHelper₂ (squash s t i) u v
-    = Bgpd₂
-        (triHelper₂ s t u)
-        (triHelper₂ s t v)
-        (λ i → pathHelper u v)
-        (λ i → refl)
-        (triHelper₂ s u v)
-        (triHelper₂ t u v)
-        i
-  triHelper₂ ∣ x ∣ (squash t u i) v
-    = Bgpd₂
-        (triHelper₁ ∣ x ∣ t u)
-        (λ i → pathHelper ∣ x ∣ v)
-        (triHelper₂ t u v)
-        (λ i → refl)
-        (triHelper₂ ∣ x ∣ t v)
-        (triHelper₂ ∣ x ∣ u v)
-        i
-  triHelper₂ ∣ x ∣ ∣ y ∣ (squash u v i)
-    = Bgpd₂
-        (λ i → kf x y)
-        (triHelper₁ ∣ x ∣ u v)
-        (triHelper₁ ∣ y ∣ u v)
-        (λ i → refl)
-        (triHelper₂ ∣ x ∣ ∣ y ∣ u)
-        (triHelper₂ ∣ x ∣ ∣ y ∣ v)
-        i
+    triHelper₂ ∣ x ∣ ∣ y ∣ ∣ z ∣ = coh₂ x y z
+    triHelper₂ (squash s t i) u v
+      = Bgpd₂
+          (triHelper₂ s t u)
+          (triHelper₂ s t v)
+          (λ i → pathHelper u v)
+          (λ i → refl)
+          (triHelper₂ s u v)
+          (triHelper₂ t u v)
+          i
+    triHelper₂ ∣ x ∣ (squash t u i) v
+      = Bgpd₂
+          (triHelper₁ ∣ x ∣ t u)
+          (λ i → pathHelper ∣ x ∣ v)
+          (triHelper₂ t u v)
+          (λ i → refl)
+          (triHelper₂ ∣ x ∣ t v)
+          (triHelper₂ ∣ x ∣ u v)
+          i
+    triHelper₂ ∣ x ∣ ∣ y ∣ (squash u v i)
+      = Bgpd₂
+          (λ i → link x y)
+          (triHelper₁ ∣ x ∣ u v)
+          (triHelper₁ ∣ y ∣ u v)
+          (λ i → refl)
+          (triHelper₂ ∣ x ∣ ∣ y ∣ u)
+          (triHelper₂ ∣ x ∣ ∣ y ∣ v)
+          i
 
-open GpdElim using (recPropTrunc→Gpd) public
+  preEquiv₁ : (∥ A ∥ → Σ (A → B) 3-Constant) ≃ Σ (A → B) 3-Constant
+  preEquiv₁ = isoToEquiv (iso fn const (λ _ → refl) retr)
+    where
+    open 3-Constant
+
+    fn : (∥ A ∥ → Σ (A → B) 3-Constant) → Σ (A → B) 3-Constant
+    fn f .fst x = f ∣ x ∣ .fst x
+    fn f .snd .link x y i = f (squash ∣ x ∣ ∣ y ∣ i) .snd .link x y i
+    fn f .snd .coh₁ x y z i j
+      = f (squash ∣ x ∣ (squash ∣ y ∣ ∣ z ∣ i) j) .snd .coh₁ x y z i j
+
+    retr : retract fn const
+    retr f i t .fst x = f (squash ∣ x ∣ t i) .fst x
+    retr f i t .snd .link x y j
+      = f (squash (squash ∣ x ∣ ∣ y ∣ j) t i) .snd .link x y j
+    retr f i t .snd .coh₁ x y z
+      = Bgpd₂
+          (λ _ → refl)
+          (λ k j → f (cb i0 j k) .snd .link x y j)
+          (λ k j → f (cb i1 j k) .snd .link x z j)
+          (λ k j → f (cb j i1 k) .snd .link y z j)
+          (λ k j → f (cb k j i0) .snd .coh₁ x y z k j )
+          (λ k j → f (cb k j i1) .snd .coh₁ x y z k j)
+          i
+      where
+      cb : I → I → I → ∥ _ ∥
+      cb i j k = squash (squash ∣ x ∣ (squash ∣ y ∣ ∣ z ∣ i) j) t k
+
+  e : B → Σ (A → B) 3-Constant
+  e b .fst _ = b
+  e b .snd = record
+           { link = λ _ _ _ → b
+           ; coh₁ = λ _ _ _ _ _ → b
+           }
+
+  eval : A → Σ (A → B) 3-Constant → B
+  eval a₀ (g , _) = g a₀
+
+  module _ where
+    open 3-Constant
+    e-eval : ∀(a₀ : A) γ → e (eval a₀ γ) ≡ γ
+    e-eval a₀ (g , 3kg) i .fst x = 3kg .link a₀ x i
+    e-eval a₀ (g , 3kg) i .snd .link x y = λ j → 3kg .coh₁ a₀ x y j i
+    e-eval a₀ (g , 3kg) i .snd .coh₁ x y z
+      = Bgpd₂
+          (λ _ → refl)
+          (λ k j → 3kg .coh₁ a₀ x y j k)
+          (λ k j → 3kg .coh₁ a₀ x z j k)
+          (λ k j → 3kg .coh₁ a₀ y z j k)
+          (λ _ _ → g a₀)
+          (3kg .coh₁ x y z)
+          i
+
+  e-isEquiv : A → isEquiv (e {A = A})
+  e-isEquiv a₀ = isoToIsEquiv (iso e (eval a₀) (e-eval a₀) λ _ → refl)
+
+  preEquiv₂ : ∥ A ∥ → B ≃ Σ (A → B) 3-Constant
+  preEquiv₂ t = e , recPropTrunc (isPropIsEquiv e) e-isEquiv t
+
+  trunc→Gpd≃ : (∥ A ∥ → B) ≃ Σ (A → B) 3-Constant
+  trunc→Gpd≃ = compEquiv (equivPi preEquiv₂) preEquiv₁
+
+open GpdElim using (recPropTrunc→Gpd; trunc→Gpd≃) public
 
 RecHSet : (P : A → HLevel {ℓ} 2) → 3-Constant P → ∥ A ∥ → HLevel {ℓ} 2
 RecHSet P 3kP = recPropTrunc→Gpd (hLevelHLevelSuc 1) P 3kP


### PR DESCRIPTION
The propositional truncation can be eliminated into non-propositional types via 'coherently constant' functions. These patches formulate the notion of coherently constant functions for low dimensions and adds the eliminators for them. This allows, for instance, definition of families of `hProp`s and `hSet`s by cases.