### PR TITLE
Make everything compatible with the new arguments to comp

### DIFF
--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -26,7 +26,7 @@ module Helpers where
   compPathD F {A = A} P Q {x} p q i =
      comp (\ j → F (hfill (λ j → \ { (i = i0) → A ; (i = i1) → Q j })
                           (inS (P i))
-                          j)) _
+                          j))
           (λ j → \ { (i = i0) → x; (i = i1) → q j })
           (p i)
 

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -191,10 +191,9 @@ fill : (A : ∀ i → Type (ℓ′ i))
        (i : I) → A i
 fill A {φ = φ} u u0 i =
   comp (λ j → A (i ∧ j))
-       _
        (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
                 ; (i = i0) → outS u0 })
-       (outS u0) -- u0 -- (inS {φ = φ ∨ (~ i)} (outS {φ = φ} u0))
+       (outS u0)
 
 -- Σ-types
 infix 2 Σ-syntax

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -103,7 +103,7 @@ private
   homotopy-π2 : (a b : Σ A B) → (p : a Σ≡T b) → (i : I) →
              (transport (λ j → B (fst (filler-comp a b p j i))) (snd a) ≡ snd b)
   homotopy-π2 {B = B} a b p i j =
-    comp (λ t → B (fst (filler-comp a b p t (i ∨ j)))) _
+    comp (λ t → B (fst (filler-comp a b p t (i ∨ j))))
          (λ t → λ { (j = i0) → coe0→i (λ t → B (fst (filler-comp a b p t i)))
                                       t (snd a)
                   ; (j = i1) → snd (sigmaPath→pathSigma a b p t)

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -94,7 +94,7 @@ fill1→i : ∀ {ℓ} (A : ∀ i → Type ℓ)
        ---------------------------
        (i : I) → A i
 fill1→i A {φ = φ} u u1 i =
-  comp (λ j → A (i ∨ ~ j)) _
+  comp (λ j → A (i ∨ ~ j))
        (λ j → λ { (φ = i1) → u (i ∨ ~ j) 1=1
                 ; (i = i1) → outS u1 })
        (outS u1)
@@ -107,7 +107,7 @@ filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
        ---------------------------
        → A i0
 filli→0 A {φ = φ} u i ui =
-  comp (λ j → A (i ∧ ~ j)) _
+  comp (λ j → A (i ∧ ~ j))
        (λ j → λ { (φ = i1) → u (i ∧ ~ j) 1=1
                 ; (i = i0) → outS ui })
        (outS ui)

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -118,22 +118,19 @@ lUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y
   PathP (λ j → PathP (λ i → lUnit (λ i → A i) j i) x y) p (compPathP refl p)
 lUnitP {A = A} {x = x} p k i =
   comp (λ j → lUnit-filler (λ i → A i) j k i)
-       _
        (λ j → λ { (i = i0) → x
-                 ; (i = i1) → p (~ k ∨ j )
-                 ; (k = i0) → p i
-                 }) (p (~ k ∧ i ))
-
+                ; (i = i1) → p (~ k ∨ j )
+                ; (k = i0) → p i
+                }) (p (~ k ∧ i ))
 
 rCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → rCancel (λ i → A i) j i) x x) (compPathP p (symP p)) refl
 rCancelP {A = A} {x = x} p j i =
   comp (λ k → rCancel-filler (λ i → A i) k j i)
-       _
        (λ k → λ { (i = i0) → x
-                 ; (i = i1) → p (~ k ∧ ~ j)
-                 ; (j = i1) → x
-                 }) (p (i ∧ ~ j))
+                ; (i = i1) → p (~ k ∧ ~ j)
+                ; (j = i1) → x
+                }) (p (i ∧ ~ j))
 
 lCancelP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
    PathP (λ j → PathP (λ i → lCancel (λ i → A i) j i) y y) (compPathP (symP p) p) refl
@@ -147,23 +144,22 @@ lCancelP p = rCancelP (symP p)
   PathP (λ j → PathP (λ i → 3outof4 (λ j i → A i j) P B j i) (α i1 i0) (α i1 i1)) (λ i → α i1 i) p
 3outof4P {A = A} {P} {B} α p β j i =
   comp (λ k → 3outof4-filler (λ j i → A i j) P B k j i)
