### PR TITLE
Homotopy colimits of graphs

### DIFF
--- a/Cubical/Data/Everything.agda
+++ b/Cubical/Data/Everything.agda
@@ -15,3 +15,4 @@ open import Cubical.Data.DiffInt public
 open import Cubical.Data.Group public hiding (_≃_)
 open import Cubical.Data.HomotopyGroup public
 open import Cubical.Data.List public
+open import Cubical.Data.Graph public

--- a/Cubical/Data/Graph.agda
+++ b/Cubical/Data/Graph.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Graph where
+
+open import Cubical.Data.Graph.Base public
+open import Cubical.Data.Graph.Examples public

--- a/Cubical/Data/Graph/Base.agda
+++ b/Cubical/Data/Graph/Base.agda
@@ -1,0 +1,55 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Graph.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+private variable ℓv ℓv' ℓv'' ℓe ℓe' ℓe'' ℓd ℓd' : Level
+
+-- The type of directed multigraphs (with loops)
+
+record Graph ℓv ℓe : Type (ℓ-suc (ℓ-max ℓv ℓe)) where
+  field
+    Obj : Type ℓv
+    Hom : Obj → Obj → Type ℓe
+
+open Graph public
+
+_ᵒᵖ : Graph ℓv ℓe → Graph ℓv ℓe
+Obj (G ᵒᵖ) = Obj G
+Hom (G ᵒᵖ) x y = Hom G y x
+
+TypeGr : ∀ ℓ → Graph (ℓ-suc ℓ) ℓ
+Obj (TypeGr ℓ) = Type ℓ
+Hom (TypeGr ℓ) A B = A → B
+
+-- Graph functors/homomorphisms
+
+record GraphHom (G  : Graph ℓv  ℓe ) (G' : Graph ℓv' ℓe')
+                : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-max ℓv' ℓe'))) where
+  field
+    _$_ : Obj G → Obj G'
+    _<$>_ : ∀ {x y : Obj G} → Hom G x y → Hom G' (_$_ x) (_$_ y)
+  
+open GraphHom public
+
+GraphGr : ∀ ℓv ℓe → Graph _ _
+Obj (GraphGr ℓv ℓe) = Graph ℓv ℓe
+Hom (GraphGr ℓv ℓe) G G' = GraphHom G G'
+
+-- Diagrams are (graph) functors with codomain Type
+
+Diag : ∀ ℓd (G : Graph ℓv ℓe) → Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd)))
+Diag ℓd G = GraphHom G (TypeGr ℓd)
+
+record DiagMor {G : Graph ℓv ℓe} (F : Diag ℓd G) (F' : Diag ℓd' G)
+               : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc (ℓ-max ℓd ℓd')))) where
+  field
+    nat : ∀ (x : Obj G) → F $ x → F' $ x
+    comSq : ∀ {x y : Obj G} (f : Hom G x y) → nat y ∘ F <$> f ≡ F' <$> f ∘ nat x
+
+open DiagMor public
+
+DiagGr : ∀ ℓd (G : Graph ℓv ℓe) → Graph _ _
+Obj (DiagGr ℓd G) = Diag ℓd G
+Hom (DiagGr ℓd G) = DiagMor

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -17,6 +17,27 @@ open import Cubical.Data.Prod
 open import Cubical.Data.Graph.Base
 
 
+-- Some small graphs of common shape
+
+⇒⇐ : Graph ℓ-zero ℓ-zero
+Obj ⇒⇐ = Fin 3
+Hom ⇒⇐ fzero               (fsuc fzero) = ⊤
+Hom ⇒⇐ (fsuc (fsuc fzero)) (fsuc fzero) = ⊤
+Hom ⇒⇐ _ _ = ⊥
+
+⇐⇒ : Graph ℓ-zero ℓ-zero
+Obj ⇐⇒ = Fin 3
+Hom ⇐⇒ (fsuc fzero) fzero               = ⊤
+Hom ⇐⇒ (fsuc fzero) (fsuc (fsuc fzero)) = ⊤
+Hom ⇐⇒ _ _ = ⊥
+
+-- paralell pair graph 
+⇉ : Graph ℓ-zero ℓ-zero
+Obj ⇉ = Fin 2
+Hom ⇉ fzero (fsuc fzero) = Fin 2
+Hom ⇉ _ _ = ⊥
+
+
 -- The graph ω = 0 → 1 → 2 → ···
 
 data Adj : ℕ → ℕ → Type₀ where
@@ -46,6 +67,43 @@ record ωDiag ℓ : Type (ℓ-suc ℓ) where
   asDiag $ n = ωObj n
   _<$>_ asDiag {m} {n} f with areAdj m n
   asDiag <$> tt | yes (adj m) = ωHom m
+
+
+-- The finite connected subgraphs of ω: 𝟘,𝟙,𝟚,𝟛,...
+
+data AdjFin : ∀ {k} → Fin k → Fin k → Type₀ where
+  adj : ∀ {k} (n : Fin k) → AdjFin (finj n) (fsuc n)
+
+adj-fsuc : ∀ {k} {m n : Fin k} → AdjFin (fsuc m) (fsuc n) → AdjFin m n
+adj-fsuc {suc k} {.(finj n)} {fsuc n} (adj .(fsuc n)) = adj n
+
+areAdjFin : ∀ {k} (m n : Fin k) → Dec (AdjFin m n)
+areAdjFin {suc k}       fzero fzero           = no λ ()
+areAdjFin {suc (suc k)} fzero (fsuc fzero)    = yes (adj fzero)
+areAdjFin {suc (suc k)} fzero (fsuc (fsuc n)) = no λ ()
+areAdjFin {suc k}       (fsuc m) fzero        = no λ ()
+areAdjFin {suc k}       (fsuc m) (fsuc n)     = mapDec (λ { (adj m) → adj (fsuc m) })
+                                                       (λ { ¬a a → ¬a (adj-fsuc a) })
+                                                       (areAdjFin {k} m n)
+
+[_]Gr : ℕ → Graph ℓ-zero ℓ-zero
+Obj [ k ]Gr = Fin k
+Hom [ k ]Gr m n with areAdjFin m n
+... | yes _ = ⊤ -- if n ≡ (suc m)
+... | no  _ = ⊥ -- otherwise
+
+𝟘Gr 𝟙Gr 𝟚Gr 𝟛Gr : Graph ℓ-zero ℓ-zero
+𝟘Gr = [ 0 ]Gr; 𝟙Gr = [ 1 ]Gr; 𝟚Gr = [ 2 ]Gr; 𝟛Gr = [ 3 ]Gr
+
+record [_]Diag ℓ (k : ℕ) : Type (ℓ-suc ℓ) where
+  field
+    []Obj : Fin (suc k) → Type ℓ
+    []Hom : ∀ (n : Fin k) → []Obj (finj n) → []Obj (fsuc n)
+
+  asDiag : Diag ℓ [ suc k ]Gr
+  asDiag $ n = []Obj n
+  _<$>_ asDiag {m} {n} f with areAdjFin m n
+  _<$>_ asDiag {.(finj n)} {fsuc n} f | yes (adj .n) = []Hom n
 
 
 -- Disjoint union of graphs

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -1,0 +1,104 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Graph.Examples where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Empty
+open import Cubical.Data.Unit renaming (Unit to ⊤)
+open import Cubical.Data.Nat
+open import Cubical.Data.SumFin
+open import Cubical.Relation.Nullary
+
+open import Cubical.Data.Sum
+open import Cubical.Data.Prod
+
+open import Cubical.Data.Graph.Base
+
+
+-- The graph ω = 0 → 1 → 2 → ···
+
+data Adj : ℕ → ℕ → Type₀ where
+  adj : ∀ n → Adj n (suc n)
+
+areAdj : ∀ m n → Dec (Adj m n)
+areAdj zero zero          = no λ ()
+areAdj zero (suc zero)    = yes (adj zero)
+areAdj zero (suc (suc n)) = no λ ()
+areAdj (suc m) zero       = no λ ()
+areAdj (suc m) (suc n)    = mapDec (λ { (adj .m) → adj (suc m) })
+                                   (λ { ¬a (adj .(suc m)) → ¬a (adj m) })
+                                   (areAdj m n)
+
+ωGr : Graph ℓ-zero ℓ-zero
+Obj ωGr = ℕ
+Hom ωGr m n with areAdj m n
+... | yes _ = ⊤ -- if n ≡ (suc m)
+... | no  _ = ⊥ -- otherwise
+
+record ωDiag ℓ : Type (ℓ-suc ℓ) where
+  field
+    ωObj : ℕ → Type ℓ
+    ωHom : ∀ n → ωObj n → ωObj (suc n)
+
+  asDiag : Diag ℓ ωGr
+  asDiag $ n = ωObj n
+  _<$>_ asDiag {m} {n} f with areAdj m n
+  asDiag <$> tt | yes (adj m) = ωHom m
+
+
+-- Disjoint union of graphs
+
+module _ {ℓv ℓe ℓv' ℓe'} where
+
+  _⊎Gr_ : ∀ (G : Graph ℓv ℓe) (G' : Graph ℓv' ℓe') → Graph (ℓ-max ℓv ℓv') (ℓ-max ℓe ℓe')
+  Obj (G ⊎Gr G') = Obj G ⊎ Obj G'
+  Hom (G ⊎Gr G') (inl x) (inl y) = Lift {j = ℓe'} (Hom G x y)
+  Hom (G ⊎Gr G') (inr x) (inr y) = Lift {j = ℓe } (Hom G' x y)
+  Hom (G ⊎Gr G') _ _ = Lift ⊥
+
+  record ⊎Diag ℓ (G : Graph ℓv ℓe) (G' : Graph ℓv' ℓe')
+               : Type (ℓ-max (ℓ-suc ℓ) (ℓ-max (ℓ-max ℓv ℓv') (ℓ-max ℓe ℓe'))) where
+    field
+      ⊎Obj : Obj G ⊎ Obj G' → Type ℓ
+      ⊎Homl : ∀ {x y} → Hom G  x y → ⊎Obj (inl x) → ⊎Obj (inl y)
+      ⊎Homr : ∀ {x y} → Hom G' x y → ⊎Obj (inr x) → ⊎Obj (inr y)
+
+    asDiag : Diag ℓ (G ⊎Gr G')
+    asDiag $ x = ⊎Obj x
+    _<$>_ asDiag {inl x} {inl y} f = ⊎Homl (lower f)
+    _<$>_ asDiag {inr x} {inr y} f = ⊎Homr (lower f)
+
+
+-- Cartesian product of graphs
+
+module _ {ℓv ℓe ℓv' ℓe'} where
+
+  -- We need decidable equality in order to define the cartesian product
+  DecGraph : ∀ ℓv ℓe → Type (ℓ-suc (ℓ-max ℓv ℓe))
+  DecGraph ℓv ℓe = Σ[ G ∈ Graph ℓv ℓe ] Discrete (Obj G)
+
+  _×Gr_ : (G : DecGraph ℓv ℓe) (G' : DecGraph ℓv' ℓe') → Graph (ℓ-max ℓv ℓv') (ℓ-max ℓe ℓe')
+  Obj (G ×Gr G') = Obj (fst G) × Obj (fst G')
+  Hom (G ×Gr G') (x , x') (y , y') with snd G x y | snd G' x' y'
+  ... | yes _ | yes _ = Hom (fst G) x y ⊎ Hom (fst G') x' y'
+  ... | yes _ | no  _ = Lift {j = ℓe } (Hom (fst G') x' y')
+  ... | no  _ | yes _ = Lift {j = ℓe'} (Hom (fst G) x y)
+  ... | no  _ | no  _ = Lift ⊥
+
+  record ×Diag ℓ (G : DecGraph ℓv ℓe) (G' : DecGraph ℓv' ℓe')
+               : Type (ℓ-max (ℓ-suc ℓ) (ℓ-max (ℓ-max ℓv ℓv') (ℓ-max ℓe ℓe'))) where
+    field
+      ×Obj : Obj (fst G) × Obj (fst G') → Type ℓ
+      ×Hom₁ : ∀ {x y} (f : Hom (fst G) x y) (x' : Obj (fst G'))    → ×Obj (x , x') → ×Obj (y , x')
+      ×Hom₂ : ∀ (x : Obj (fst G)) {x' y'} (f : Hom (fst G') x' y') → ×Obj (x , x') → ×Obj (x , y')
+
+    asDiag : Diag ℓ (G ×Gr G')
+    asDiag $ x = ×Obj x
+    _<$>_ asDiag {x , x'} {y , y'} f with snd G x y | snd G' x' y'
+    _<$>_ asDiag {x , x'} {y , y'} (inl f) | yes _ | yes p' = subst _ p' (×Hom₁ f x')
+    _<$>_ asDiag {x , x'} {y , y'} (inr f) | yes p | yes _  = subst _ p  (×Hom₂ x f )
+    _<$>_ asDiag {x , x'} {y , y'} f | yes p | no  _  = subst _ p  (×Hom₂ x (lower f) )
+    _<$>_ asDiag {x , x'} {y , y'} f | no  _ | yes p' = subst _ p' (×Hom₁ (lower f) x')
+

--- a/Cubical/Data/SumFin.agda
+++ b/Cubical/Data/SumFin.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.SumFin where
+
+open import Cubical.Data.SumFin.Base public

--- a/Cubical/Data/SumFin/Base.agda
+++ b/Cubical/Data/SumFin/Base.agda
@@ -1,0 +1,45 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.SumFin.Base where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Empty using (⊥; ⊥-elim) public
+open import Cubical.Data.Unit using (tt) renaming (Unit to ⊤) public
+open import Cubical.Data.Sum using (_⊎_; inl; inr) public
+
+open import Cubical.Data.Nat
+
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Nullary.DecidableEq
+
+private variable k : ℕ
+
+Fin : ℕ → Type₀
+Fin zero = ⊥
+Fin (suc n) = ⊤ ⊎ (Fin n)
+
+pattern fzero = inl tt
+pattern fsuc n = inr n
+
+finj : Fin k → Fin (suc k)
+finj {suc k} fzero    = fzero
+finj {suc k} (fsuc n) = fsuc (finj {k} n)
+
+toℕ : Fin k → ℕ
+toℕ {suc k} (inl tt) = zero
+toℕ {suc k} (inr x)  = suc (toℕ {k} x)
+
+toℕ-injective : {m n : Fin k} → toℕ m ≡ toℕ n → m ≡ n
+toℕ-injective {suc k} {fzero}  {fzero}  _ = refl
+toℕ-injective {suc k} {fzero}  {fsuc x} p = ⊥-elim (znots p)
+toℕ-injective {suc k} {fsuc m} {fzero}  p = ⊥-elim (snotz p)
+toℕ-injective {suc k} {fsuc m} {fsuc x} p = cong fsuc (toℕ-injective (injSuc p))
+
+-- Thus, Fin k is discrete
+discreteFin : Discrete (Fin k)
+discreteFin fj fk with discreteℕ (toℕ fj) (toℕ fk)
+... | yes p = yes (toℕ-injective p)
+... | no ¬p = no (λ p → ¬p (cong toℕ p))
+
+isSetFin : isSet (Fin k)
+isSetFin = Discrete→isSet discreteFin

--- a/Cubical/HITs/Colimit.agda
+++ b/Cubical/HITs/Colimit.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Colimit where
+
+open import Cubical.HITs.Colimit.Base public
+open import Cubical.HITs.Colimit.Examples public

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -1,0 +1,136 @@
+{-
+
+  Homotopy colimits of graphs
+
+-}
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Colimit.Base where
+
+open import Cubical.Core.Glue
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Graph
+
+
+-- Cones under a diagram
+
+record Cocone ℓ {ℓd ℓv ℓe} {I : Graph ℓv ℓe} (F : Diag ℓd I) (X : Type ℓ)
+              : Type (ℓ-suc (ℓ-max ℓ (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd)))) where
+  field
+    leg : ∀ (j : Obj I) → F $ j → X
+    com : ∀ {j k} (f : Hom I j k) → leg k ∘ F <$> f ≡ leg j
+
+  postcomp : ∀ {ℓ'} {Y : Type ℓ'} → (X → Y) → Cocone ℓ' F Y
+  leg (postcomp h) j = h ∘ leg j
+  com (postcomp h) f = cong (h ∘_) (com f)
+
+open Cocone public
+
+
+-- Σ (Type ℓ) (Cocone ℓ F) forms a category:
+
+module _ {ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} where
+
+  private
+    -- the "lower star" functor
+    _* : ∀ {ℓ ℓ'} {X : Type ℓ} {Y : Type ℓ'} → (X → Y) → Cocone _ F X → Cocone _ F Y
+    (h *) C = postcomp C h
+
+  CoconeMor : ∀ {ℓ ℓ'} → Σ (Type ℓ) (Cocone ℓ F) → Σ (Type ℓ') (Cocone ℓ' F) → Type _
+  CoconeMor (X , C) (Y , D) = Σ[ h ∈ (X → Y) ] (h *) C ≡ D
+
+  idCoconeMor : ∀ {ℓ} (Cp : Σ (Type ℓ) (Cocone ℓ F)) → CoconeMor Cp Cp
+  idCoconeMor Cp = (λ x → x) , refl
+
+  compCoconeMor : ∀ {ℓ ℓ' ℓ''} {C : Σ (Type ℓ) (Cocone ℓ F)} {D : Σ (Type ℓ') (Cocone ℓ' F)}
+                    {E : Σ (Type ℓ'') (Cocone ℓ'' F)}
+                  → CoconeMor D E → CoconeMor C D → CoconeMor C E
+  compCoconeMor (g , q) (f , p) = g ∘ f , (cong (g *) p) ∙ q
+
+
+-- Universal cocones are initial objects in the category Σ (Type ℓ) (Cocone ℓ F)
+
+module _ {ℓ ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} {X : Type ℓ} where
+
+  isUniversalAt : ∀ ℓq → Cocone ℓ F X → Type (ℓ-max ℓ (ℓ-suc (ℓ-max ℓq (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd)))))
+  isUniversalAt ℓq C = ∀ (Y : Type ℓq) → isEquiv {A = (X → Y)} {B = Cocone ℓq F Y} (postcomp C)
+                  -- (unfolding isEquiv, this ^ is equivalent to what one might expect:)
+                  -- ∀ (Y : Type ℓ) (D : Cocone ℓ F Y) → isContr (Σ[ h ∈ (X → Y) ] (h *) C ≡ D)
+                  --                                  (≡ isContr (CoconeMor (X , C) (Y , D)))
+
+  isPropIsUniversalAt : ∀ ℓq (C : Cocone ℓ F X) → isProp (isUniversalAt ℓq C)
+  isPropIsUniversalAt ℓq C = propPi (λ Y → isPropIsEquiv (postcomp C))
+
+  isUniversal : Cocone ℓ F X → Typeω
+  isUniversal C = ∀ ℓq → isUniversalAt ℓq C
+
+
+-- Colimits are universal cocones
+
+record isColimit {ℓ ℓd ℓv ℓe} {I : Graph ℓv ℓe} (F : Diag ℓd I) (X : Type ℓ) : Typeω where
+  field
+    cone : Cocone ℓ F X
+    univ : isUniversal cone
+open isColimit public
+
+module _ {ℓ ℓ' ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} {X : Type ℓ} {Y : Type ℓ'} where
+
+  postcomp⁻¹ : isColimit F X → Cocone ℓ' F Y → (X → Y)
+  postcomp⁻¹ cl = invEq (_ , univ cl _ Y)
+
+  postcomp⁻¹-inv : (cl : isColimit F X) (D : Cocone ℓ' F Y) → (postcomp (cone cl) (postcomp⁻¹ cl D)) ≡ D
+  postcomp⁻¹-inv cl D = retEq (_ , univ cl _ Y) D
+
+  postcomp⁻¹-mor : (cl : isColimit F X) (D : Cocone ℓ' F Y) → CoconeMor (X , cone cl) (Y , D)
+  postcomp⁻¹-mor cl D = (postcomp⁻¹ cl D) , (postcomp⁻¹-inv cl D)
+
+-- Colimits are unique
+
+module _ {ℓ ℓ' ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} {X : Type ℓ} {Y : Type ℓ'} where
+
+  uniqColimit : isColimit F X → isColimit F Y → X ≃ Y
+  uniqColimit cl cl'
+    = isoToEquiv (iso (fst fwd) (fst bwd)
+                      (λ x i → fst (isContr→isProp (equiv-proof (univ cl' ℓ' Y) (cone cl'))
+                                                   (compCoconeMor fwd bwd)
+                                                   (idCoconeMor (Y , cone cl')) i) x)
+                      (λ x i → fst (isContr→isProp (equiv-proof (univ cl ℓ  X) (cone cl))
+                                                   (compCoconeMor bwd fwd)
+                                                   (idCoconeMor (X , cone cl)) i) x))
+    where fwd : CoconeMor (X , cone cl ) (Y , cone cl')
+          bwd : CoconeMor (Y , cone cl') (X , cone cl )
+          fwd = postcomp⁻¹-mor cl (cone cl')
+          bwd = postcomp⁻¹-mor cl' (cone cl)
+
+-- Colimits always exist
+
+data colim {ℓd ℓe ℓv} {I : Graph ℓv ℓe} (F : Diag ℓd I) : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd))) where
+  colim-leg : ∀ (j : Obj I) → F $ j → colim F
+  colim-com : ∀ {j k} (f : Hom I j k) → colim-leg k ∘ F <$> f ≡ colim-leg j
+
+module _ {ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} where
+
+  colimCone : Cocone _ F (colim F)
+  leg colimCone = colim-leg
+  com colimCone = colim-com
+
+  colim-rec : ∀ {ℓ} {X : Type ℓ} → Cocone ℓ F X → (colim F → X)
+  colim-rec C (colim-leg j A)   = leg C j A
+  colim-rec C (colim-com f i A) = com C f i A
+
+  colimIsColimit : isColimit F (colim F)
+  cone colimIsColimit = colimCone
+  univ colimIsColimit ℓq Y
+    = isoToIsEquiv record { fun = postcomp colimCone
+                          ; inv = colim-rec
+                          ; rightInv = λ C → refl
+                          ; leftInv  = λ h → funExt (eq h) }
+    where eq : ∀ h (x : colim _) → colim-rec (postcomp colimCone h) x ≡ h x
+          eq h (colim-leg j A)   = refl
+          eq h (colim-com f i A) = refl
+          
+ 

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -1,0 +1,3 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Colimit.Examples where
+

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -1,3 +1,78 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Colimit.Examples where
 
+open import Cubical.Core.Glue
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.SumFin
+
+open import Cubical.Data.Graph
+open import Cubical.HITs.Colimit.Base
+
+open import Cubical.HITs.Pushout
+
+
+-- Pushouts are colimits over the graph ⇐⇒
+
+module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} where
+
+  PushoutDiag : (A → B) → (A → C) → Diag (ℓ-max ℓ (ℓ-max ℓ' ℓ'')) ⇐⇒
+  (PushoutDiag f g) $ fzero             = Lift {j = ℓ-max ℓ  ℓ'' } B
+  (PushoutDiag f g) $ fsuc fzero        = Lift {j = ℓ-max ℓ' ℓ'' } A
+  (PushoutDiag f g) $ fsuc (fsuc fzero) = Lift {j = ℓ-max ℓ  ℓ'  } C
+  _<$>_ (PushoutDiag f g) {fsuc fzero} {fzero}             tt (lift a) = lift (f a)
+  _<$>_ (PushoutDiag f g) {fsuc fzero} {fsuc (fsuc fzero)} tt (lift a) = lift (g a)
+
+module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {f : A → B} {g : A → C} where
+
+  PushoutCocone : Cocone _ (PushoutDiag f g) (Pushout f g)
+  leg PushoutCocone fzero               (lift b) = inl b
+  leg PushoutCocone (fsuc fzero)        (lift a) = inr (g a)
+  leg PushoutCocone (fsuc (fsuc fzero)) (lift c) = inr c
+  com PushoutCocone {fsuc fzero} {fzero}             tt i (lift a) = push a i
+  com PushoutCocone {fsuc fzero} {fsuc (fsuc fzero)} tt i (lift a) = inr (g a)
+
+  private
+    module _ ℓq (Y : Type ℓq) where
+
+      fwd : (Pushout f g → Y) → Cocone ℓq (PushoutDiag f g) Y
+      fwd = postcomp PushoutCocone
+
+      module _ (C : Cocone ℓq (PushoutDiag f g) Y) where
+        coml : ∀ a → leg C fzero               (lift (f a)) ≡ leg C (fsuc fzero) (lift a)
+        comr : ∀ a → leg C (fsuc (fsuc fzero)) (lift (g a)) ≡ leg C (fsuc fzero) (lift a)
+        coml a i = com C {j = fsuc fzero} {k = fzero}             tt i (lift a)
+        comr a i = com C {j = fsuc fzero} {k = fsuc (fsuc fzero)} tt i (lift a)
+
+      bwd : Cocone ℓq (PushoutDiag f g) Y → (Pushout f g → Y)
+      bwd C (inl b)    = leg C fzero (lift b)
+      bwd C (inr c)    = leg C (fsuc (fsuc fzero)) (lift c)
+      bwd C (push a i) = (coml C a ∙ sym (comr C a)) i
+
+      bwd-fwd : ∀ F → bwd (fwd F) ≡ F
+      bwd-fwd F i (inl b) = F (inl b)
+      bwd-fwd F i (inr c) = F (inr c)
+      bwd-fwd F i (push a j) = compPath-filler (coml (fwd F) a) (sym (comr (fwd F) a)) (~ i) j
+
+      fwd-bwd : ∀ C → fwd (bwd C) ≡ C
+      leg (fwd-bwd C i) fzero               (lift b) = leg C fzero (lift b)
+      leg (fwd-bwd C i) (fsuc fzero)        (lift a) = comr C a i
+      leg (fwd-bwd C i) (fsuc (fsuc fzero)) (lift c) = leg C (fsuc (fsuc fzero)) (lift c)
+      com (fwd-bwd C i) {fsuc fzero} {fzero}             tt j (lift a) -- coml (fwd-bwd C i) = ...
+        = compPath-filler (coml C a) (sym (comr C a)) (~ i) j
+      com (fwd-bwd C i) {fsuc fzero} {fsuc (fsuc fzero)} tt j (lift a) -- comr (fwd-bwd C i) = ...
+        = comr C a (i ∧ j)
+
+      eqv : isEquiv {A = (Pushout f g → Y)} {B = Cocone ℓq (PushoutDiag f g) Y} (postcomp PushoutCocone)
+      eqv = isoToIsEquiv (iso fwd bwd fwd-bwd bwd-fwd)
+
+  isColimPushout : isColimit (PushoutDiag f g) (Pushout f g)
+  cone isColimPushout = PushoutCocone
+  univ isColimPushout = eqv
+
+  colim≃Pushout : colim (PushoutDiag f g) ≃ Pushout f g
+  colim≃Pushout = uniqColimit colimIsColimit isColimPushout
+  
+  

--- a/Cubical/HITs/Everything.agda
+++ b/Cubical/HITs/Everything.agda
@@ -25,3 +25,4 @@ open import Cubical.HITs.GroupoidTruncation public
 open import Cubical.HITs.2GroupoidTruncation public
 open import Cubical.HITs.SetQuotients public
 open import Cubical.HITs.FiniteMultiset public hiding ( _++_ ; [_] ; assoc-++ )
+open import Cubical.HITs.Colimit

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -56,3 +56,7 @@ isPropDec Aprop (yes a) (yes a') = cong yes (Aprop a a')
 isPropDec Aprop (yes a) (no ¬a) = ⊥-elim (¬a a)
 isPropDec Aprop (no ¬a) (yes a) = ⊥-elim (¬a a)
 isPropDec {A = A} Aprop (no ¬a) (no ¬a') = cong no (isProp¬ A ¬a ¬a')
+
+mapDec : ∀ {B : Type ℓ} → (A → B) → (¬ A → ¬ B) → Dec A → Dec B
+mapDec f _ (yes p) = yes (f p)
+mapDec _ f (no ¬p) = no (f ¬p)


### PR DESCRIPTION
This pull request adds a type of undirected multigraphs (in `Data.Graph`) and a HIT giving the unique homotopy colimit of a diagram over a graph (in `HITs.Colimit`). I also included some examples of graphs and proved that pushouts are indeed colimits.

Also included in this PR is yet another equivalent definition of `Fin`. When defining finite graphs I found the definition of `Fin` in `Data.Fin` very hard to work with, specifically in regards to pattern matching. The new definition (in `Data.SumFin`) behaves identically to the usual inductive version.

In future PRs I will add more examples of colimits (coequalizers, sums, and direct limits were what I had in mind), define homotopy *limits* of graphs, and prove some more categorical facts about cocones... but this pull request is already quite large as-is so I'm cutting it off!

I wrote most of this code a while ago, but I believe I drew inspiration from:
https://homotopytypetheory.org/2016/01/08/colimits-in-hott/
(Perhaps formalizing the constructions in this post is another good PR?)