### PR TITLE
A "near inverse" to `∣_∣ : A → ∥ A ∥`

### DIFF
--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -4,14 +4,12 @@ module Cubical.Data.HomotopyGroup.Base where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 import Cubical.Foundations.GroupoidLaws as GL
+open import Cubical.Foundations.Pointed
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Group.Base
 
 open import Cubical.HITs.SetTruncation
-
-Pointed : ∀ ℓ → Type (ℓ-suc ℓ)
-Pointed ℓ = Σ[ A ∈ Type ℓ ] A
 
 Ω : ∀ {ℓ} → Pointed ℓ → Pointed ℓ
 Ω (A , a ) = ( (a ≡ a) , refl)
@@ -27,13 +25,13 @@ Pointed ℓ = Σ[ A ∈ Type ℓ ] A
     n' = suc n
 
     A : Type ℓ
-    A = (Ω^ n') p .fst
+    A = typ ((Ω^ n') p)
 
     g : isGroup ∥ A ∥₀
     g = group-struct e _⁻¹ _⊙_ lUnit rUnit assoc lCancel rCancel
       where
         e : ∥ A ∥₀
-        e = ∣ (Ω^ n') p .snd ∣₀
+        e = ∣ pt ((Ω^ n') p) ∣₀
 
         _⁻¹ : ∥ A ∥₀ → ∥ A ∥₀
         _⁻¹ = elimSetTrunc {B = λ _ → ∥ A ∥₀} (λ x → squash₀) λ a → ∣  sym a ∣₀

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -39,6 +39,7 @@ open import Cubical.Foundations.BiInvEquiv public
 open import Cubical.Foundations.FunExtEquiv public
 open import Cubical.Foundations.HLevels public
 open import Cubical.Foundations.Path public
+open import Cubical.Foundations.Pointed public
 open import Cubical.Foundations.Transport public
 open import Cubical.Foundations.Univalence public
 open import Cubical.Foundations.UnivalenceId public

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -75,9 +75,31 @@ toPathP-isEquiv A {x} {y} = isoToIsEquiv (iso toPathP fromPathP to-from from-to)
                           })
                           (transp (\ j → A ((i ∨ h) ∧ j)) (~ (i ∨ h)) x)
 
+compPathl-cancel : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : x ≡ z) → p ∙ (sym p ∙ q) ≡ q
+compPathl-cancel p q = p ∙ (sym p ∙ q) ≡⟨ assoc p (sym p) q ⟩
+                       (p ∙ sym p) ∙ q ≡⟨ cong (_∙ q) (rCancel p) ⟩
+                              refl ∙ q ≡⟨ sym (lUnit q) ⟩
+                                     q ∎
+
+compPathr-cancel : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : z ≡ y) (q : x ≡ y) → (q ∙ sym p) ∙ p ≡ q
+compPathr-cancel p q = (q ∙ sym p) ∙ p ≡⟨ sym (assoc q (sym p) p) ⟩
+                       q ∙ (sym p ∙ p) ≡⟨ cong (q ∙_) (lCancel p) ⟩
+                              q ∙ refl ≡⟨ sym (rUnit q) ⟩
+                                     q ∎
+
+compPathl-isEquiv : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) → isEquiv (λ (q : y ≡ z) → p ∙ q)
+compPathl-isEquiv p = isoToIsEquiv (iso (p ∙_) (sym p ∙_) (compPathl-cancel p) (compPathl-cancel (sym p)))
+
+compPathr-isEquiv : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : y ≡ z) → isEquiv (λ (q : x ≡ y) → q ∙ p)
+compPathr-isEquiv p = isoToIsEquiv (iso (_∙ p) (_∙ sym p) (compPathr-cancel p) (compPathr-cancel (sym p)))
+
 -- Variation of isProp→isSet for PathP
 isProp→isSet-PathP : ∀ {ℓ} {B : I → Type ℓ} → ((i : I) → isProp (B i))
                    → (b0 : B i0) (b1 : B i1)
                    → isProp (PathP (λ i → B i) b0 b1)
 isProp→isSet-PathP {B = B} hB b0 b1 =
   transport (λ i → isProp (PathP≡Path B b0 b1 (~ i))) (isProp→isSet (hB i1) _ _)
