### PR TITLE
3x3 reorganization, pushout span equivalences, join associativity

### DIFF
--- a/Cubical/HITs/Join.agda
+++ b/Cubical/HITs/Join.agda
@@ -2,5 +2,4 @@
 module Cubical.HITs.Join where
 
 open import Cubical.HITs.Join.Base public
-
--- open import Cubical.HITs.Join.Properties public
+open import Cubical.HITs.Join.Properties public

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -33,39 +33,39 @@ private
 
 
 -- Alternative definition of the join using a pushout
-joinAlt : (A : Type ℓ) → (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
-joinAlt A B = Pushout {_} {_} {_} {A × B} {A} {B} proj₁ proj₂
+joinPushout : (A : Type ℓ) → (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
+joinPushout A B = Pushout {_} {_} {_} {A × B} {A} {B} proj₁ proj₂
 
 -- Proof that it is equal
-joinAlt-iso-join : (A : Type ℓ) → (B : Type ℓ') → Iso (joinAlt A B) (join A B)
-joinAlt-iso-join A B = iso (joinAlt→join A B) (join→joinAlt A B) (join→joinAlt→join A B) (joinAlt→join→joinAlt A B)
+joinPushout-iso-join : (A : Type ℓ) → (B : Type ℓ') → Iso (joinPushout A B) (join A B)
+joinPushout-iso-join A B = iso joinPushout→join join→joinPushout join→joinPushout→join joinPushout→join→joinPushout
   where
-    joinAlt→join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B → join A B
-    joinAlt→join A B (inl x) = inl x
-    joinAlt→join A B (inr x) = inr x
-    joinAlt→join A B (push y i) = push (proj₁ y) (proj₂ y) i
+    joinPushout→join : joinPushout A B → join A B
+    joinPushout→join (inl x) = inl x
+    joinPushout→join (inr x) = inr x
+    joinPushout→join (push y i) = push (proj₁ y) (proj₂ y) i
 
-    join→joinAlt : (A : Type ℓ) → (B : Type ℓ') → join A B → joinAlt A B
-    join→joinAlt A B (inl x) = inl x
-    join→joinAlt A B (inr x) = inr x
-    join→joinAlt A B (push a b i) = push (a , b) i
+    join→joinPushout : join A B → joinPushout A B
+    join→joinPushout (inl x) = inl x
+    join→joinPushout (inr x) = inr x
+    join→joinPushout (push a b i) = push (a , b) i
 
-    joinAlt→join→joinAlt : (A : Type ℓ) → (B : Type ℓ') → ∀ x → join→joinAlt A B (joinAlt→join A B x) ≡ x
-    joinAlt→join→joinAlt A B (inl x) = refl
-    joinAlt→join→joinAlt A B (inr x) = refl
-    joinAlt→join→joinAlt A B (push (a , b) j) = refl
+    joinPushout→join→joinPushout : ∀ x → join→joinPushout (joinPushout→join x) ≡ x
+    joinPushout→join→joinPushout (inl x) = refl
+    joinPushout→join→joinPushout (inr x) = refl
+    joinPushout→join→joinPushout (push (a , b) j) = refl
 
-    join→joinAlt→join : (A : Type ℓ) → (B : Type ℓ') → ∀ x → joinAlt→join A B (join→joinAlt A B x) ≡ x
-    join→joinAlt→join A B (inl x) = refl
-    join→joinAlt→join A B (inr x) = refl
-    join→joinAlt→join A B (push a b j) = refl
+    join→joinPushout→join : ∀ x → joinPushout→join (join→joinPushout x) ≡ x
+    join→joinPushout→join (inl x) = refl
+    join→joinPushout→join (inr x) = refl
+    join→joinPushout→join (push a b j) = refl
 
 -- We will need both the equivalence and path version
-joinAlt≃join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B ≃ join A B
-joinAlt≃join A B = isoToEquiv (joinAlt-iso-join A B)
+joinPushout≃join : (A : Type ℓ) → (B : Type ℓ') → joinPushout A B ≃ join A B
+joinPushout≃join A B = isoToEquiv (joinPushout-iso-join A B)
 
-joinAlt≡join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B ≡ join A B
-joinAlt≡join A B = isoToPath (joinAlt-iso-join A B)
+joinPushout≡join : (A : Type ℓ) → (B : Type ℓ') → joinPushout A B ≡ join A B
+joinPushout≡join A B = isoToPath (joinPushout-iso-join A B)
 
 
 {-
@@ -73,11 +73,11 @@ joinAlt≡join A B = isoToPath (joinAlt-iso-join A B)
 -}
 join-assoc : (A : Type₀) → (B : Type₀) → (C : Type₀)
              → join (join A B) C ≡ join A (join B C)
-join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
-                   ∙ (spanEquivToPath sp3≃sp4) ⁻¹
+join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
+                   ∙ (spanEquivToPushoutPath sp3≃sp4) ⁻¹
                    ∙ (3x3-span.3x3-lemma span) ⁻¹
-                   ∙ (spanEquivToPath sp1≃sp2)
-                   ∙ (joinAlt≡join A (join B C))
+                   ∙ (spanEquivToPushoutPath sp1≃sp2)
+                   ∙ (joinPushout≡join A (join B C))
   where
     -- the meat of the proof is handled by the 3x3 lemma applied to this diagram
     span : 3x3-span
@@ -132,7 +132,7 @@ join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
     sp1≃sp2 = record {
       e0 = A□0≃A;
       e2 = A□2≃A×join;
-      e4 = joinAlt≃join B C;
+      e4 = joinPushout≃join B C;
       H1 = H1;
       H3 = H2 }
       where
@@ -186,10 +186,10 @@ join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
         H1 (inr (a , c)) = refl
         H1 (push (a , (b , c)) i) j = A□0→A (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
 
-        H2 : (x : 3x3-span.A□2 span) → proj₂ (A□2→A×join x) ≡ fst (joinAlt≃join _ _) (3x3-span.f□3 span x)
+        H2 : (x : 3x3-span.A□2 span) → proj₂ (A□2→A×join x) ≡ fst (joinPushout≃join _ _) (3x3-span.f□3 span x)
         H2 (inl (a , b)) = refl
         H2 (inr (a , c)) = refl
-        H2 (push (a , (b , c)) i) j = fst (joinAlt≃join _ _) (doubleCompPath-filler refl (λ i → push (b , c) i) refl i j)
+        H2 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (b , c) i) refl i j)
 
     -- the second span appearing in 3x3 lemma
     sp3 : 3-span
@@ -212,7 +212,7 @@ join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
     -- proof that they are in fact equivalent
     sp3≃sp4 : 3-span-equiv sp3 sp4
     sp3≃sp4 = record {
-      e0 = joinAlt≃join A B;
+      e0 = joinPushout≃join A B;
       e2 = A2□≃join×C;
       e4 = A4□≃C;
       H1 = H4;
@@ -268,7 +268,7 @@ join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
         H3 (inr (b , c)) = refl
         H3 (push (a , (b , c)) i) j = A4□→C (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
 
-        H4 : (x : 3x3-span.A2□ span) → proj₁ (A2□→join×C x) ≡ fst (joinAlt≃join _ _) (3x3-span.f1□ span x)
+        H4 : (x : 3x3-span.A2□ span) → proj₁ (A2□→join×C x) ≡ fst (joinPushout≃join _ _) (3x3-span.f1□ span x)
         H4 (inl (a , c)) = refl
         H4 (inr (b , c)) = refl
-        H4 (push (a , (b , c)) i) j = fst (joinAlt≃join _ _) (doubleCompPath-filler refl (λ i → push (a , b) i) refl i j)
+        H4 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (a , b) i) refl i j)

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -1,0 +1,274 @@
+{-
+
+This file contains:
+
+- Equivalence with the pushout definition
+  Written by: Loïc Pujet, September 2019
+
+- Associativity of the join
+  Written by: Loïc Pujet, September 2019
+
+-}
+
+{-# OPTIONS --cubical --safe #-}
+
+module Cubical.HITs.Join.Properties where
+
+open import Cubical.Core.Glue
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.GroupoidLaws
+
+open import Cubical.Data.Prod
+
+open import Cubical.HITs.Join.Base
+open import Cubical.HITs.Pushout
+
+private
+  variable
+    ℓ : Level
+    ℓ' : Level
+
+
+-- Alternative definition of the join using a pushout
+joinAlt : (A : Type ℓ) → (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
+joinAlt A B = Pushout {_} {_} {_} {A × B} {A} {B} proj₁ proj₂
+
+-- Proof that it is equal
+joinAlt-iso-join : (A : Type ℓ) → (B : Type ℓ') → Iso (joinAlt A B) (join A B)
+joinAlt-iso-join A B = iso (joinAlt→join A B) (join→joinAlt A B) (join→joinAlt→join A B) (joinAlt→join→joinAlt A B)
+  where
+    joinAlt→join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B → join A B
+    joinAlt→join A B (inl x) = inl x
+    joinAlt→join A B (inr x) = inr x
+    joinAlt→join A B (push y i) = push (proj₁ y) (proj₂ y) i
+
+    join→joinAlt : (A : Type ℓ) → (B : Type ℓ') → join A B → joinAlt A B
+    join→joinAlt A B (inl x) = inl x
+    join→joinAlt A B (inr x) = inr x
+    join→joinAlt A B (push a b i) = push (a , b) i
+
+    joinAlt→join→joinAlt : (A : Type ℓ) → (B : Type ℓ') → ∀ x → join→joinAlt A B (joinAlt→join A B x) ≡ x
+    joinAlt→join→joinAlt A B (inl x) = refl
+    joinAlt→join→joinAlt A B (inr x) = refl
+    joinAlt→join→joinAlt A B (push (a , b) j) = refl
+
+    join→joinAlt→join : (A : Type ℓ) → (B : Type ℓ') → ∀ x → joinAlt→join A B (join→joinAlt A B x) ≡ x
+    join→joinAlt→join A B (inl x) = refl
+    join→joinAlt→join A B (inr x) = refl
+    join→joinAlt→join A B (push a b j) = refl
+
+-- We will need both the equivalence and path version
+joinAlt≃join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B ≃ join A B
+joinAlt≃join A B = isoToEquiv (joinAlt-iso-join A B)
+
+joinAlt≡join : (A : Type ℓ) → (B : Type ℓ') → joinAlt A B ≡ join A B
+joinAlt≡join A B = isoToPath (joinAlt-iso-join A B)
+
+
+{-
+  Proof of associativity of the join
+-}
+join-assoc : (A : Type₀) → (B : Type₀) → (C : Type₀)
+             → join (join A B) C ≡ join A (join B C)
+join-assoc A B C = (joinAlt≡join (join A B) C) ⁻¹
+                   ∙ (spanEquivToPath sp3≃sp4) ⁻¹
+                   ∙ (3x3-span.3x3-lemma span) ⁻¹
+                   ∙ (spanEquivToPath sp1≃sp2)
+                   ∙ (joinAlt≡join A (join B C))
+  where
+    -- the meat of the proof is handled by the 3x3 lemma applied to this diagram
+    span : 3x3-span
+    span = record {
+      A00 = A;      A02 = A × B;      A04 = B;
+      A20 = A × C;  A22 = A × B × C;  A24 = B × C;
+      A40 = A × C;  A42 = A × C;      A44 = C;
+      f10 = proj₁;   f12 = proj₁₂; f14 = proj₁;
+      f30 = λ x → x; f32 = proj₁₃; f34 = proj₂;
+      f01 = proj₁;   f21 = proj₁₃; f41 = λ x → x;
+      f03 = proj₂;   f23 = proj₂;  f43 = proj₂;
+      H11 = H11;    H13 = H13;    H31 = H31;    H33 = H33  }
+      where
+        proj₁₃ : A × B × C → A × C
+        proj₁₃ (a , (b , c)) = a , c
+
+        proj₁₂ : A × B × C → A × B
+        proj₁₂ (a , (b , c)) = a , b
+
+        H11 : (x : A × B × C) → proj₁ (proj₁₂ x) ≡ proj₁ (proj₁₃ x)
+        H11 (a , (b , c)) = refl
+
+        H13 : (x : A × B × C) → proj₂ (proj₁₂ x) ≡ proj₁ (proj₂ x)
+        H13 (a , (b , c)) = refl
+
+        H31 : (x : A × B × C) → proj₁₃ x ≡ proj₁₃ x
+        H31 (a , (b , c)) = refl
+
+        H33 : (x : A × B × C) → proj₂ (proj₁₃ x) ≡ proj₂ (proj₂ x)
+        H33 (a , (b , c)) = refl
+
+    -- the first pushout span appearing in the 3x3 lemma
+    sp1 : 3-span
+    sp1 = record {
+      A0 = 3x3-span.A□0 span;
+      A2 = 3x3-span.A□2 span;
+      A4 = 3x3-span.A□4 span;
+      f1 = 3x3-span.f□1 span;
+      f3 = 3x3-span.f□3 span }
+
+    -- the first span we are interested in
+    sp2 : 3-span
+    sp2 = record {
+      A0 = A ;
+      A2 = A × (join B C) ;
+      A4 = join B C ;
+      f1 = proj₁ ;
+      f3 = proj₂ }
+
+    -- proof that they are in fact equivalent
+    sp1≃sp2 : 3-span-equiv sp1 sp2
+    sp1≃sp2 = record {
+      e0 = A□0≃A;
+      e2 = A□2≃A×join;
+      e4 = joinAlt≃join B C;
+      H1 = H1;
+      H3 = H2 }
+      where
+        A×join : Type₀
+        A×join = A × (join B C)
+
+        A□2→A×join : 3x3-span.A□2 span → A×join
+        A□2→A×join (inl (a , b)) = a , inl b
+        A□2→A×join (inr (a , c)) = a , inr c
+        A□2→A×join (push (a , (b , c)) i) = a , push b c i
+
+        A×join→A□2 : A×join → 3x3-span.A□2 span
+        A×join→A□2 (a , inl b) = inl (a , b)
+        A×join→A□2 (a , inr c) = inr (a , c)
+        A×join→A□2 (a , push b c i) = push (a , (b , c)) i
+
+        A×join→A□2→A×join : ∀ x → A×join→A□2 (A□2→A×join x) ≡ x
+        A×join→A□2→A×join (inl (a , b)) = refl
+        A×join→A□2→A×join (inr (a , c)) = refl
+        A×join→A□2→A×join (push (a , (b , c)) i) = refl
+
+        A□2→A×join→A□2 : ∀ x → A□2→A×join (A×join→A□2 x) ≡ x
+        A□2→A×join→A□2 (a , inl b) = refl
+        A□2→A×join→A□2 (a , inr c) = refl
+        A□2→A×join→A□2 (a , push b c i) = refl
+
+        A□2≃A×join : 3x3-span.A□2 span ≃ A×join
+        A□2≃A×join = isoToEquiv (iso A□2→A×join A×join→A□2 A□2→A×join→A□2 A×join→A□2→A×join)
+
+        A→A□0 : A → 3x3-span.A□0 span
+        A→A□0 b = inl b
+
+        A□0→A : 3x3-span.A□0 span → A
+        A□0→A (inl b) = b
+        A□0→A (inr a) = proj₁ a
+        A□0→A (push a i) = proj₁ a
+
+        A→A□0→A : ∀ x → A□0→A (A→A□0 x) ≡ x
+        A→A□0→A x = refl
+
+        A□0→A→A□0 : ∀ x → A→A□0 (A□0→A x) ≡ x
+        A□0→A→A□0 (inl b) = refl
+        A□0→A→A□0 (inr a) j = push a j
+        A□0→A→A□0 (push a i) j = push a (j ∧ i)
+
+        A□0≃A :  3x3-span.A□0 span ≃ A
+        A□0≃A = isoToEquiv (iso A□0→A A→A□0 A→A□0→A A□0→A→A□0)
+
+        H1 : (x : 3x3-span.A□2 span) → proj₁ (A□2→A×join x) ≡ A□0→A (3x3-span.f□1 span x)
+        H1 (inl (a , b)) = refl
+        H1 (inr (a , c)) = refl
+        H1 (push (a , (b , c)) i) j = A□0→A (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
+
+        H2 : (x : 3x3-span.A□2 span) → proj₂ (A□2→A×join x) ≡ fst (joinAlt≃join _ _) (3x3-span.f□3 span x)
+        H2 (inl (a , b)) = refl
+        H2 (inr (a , c)) = refl
+        H2 (push (a , (b , c)) i) j = fst (joinAlt≃join _ _) (doubleCompPath-filler refl (λ i → push (b , c) i) refl i j)
+
+    -- the second span appearing in 3x3 lemma
+    sp3 : 3-span
+    sp3 = record {
+      A0 = 3x3-span.A0□ span;
+      A2 = 3x3-span.A2□ span;
+      A4 = 3x3-span.A4□ span;
+      f1 = 3x3-span.f1□ span;
+      f3 = 3x3-span.f3□ span }
+
+    -- the second span we are interested in
+    sp4 : 3-span
+    sp4 = record {
+      A0 = join A B ;
+      A2 = (join A B) × C ;
+      A4 = C ;
+      f1 = proj₁ ;
+      f3 = proj₂ }
+
+    -- proof that they are in fact equivalent
+    sp3≃sp4 : 3-span-equiv sp3 sp4
+    sp3≃sp4 = record {
+      e0 = joinAlt≃join A B;
+      e2 = A2□≃join×C;
+      e4 = A4□≃C;
+      H1 = H4;
+      H3 = H3 }
+      where
+        join×C : Type₀
+        join×C = (join A B) × C
+
+        A2□→join×C : 3x3-span.A2□ span → join×C
+        A2□→join×C (inl (a , c)) = (inl a) , c
+        A2□→join×C (inr (b , c)) = (inr b) , c
+        A2□→join×C (push (a , (b , c)) i) = push a b i , c
+
+        join×C→A2□ : join×C → 3x3-span.A2□ span
+        join×C→A2□ (inl a , c) = inl (a , c)
+        join×C→A2□ (inr b , c) = inr (b , c)
+        join×C→A2□ (push a b i , c) = push (a , (b , c)) i
+
+        join×C→A2□→join×C : ∀ x → join×C→A2□ (A2□→join×C x) ≡ x
+        join×C→A2□→join×C (inl (a , c)) = refl
+        join×C→A2□→join×C (inr (b , c)) = refl
+        join×C→A2□→join×C (push (a , (b , c)) j) = refl
+
+        A2□→join×C→A2□ : ∀ x → A2□→join×C (join×C→A2□ x) ≡ x
+        A2□→join×C→A2□ (inl a , c) = refl
+        A2□→join×C→A2□ (inr b , c) = refl
+        A2□→join×C→A2□ (push a b i , c) = refl
+
+        A2□≃join×C : 3x3-span.A2□ span ≃ join×C
+        A2□≃join×C = isoToEquiv (iso A2□→join×C join×C→A2□ A2□→join×C→A2□ join×C→A2□→join×C)
+
+        C→A4□ : C → 3x3-span.A4□ span
+        C→A4□ b = inr b
+
+        A4□→C : 3x3-span.A4□ span → C
+        A4□→C (inl x) = proj₂ x
+        A4□→C (inr c) = c
+        A4□→C (push x i) = proj₂ x
+
+        C→A4□→C : ∀ x → A4□→C (C→A4□ x) ≡ x
+        C→A4□→C x = refl
+
+        A4□→C→A4□ : ∀ x → C→A4□ (A4□→C x) ≡ x
+        A4□→C→A4□ (inl x) j = push x (~ j)
+        A4□→C→A4□ (inr c) = refl
+        A4□→C→A4□ (push x i) j = push x (~ j ∨ i)
+
+        A4□≃C :  3x3-span.A4□ span ≃ C
+        A4□≃C = isoToEquiv (iso A4□→C C→A4□ C→A4□→C A4□→C→A4□)
+
+        H3 : (x : 3x3-span.A2□ span) → proj₂ (A2□→join×C x) ≡ A4□→C (3x3-span.f3□ span x)
+        H3 (inl (a , c)) = refl
+        H3 (inr (b , c)) = refl
+        H3 (push (a , (b , c)) i) j = A4□→C (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
+
+        H4 : (x : 3x3-span.A2□ span) → proj₁ (A2□→join×C x) ≡ fst (joinAlt≃join _ _) (3x3-span.f1□ span x)
+        H4 (inl (a , c)) = refl
+        H4 (inr (b , c)) = refl
+        H4 (push (a , (b , c)) i) j = fst (joinAlt≃join _ _) (doubleCompPath-filler refl (λ i → push (a , b) i) refl i j)

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -2,6 +2,9 @@
 
 This file contains:
 
+- Homotopy natural equivalences of pushout spans
+  Written by: Loïc Pujet, September 2019
+
 - 3×3 lemma for pushouts
   Written by: Loïc Pujet, April 2019
 
@@ -16,12 +19,165 @@ open import Cubical.Core.Glue
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HAEquiv
 open import Cubical.Foundations.GroupoidLaws
 
 open import Cubical.Data.Prod.Base
 open import Cubical.Data.Unit
 
 open import Cubical.HITs.Pushout.Base
+
+{-
+  Definition of pushout diagrams
+-}
+
+record 3-span : Type₁ where
+  field
+    A0 A2 A4 : Type₀
+    f1 : A2 → A0
+    f3 : A2 → A4
+
+spanPushout : (s : 3-span) → Type₀
+spanPushout s = Pushout (3-span.f1 s) (3-span.f3 s)
+
+{-
+  Definition of a homotopy natural diagram equivalence
+-}
+
+record 3-span-equiv (s1 : 3-span) (s2 : 3-span) : Type₀ where
+   field
+     e0 : 3-span.A0 s1 ≃ 3-span.A0 s2
+     e2 : 3-span.A2 s1 ≃ 3-span.A2 s2
+     e4 : 3-span.A4 s1 ≃ 3-span.A4 s2
+     H1 : ∀ x → 3-span.f1 s2 (e2 .fst x) ≡ e0 .fst (3-span.f1 s1 x)
+     H3 : ∀ x → 3-span.f3 s2 (e2 .fst x) ≡ e4 .fst (3-span.f3 s1 x)
+
+{-
+  Proof that the pushouts of equivalent diagrams are equal
+-}
+
+spanEquivToPath : {s1 : 3-span} → {s2 : 3-span} → (e : 3-span-equiv s1 s2)
+                  → spanPushout s1 ≡ spanPushout s2
+spanEquivToPath {s1} {s2} e = p1≡p2
+  where
+    open 3-span-equiv e
+    open isHAEquiv
+    open 3-span
+
+    -- we use half-adjoint equivalences because we will need the higher coherences
+    -- built inside the equivalences
+    hae0 : isHAEquiv (fst e0)
+    hae0 = snd (equiv→HAEquiv e0)
+
+    hae2 : isHAEquiv (fst e2)
+    hae2 = snd (equiv→HAEquiv e2)
+
+    hae4 : isHAEquiv (fst e4)
+    hae4 = snd (equiv→HAEquiv e4)
+
+    -- construct a pushout map from a homotopy coherent equivalence
+    filler1 : A2 s1 → I → I → spanPushout s2
+    filler1 a = doubleCompPath-filler (λ j → inl (H1 a (~ j)))
+                                      (push (e2 .fst a))
+                                      (λ j → inr (H3 a j))
+
+    p1→p2 : spanPushout s1 → spanPushout s2
+    p1→p2 (inl x) = inl (e0 .fst x)
+    p1→p2 (inr x) = inr (e4 .fst x)
+    p1→p2 (push a i) = filler1 a i i1
+
+    -- construct a homotopy coherent inverse
+    filler2 : A2 s2 → I → I → spanPushout s1
+    filler2 a = doubleCompPath-filler (λ j → inl (sec hae0 (f1 s1 (g hae2 a)) j))
+                                      (push (g hae2 a))
+                                      (λ j → inr (sec hae4 (f3 s1 (g hae2 a)) (~ j)))
+
+    filler3 : A2 s2 → I → I → spanPushout s1
+    filler3 a = doubleCompPath-filler (λ j → inl (g hae0 (H1 (g hae2 a) j)))
+                                      (λ i → filler2 a i i1)
+                                      (λ j → inr (g hae4 (H3 (g hae2 a) (~ j))))
+
+    filler4 : A2 s2 → I → I → spanPushout s1
+    filler4 a = doubleCompPath-filler ((λ j → inl (g hae0 (f1 s2 (ret hae2 a (~ j))))))
+                                      (λ i → filler3 a i i1)
+                                      (λ j → inr (g hae4 (f3 s2 (ret hae2 a j))))
+
+    p2→p1 : spanPushout s2 → spanPushout s1
+    p2→p1 (inl x) = inl (g hae0 x)
+    p2→p1 (inr x) = inr (g hae4 x)
+    p2→p1 (push a i) = filler4 a i i1
+
+    -- construct a homotopy coherent retraction
+    sq1 : (x : A2 s2) → I → I → spanPushout s2
+    sq1 x i j = hcomp (λ k → λ { (i = i0) → inl (ret hae0 ((f1 s2 (e2 .fst (g hae2 x)))) j)
+                               ; (i = i1) → inl (com hae0 (f1 s1 (g hae2 x)) (~ k) j)
+                               ; (j = i0) → inl (e0 .fst (g hae0 (H1 (g hae2 x) i)))
+                               ; (j = i1) → inl (H1 (g hae2 x) i) })
+                      (inl (ret hae0 (H1 (g hae2 x) i) j))
+
+    sq2 : (x : A2 s2) → I → I → spanPushout s2
+    sq2 x i j = hcomp (λ k → λ { (i = i0) → inr (ret hae4 ((f3 s2 (e2 .fst (g hae2 x)))) j)
+                               ; (i = i1) → inr (com hae4 (f3 s1 (g hae2 x)) (~ k) j)
+                               ; (j = i0) → inr (e4 .fst (g hae4 (H3 (g hae2 x) i)))
+                               ; (j = i1) → inr (H3 (g hae2 x) i) })
+                      (inr (ret hae4 (H3 (g hae2 x) i) j))
+
+    sq3 : (x : A2 s2) → I → I → spanPushout s2
+    sq3 x i j = hcomp (λ k → λ { (i = i0) → sq1 x (~ k) j
+                               ; (i = i1) → sq2 x (~ k) j
+                               ; (j = i0) → p1→p2 (filler3 x i k)
+                               ; (j = i1) → filler1 (g hae2 x) i (~ k) })
+                      (p1→p2 (filler2 x i (~ j)))
+
+    sq4 : (x : A2 s2) → I → I → spanPushout s2
+    sq4 x i j = hcomp (λ k → λ { (i = i0) → inl (ret hae0 (f1 s2 (ret hae2 x k)) j)
+                               ; (i = i1) → inr (ret hae4 (f3 s2 (ret hae2 x k)) j)
+                               ; (j = i0) → p1→p2 (filler4 x i k)
+                               ; (j = i1) → push (ret hae2 x k) i })
+                      (sq3 x i j)
+
+    p2→p1→p2 : ∀ x → p1→p2 (p2→p1 x) ≡ x
+    p2→p1→p2 (inl x) i = inl (ret hae0 x i)
+    p2→p1→p2 (inr x) i = inr (ret hae4 x i)
+    p2→p1→p2 (push a j) i = sq4 a j i
+
+    -- construct a homotopy coherent section
+    sq5 : (x : A2 s1) → I → I → spanPushout s1
+    sq5 x i j = hcomp (λ k → λ { (i = i0) → inl (g hae0 (f1 s2 (com hae2 x k j)))
+                               ; (i = i1) → inl (g hae0 (e0 .fst (f1 s1 (sec hae2 x j))))
+                               ; (j = i0) → inl (g hae0 (H1 (g hae2 (e2 .fst x)) i))
+                               ; (j = i1) → inl (g hae0 (H1 x i)) })
+                      (inl (g hae0 (H1 (sec hae2 x j) i)))
+
+    sq6 : (x : A2 s1) → I → I → spanPushout s1
+    sq6 x i j = hcomp (λ k → λ { (i = i0) → inr (g hae4 (f3 s2 (com hae2 x k j)))
+                               ; (i = i1) → inr (g hae4 (e4 .fst (f3 s1 (sec hae2 x j))))
+                               ; (j = i0) → inr (g hae4 (H3 (g hae2 (e2 .fst x)) i))
+                               ; (j = i1) → inr (g hae4 (H3 x i)) })
+                      (inr (g hae4 (H3 (sec hae2 x j) i)))
+
+    sq7 : (x : A2 s1) → I → I → spanPushout s1
+    sq7 x i j = hcomp (λ k → λ { (i = i0) → sq5 x k (~ j)
+                               ; (i = i1) → sq6 x k (~ j)
+                               ; (j = i0) → p2→p1 (filler1 x i k)
+                               ; (j = i1) → filler3 (e2 .fst x) i (~ k) })
+                      (filler4 (e2 .fst x) i (~ j))
+
+    sq8 : (x : A2 s1) → I → I → spanPushout s1
+    sq8 x i j = hcomp (λ k → λ { (i = i0) → inl (sec hae0 (f1 s1 (sec hae2 x k)) j)
+                               ; (i = i1) → inr (sec hae4 (f3 s1 (sec hae2 x k)) j)
+                               ; (j = i0) → sq7 x i (~ k)
+                               ; (j = i1) → push (sec hae2 x k) i })
+                      (filler2 (e2 .fst x) i (~ j))
+
+    p1→p2→p1 : ∀ x → p2→p1 (p1→p2 x) ≡ x
+    p1→p2→p1 (inl x) i = inl (sec hae0 x i)
+    p1→p2→p1 (inr x) i = inr (sec hae4 x i)
+    p1→p2→p1 (push a j) i = sq8 a j i
+
+    -- deduce equality of the pushouts
+    p1≡p2 : spanPushout s1 ≡ spanPushout s2
+    p1≡p2 = isoToPath (iso p1→p2 p2→p1 p2→p1→p2 p1→p2→p1)
 
 {-
 
@@ -48,30 +204,30 @@ Then the lemma states there is an equivalence A□○ ≃ A○□.
 
 -}
 
-module 3x3-span
-  (A00 A02 A04 A20 A22 A24 A40 A42 A44 : Type₀)
+record 3x3-span : Type₁ where
+  field
+    A00 A02 A04 A20 A22 A24 A40 A42 A44 : Type₀
 
-  (f10 : A20 → A00)
-  (f12 : A22 → A02)
-  (f14 : A24 → A04)
+    f10 : A20 → A00
+    f12 : A22 → A02
+    f14 : A24 → A04
 
-  (f30 : A20 → A40)
-  (f32 : A22 → A42)
-  (f34 : A24 → A44)
+    f30 : A20 → A40
+    f32 : A22 → A42
+    f34 : A24 → A44
 
-  (f01 : A02 → A00)
-  (f21 : A22 → A20)
-  (f41 : A42 → A40)
+    f01 : A02 → A00
+    f21 : A22 → A20
+    f41 : A42 → A40
 
-  (f03 : A02 → A04)
-  (f23 : A22 → A24)
-  (f43 : A42 → A44)
+    f03 : A02 → A04
+    f23 : A22 → A24
+    f43 : A42 → A44
 
-  (H11 : ∀ x → f01 (f12 x) ≡ f10 (f21 x))
-  (H13 : ∀ x → f03 (f12 x) ≡ f14 (f23 x))
-  (H31 : ∀ x → f41 (f32 x) ≡ f30 (f21 x))
-  (H33 : ∀ x → f43 (f32 x) ≡ f34 (f23 x))
-  where
+    H11 : ∀ x → f01 (f12 x) ≡ f10 (f21 x)
+    H13 : ∀ x → f03 (f12 x) ≡ f14 (f23 x)
+    H31 : ∀ x → f41 (f32 x) ≡ f30 (f21 x)
+    H33 : ∀ x → f43 (f32 x) ≡ f34 (f23 x)
 
   -- pushouts of the lines
   A□0 : Type₀
@@ -131,111 +287,106 @@ module 3x3-span
   A○□ : Type₀
   A○□ = Pushout f1□ f3□
 
-  -- forward map of the equivalence A□○ ≃ A○□
-  forward-l : A□0 → A○□
-  forward-l (inl x) = inl (inl x)
-  forward-l (inr x) = inr (inl x)
-  forward-l (push a i) = push (inl a) i
+  -- the claimed result
+  3x3-lemma : A□○ ≡ A○□
+  3x3-lemma = isoToPath (iso A□○→A○□ A○□→A□○ A○□→A□○→A○□ A□○→A○□→A□○)
+    where
+      -- forward map of the equivalence A□○ ≃ A○□
+      forward-l : A□0 → A○□
+      forward-l (inl x) = inl (inl x)
+      forward-l (inr x) = inr (inl x)
+      forward-l (push a i) = push (inl a) i
 
-  forward-r : A□4 → A○□
-  forward-r (inl x) = inl (inr x)
-  forward-r (inr x) = inr (inr x)
-  forward-r (push a i) = push (inr a) i
+      forward-r : A□4 → A○□
+      forward-r (inl x) = inl (inr x)
+      forward-r (inr x) = inr (inr x)
+      forward-r (push a i) = push (inr a) i
 
-  forward-filler : A22 → I → I → I → A○□
-  forward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
-                                 ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
-                                 ; (j = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t)
-                                 ; (j = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) })
-                        (inS (push (push a j) i))
+      forward-filler : A22 → I → I → I → A○□
+      forward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
+                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
+                                     ; (j = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t)
+                                     ; (j = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) })
+                            (inS (push (push a j) i))
 
-  A□○→A○□ : A□○ → A○□
-  A□○→A○□ (inl x) = forward-l x
-  A□○→A○□ (inr x) = forward-r x
-  A□○→A○□ (push (inl x) i) = inl (push x i)
-  A□○→A○□ (push (inr x) i) = inr (push x i)
-  A□○→A○□ (push (push a i) j) = forward-filler a i j i1
+      A□○→A○□ : A□○ → A○□
+      A□○→A○□ (inl x) = forward-l x
+      A□○→A○□ (inr x) = forward-r x
+      A□○→A○□ (push (inl x) i) = inl (push x i)
+      A□○→A○□ (push (inr x) i) = inr (push x i)
+      A□○→A○□ (push (push a i) j) = forward-filler a i j i1
 
-  -- backward map
-  backward-l : A0□ → A□○
-  backward-l (inl x) = inl (inl x)
-  backward-l (inr x) = inr (inl x)
-  backward-l (push a i) = push (inl a) i
+      -- backward map
+      backward-l : A0□ → A□○
+      backward-l (inl x) = inl (inl x)
+      backward-l (inr x) = inr (inl x)
+      backward-l (push a i) = push (inl a) i
 
-  backward-r : A4□ → A□○
-  backward-r (inl x) = inl (inr x)
-  backward-r (inr x) = inr (inr x)
-  backward-r (push a i) = push (inr a) i
+      backward-r : A4□ → A□○
+      backward-r (inl x) = inl (inr x)
+      backward-r (inr x) = inr (inr x)
+      backward-r (push a i) = push (inr a) i
 
-  backward-filler : A22 → I → I → I → A□○
-  backward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
-                                 ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
-                                 ; (j = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t)
-                                 ; (j = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) })
-                        (inS (push (push a j) i))
+      backward-filler : A22 → I → I → I → A□○
+      backward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
+                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
+                                     ; (j = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t)
+                                     ; (j = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) })
+                            (inS (push (push a j) i))
 
-  A○□→A□○ : A○□ → A□○
-  A○□→A□○ (inl x) = backward-l x
-  A○□→A□○ (inr x) = backward-r x
-  A○□→A□○ (push (inl x) i) = inl (push x i)
-  A○□→A□○ (push (inr x) i) = inr (push x i)
-  A○□→A□○ (push (push a i) j) = backward-filler a i j i1
+      A○□→A□○ : A○□ → A□○
+      A○□→A□○ (inl x) = backward-l x
+      A○□→A□○ (inr x) = backward-r x
+      A○□→A□○ (push (inl x) i) = inl (push x i)
+      A○□→A□○ (push (inr x) i) = inr (push x i)
+      A○□→A□○ (push (push a i) j) = backward-filler a i j i1
 
-  -- first homotopy
-  homotopy1-l : ∀ x → A□○→A○□ (backward-l x) ≡ inl x
-  homotopy1-l (inl x) = refl
-  homotopy1-l (inr x) = refl
-  homotopy1-l (push a i) = refl
+      -- first homotopy
+      homotopy1-l : ∀ x → A□○→A○□ (backward-l x) ≡ inl x
+      homotopy1-l (inl x) = refl
+      homotopy1-l (inr x) = refl
+      homotopy1-l (push a i) = refl
 
-  homotopy1-r : ∀ x → A□○→A○□ (backward-r x) ≡ inr x
-  homotopy1-r (inl x) = refl
-  homotopy1-r (inr x) = refl
-  homotopy1-r (push a i) = refl
+      homotopy1-r : ∀ x → A□○→A○□ (backward-r x) ≡ inr x
+      homotopy1-r (inl x) = refl
+      homotopy1-r (inr x) = refl
+      homotopy1-r (push a i) = refl
 
-  A○□→A□○→A○□ : ∀ x → A□○→A○□ (A○□→A□○ x) ≡ x
-  A○□→A□○→A○□ (inl x) = homotopy1-l x
-  A○□→A□○→A○□ (inr x) = homotopy1-r x
-  A○□→A□○→A○□ (push (inl x) i) k = push (inl x) i
-  A○□→A□○→A○□ (push (inr x) i) k = push (inr x) i
-  A○□→A□○→A○□ (push (push a i) j) k =
-    hcomp (λ t → λ { (i = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
-                   ; (i = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
-                   ; (j = i0) → homotopy1-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t) k
-                   ; (j = i1) → homotopy1-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) k
-                   ; (k = i0) → A□○→A○□ (backward-filler a i j t)
-                   ; (k = i1) → forward-filler a j i (~ t) })
-          (forward-filler a j i i1)
+      A○□→A□○→A○□ : ∀ x → A□○→A○□ (A○□→A□○ x) ≡ x
+      A○□→A□○→A○□ (inl x) = homotopy1-l x
+      A○□→A□○→A○□ (inr x) = homotopy1-r x
+      A○□→A□○→A○□ (push (inl x) i) k = push (inl x) i
+      A○□→A□○→A○□ (push (inr x) i) k = push (inr x) i
+      A○□→A□○→A○□ (push (push a i) j) k =
+        hcomp (λ t → λ { (i = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
+                       ; (i = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
+                       ; (j = i0) → homotopy1-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t) k
+                       ; (j = i1) → homotopy1-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) k
+                       ; (k = i0) → A□○→A○□ (backward-filler a i j t)
+                       ; (k = i1) → forward-filler a j i (~ t) })
+              (forward-filler a j i i1)
 
-  -- second homotopy
-  homotopy2-l : ∀ x → A○□→A□○ (forward-l x) ≡ inl x
-  homotopy2-l (inl x) = refl
-  homotopy2-l (inr x) = refl
-  homotopy2-l (push a i) = refl
+      -- second homotopy
+      homotopy2-l : ∀ x → A○□→A□○ (forward-l x) ≡ inl x
+      homotopy2-l (inl x) = refl
+      homotopy2-l (inr x) = refl
+      homotopy2-l (push a i) = refl
 
-  homotopy2-r : ∀ x → A○□→A□○ (forward-r x) ≡ inr x
-  homotopy2-r (inl x) = refl
-  homotopy2-r (inr x) = refl
-  homotopy2-r (push a i) = refl
+      homotopy2-r : ∀ x → A○□→A□○ (forward-r x) ≡ inr x
+      homotopy2-r (inl x) = refl
+      homotopy2-r (inr x) = refl
+      homotopy2-r (push a i) = refl
 
-  A□○→A○□→A□○ : ∀ x → A○□→A□○ (A□○→A○□ x) ≡ x
-  A□○→A○□→A□○ (inl x) = homotopy2-l x
-  A□○→A○□→A□○ (inr x) = homotopy2-r x
-  A□○→A○□→A□○ (push (inl x) i) k = push (inl x) i
-  A□○→A○□→A□○ (push (inr x) i) k = push (inr x) i
-  A□○→A○□→A□○ (push (push a i) j) k =
-    hcomp (λ t → λ { (i = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
-                   ; (i = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
-                   ; (j = i0) → homotopy2-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t) k
-                   ; (j = i1) → homotopy2-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) k
-                   ; (k = i0) → A○□→A□○ (forward-filler a i j t)
-                   ; (k = i1) → backward-filler a j i (~ t) })
-          (backward-filler a j i i1)
-
-  -- equivalence
-  Pushout3x3 : A□○ ≡ A○□
-  Pushout3x3 = isoToPath (iso A□○→A○□ A○□→A□○ A○□→A□○→A○□ A□○→A○□→A□○)
-
-Pushout3x3 : ∀ A00 A02 A04 A20 A22 A24 A40 A42 A44 f10 f12 f14 f30 f32 f34 f01 f21 f41 f03 f23 f43 H11 H13 H31 H33 →
-  3x3-span.A□○ A00 A02 A04 A20 A22 A24 A40 A42 A44 f10 f12 f14 f30 f32 f34 f01 f21 f41 f03 f23 f43 H11 H13 H31 H33
-  ≡ 3x3-span.A○□ A00 A02 A04 A20 A22 A24 A40 A42 A44 f10 f12 f14 f30 f32 f34 f01 f21 f41 f03 f23 f43 H11 H13 H31 H33
-Pushout3x3 = 3x3-span.Pushout3x3
+      A□○→A○□→A□○ : ∀ x → A○□→A□○ (A□○→A○□ x) ≡ x
+      A□○→A○□→A□○ (inl x) = homotopy2-l x
+      A□○→A○□→A□○ (inr x) = homotopy2-r x
+      A□○→A○□→A□○ (push (inl x) i) k = push (inl x) i
+      A□○→A○□→A□○ (push (inr x) i) k = push (inr x) i
+      A□○→A○□→A□○ (push (push a i) j) k =
+        hcomp (λ t → λ { (i = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
+                       ; (i = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
+                       ; (j = i0) → homotopy2-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t) k
+                       ; (j = i1) → homotopy2-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) k
+                       ; (k = i0) → A○□→A□○ (forward-filler a i j t)
+                       ; (k = i1) → backward-filler a j i (~ t) })
+              (backward-filler a j i i1)


### PR DESCRIPTION
- Make better use of the module system to render the 3x3 lemma more practical.
- Define pushout spans, homotopy natural equivalences, and prove that two equivalent spans induce equivalent pushouts.
- Use 3x3-lemma and homotopy natural equivalences to prove associativity of the join.