### PR TITLE
Make level variables in several structures explicit.

### DIFF
--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -20,7 +20,7 @@ record isGroup {ℓ} (A : Type ℓ) : Type ℓ where
     rUnit : ∀ a → comp a id ≡ a
     assoc  : ∀ a b c → comp (comp a b) c ≡ comp a (comp b c)
     lCancel  : ∀ a → comp (inv a) a ≡ id
-    rCalcel : ∀ a → comp a (inv a) ≡ id
+    rCancel : ∀ a → comp a (inv a) ≡ id
 
 record Group {ℓ} : Type (ℓ-suc ℓ) where
   constructor group

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -22,22 +22,22 @@ record isGroup {ℓ} (A : Type ℓ) : Type ℓ where
     lCancel  : ∀ a → comp (inv a) a ≡ id
     rCancel : ∀ a → comp a (inv a) ≡ id
 
-record Group {ℓ} : Type (ℓ-suc ℓ) where
+record Group ℓ : Type (ℓ-suc ℓ) where
   constructor group
   field
     type : Type ℓ
     setStruc : isSet type
     groupStruc : isGroup type
 
-isMorph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → (f : (Group.type G → Group.type H)) → Type (ℓ-max ℓ ℓ')
+isMorph : ∀ {ℓ ℓ'} (G : Group ℓ) (H : Group ℓ') → (f : (Group.type G → Group.type H)) → Type (ℓ-max ℓ ℓ')
 isMorph (group G Gset (group-struct _ _ _⊙_ _ _ _ _ _))
         (group H Hset (group-struct _ _ _∘_ _ _ _ _ _)) f
         = (g0 g1 : G) → f (g0 ⊙ g1) ≡ (f g0) ∘ (f g1)
 
-morph : ∀ {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
+morph : ∀ {ℓ ℓ'} (G : Group ℓ) (H : Group ℓ') → Type (ℓ-max ℓ ℓ')
 morph G H = Σ (Group.type G →  Group.type H) (isMorph G H)
 
-record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
+record Iso {ℓ ℓ'} (G : Group ℓ) (H : Group ℓ') : Type (ℓ-max ℓ ℓ') where
   constructor iso
   field
     fun : morph G H
@@ -45,22 +45,22 @@ record Iso {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ �
     rightInv : I.section (fun .fst) (inv .fst)
     leftInv : I.retract (fun .fst) (inv .fst)
 
-record Iso' {ℓ ℓ'} (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
+record Iso' {ℓ ℓ'} (G : Group ℓ) (H : Group ℓ') : Type (ℓ-max ℓ ℓ') where
   constructor iso'
   field
     isoSet : I.Iso (Group.type G) (Group.type H)
     isoSetMorph : isMorph G H (I.Iso.fun isoSet)
 
-_≃_ : ∀ {ℓ ℓ'} (A : Group {ℓ}) (B : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
+_≃_ : ∀ {ℓ ℓ'} (A : Group ℓ) (B : Group ℓ') → Type (ℓ-max ℓ ℓ')
 A ≃ B = Σ (morph A B) \ f → (G.isEquiv (f .fst))
 
-Iso'→Iso : ∀ {ℓ ℓ'} {G : Group {ℓ}} {H : Group {ℓ'}} → Iso' G  H → Iso G H
+Iso'→Iso : ∀ {ℓ ℓ'} {G : Group ℓ} {H : Group ℓ'} → Iso' G  H → Iso G H
 Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , funMorph) (inv , invMorph) rightInv leftInv
   where
-    G_ : Group
+    G_ : Group _
     G_ = (group G Gset Ggroup)
 
-    H_ : Group
+    H_ : Group _
     H_ = (group H Hset Hgroup)
 
     open Iso'
@@ -98,7 +98,7 @@ Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , fu
            fun ((inv h0) ⊙ (inv h1)) ∎ )
 
 
-Equiv→Iso' : ∀ {ℓ ℓ'} {G : Group {ℓ}} {H : Group {ℓ'}} → G ≃ H → Iso' G H
+Equiv→Iso' : ∀ {ℓ ℓ'} {G : Group ℓ} {H : Group ℓ'} → G ≃ H → Iso' G H
 Equiv→Iso' {G = group G Gset Ggroup}
            {H = group H Hset Hgroup}
            e = iso' i' (e .fst .snd)
@@ -109,7 +109,7 @@ Equiv→Iso' {G = group G Gset Ggroup}
     i' : I.Iso G H
     i' = E.equivToIso e'
 
-compMorph : ∀ {ℓ} {F G H : Group {ℓ}} (I : morph F G) (J : morph G H) → morph F H
+compMorph : ∀ {ℓ} {F G H : Group ℓ} (I : morph F G) (J : morph G H) → morph F H
 compMorph {ℓ} {group F Fset (group-struct _ _ _⊙_ _ _ _ _ _)}
               {group G Gset (group-struct _ _ _∙_ _ _ _ _ _)}
               {group H Hset (group-struct _ _ _∘_ _ _ _ _ _)}
@@ -123,7 +123,7 @@ compMorph {ℓ} {group F Fset (group-struct _ _ _⊙_ _ _ _ _ _)}
                 j (i g0 ∙ i g1) ≡⟨ jc _ _ ⟩
                 j (i g0) ∘ j (i g1) ∎
 
-compIso : ∀ {ℓ} {F G H : Group {ℓ}} (I : Iso F G) (J : Iso G H) → Iso F H
+compIso : ∀ {ℓ} {F G H : Group ℓ} (I : Iso F G) (J : Iso G H) → Iso F H
 compIso {ℓ} {F} {G} {H}
         (iso F→G G→F fg gf) (iso G→H H→G gh hg ) = iso F→H H→F sec ret
   where

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -10,17 +10,17 @@ open import Cubical.Data.Group.Base
 
 open import Cubical.HITs.SetTruncation
 
-Pointed : ∀ {ℓ} → Type (ℓ-suc ℓ)
-Pointed {ℓ} = Σ[ A ∈ Type ℓ ] A
+Pointed : ∀ ℓ → Type (ℓ-suc ℓ)
+Pointed ℓ = Σ[ A ∈ Type ℓ ] A
 
-Ω : ∀ {ℓ} → Pointed {ℓ} → Pointed {ℓ}
+Ω : ∀ {ℓ} → Pointed ℓ → Pointed ℓ
 Ω (A , a ) = ( (a ≡ a) , refl)
 
-Ω^_ : ∀ {ℓ} → ℕ → Pointed {ℓ} → Pointed {ℓ}
+Ω^_ : ∀ {ℓ} → ℕ → Pointed ℓ → Pointed ℓ
 (Ω^ 0) p = p
 (Ω^ (suc n)) p = Ω ((Ω^ n) p)
 
-π^_ : ∀ {ℓ} → ℕ → Pointed {ℓ} → Group {ℓ}
+π^_ : ∀ {ℓ} → ℕ → Pointed ℓ → Group ℓ
 π^_ {ℓ} n p = group ∥ A ∥₀  squash₀ g
   where
     n' : ℕ

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -33,8 +33,8 @@ private
     x y : A
     n : ℕ
 
-hProp : Type (ℓ-suc ℓ)
-hProp {ℓ} = Σ (Type ℓ) isProp
+hProp : ∀ ℓ → Type (ℓ-suc ℓ)
+hProp ℓ = Σ (Type ℓ) isProp
 
 isOfHLevel : ℕ → Type ℓ → Type ℓ
 isOfHLevel 0 A = isContr A
@@ -59,8 +59,8 @@ isOfHLevel→isOfHLevelDep {n = suc (suc n)} {A = A} {B} h {a0} {a1} b0 b1 =
                          (λ a1 p → ∀ b1 → isOfHLevel (suc n) (PathP (λ i → B (p i)) b0 b1))
                          (λ _ → h _ _ _) p b1
 
-HLevel : ℕ → Type (ℓ-suc ℓ)
-HLevel {ℓ} n = Σ[ A ∈ Type ℓ ] (isOfHLevel n A)
+HLevel : ∀ ℓ → ℕ → Type (ℓ-suc ℓ)
+HLevel ℓ n = Σ[ A ∈ Type ℓ ] (isOfHLevel n A)
 
 inhProp→isContr : A → isProp A → isContr A
 inhProp→isContr x h = x , h x
@@ -302,19 +302,19 @@ hLevel≡ : ∀ n → {A B : Type ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n 
   isOfHLevel n (A ≡ B)
 hLevel≡ n hA hB = hLevelRespectEquiv n (invEquiv univalence) (hLevel≃ n hA hB)
 
-hLevelHLevel1 : isProp (HLevel {ℓ = ℓ} 0)
+hLevelHLevel1 : isProp (HLevel ℓ 0)
 hLevelHLevel1 x y = ΣProp≡ (λ _ → isPropIsContr) ((hLevel≡ 0 (x .snd) (y .snd) .fst))
 
-hLevelHLevelSuc : ∀ n → isOfHLevel (suc (suc n)) (HLevel {ℓ = ℓ} (suc n))
+hLevelHLevelSuc : ∀ n → isOfHLevel (suc (suc n)) (HLevel ℓ (suc n))
 hLevelHLevelSuc n x y = subst (λ e → isOfHLevel (suc n) e) HLevel≡ (hLevel≡ (suc n) (snd x) (snd y))
 
-hProp≡HLevel1 : hProp {ℓ} ≡ HLevel {ℓ} 1
+hProp≡HLevel1 : hProp ℓ ≡ HLevel ℓ 1
 hProp≡HLevel1 {ℓ} = isoToPath (iso intro elim intro-elim elim-intro)
   where
-    intro : hProp {ℓ} → HLevel {ℓ} 1
+    intro : hProp ℓ → HLevel ℓ 1
     intro h = fst h , snd h
 
-    elim : HLevel 1 → hProp
+    elim : HLevel ℓ 1 → hProp ℓ
     elim h = (fst h) , (snd h)
 
     intro-elim : ∀ h → intro (elim h) ≡ h
@@ -323,7 +323,7 @@ hProp≡HLevel1 {ℓ} = isoToPath (iso intro elim intro-elim elim-intro)
     elim-intro : ∀ h → elim (intro h) ≡ h
     elim-intro h = ΣProp≡ (λ _ → isPropIsProp) refl
 
-isSetHProp : isSet (hProp {ℓ = ℓ})
+isSetHProp : isSet (hProp ℓ)
 isSetHProp = subst (λ X → isOfHLevel 2 X) (sym hProp≡HLevel1) (hLevelHLevelSuc 0)
 
 

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -44,16 +44,16 @@ infix 2 ⇐∶_⇒∶_
 private
   variable
     ℓ ℓ' ℓ'' : Level
-    P Q R : hProp {ℓ}
+    P Q R : hProp ℓ
     A B C : Type ℓ
 
-[_] : hProp → Type ℓ
+[_] : hProp ℓ → Type ℓ
 [_] = fst
 
-∥_∥ₚ : Type ℓ → hProp
+∥_∥ₚ : Type ℓ → hProp ℓ
 ∥ A ∥ₚ = ∥ A ∥ , propTruncIsProp
 
-_≡ₚ_ : (x y : A) → hProp
+_≡ₚ_ : (x y : A) → hProp _
 x ≡ₚ y = ∥ x ≡ y ∥ₚ
 
 hProp≡ : [ P ] ≡ [ Q ] → P ≡ Q
@@ -62,7 +62,7 @@ hProp≡ p = ΣProp≡ (\ _ → isPropIsProp) p
 --------------------------------------------------------------------------------
 -- Logical implication of mere propositions
 
-_⇒_ : (A : hProp {ℓ}) → (B : hProp {ℓ'}) → hProp
+_⇒_ : (A : hProp ℓ) → (B : hProp ℓ') → hProp _
 A ⇒ B = ([ A ] → [ B ]) , propPi λ _ → B .snd
 
 ⇔toPath : [ P ⇒ Q ] → [ Q ⇒ P ] → P ≡ Q
@@ -75,7 +75,7 @@ pathTo⇒ p x = subst fst  p x
 pathTo⇐ : P ≡ Q → [ Q ⇒ P ]
 pathTo⇐ p x = subst fst (sym p) x
 
-substₚ : {x y : A} (B : A → hProp {ℓ}) → [ x ≡ₚ y ⇒ B x ⇒ B y ]
+substₚ : {x y : A} (B : A → hProp ℓ) → [ x ≡ₚ y ⇒ B x ⇒ B y ]
 substₚ {x = x} {y = y} B = elimPropTrunc (λ _ → propPi λ _ → B y .snd) (subst (fst ∘ B))
 
 --------------------------------------------------------------------------------
@@ -90,19 +90,19 @@ substₚ {x = x} {y = y} B = elimPropTrunc (λ _ → propPi λ _ → B y .snd) (
 --------------------------------------------------------------------------------
 -- False and True
 
-⊥ : hProp
+⊥ : hProp _
 ⊥ = D.⊥ , λ ()
 
-⊤ : hProp
+⊤ : hProp _
 ⊤ = D.Unit , (λ _ _ _ → D.tt)
 
 --------------------------------------------------------------------------------
 -- Pseudo-complement of mere propositions
 
-¬_ : hProp {ℓ} → hProp
+¬_ : hProp ℓ → hProp _
 ¬ A = ([ A ] → D.⊥) , propPi λ _ → D.isProp⊥
 
-_≢ₚ_ : (x y : A) → hProp
+_≢ₚ_ : (x y : A) → hProp _
 x ≢ₚ y = ¬ x ≡ₚ y
 
 --------------------------------------------------------------------------------
@@ -111,7 +111,7 @@ x ≢ₚ y = ¬ x ≡ₚ y
 _⊔′_ : Type ℓ → Type ℓ' → Type _
 A ⊔′ B = ∥ A D.⊎ B ∥
 
-_⊔_ : hProp {ℓ} → hProp {ℓ'} → hProp
+_⊔_ : hProp ℓ → hProp ℓ' → hProp _
 P ⊔ Q = ∥ [ P ] D.⊎ [ Q ] ∥ₚ
 
 inl : A → A ⊔′ B
@@ -120,7 +120,7 @@ inl x = ∣ D.inl x ∣
 inr : B → A ⊔′ B
 inr x = ∣ D.inr x ∣
 
-⊔-elim : (P : hProp {ℓ}) (Q : hProp {ℓ'}) (R : [ P ⊔ Q ] → hProp {ℓ''})
+⊔-elim : (P : hProp ℓ) (Q : hProp ℓ') (R : [ P ⊔ Q ] → hProp ℓ'')
   → (∀ x → [ R (inl x) ]) → (∀ y → [ R (inr y) ]) → (∀ z → [ R z ])
 ⊔-elim _ _ R P⇒R Q⇒R = elimPropTrunc (snd ∘ R) (D.elim-⊎ P⇒R Q⇒R)
 
@@ -129,27 +129,27 @@ inr x = ∣ D.inr x ∣
 _⊓′_ : Type ℓ → Type ℓ' → Type _
 A ⊓′ B = A D.× B
 
-_⊓_ : hProp {ℓ} → hProp {ℓ'} → hProp
+_⊓_ : hProp ℓ → hProp ℓ' → hProp _
 A ⊓ B = [ A ] ⊓′ [ B ] , D.hLevelProd 1 (A .snd) (B .snd)
 
-⊓-intro : (P : hProp {ℓ}) (Q : [ P ] → hProp {ℓ'}) (R : [ P ] → hProp {ℓ''})
+⊓-intro : (P : hProp ℓ) (Q : [ P ] → hProp ℓ') (R : [ P ] → hProp ℓ'')
        → (∀ a → [ Q a ]) → (∀ a → [ R a ]) → (∀ (a : [ P ]) → [ Q a ⊓ R a ] )
 ⊓-intro _ _ _ = D.intro-×
 
 --------------------------------------------------------------------------------
 -- Logical bi-implication of mere propositions
 
-_⇔_ : hProp {ℓ} → hProp {ℓ'} → hProp
+_⇔_ : hProp ℓ → hProp ℓ' → hProp _
 A ⇔ B = (A ⇒ B) ⊓ (B ⇒ A)
 
 --------------------------------------------------------------------------------
 -- Universal Quantifier
 
 
-∀[∶]-syntax : (A → hProp {ℓ}) → hProp
+∀[∶]-syntax : (A → hProp ℓ) → hProp _
 ∀[∶]-syntax {A = A} P = (∀ x → [ P x ]) , propPi (snd ∘ P)
 
-∀[]-syntax : (A → hProp {ℓ}) → hProp
+∀[]-syntax : (A → hProp ℓ) → hProp _
 ∀[]-syntax {A = A} P = (∀ x → [ P x ]) , propPi (snd ∘ P)
 
 syntax ∀[∶]-syntax {A = A} (λ a → P) = ∀[ a ∶ A ] P
@@ -158,10 +158,10 @@ syntax ∀[]-syntax (λ a → P)          = ∀[ a ] P
 -- Existential Quantifier
 
 
-∃[]-syntax : (A → hProp {ℓ}) → hProp
+∃[]-syntax : (A → hProp ℓ) → hProp _
 ∃[]-syntax {A = A} P = ∥ Σ A (fst ∘ P) ∥ₚ
 
-∃[∶]-syntax : (A → hProp {ℓ}) → hProp
+∃[∶]-syntax : (A → hProp ℓ) → hProp _
 ∃[∶]-syntax {A = A} P = ∥ Σ A (fst ∘ P) ∥ₚ
 
 syntax ∃[]-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
@@ -169,7 +169,7 @@ syntax ∃[∶]-syntax (λ x → P) = ∃[ x ] P
 --------------------------------------------------------------------------------
 -- Decidable mere proposition
 
-Decₚ : (P : hProp {ℓ}) → hProp {ℓ}
+Decₚ : (P : hProp ℓ) → hProp ℓ
 Decₚ P = Dec [ P ] , isPropDec (snd P)
 
 --------------------------------------------------------------------------------
@@ -184,7 +184,7 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
 --------------------------------------------------------------------------------
 -- (hProp, ⊔, ⊥) is a bounded ⊔-semilattice
 
-⊔-assoc : (P : hProp {ℓ}) (Q : hProp {ℓ'}) (R : hProp {ℓ''})
+⊔-assoc : (P : hProp ℓ) (Q : hProp ℓ') (R : hProp ℓ'')
   → P ⊔ (Q ⊔ R) ≡ (P ⊔ Q) ⊔ R
 ⊔-assoc P Q R =
   ⇒∶ ⊔-elim P (Q ⊔ R) (λ _ → (P ⊔ Q) ⊔ R)
@@ -200,55 +200,55 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
     assoc2 ∣ D.inl (squash x y i) ∣ = propTruncIsProp (assoc2 ∣ D.inl x ∣) (assoc2 ∣ D.inl y ∣) i
     assoc2 (squash x y i)           = propTruncIsProp (assoc2 x) (assoc2 y) i
 
-⊔-idem : (P : hProp {ℓ}) → P ⊔ P ≡ P
+⊔-idem : (P : hProp ℓ) → P ⊔ P ≡ P
 ⊔-idem P =
   ⇒∶ (⊔-elim P P (\ _ → P) (\ x → x) (\ x → x))
   ⇐∶ inl
 
-⊔-comm : (P : hProp {ℓ}) (Q : hProp {ℓ'}) → P ⊔ Q ≡ Q ⊔ P
+⊔-comm : (P : hProp ℓ) (Q : hProp ℓ') → P ⊔ Q ≡ Q ⊔ P
 ⊔-comm P Q =
   ⇒∶ (⊔-elim P Q (\ _ → (Q ⊔ P)) inr inl)
   ⇐∶ (⊔-elim Q P (\ _ → (P ⊔ Q)) inr inl)
 
-⊔-identityˡ : (P : hProp {ℓ}) → ⊥ ⊔ P ≡ P
+⊔-identityˡ : (P : hProp ℓ) → ⊥ ⊔ P ≡ P
 ⊔-identityˡ P =
   ⇒∶ (⊔-elim ⊥ P (λ _ → P) (λ ()) (λ x → x))
   ⇐∶ inr
 
-⊔-identityʳ : (P : hProp {ℓ}) → P ⊔ ⊥ ≡ P
+⊔-identityʳ : (P : hProp ℓ) → P ⊔ ⊥ ≡ P
 ⊔-identityʳ P = ⇔toPath (⊔-elim P ⊥ (λ _ → P) (λ x → x) λ ()) inl
 
 --------------------------------------------------------------------------------
 -- (hProp, ⊓, ⊤) is a bounded ⊓-lattice
 
-⊓-assoc : (P : hProp {ℓ}) (Q : hProp {ℓ'}) (R : hProp {ℓ''})
+⊓-assoc : (P : hProp ℓ) (Q : hProp ℓ') (R : hProp ℓ'')
   → P ⊓ Q ⊓ R ≡ (P ⊓ Q) ⊓ R
 ⊓-assoc _ _ _ =
   ⇒∶ (λ {(x D., (y D., z)) →  (x D., y) D., z})
   ⇐∶ (λ {((x D., y) D., z) → x D., (y D., z) })
 
-⊓-comm : (P : hProp {ℓ}) (Q : hProp {ℓ'}) → P ⊓ Q ≡ Q ⊓ P
+⊓-comm : (P : hProp ℓ) (Q : hProp ℓ') → P ⊓ Q ≡ Q ⊓ P
 ⊓-comm _ _ = ⇔toPath D.swap D.swap
 
-⊓-idem : (P : hProp {ℓ}) → P ⊓ P ≡ P
+⊓-idem : (P : hProp ℓ) → P ⊓ P ≡ P
 ⊓-idem _ = ⇔toPath D.proj₁ (λ x → x D., x)
 
-⊓-identityˡ : (P : hProp {ℓ}) → ⊤ ⊓ P ≡ P
+⊓-identityˡ : (P : hProp ℓ) → ⊤ ⊓ P ≡ P
 ⊓-identityˡ _ = ⇔toPath D.proj₂ λ x → D.tt D., x
 
-⊓-identityʳ : (P : hProp {ℓ}) → P ⊓ ⊤ ≡ P
+⊓-identityʳ : (P : hProp ℓ) → P ⊓ ⊤ ≡ P
 ⊓-identityʳ _ = ⇔toPath D.proj₁ λ x → x D., D.tt
 
 --------------------------------------------------------------------------------
 -- Distributive laws
 
-⇒-⊓-distrib : (P : hProp {ℓ}) (Q : hProp {ℓ'})(R : hProp {ℓ''})
+⇒-⊓-distrib : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
   → P ⇒ (Q ⊓ R) ≡ (P ⇒ Q) ⊓ (P ⇒ R)
 ⇒-⊓-distrib _ _ _ =
   ⇒∶ (λ f → (D.proj₁ ∘ f) D., (D.proj₂ ∘ f))
   ⇐∶ (λ { (f D., g) x → f x D., g x})
 
-⊓-⊔-distribˡ : (P : hProp {ℓ}) (Q : hProp {ℓ'})(R : hProp {ℓ''})
+⊓-⊔-distribˡ : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
   → P ⊓ (Q ⊔ R) ≡ (P ⊓ Q) ⊔ (P ⊓ R)
 ⊓-⊔-distribˡ P Q R =
   ⇒∶ (λ { (x D., a) → ⊔-elim Q R (λ _ → (P ⊓ Q) ⊔ (P ⊓ R))
@@ -259,7 +259,7 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
        (λ y → D.proj₁ y D., inl (D.proj₂ y))
        (λ z → D.proj₁ z D., inr (D.proj₂ z))
 
-⊔-⊓-distribˡ : (P : hProp {ℓ}) (Q : hProp {ℓ'})(R : hProp {ℓ''})
+⊔-⊓-distribˡ : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
   → P ⊔ (Q ⊓ R) ≡ (P ⊔ Q) ⊓ (P ⊔ R)
 ⊔-⊓-distribˡ P Q R =
   ⇒∶ ⊔-elim P (Q ⊓ R) (λ _ → (P ⊔ Q) ⊓ (P ⊔ R) )
@@ -268,7 +268,7 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
   ⇐∶ (λ { (x D., y) → ⊔-elim P R (λ _ → P ⊔ Q ⊓ R) inl
       (λ z → ⊔-elim P Q (λ _ → P ⊔ Q ⊓ R) inl (λ y → inr (y D., z)) x) y })
 
-⊓-∀-distrib :  (P : A → hProp {ℓ}) (Q : A → hProp {ℓ'})
+⊓-∀-distrib :  (P : A → hProp ℓ) (Q : A → hProp ℓ')
   → (∀[ a ∶ A ] P a) ⊓ (∀[ a ∶ A ] Q a) ≡ (∀[ a ∶ A ] (P a ⊓ Q a))
 ⊓-∀-distrib P Q =
   ⇒∶ (λ {(p D., q) a → p a D., q a})

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -26,7 +26,7 @@ data LFSet (A : Type₀) : Type₀ where
 -- Doing some proofs with equational reasoning adds an extra "_∙ refl"
 -- at the end.
 -- We might want to avoid it, or come up with a more clever equational reasoning.
-_∈_ : A → LFSet A → hProp
+_∈_ : A → LFSet A → hProp _
 z ∈ []                  = ⊥
 z ∈ (y ∷ xs)            = (z ≡ₚ y) ⊔ (z ∈ xs)
 z ∈ dup x xs i          = proof i

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -157,7 +157,7 @@ elimPropTrunc→Set {A = A} {P = P} Pset f kf t
   gk : 2-Constant g
   gk x y i = transp (λ j → P (squash (squash ∣ x ∣ ∣ y ∣ i) t j)) i0 (kf x y i)
 
-RecHProp : (P : A → hProp {ℓ}) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp {ℓ}
+RecHProp : (P : A → hProp ℓ) (kP : ∀ x y → P x ≡ P y) → ∥ A ∥ → hProp ℓ
 RecHProp P kP = recPropTrunc→Set isSetHProp P kP
 
 module GpdElim (Bgpd : isGroupoid B) where
@@ -304,5 +304,5 @@ module GpdElim (Bgpd : isGroupoid B) where
 
 open GpdElim using (recPropTrunc→Gpd; trunc→Gpd≃) public
 
-RecHSet : (P : A → HLevel {ℓ} 2) → 3-Constant P → ∥ A ∥ → HLevel {ℓ} 2
+RecHSet : (P : A → HLevel ℓ 2) → 3-Constant P → ∥ A ∥ → HLevel ℓ 2
 RecHSet P 3kP = recPropTrunc→Gpd (hLevelHLevelSuc 1) P 3kP

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -98,7 +98,7 @@ open BinaryRelation
 effective : (Rprop : isPropValued R) (Requiv : isEquivRel R) (a b : A) → [ a ] ≡ [ b ] → R a b
 effective {A = A} {R = R} Rprop (EquivRel R/refl R/sym R/trans) a b p = transport aa≡ab (R/refl _)
   where
-    helper : A / R → hProp
+    helper : A / R → hProp _
     helper = elimSetQuotients (λ _ → isSetHProp) (λ c → (R a c , Rprop a c))
                               (λ c d cd → ΣProp≡ (λ _ → isPropIsProp)
                                                  (ua (PropEquiv→Equiv (Rprop a c) (Rprop a d)


### PR DESCRIPTION
Fixes #195 I believe.

Several structures had implicit level variable parameters that could not be inferred most of the time. This patch makes them explicit. It's generally more convenient to have them explicit and use `_` when they can actually be inferred than to make them implicit and require `{l}` almost everywhere.

This also fixes a typo in the `isGroup` record, because I originally made this as part of another branch. Apologies.