+
+-- Lemma 3.11.8 in the HoTT book
+isContrPathAt : ∀ {ℓ} {A : Type ℓ} (x : A) → isContr (Σ[ y ∈ A ] x ≡ y)
+isContrPathAt x = (x , refl) , (λ { (y , p) i → (p i , λ j → p (i ∧ j)) })

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -99,7 +99,3 @@ isProp→isSet-PathP : ∀ {ℓ} {B : I → Type ℓ} → ((i : I) → isProp (B
                    → isProp (PathP (λ i → B i) b0 b1)
 isProp→isSet-PathP {B = B} hB b0 b1 =
   transport (λ i → isProp (PathP≡Path B b0 b1 (~ i))) (isProp→isSet (hB i1) _ _)
-
--- Lemma 3.11.8 in the HoTT book
-isContrPathAt : ∀ {ℓ} {A : Type ℓ} (x : A) → isContr (Σ[ y ∈ A ] x ≡ y)
-isContrPathAt x = (x , refl) , (λ { (y , p) i → (p i , λ j → p (i ∧ j)) })

--- a/Cubical/Foundations/Pointed.agda
+++ b/Cubical/Foundations/Pointed.agda
@@ -1,0 +1,7 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Pointed where
+
+open import Cubical.Foundations.Pointed.Base public
+open import Cubical.Foundations.Pointed.Properties public
+
+open import Cubical.Foundations.Pointed.Homogeneous

--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -1,0 +1,11 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Pointed.Base where
+
+open import Cubical.Foundations.Prelude
+
+record Pointed ℓ : Type (ℓ-suc ℓ) where
+  constructor _,_
+  field
+    typ : Type ℓ
+    pt  : typ
+open Pointed public

--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -3,9 +3,11 @@ module Cubical.Foundations.Pointed.Base where
 
 open import Cubical.Foundations.Prelude
 
-record Pointed ℓ : Type (ℓ-suc ℓ) where
-  constructor _,_
-  field
-    typ : Type ℓ
-    pt  : typ
-open Pointed public
+Pointed : (ℓ : Level) → Type (ℓ-suc ℓ)
+Pointed ℓ = Σ[ A ∈ Type ℓ ] A
+
+typ : ∀ {ℓ} (A∙ : Pointed ℓ) → Type ℓ
+typ = fst
+
+pt : ∀ {ℓ} (A∙ : Pointed ℓ) → typ A∙
+pt = snd

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -1,0 +1,82 @@
+{-
+
+Definition of a homogeneous pointed type, and proofs that pi, product, path, and discrete types are homogeneous
+
+Portions of this file adapted from Nicolai Kraus' code here:
+  https://bitbucket.org/nicolaikraus/agda/src/e30d70c72c6af8e62b72eefabcc57623dd921f04/trunc-inverse.lagda
+
+-}
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Pointed.Homogeneous where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Path
+open import Cubical.Data.Prod
+open import Cubical.Data.Empty
+open import Cubical.Relation.Nullary
+
+open import Cubical.Foundations.Pointed.Base
+open import Cubical.Foundations.Pointed.Properties
+
+isHomogeneous : ∀ {ℓ} → Pointed ℓ → Type (ℓ-suc ℓ)
+isHomogeneous {ℓ} (A , x) = ∀ y → Path (Pointed ℓ) (A , x) (A , y)
+
+
+isHomogeneousPi : ∀ {ℓ ℓ'} {A : Type ℓ} {B∙ : A → Pointed ℓ'}
+                 → (∀ a → isHomogeneous (B∙ a)) → isHomogeneous (Π∙ A B∙)
+isHomogeneousPi h f i = (∀ a → typ (h a (f a) i)) , (λ a → pt (h a (f a) i))
+
+isHomogeneousProd : ∀ {ℓ ℓ'} {A∙ : Pointed ℓ} {B∙ : Pointed ℓ'}
+                   → isHomogeneous A∙ → isHomogeneous B∙ → isHomogeneous (A∙ ×∙ B∙)
+isHomogeneousProd hA hB (a , b) i = (typ (hA a i)) × (typ (hB b i)) , (pt (hA a i) , pt (hB b i))
+
+isHomogeneousPath : ∀ {ℓ} (A : Type ℓ) {x y : A} (p : x ≡ y) → isHomogeneous ((x ≡ y) , p)
+isHomogeneousPath A {x} {y} p q i
+  = ua eqv i , ua-gluePath eqv (compPathr-cancel p q) i
+  where eqv : (x ≡ y) ≃ (x ≡ y)
+        eqv = ((q ∙ sym p) ∙_) , compPathl-isEquiv (q ∙ sym p)
+
+module HomogeneousDiscrete {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙)) (y : typ A∙) where
+
+  -- switches pt A∙ with y
+  switch : typ A∙ → typ A∙
+  switch x with dA x (pt A∙)
+  ...         | yes _ = y
+  ...         | no _ with dA x y
+  ...                | yes _  = pt A∙
+  ...                | no  _  = x
+
+  switch-ptA∙ : switch (pt A∙) ≡ y
+  switch-ptA∙ with dA (pt A∙) (pt A∙)
+  ...         | yes _ = refl
+  ...         | no ¬p = ⊥-elim (¬p refl)
+
+  switch-idp : ∀ x → switch (switch x) ≡ x
+  switch-idp x with dA x (pt A∙)
+  switch-idp x | yes p with dA y (pt A∙)
+  switch-idp x | yes p | yes q = q ∙ sym p
+  switch-idp x | yes p | no  _ with dA y y
+  switch-idp x | yes p | no  _ | yes _ = sym p
+  switch-idp x | yes p | no  _ | no ¬p = ⊥-elim (¬p refl)
+  switch-idp x | no ¬p with dA x y
+  switch-idp x | no ¬p | yes p with dA y (pt A∙)
+  switch-idp x | no ¬p | yes p | yes q = ⊥-elim (¬p (p ∙ q))
+  switch-idp x | no ¬p | yes p | no  _ with dA (pt A∙) (pt A∙)
+  switch-idp x | no ¬p | yes p | no  _ | yes _ = sym p
+  switch-idp x | no ¬p | yes p | no  _ | no ¬q = ⊥-elim (¬q refl)
+  switch-idp x | no ¬p | no ¬q with dA x (pt A∙)
+  switch-idp x | no ¬p | no ¬q | yes p = ⊥-elim (¬p p)
+  switch-idp x | no ¬p | no ¬q | no  _ with dA x y
+  switch-idp x | no ¬p | no ¬q | no  _ | yes q = ⊥-elim (¬q q)
+  switch-idp x | no ¬p | no ¬q | no  _ | no  _ = refl
+
+  switch-eqv : typ A∙ ≃ typ A∙
+  switch-eqv = isoToEquiv (iso switch switch switch-idp switch-idp)
+
+isHomogeneousDiscrete : ∀ {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙)) → isHomogeneous A∙
+isHomogeneousDiscrete {ℓ} {A∙} dA y i
+  = ua switch-eqv i , ua-gluePath switch-eqv switch-ptA∙ i
+  where open HomogeneousDiscrete {ℓ} {A∙} dA y

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -1,0 +1,15 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Pointed.Properties where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Pointed.Base
+open import Cubical.Data.Prod
+
+Π∙ : ∀ {ℓ ℓ'} (A : Type ℓ) (B∙ : A → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
+Π∙ A B∙ = (∀ a → typ (B∙ a)) , (λ a → pt (B∙ a))
+
+Σ∙ : ∀ {ℓ ℓ'} (A∙ : Pointed ℓ) (B∙ : typ A∙ → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
+Σ∙ A∙ B∙ = (Σ[ a ∈ typ A∙ ] typ (B∙ a)) , (pt A∙ , pt (B∙ (pt A∙)))
+
+_×∙_ : ∀ {ℓ ℓ'} (A∙ : Pointed ℓ) (B∙ : Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
+A∙ ×∙ B∙ = ((typ A∙) × (typ B∙)) , (pt A∙ , pt B∙)

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -37,9 +37,20 @@ uaIdEquiv : {A : Type ℓ} → ua (idEquiv A) ≡ refl
 uaIdEquiv {A = A} i j = Glue A {φ = i ∨ ~ j ∨ j} (λ _ → A , idEquiv A)
 
 -- Give detailed type to unglue, mainly for documentation purposes
-unglueua : ∀ {A B : Type ℓ} → (e : A ≃ B) → (i : I) (x : ua e i)
-           → B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → x }) ]
-unglueua e i x = inS (unglue (i ∨ ~ i) x)
+ua-unglue : ∀ {A B : Type ℓ} → (e : A ≃ B) → (i : I) (x : ua e i)
+            → B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → x }) ]
+ua-unglue e i x = inS (unglue (i ∨ ~ i) x)
+
+-- Give detailed type to glue
+ua-glue : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A) (y : B)
+          → B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → y }) ]
+          → (ua e i) [ _ ↦ (λ { (i = i0) → x ; (i = i1) → y }) ]
+ua-glue e i x y s = inS (glue (λ { (i = i0) → x ; (i = i1) → y }) (outS s))
+
+ua-gluePath : ∀ {A B : Type ℓ} (e : A ≃ B) {x : A} {y : B}
+              → e .fst x ≡ y
+              → PathP (λ i → ua e i) x y
+ua-gluePath e {x} {y} p i = glue (λ { (i = i0) → x ; (i = i1) → y }) (p i)
 
 -- Proof of univalence using that unglue is an equivalence:
 

