### PR TITLE
Use travis_wait to avoid build timeouts due to no output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,4 @@ install:
   - cd $TRAVIS_BUILD_DIR
 
 script:
-  - make test
+  - travis_wait 30 make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  - cabal install
+  - travis_wait 30 cabal install
   - cd -
   # installing fix-agda-whitespace
   - cd agda/src/fix-agda-whitespace
@@ -64,4 +64,4 @@ install:
   - cd $TRAVIS_BUILD_DIR
 
 script:
-  - travis_wait 30 make test
+  - make test


### PR DESCRIPTION
Timeout extended to 30 minutes from 10 minutes (the default).

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received