-       _
        (λ k → λ { (i = i0) → α k i0
-                 ; (i = i1) → α k i1
-                 ; (j = i0) → α k i
-                 ; (j = i1) → β k i
-                 }) (α i0 i)
+                ; (i = i1) → α k i1
+                ; (j = i0) → α k i
+                ; (j = i1) → β k i
+                }) (α i0 i)
 
 preassocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
   {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
   PathP (λ j → PathP (λ i → preassoc (λ i → A i) B C j i) x ((compPathP q r) j)) p (compPathP (compPathP p q) r)
 preassocP {A = A} {x = x} {B = B} {C = C} p q r j i =
-  comp (λ k → preassoc-filler (λ i → A i) B C k j i) _
+  comp (λ k → preassoc-filler (λ i → A i) B C k j i)
        (λ k → λ { (i = i0) → x
-                 ; (i = i1) → compPathP-filler q r j k
-                 ; (j = i0) → p i
-              -- ; (j = i1) → compPathP-filler (compPathP p q) r i k
-                 }) (compPathP-filler p q i j)
+                ; (i = i1) → compPathP-filler q r j k
+                ; (j = i0) → p i
+             -- ; (j = i1) → compPathP-filler (compPathP p q) r i k
+                }) (compPathP-filler p q i j)
 
 assocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
   {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -78,7 +78,6 @@ module _ {x : A} (P : ∀ (y : A) → Id x y → Type ℓ') (d : P x refl) where
   J : ∀ {y : A} (w : x ≡ y) → P y w
   J {y = y} = elimId P (λ φ y w → comp (λ i → P _ (conId (φ ∨ ~ i) (inS (outS w i))
                                                                    (inS (λ j → outS w (i ∧ j)))))
-                                       _
                                        (λ i → λ { (φ = i1) → d}) d) {y = y}
 
   -- Check that J of refl is the identity function

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -36,7 +36,7 @@ toPathP-isEquiv A {x} {y} = isoToIsEquiv (iso toPathP fromPathP to-from from-to)
                                                       ; (i = i1) → A (h ∨ (w ∧ z))
                                                       ; (h = i0) → A (i ∧ (w ∧ z))
                                                       ; (h = i1) → A i})
-                                                   ((A (i ∧ h))))) _
+                                                   ((A (i ∧ h)))))
                                           (\ z → \ { (i = i0) → x
                                                    ; (i = i1) → transp (\ j → A (h ∨ (z ∧ j))) (h ∨ ~ z) (p h)
                                                    ; (h = i0) → transp (λ j → A ((i ∧ z) ∧ j)) (~ (i ∧ z)) x
@@ -60,7 +60,7 @@ toPathP-isEquiv A {x} {y} = isoToIsEquiv (iso toPathP fromPathP to-from from-to)
                                               ; (h = i1) → A i1
                                               ; (z = i0) → A (i ∨ h)
                                               ; (z = i1) → A ((i ∨ h) ∨ w) })
-                                             (A (i ∨ h))) _
+                                             (A (i ∨ h)))
                  (\ z → \ { (i = i0) → transp (λ j → A ((z ∨ h) ∧ j)) (~ z ∧ ~ h) x
                           ; (i = i1) → q (z ∧ h)
                           ; (h = i1) → compPath-filler refl q z i

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -43,7 +43,7 @@ g2TruncFib {A} P {a} {b} sPb {p} {q} {r} {s} {u} {v} w
           (Lb i j k l)
   where
   L : Path (Path (b1 ≡ b1) refl refl) refl refl
-  L i j k = comp (λ l → P (w i j k l)) _
+  L i j k = comp (λ l → P (w i j k l))
                  (λ l → λ { (i = i0) → u1 j k l
                           ; (i = i1) → v1 j k l
                           ; (j = i0) → r1 k l

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -38,7 +38,7 @@ groupoidTruncFib P {a} {b} sPb u {a1} {b1} {p1} {q1} r1 s1 i j k =
         (Lb i j k)
   where
   L : (i j : I) → P b
-  L i j = comp (λ k → P (u i j k)) _
+  L i j = comp (λ k → P (u i j k))
                (λ k → λ { (i = i0) → r1 j k
                         ; (i = i1) → s1 j k
                         ; (j = i0) → p1 k

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -28,7 +28,7 @@ module _ where
   transpS¹ φ u0 = refl
 
   compS1 : ∀ (φ : I) (u : ∀ i → Partial φ S¹) (u0 : S¹ [ φ ↦ u i0 ]) →
-    comp (λ _ → S¹) _ u (outS u0) ≡ hcomp u (outS u0)
+    comp (λ _ → S¹) u (outS u0) ≡ hcomp u (outS u0)
   compS1 φ u u0 = refl
 
 helix : S¹ → Type₀


### PR DESCRIPTION
The Agda patch https://github.com/agda/agda/pull/3713 changed the implicit arguments to `comp` so that the formula is implicit. This patch makes the agda/cubical library typecheck with this change. 

**NOTE**: Once this PR has been merged everyone will have to update their Agda installation in order to typecheck the library.