--- a/Cubical/HITs/PropositionalTruncation.agda
+++ b/Cubical/HITs/PropositionalTruncation.agda
@@ -3,3 +3,5 @@ module Cubical.HITs.PropositionalTruncation where
 
 open import Cubical.HITs.PropositionalTruncation.Base public
 open import Cubical.HITs.PropositionalTruncation.Properties public
+
+open import Cubical.HITs.PropositionalTruncation.MagicTrick

--- a/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
+++ b/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
@@ -1,0 +1,89 @@
+{-
+
+Based on Nicolai Kraus' blog post:
+  The Truncation Map |_| : ℕ -> ‖ℕ‖ is nearly Invertible
+  https://homotopytypetheory.org/2013/10/28/the-truncation-map-_-ℕ-‖ℕ‖-is-nearly-invertible/
+
+Defines [recover], which definitionally satisfies `recover ∣ x ∣ ≡ x` ([recover∣∣]) for homogeneous types
+
+Also see the follow-up post by Jason Gross:
+  Composition is not what you think it is! Why “nearly invertible” isn’t.
+  https://homotopytypetheory.org/2014/02/24/composition-is-not-what-you-think-it-is-why-nearly-invertible-isnt/
+
+-}
+{-# OPTIONS --cubical --safe #-}
+
+module Cubical.HITs.PropositionalTruncation.MagicTrick where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.Pointed
+open import Cubical.Foundations.Pointed.Homogeneous
+
+open import Cubical.HITs.PropositionalTruncation.Base
+open import Cubical.HITs.PropositionalTruncation.Properties
+
+module Recover {ℓ} (A∙ : Pointed ℓ) (h : isHomogeneous A∙) where
+  private
+    A = typ A∙
+    a = pt A∙
+
+  toEquivPtd : ∥ A ∥ → Σ[ B∙ ∈ Pointed ℓ ] (A , a) ≡ B∙
+  toEquivPtd = recPropTrunc (isContr→isProp (isContrPathAt (A , a)))
+                            (λ x → (A , x) , h x)
+  private
+    B∙ : ∥ A ∥ → Pointed ℓ
+    B∙ tx = fst (toEquivPtd tx)
+
+  -- the key observation is that B∙ ∣ x ∣ is definitionally equal to (A , x)
+  private
+    obvs : ∀ x → B∙ ∣ x ∣ ≡ (A , x)
+    obvs x = refl -- try it: `C-c C-n B∙ ∣ x ∣` gives `(A , x)`
+
+  -- thus any truncated element (of a homogeneous type) can be recovered by agda's normalizer!
+
+  recover : ∀ (tx : ∥ A ∥) → typ (B∙ tx)
+  recover tx = pt (B∙ tx)
+
+  recover∣∣ : ∀ (x : A) → recover ∣ x ∣ ≡ x
+  recover∣∣ x = refl -- try it: `C-c C-n recover ∣ x ∣` gives `x`
+
+  private
+    -- notice that the following typechecks because typ (B∙ ∣ x ∣) is definitionally equal to to A, but
+    --  `recover : ∥ A ∥ → A` does not because typ (B∙ tx) is not definitionally equal to A (though it is
+    --  judegmentally equal to A by cong typ (snd (toEquivPtd tx)) : A ≡ typ (B∙ tx))
+    obvs2 : A → A
+    obvs2 = recover ∘ ∣_∣
+
+    -- one might wonder if (cong recover (squash ∣ x ∣ ∣ y ∣)) therefore has type x ≡ y, but thankfully
+    --  typ (B∙ (squash ∣ x ∣ ∣ y ∣ i)) is *not* A (it's a messy hcomp involving h x and h y)
+    recover-squash : ∀ x y → -- x ≡ y -- this raises an error
+                             PathP (λ i → typ (B∙ (squash ∣ x ∣ ∣ y ∣ i))) x y
+    recover-squash x y = cong recover (squash ∣ x ∣ ∣ y ∣)
+
+
+-- Demo, adapted from:
+-- https://bitbucket.org/nicolaikraus/agda/src/e30d70c72c6af8e62b72eefabcc57623dd921f04/trunc-inverse.lagda
+
+private
+  open import Cubical.Data.Nat
+  open Recover (ℕ , zero) (isHomogeneousDiscrete discreteℕ)
+
+  -- only `∣hidden∣` is exported, `hidden` is no longer in scope
+  module _ where
+    private
+      hidden : ℕ
+      hidden = 17
+
+    ∣hidden∣ : ∥ ℕ ∥
+    ∣hidden∣ = ∣ hidden ∣
+
+  -- we can still recover the value, even though agda can no longer see `hidden`!
+  test : recover ∣hidden∣ ≡ 17
+  test = refl -- try it: `C-c C-n recover ∣hidden∣` gives `17`
+              --         `C-c C-n hidden` gives an error
+
+  -- Finally, note that the definition of recover is independent of the proof that A is homogeneous. Thus we
+  --  still can definitionally recover information hidden by ∣_∣ as long as we permit holes. Try replacing
+  --  `isHomogeneousDiscrete discreteℕ` above with a hole (`?`) and notice that everything still works

--- a/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
+++ b/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
@@ -30,7 +30,7 @@ module Recover {ℓ} (A∙ : Pointed ℓ) (h : isHomogeneous A∙) where
     a = pt A∙
 
   toEquivPtd : ∥ A ∥ → Σ[ B∙ ∈ Pointed ℓ ] (A , a) ≡ B∙
-  toEquivPtd = recPropTrunc (isContr→isProp (isContrPathAt (A , a)))
+  toEquivPtd = recPropTrunc (isContr→isProp (_ , λ p → contrSingl (snd p)))
                             (λ x → (A , x) , h x)
   private
     B∙ : ∥ A ∥ → Pointed ℓ


### PR DESCRIPTION
Adds a function `recover` which definitionally satisfies `recover ∣ x ∣ ≡ x`, meaning agda's normalizer can uncover the information supposedly hidden by `∣_∣` for any type. Based on Nicolai Kraus' blog post: [The Truncation Map |_| : ℕ -> ‖ℕ‖ is nearly Invertible](https://homotopytypetheory.org/2013/10/28/the-truncation-map-_-%E2%84%95-%E2%80%96%E2%84%95%E2%80%96-is-nearly-invertible/).

The definition of `recover` and a small demo can be found in `HITs.PropositionalTruncation.MagicTrick`. This PR also adds:
- some facts about pointed types in `Foundations.Pointed.Properties`
- a definition and some facts about homogenous types in `Foundations.Pointed.Homogeneous`
- HoTT book Lemma 3.11.8 and equivalences defined by `_∙_` in `Foundations.Path`
- a useful function (`ua-gluePath`) in `Foundations.Univalence`