### PR TITLE
export equivalences and glue types in Foundations

### DIFF
--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -61,8 +61,6 @@ http://www.cs.bham.ac.uk/~mhe/agda-new/BinaryNaturals.html
 {-# OPTIONS --cubical --no-exact-split --safe #-}
 module Cubical.Data.BinNat.BinNat where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -2,8 +2,6 @@
 
 module Cubical.Data.Group.Base where
 
-import Cubical.Core.Glue as G
-
 open import Cubical.Foundations.Prelude hiding ( comp )
 
 import Cubical.Foundations.Isomorphism as I
@@ -52,7 +50,7 @@ record Iso' {ℓ ℓ'} (G : Group ℓ) (H : Group ℓ') : Type (ℓ-max ℓ ℓ'
     isoSetMorph : isMorph G H (I.Iso.fun isoSet)
 
 _≃_ : ∀ {ℓ ℓ'} (A : Group ℓ) (B : Group ℓ') → Type (ℓ-max ℓ ℓ')
-A ≃ B = Σ (morph A B) \ f → (G.isEquiv (f .fst))
+A ≃ B = Σ (morph A B) \ f → (E.isEquiv (f .fst))
 
 Iso'→Iso : ∀ {ℓ ℓ'} {G : Group ℓ} {H : Group ℓ'} → Iso' G  H → Iso G H
 Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , funMorph) (inv , invMorph) rightInv leftInv
@@ -77,7 +75,7 @@ Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , fu
     leftInv : I.retract fun inv
     leftInv = I.Iso.leftInv (isoSet i)
 
-    e' : G G.≃ H
+    e' : G E.≃ H
     e' = E.isoToEquiv (I.iso fun inv rightInv leftInv)
 
     funMorph : isMorph G_ H_ fun
@@ -103,7 +101,7 @@ Equiv→Iso' {G = group G Gset Ggroup}
            {H = group H Hset Hgroup}
            e = iso' i' (e .fst .snd)
   where
-    e' : G G.≃ H
+    e' : G E.≃ H
     e' = (e .fst .fst) , (e .snd)
 
     i' : I.Iso G H

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -1,10 +1,10 @@
 {-# OPTIONS --cubical #-}
 module Cubical.Experiments.Brunerie where
 
-open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Univalence
 open import Cubical.Data.Bool
 open import Cubical.Data.Nat
 open import Cubical.Data.Int

--- a/Cubical/Experiments/FunExtFromUA.agda
+++ b/Cubical/Experiments/FunExtFromUA.agda
@@ -4,7 +4,6 @@
 
 module Cubical.Experiments.FunExtFromUA where
 
-open import Cubical.Core.Everything
 open import Cubical.Foundations.Everything
 
 variable

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -6,10 +6,7 @@ module Cubical.Experiments.Generic where
 open import Agda.Builtin.String
 open import Agda.Builtin.List
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence
 

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -2,8 +2,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Experiments.Problem where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Int

--- a/Cubical/Foundations/BiInvEquiv.agda
+++ b/Cubical/Foundations/BiInvEquiv.agda
@@ -11,8 +11,6 @@ Some theory about Bi-Invertible Equivalences
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.BiInvEquiv where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -2,8 +2,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.CartesianKanOps where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 
 coe0→1 : ∀ {ℓ} (A : I → Type ℓ) → A i0 → A i1

--- a/Cubical/Foundations/Embedding.agda
+++ b/Cubical/Foundations/Embedding.agda
@@ -2,8 +2,6 @@
 
 module Cubical.Foundations.Embedding where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -1,6 +1,8 @@
 {-
 
-Theory about equivalences (definitions are in Core/Glue.agda)
+Theory about equivalences
+
+Definitions are in Core/Glue.agda but re-exported by this module
 
 - isEquiv is a proposition ([isPropIsEquiv])
 - Any isomorphism is an equivalence ([isoToEquiv])
@@ -15,14 +17,13 @@ There are more statements about equivalences in Equiv/Properties.agda:
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Equiv where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws
 
-open import Cubical.Data.Nat
+open import Cubical.Core.Glue public
+  using ( isEquiv ; equiv-proof ; _≃_ ; equivFun ; equivProof )
 
 private
   variable

--- a/Cubical/Foundations/FunExtEquiv.agda
+++ b/Cubical/Foundations/FunExtEquiv.agda
@@ -2,8 +2,6 @@
 
 module Cubical.Foundations.FunExtEquiv where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -4,8 +4,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Function where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 
 -- The identity function

--- a/Cubical/Foundations/HAEquiv.agda
+++ b/Cubical/Foundations/HAEquiv.agda
@@ -10,8 +10,6 @@ Half adjoint equivalences ([HAEquiv])
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.HAEquiv where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -10,16 +10,14 @@ Basic theory about h-levels/n-types:
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.HLevels where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.FunExtEquiv
 open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.HAEquiv      using (congEquiv)
-open import Cubical.Foundations.Equiv        using (isoToEquiv; isPropIsEquiv; retEq; invEquiv)
 open import Cubical.Foundations.Univalence   using (ua; univalence)
 
 open import Cubical.Data.Sigma  using (ΣPathP; sigmaPath→pathSigma; pathSigma≡sigmaPath; _Σ≡T_)

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -34,15 +34,13 @@ open import Cubical.Foundations.Prelude public
            ; isProp    to isPropPath
            ; isSet     to isSetPath
            ; fst       to pr₁ -- as in the HoTT book
-           ; snd       to pr₂
-           )
-open import Cubical.Core.Glue
-  renaming ( isEquiv      to isEquivPath
-           ; _≃_         to EquivPath
-           ; equivFun     to equivFunPath )
+           ; snd       to pr₂ )
 
 open import Cubical.Foundations.Equiv
-  renaming ( fiber        to fiberPath )
+  renaming ( fiber        to fiberPath
+           ; isEquiv   to isEquivPath
+           ; _≃_       to EquivPath
+           ; equivFun  to equivFunPath )
   hiding   ( isPropIsEquiv
            ; equivCtr
            ; equivIsEquiv )

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -1,10 +1,9 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Path where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Transport
 

--- a/Cubical/Foundations/PathSplitEquiv.agda
+++ b/Cubical/Foundations/PathSplitEquiv.agda
@@ -18,8 +18,6 @@ The module starts with a couple of general facts about equivalences:
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.PathSplitEquiv where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -7,8 +7,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Transport where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -3,6 +3,7 @@
 Proof of the standard formulation of the univalence theorem and
 various consequences of univalence
 
+- Re-exports Glue types from Cubical.Core.Glue
 - The ua constant and its computation rule (up to a path)
 - Proof of univalence using that unglue is an equivalence ([EquivContr])
 - Equivalence induction ([EquivJ], [elimEquiv])
@@ -14,13 +15,14 @@ various consequences of univalence
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.Univalence where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.GroupoidLaws
+
+open import Cubical.Core.Glue public
+  using ( Glue ; glue ; unglue ; lineToEquiv )
 
 private
   variable

--- a/Cubical/Foundations/UnivalenceId.agda
+++ b/Cubical/Foundations/UnivalenceId.agda
@@ -1,17 +1,14 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Foundations.UnivalenceId where
 
-open import Cubical.Core.Glue
-  renaming ( isEquiv      to isEquivPath
-           ; _≃_          to EquivPath
-           ; equivFun     to equivFunPath )
-open import Cubical.Core.Id
-
 open import Cubical.Foundations.Prelude public
   hiding ( _≡_ ; _≡⟨_⟩_ ; _∎ )
 open import Cubical.Foundations.Id
 open import Cubical.Foundations.Equiv
-  renaming ( isPropIsEquiv to isPropIsEquivPath )
+  renaming ( isEquiv      to isEquivPath
+           ; _≃_          to EquivPath
+           ; equivFun     to equivFunPath
+           ; isPropIsEquiv to isPropIsEquivPath )
 open import Cubical.Foundations.Univalence
   renaming ( EquivContr   to EquivContrPath )
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -6,7 +6,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Colimit.Base where
 
-open import Cubical.Core.Glue
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -1,7 +1,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Colimit.Examples where
 
-open import Cubical.Core.Glue
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -1,12 +1,11 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Hopf where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Int
 open import Cubical.Data.Prod

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -14,8 +14,6 @@ This file contains:
 
 module Cubical.HITs.Join.Properties where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Pushout.Base where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -14,8 +14,6 @@ This file contains:
 
 module Cubical.HITs.Pushout.Properties where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -6,8 +6,6 @@ Definition of the circle as a HIT with a proof that Ω(S¹) ≡ ℤ
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.S1.Base where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Equiv

--- a/Cubical/HITs/S1/Properties.agda
+++ b/Cubical/HITs/S1/Properties.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.S1.Properties where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Equiv

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -8,8 +8,6 @@ This file contains:
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.SetTruncation.Properties where
 
-open import Cubical.Core.Glue
-
 open import Cubical.HITs.SetTruncation.Base
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Susp.Base where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -7,11 +7,10 @@ equivalent to two circles
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.Torus.Base where
 
-open import Cubical.Core.Glue
-
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Int

--- a/Cubical/Modalities/Modality.agda
+++ b/Cubical/Modalities/Modality.agda
@@ -6,7 +6,6 @@ module Cubical.Modalities.Modality where
   https://github.com/HoTT/HoTT-Agda/blob/master/core/lib/types/Modality.agda
 -}
 
-open import Cubical.Core.Everything
 open import Cubical.Foundations.Everything
 
 record Modality ℓ : Type (ℓ-suc ℓ) where

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --cubical --safe #-}
 module Cubical.Relation.Nullary where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Empty


### PR DESCRIPTION
Proposed resolution to #176: 
- export the equivalence definitions from Cubical.Core.Glue in Foundations.Equiv,
- export the Glue type definitions in Foundations.Univalence.