### PR TITLE
prove that transport is injective

### DIFF
--- a/Cubical/Data/Everything.agda
+++ b/Cubical/Data/Everything.agda
@@ -11,6 +11,7 @@ open import Cubical.Data.Sum public
 open import Cubical.Data.Prod public
 open import Cubical.Data.Unit public
 open import Cubical.Data.Sigma public
+open import Cubical.Data.Universe public
 open import Cubical.Data.DiffInt public
 open import Cubical.Data.Group public hiding (_≃_)
 open import Cubical.Data.HomotopyGroup public

--- a/Cubical/Data/Universe.agda
+++ b/Cubical/Data/Universe.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Universe where
+
+open import Cubical.Data.Universe.Base public
+
+open import Cubical.Data.Universe.Properties public

--- a/Cubical/Data/Universe/Base.agda
+++ b/Cubical/Data/Universe/Base.agda
@@ -1,0 +1,2 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Universe.Base where

--- a/Cubical/Data/Universe/Properties.agda
+++ b/Cubical/Data/Universe/Properties.agda
@@ -1,0 +1,21 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Universe.Properties where
+
+open import Cubical.Core.Everything
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Univalence
+
+isInjectiveTransport : ∀ {ℓ : Level} {A B : Type ℓ} {p q : A ≡ B}
+  → transport p ≡ transport q → p ≡ q
+isInjectiveTransport {p = p} {q} α i =
+  hcomp
+    (λ j → λ
+      { (i = i0) → secEq univalence p j
+      ; (i = i1) → secEq univalence q j
+      })
+    (invEq univalence ((λ a → α i a) , t i))
+  where
+  t : PathP (λ i → isEquiv (λ a → α i a)) (pathToEquiv p .snd) (pathToEquiv q .snd)
+  t = isProp→isContrPathP isPropIsEquiv (λ i a → α i a) _ _ .fst


### PR DESCRIPTION
As requested in https://github.com/agda/cubical/issues/77#issuecomment-546688162.

Putting this somewhere reasonable in Cubical.Foundations was problematic because of circular dependencies, so I created a new folder in Data for facts about the universe. (This one is a fact about the identity type of the universe.) Suggestions are welcome for better places to put it, but my experience suggests that it's helpful to separate lemmas that are used to prove basic facts about primitive type formers and HITs (like univalence itself) from lemmas that are mainly useful in more complex results (like this one).