### PR TITLE
Add listings make rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.agdai
 *~
+html

--- a/Cubical/Core/README.md
+++ b/Cubical/Core/README.md
@@ -6,21 +6,11 @@ the following things:
 
 * **Primitives**: exposes cubical agda primitives.
 
-* **Prelude**: basic cubical prelude.
-
 * **Glue**: definition of equivalences, Glue types and the univalence
   theorem.
 
-* **PropositionalTruncation**: propositional truncation defined as a
-  higher inductive type.
-
 * **Id**: identity types and definitions of J, funExt, univalence and
   propositional truncation using Id instead of Path.
-
-* **HoTT-UF**: core library for HoTT/UF based on cubical type theory,
-  where the cubical machinery is hidden, using the HoTT Book
-  terminology and notations.
-
 
 This library is intentionally kept as minimal as possible and does not
 depend on the Agda standard library.

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -31,6 +31,7 @@ open import Cubical.Foundations.Id
 open import Cubical.Foundations.GroupoidLaws public
 open import Cubical.Foundations.CartesianKanOps public
 open import Cubical.Foundations.Function public
+open import Cubical.Foundations.Embedding public
 open import Cubical.Foundations.Equiv public
 open import Cubical.Foundations.Equiv.Properties public
 open import Cubical.Foundations.PathSplitEquiv public

--- a/Cubical/README.agda
+++ b/Cubical/README.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --cubical #-}
+module Cubical.README where
+
+------------------------------------------------------------------------
+-- An experimental library for Cubical Agda
+-----------------------------------------------------------------------
+
+-- The library comes with a .agda-lib file, for use with the library
+-- management system.
+
+------------------------------------------------------------------------
+-- Module hierarchy
+------------------------------------------------------------------------
+
+-- The core library for Cubical Agda.
+-- It contains basic primitives, equivalences, glue types.
+import Cubical.Core.Everything
+
+-- The foundations for Cubical Agda.
+-- The Prelude module is self-explanatory.
+import Cubical.Foundations.Prelude
+import Cubical.Foundations.Everything
+
+-- Data types and properties
+import Cubical.Data.Everything
+
+-- Properties and proofs about relations
+import Cubical.Relation.Everything
+
+-- Higher-inductive types
+import Cubical.HITs.Everything
+
+-- Coinductive data types and properties
+import Cubical.Codata.Everything
+
+-- Various experiments using Cubical Agda
+import Cubical.Experiments.Everything

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,7 +17,7 @@ check-whitespace:
 	cabal exec -- fix-agda-whitespace --check
 
 .PHONY : check
-check: $(wildcard **/*.agda)
+check: $(wildcard Cubical/**/*.agda)
 	$(AGDA) Cubical/Core/Everything.agda
 	$(AGDA) Cubical/Foundations/Everything.agda
 	$(AGDA) Cubical/Codata/Everything.agda
@@ -25,6 +25,10 @@ check: $(wildcard **/*.agda)
 	$(AGDA) Cubical/HITs/Everything.agda
 	$(AGDA) Cubical/Relation/Everything.agda
 	$(AGDA) Cubical/Experiments/Everything.agda
+
+.PHONY: listings
+listings: $(wildcard Cubical/**/*.agda)
+	$(AGDA) -i. -isrc --html Cubical/README.agda -v0
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
Adding also the README module.

---

The HTML version is handy, it's nice to click around the source to explore what's in the library.
We can setup travis to upload html, so it would be available as it's done for `agda-stdlib` (https://agda.github.io/agda-stdlib/README.html is super handy)

---

It would be cleaner to move sources into `src` directory (like in `agda-stdlib`), then `README` module won't be "accidentally" part of the library, as we could say

```
name: cubical
include: src
```

in `cubical.agda-lib`
