### PR TITLE
[ build ] make "make" only build the library by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ install:
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
 
 script:
-  - make
+  - make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,14 +2,21 @@ AGDA_EXEC=agda
 RTS_OPTIONS=+RTS -H3G -RTS
 AGDA=$(AGDA_EXEC) $(RTS_OPTIONS)
 
+.PHONY : all
+all : check
+
+.PHONY : test
 test: check-whitespace check
 
-fix-whitespace: 
+.PHONY : fix-whitespace
+fix-whitespace:
 	cabal exec -- fix-agda-whitespace
 
+.PHONY : check-whitespace
 check-whitespace:
 	cabal exec -- fix-agda-whitespace --check
 
+.PHONY : check
 check: $(wildcard **/*.agda)
 	$(AGDA) Cubical/Core/Everything.agda
 	$(AGDA) Cubical/Foundations/Everything.agda
@@ -19,5 +26,6 @@ check: $(wildcard **/*.agda)
 	$(AGDA) Cubical/Relation/Everything.agda
 	$(AGDA) Cubical/Experiments/Everything.agda
 
+.PHONY : clean
 clean :
 	find . -type f -name '*.agdai' -delete


### PR DESCRIPTION
I think it's fairly conventional for ```make``` to just "build" the project, which for an agda library means typechecking.

So now ```test``` is not the default target anymore, but it's still the one travis runs.

The new ```all``` target is the default, which just runs ```check```.

Also, all of these are declared ```.PHONY```, as they are.