### PR TITLE
Sip pr

### DIFF
--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -2,7 +2,7 @@
 This is a rather literal translation of Martin Hötzel-Escardó's structure identity principle into cubical Agda. See
 https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns
 
-All the needed preliminary results from the lecture notes are stated and proven in this file. 
+All the needed preliminary results from the lecture notes are stated and proven in this file.
 It would be interesting to compare the proves with the one in Cubical.Foundations.SIP
 -}
 
@@ -97,7 +97,7 @@ NatΣ τ (x , a) = (x , τ x a)
    η = isHAEquiv.ret isHAEquivf
    τ :  (x : X) → cong f (ε x) ≡ η (f x)
    τ = isHAEquiv.com isHAEquivf
-   
+
    φ : (Σ X (A ∘ f)) → (Σ Y A)
    φ (x , a) = (f x , a)
 
@@ -109,12 +109,12 @@ NatΣ τ (x , a) = (x , τ x a)
                                     (η y ,  transportTransport⁻ (λ i → A (η y i)) a)
      -- last term proves transp (λ i → A (η y i)) i0 (transp (λ i → A (η y (~ i))) i0 a) ≡ a
 
-   ψφ : (z : (Σ X (A ∘ f))) → ψ (φ z) ≡ z 
+   ψφ : (z : (Σ X (A ∘ f))) → ψ (φ z) ≡ z
    ψφ (x , a) = sigmaPath→pathSigma (ψ (φ (x , a))) (x , a) (ε x , q)
      where
       b : A (f (g (f x)))
       b = (transp (λ i → A (η (f x) (~ i))) i0 a)
-    
+
       q : transp (λ i → A (f (ε x i))) i0 (transp (λ i → A (η (f x) (~ i))) i0 a) ≡ a
       q =  transp (λ i → A (f (ε x i))) i0 b  ≡⟨ S ⟩
            transp (λ i → A (η (f x) i)) i0 b  ≡⟨ transportTransport⁻ (λ i → A (η (f x) i)) a ⟩
@@ -152,7 +152,7 @@ NatΣ τ (x , a) = (x , τ x a)
 Σ-assoc-≃ X A P = isoToEquiv (Σ-assoc-Iso X A P)
 
 
- 
+
 
 -- A structure is a type-family S : Type ℓ → Type ℓ', i.e. for X : Type ℓ and s : S X, the pair (X , s)
 -- means that X is equipped with a S-structure, which is witnessed by s.
@@ -214,7 +214,7 @@ ua-lemma : (A B : Type ℓ) (e : A ≃ B) → (pathToEquiv (ua e)) ≡ e
 ua-lemma A B e = EquivJ (λ b a f →  (pathToEquiv (ua f)) ≡ f)
                        (λ x → subst (λ r → pathToEquiv r ≡ idEquiv x) (sym uaIdEquiv) pathToEquivRefl)
                         B A e
-             
+
 
 homEq→Id : (S : Type ℓ → Type ℓ')
           → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
@@ -226,7 +226,7 @@ homEq→Id S ι θ A B (f , φ) = ΣPathP (p , q)
 
          ψ : ι A B (pathToEquiv p)
          ψ = subst (λ g → ι A B g) (sym (ua-lemma (A .fst) (B. fst) f)) φ
-         
+
          q : PathP (λ i → S (p i)) (A .snd) (B .snd)
          q = equivFun (invEquiv (hom-lemma-dep S ι θ A B p)) ψ
 
@@ -236,7 +236,7 @@ SIP : (S : Type ℓ → Type ℓ')
      → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
      → (θ : SNS S ι)
      → (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A ≡ B) ≃ (A ≃[ ι ] B))
-SIP S ι θ A B = 
+SIP S ι θ A B =
             (A ≡ B)                                                                 ≃⟨ i ⟩
             (Σ[ p ∈ (A .fst) ≡ (B. fst) ] PathP (λ i → S (p i)) (A .snd) (B .snd))  ≃⟨ ii ⟩
             (Σ[ p ∈ (A .fst) ≡ (B. fst) ] (ι A B (pathToEquiv p)))                  ≃⟨ iii ⟩
@@ -267,4 +267,3 @@ pointed-is-sns s t = idEquiv (s ≡ t)
 pointed-type-sip : (X Y : Type ℓ) (x : X) (y : Y)
                   → (Σ[ f ∈ X ≃ Y ] (f .fst) x ≡ y) ≃ ((X , x) ≡ (Y , y))
 pointed-type-sip X Y x y = invEquiv (SIP pointed-structure pointed-ι pointed-is-sns (X , x) (Y , y))
- 

--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -1,0 +1,270 @@
+{-
+This is a rather literal translation of Martin Hötzel-Escardó's structure identity principle into cubical Agda. See
+https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns
+
+All the needed preliminary results from the lecture notes are stated and proven in this file. 
+It would be interesting to compare the proves with the one in Cubical.Foundations.SIP
+-}
+
+
+
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Experiments.EscardoSIP where
+
+open import Cubical.Core.Everything
+open import Cubical.Foundations.Everything
+open import Cubical.Foundations.HAEquiv
+open import Cubical.Data.Sigma.Properties
+
+
+private
+ variable
+  ℓ ℓ' ℓ'' : Level
+
+
+-- We prove several useful equalities and equivalences between Σ-types all the proofs are taken from
+-- Martin Hötzel-Escardó's lecture notes.
+-- We begin by introducing some helpful notation.
+
+_≃⟨_⟩_ : (X : Type ℓ) {Y : Type ℓ'} {Z : Type ℓ''} → (X ≃ Y) → (Y ≃ Z) → (X ≃ Z)
+_ ≃⟨ f ⟩ g = compEquiv f g
+
+_■ : (X : Type ℓ) → (X ≃ X)
+_■ = idEquiv
+
+infixr  0 _≃⟨_⟩_
+infix   1 _■
+
+-- The next result is just a reformulation of pathSigma≡sigmaPath from Sigma.Properties.
+
+Σ-≡-≃ : {X : Type ℓ} {A : X → Type ℓ'}
+       → (σ τ : Σ X A) → ((σ ≡ τ) ≃ (Σ[ p ∈ (σ .fst) ≡ (τ .fst) ] (subst A p (σ .snd) ≡ (τ .snd))))
+Σ-≡-≃ {A = A} σ τ = pathToEquiv (pathSigma≡sigmaPath σ τ)
+
+
+
+-- This cubical proof is much shorter than in HoTT but requires that A, B live in the same universe.
+Σ-cong : {X : Type ℓ} {A B : X → Type ℓ'} →
+         ((x : X) → (A x ≡ B x)) → (Σ X A ≡ Σ X B)
+Σ-cong {X = X} p i = Σ[ x ∈ X ] (p x i)
+
+-- Two lemmas for the more general formulation using equivalences
+NatΣ : {X : Type ℓ} {A : X → Type ℓ'} {B : X → Type ℓ''}
+      → ((x : X) → (A x) → (B x)) → (Σ X A) → (Σ X B)
+NatΣ τ (x , a) = (x , τ x a)
+
+Σ-to-PathP : {X : Type ℓ} {A : X → Type ℓ'} {x : X} {a b : A x}
+          → (a ≡ b) → PathP (λ i → Σ X A) (x , a) (x , b)
+Σ-to-PathP {x = x} p i = (x , p i)
+
+
+Σ-cong-≃ :  {X : Type ℓ} {A : X → Type ℓ'} {B : X → Type ℓ''} →
+         ((x : X) → (A x ≃ B x)) → (Σ X A ≃ Σ X B)
+Σ-cong-≃ {X = X} {A = A} {B = B} φ = isoToEquiv (iso (NatΣ f) (NatΣ g) NatΣ-ε NatΣ-η)
+ where
+  f : (x : X) → (A x) → (B x)
+  f x = equivFun (φ x)
+
+  g : (x : X) → (B x) → (A x)
+  g x = equivFun (invEquiv (φ x))
+
+  η : (x : X) → (a : A x) → (g x) ((f x) a) ≡ a
+  η x = retEq (invEquiv (φ x))
+
+  ε : (x : X) → (b : B x) → f x (g x b) ≡ b
+  ε x = secEq  (invEquiv (φ x))
+
+  NatΣ-η : (w : Σ X A) → NatΣ g (NatΣ f w) ≡ w
+  NatΣ-η (x , a)  = (x , g x (f x a)) ≡⟨ Σ-to-PathP (η x a)  ⟩
+                    (x , a)           ∎
+
+  NatΣ-ε : (u : Σ X B) → NatΣ f (NatΣ g u) ≡ u
+  NatΣ-ε (x , b) = (x , f x (g x b)) ≡⟨ Σ-to-PathP (ε x b) ⟩
+                   (x , b)           ∎
+
+
+
+-- The next result is stated a bit awkwardly but is rather straightforward to prove.
+Σ-change-of-variable-Iso :  {X : Type ℓ} {Y : Type ℓ'} {A : Y → Type ℓ''} (f : X → Y)
+                           → (isHAEquiv f) → (Iso (Σ X (A ∘ f)) (Σ Y A))
+Σ-change-of-variable-Iso {ℓ = ℓ} {ℓ' = ℓ'} {X = X} {Y = Y} {A = A} f isHAEquivf = iso φ ψ φψ ψφ
+  where
+   g : Y → X
+   g = isHAEquiv.g isHAEquivf
+   ε : (x : X) → (g (f x)) ≡ x
+   ε = isHAEquiv.sec isHAEquivf
+   η : (y : Y) → f (g y) ≡ y
+   η = isHAEquiv.ret isHAEquivf
+   τ :  (x : X) → cong f (ε x) ≡ η (f x)
+   τ = isHAEquiv.com isHAEquivf
+   
+   φ : (Σ X (A ∘ f)) → (Σ Y A)
+   φ (x , a) = (f x , a)
+
+   ψ : (Σ Y A) → (Σ X (A ∘ f))
+   ψ (y , a) = (g y , subst A (sym (η y)) a)
+
+   φψ : (z : (Σ Y A)) → φ (ψ z) ≡ z
+   φψ (y , a) = sigmaPath→pathSigma (φ (ψ (y , a))) (y , a)
+                                    (η y ,  transportTransport⁻ (λ i → A (η y i)) a)
+     -- last term proves transp (λ i → A (η y i)) i0 (transp (λ i → A (η y (~ i))) i0 a) ≡ a
+
+   ψφ : (z : (Σ X (A ∘ f))) → ψ (φ z) ≡ z 
+   ψφ (x , a) = sigmaPath→pathSigma (ψ (φ (x , a))) (x , a) (ε x , q)
+     where
+      b : A (f (g (f x)))
+      b = (transp (λ i → A (η (f x) (~ i))) i0 a)
+    
+      q : transp (λ i → A (f (ε x i))) i0 (transp (λ i → A (η (f x) (~ i))) i0 a) ≡ a
+      q =  transp (λ i → A (f (ε x i))) i0 b  ≡⟨ S ⟩
+           transp (λ i → A (η (f x) i)) i0 b  ≡⟨ transportTransport⁻ (λ i → A (η (f x) i)) a ⟩
+           a                                  ∎
+       where
+        S : (transp (λ i → A (f (ε x i))) i0 b)  ≡ (transp (λ i → A (η (f x) i)) i0 b)
+        S = subst (λ p → (transp (λ i → A (f (ε x i))) i0 b)  ≡ (transp (λ i → A (p i)) i0 b))
+                 (τ x) refl
+
+
+-- Using the result above we can prove the following quite useful result.
+Σ-change-of-variable-≃ : {X : Type ℓ} {Y : Type ℓ'} {A : Y → Type ℓ''} (f : X → Y)
+                      → (isEquiv f) → ((Σ X (A ∘ f)) ≃ (Σ Y A))
+Σ-change-of-variable-≃ f isEquivf =
+                      isoToEquiv (Σ-change-of-variable-Iso f (equiv→HAEquiv (f , isEquivf) .snd))
+
+
+
+
+Σ-assoc-Iso : (X : Type ℓ) (A : X → Type ℓ') (P : Σ X A → Type ℓ'')
+         → (Iso (Σ (Σ X A) P) (Σ[ x ∈ X ] (Σ[ a ∈ A x ] P (x , a))))
+Σ-assoc-Iso X A P = iso f g ε η
+   where
+    f : (Σ (Σ X A) P) → (Σ[ x ∈ X ] (Σ[ a ∈ A x ] P (x , a)))
+    f ((x , a) , p) = (x , (a , p))
+    g : (Σ[ x ∈ X ] (Σ[ a ∈ A x ] P (x , a))) →  (Σ (Σ X A) P)
+    g (x , (a , p)) = ((x , a) , p)
+    ε : section f g
+    ε n = refl
+    η : retract f g
+    η m = refl
+
+Σ-assoc-≃ : (X : Type ℓ) (A : X → Type ℓ') (P : Σ X A → Type ℓ'')
+         → (Σ (Σ X A) P) ≃ (Σ[ x ∈ X ] (Σ[ a ∈ A x ] P (x , a)))
+Σ-assoc-≃ X A P = isoToEquiv (Σ-assoc-Iso X A P)
+
+
+ 
+
+-- A structure is a type-family S : Type ℓ → Type ℓ', i.e. for X : Type ℓ and s : S X, the pair (X , s)
+-- means that X is equipped with a S-structure, which is witnessed by s.
+-- An S-structure should have a notion of S-homomorphism, or rather S-isomorphism.
+-- This will be implemented by a function ι
+-- that gives us for any two types with S-structure (X , s) and (Y , t) a family:
+--    ι (X , s) (Y , t) : (X ≃ Y) → Type ℓ''
+-- Note that for any equivalence (f , e) : X ≃ Y the type  ι (X , s) (Y , t) (f , e) need not to be
+-- a proposition. Indeed this type should correspond to the ways s and t can be identified
+-- as S-structures. This we call a standard notion of structure.
+
+
+SNS : (S : Type ℓ → Type ℓ')
+     → ((A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → Type (ℓ-max (ℓ-max(ℓ-suc ℓ) ℓ') ℓ'')
+SNS  {ℓ = ℓ} S ι = ∀ {X : (Type ℓ)} (s t : S X) → ((s ≡ t) ≃ ι (X , s) (X , t) (idEquiv X))
+
+
+-- Escardo's ρ can actually be  defined from this:
+ρ :  {S : Type ℓ → Type ℓ'}
+    → {ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ''}
+    → (SNS S ι)
+    → (A : Σ[ X ∈ (Type ℓ) ] (S X)) → (ι A A (idEquiv (A .fst)))
+ρ θ A = equivFun (θ (A .snd) (A .snd)) refl
+
+-- We introduce the notation a bit differently:
+_≃[_]_ : {S : Type ℓ → Type ℓ'} → (Σ[ X ∈ (Type ℓ) ] (S X))
+                           → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+                           → (Σ[ X ∈ (Type ℓ) ] (S X))
+                           → (Type (ℓ-max ℓ ℓ''))
+A ≃[ ι ] B = Σ[ f ∈ ((A .fst) ≃ (B. fst)) ] (ι A B f)
+
+
+
+Id→homEq : (S : Type ℓ → Type ℓ')
+          → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+          → (ρ : (A : Σ[ X ∈ (Type ℓ) ] (S X)) → ι A A (idEquiv (A .fst)))
+          → (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → A ≡ B → (A ≃[ ι ] B)
+Id→homEq S ι ρ A B p = J (λ y x → A ≃[ ι ] y) (idEquiv (A .fst) , ρ A) p
+
+
+-- Use a PathP version of Escardó's homomorphism-lemma
+hom-lemma-dep : (S : Type ℓ → Type ℓ')
+               → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+               → (θ : SNS S ι)
+               → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+               → (p : (A .fst) ≡ (B. fst))
+               → (PathP (λ i → S (p i)) (A .snd) (B .snd)) ≃ (ι A B (pathToEquiv p))
+hom-lemma-dep S ι θ A B p = (J P (λ s → γ s) p) (B .snd)
+     where
+      P = (λ y x → (s : S y) → PathP (λ i → S (x i)) (A .snd) s ≃ ι A (y , s) (pathToEquiv x))
+
+      γ : (s : S (A .fst)) → ((A .snd) ≡ s) ≃ ι A ((A .fst) , s) (pathToEquiv refl)
+      γ s = subst (λ f → ((A .snd) ≡ s) ≃ ι A ((A .fst) , s) f)  (sym pathToEquivRefl) (θ (A. snd) s)
+
+
+-- Define the inverse of Id→homEq directly.
+ua-lemma : (A B : Type ℓ) (e : A ≃ B) → (pathToEquiv (ua e)) ≡ e
+ua-lemma A B e = EquivJ (λ b a f →  (pathToEquiv (ua f)) ≡ f)
+                       (λ x → subst (λ r → pathToEquiv r ≡ idEquiv x) (sym uaIdEquiv) pathToEquivRefl)
+                        B A e
+             
+
+homEq→Id : (S : Type ℓ → Type ℓ')
+          → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+          → (θ : SNS S ι)
+          → (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → (A ≃[ ι ] B) → A ≡ B
+homEq→Id S ι θ A B (f , φ) = ΣPathP (p , q)
+        where
+         p = ua f
+
+         ψ : ι A B (pathToEquiv p)
+         ψ = subst (λ g → ι A B g) (sym (ua-lemma (A .fst) (B. fst) f)) φ
+         
+         q : PathP (λ i → S (p i)) (A .snd) (B .snd)
+         q = equivFun (invEquiv (hom-lemma-dep S ι θ A B p)) ψ
+
+
+-- Proof of the SIP:
+SIP : (S : Type ℓ → Type ℓ')
+     → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → (θ : SNS S ι)
+     → (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A ≡ B) ≃ (A ≃[ ι ] B))
+SIP S ι θ A B = 
+            (A ≡ B)                                                                 ≃⟨ i ⟩
+            (Σ[ p ∈ (A .fst) ≡ (B. fst) ] PathP (λ i → S (p i)) (A .snd) (B .snd))  ≃⟨ ii ⟩
+            (Σ[ p ∈ (A .fst) ≡ (B. fst) ] (ι A B (pathToEquiv p)))                  ≃⟨ iii ⟩
+            (A ≃[ ι ] B)                                                            ■
+    where
+     i = invEquiv Σ≡
+     ii = Σ-cong-≃ (hom-lemma-dep S ι θ A B)
+     iii = Σ-change-of-variable-≃ pathToEquiv (equivIsEquiv univalence)
+
+
+
+
+
+
+-- A simple example: pointed types
+pointed-structure : Type ℓ → Type ℓ
+pointed-structure X = X
+
+Pointed-Type : Type (ℓ-suc ℓ)
+Pointed-Type {ℓ = ℓ} = Σ (Type ℓ) pointed-structure
+
+pointed-ι : (A B : Pointed-Type) → (A .fst) ≃ (B. fst) → Type ℓ
+pointed-ι (X , x) (Y , y) f = (equivFun f) x ≡ y
+
+pointed-is-sns : SNS {ℓ = ℓ} pointed-structure pointed-ι
+pointed-is-sns s t = idEquiv (s ≡ t)
+
+pointed-type-sip : (X Y : Type ℓ) (x : X) (y : Y)
+                  → (Σ[ f ∈ X ≃ Y ] (f .fst) x ≡ y) ≃ ((X , x) ≡ (Y , y))
+pointed-type-sip X Y x y = invEquiv (SIP pointed-structure pointed-ι pointed-is-sns (X , x) (Y , y))
+ 

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -44,4 +44,5 @@ open import Cubical.Foundations.UnivalenceId public
 open import Cubical.Foundations.GroupoidLaws public
 open import Cubical.Foundations.Isomorphism public
 open import Cubical.Foundations.Logic
+open import Cubical.Foundations.SIP
 open import Cubical.Foundations.HoTT-UF

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -1,0 +1,511 @@
+{-
+
+In this file we apply the cubical machinery to Martin Hötzel-Escardó's structure identity principle
+https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns
+
+-}
+
+
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.SIP where
+
+open import Cubical.Core.Everything
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Transport
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.FunExtEquiv
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HAEquiv
+open import Cubical.Data.Sigma.Properties
+open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+
+
+private
+ variable
+  ℓ ℓ' ℓ'' ℓ''' ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅ : Level
+
+
+-- Some helpful notation:
+_≃⟨_⟩_ : (X : Type ℓ) {Y : Type ℓ'} {Z : Type ℓ''} → (X ≃ Y) → (Y ≃ Z) → (X ≃ Z)
+_ ≃⟨ f ⟩ g = compEquiv f g
+
+_■ : (X : Type ℓ) → (X ≃ X)
+_■ = idEquiv
+
+infixr  0 _≃⟨_⟩_
+infix   1 _■
+
+
+-- -- these two lemmas can actually be found in the proof of Univalence.thm but are not stated as explicit results.
+-- -- we repeat them here explicitly because we will use them a lot.
+
+-- ua-pathToEquiv : ∀ {ℓ} (A B : Type ℓ) (p : A ≡ B) → ua (pathToEquiv p) ≡ p
+-- ua-pathToEquiv A B p = J (λ b p → ua (pathToEquiv p) ≡ p)
+--                       ((cong ua (pathToEquivRefl {A = A})) ∙ uaIdEquiv) p
+
+-- For technical reasons we prove ua-pathToEquiv temporarily here and then
+-- reprove it again using the particular proof constructed by
+-- iso→HAEquiv. The reason is that we want to later be able to extract
+--
+--   eq : ua-au (ua e) ≡ cong ua (au-ua e)
+
+ua-pathToEquiv' : ∀ {ℓ} (A B : Type ℓ) (p : A ≡ B) → ua (pathToEquiv p) ≡ p
+ua-pathToEquiv' A B p = J (λ b p → ua (pathToEquiv p) ≡ p)
+                            (cong ua (pathToEquivRefl {A = A}) ∙ uaIdEquiv) p
+
+
+pathToEquiv-ua : (A B : Type ℓ) (e : A ≃ B) → (pathToEquiv (ua e)) ≡ e
+pathToEquiv-ua A B e = EquivJ (λ b a f →  (pathToEquiv (ua f)) ≡ f)
+                       (λ x → subst (λ r → pathToEquiv r ≡ idEquiv x) (sym uaIdEquiv) pathToEquivRefl)
+                        B A e
+
+uaHAEquiv : (A B : Type ℓ) → HAEquiv (A ≃ B) (A ≡ B)
+uaHAEquiv A B = iso→HAEquiv (iso ua pathToEquiv (ua-pathToEquiv' A B) (pathToEquiv-ua A B))
+open isHAEquiv
+
+-- We now extract the particular proof constructed from iso→HAEquiv
+-- for reasons explained above.
+ua-pathToEquiv : (A B : Type ℓ) (e : A ≡ B) → ua (pathToEquiv e) ≡ e
+ua-pathToEquiv A B e = uaHAEquiv A B .snd .ret e
+
+
+
+
+
+-- A structure is a type-family S : Type ℓ → Type ℓ', i.e. for X : Type ℓ and s : S X, the pair (X , s)
+-- means that X is equipped with a S-structure, which is witnessed by s.
+-- An S-structure should have a notion of S-homomorphism, or rather S-isomorphism.
+-- This will be implemented by a function ι
+-- that gives us for any two types with S-structure (X , s) and (Y , t) a family:
+--    ι (X , s) (Y , t) : (X ≃ Y) → Type ℓ''
+-- Note that for any equivalence (f , e) : X ≃ Y the type  ι (X , s) (Y , t) (f , e) need not to be
+-- a proposition. Indeed this type should correspond to the ways s and t can be identified
+-- as S-structures. This we call a standard notion of structure or SNS.
+-- We will use a different definition, but the two definitions are interchangeable.
+SNS : (S : Type ℓ → Type ℓ')
+     → ((A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → Type (ℓ-max (ℓ-max(ℓ-suc ℓ) ℓ') ℓ'')
+SNS  {ℓ = ℓ} S ι = ∀ {X : (Type ℓ)} (s t : S X) → ((s ≡ t) ≃ ι (X , s) (X , t) (idEquiv X))
+
+
+-- We introduce the notation for structure preserving equivalences a bit differently,
+-- but this definition doesn't actually change from Escardó's notes.
+_≃[_]_ : {S : Type ℓ → Type ℓ'} → (Σ[ X ∈ (Type ℓ) ] (S X))
+                           → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+                           → (Σ[ X ∈ (Type ℓ) ] (S X))
+                           → (Type (ℓ-max ℓ ℓ''))
+A ≃[ ι ] B = Σ[ f ∈ ((A .fst) ≃ (B. fst)) ] (ι A B f)
+
+-- Before we can formulate our version of an SNS we have to introduce a bit of notation
+-- and prove a few basic results.
+-- First, we define the "cong-≃":
+_⋆_ : (S : Type ℓ → Type ℓ') → {X Y : Type ℓ} → (X ≃ Y) → (S X ≃ S Y)
+S ⋆ f = pathToEquiv (cong S (ua f))
+
+
+-- Next, we prove a couple of helpful results about this ⋆ opreation:
+⋆-idEquiv : (S : Type ℓ → Type ℓ') (X : Type ℓ) → (S ⋆ (idEquiv X)) ≡ idEquiv (S X)
+⋆-idEquiv S X = (S ⋆ (idEquiv X))  ≡⟨ cong (λ p → pathToEquiv (cong S p)) uaIdEquiv  ⟩
+                pathToEquiv refl   ≡⟨ pathToEquivRefl ⟩
+                idEquiv (S X)      ∎
+
+⋆-char : (S : Type ℓ → Type ℓ') (X Y : Type ℓ) (f : X ≃ Y) → ua (S ⋆ f) ≡ cong S (ua f)
+⋆-char S X Y f = ua-pathToEquiv (S X) (S Y) (cong S (ua f))
+
+PathP-⋆-lemma : (S : Type ℓ → Type ℓ') (A B : Σ[ X ∈ (Type ℓ) ] (S X)) (f : (A .fst) ≃ (B .fst))
+    → (PathP (λ i →  ua (S ⋆ f) i) (A .snd) (B .snd)) ≡ (PathP (λ i → S ((ua f) i)) (A .snd) (B .snd))
+PathP-⋆-lemma S A B f i = PathP (λ j → (⋆-char S (A .fst) (B .fst) f) i j) (A .snd) (B .snd)
+     
+
+
+
+-- Our new definition of standard notion of structure SNS' using the ⋆ notation.
+-- This is easier to work with than SNS wrt Glue-types
+SNS' : (S : Type ℓ → Type ℓ')
+     → ((A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → Type (ℓ-max (ℓ-max(ℓ-suc ℓ) ℓ') ℓ'')
+SNS'  {ℓ = ℓ} S ι = (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → (f : (A .fst) ≃ (B .fst))
+                  → ((equivFun (S ⋆ f)) (A .snd) ≡ (B .snd)) ≃ (ι A B f)
+
+
+-- We can unfold SNS' as follows:
+SNS'' : (S : Type ℓ → Type ℓ')
+     → ((A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → Type (ℓ-max (ℓ-max(ℓ-suc ℓ) ℓ') ℓ'')
+SNS''  {ℓ = ℓ} S ι = (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → (f : (A .fst) ≃ (B .fst))
+                  → (transport (λ i → S (ua f i)) (A .snd) ≡ (B .snd)) ≃ (ι A B f)
+
+SNS'≡SNS'' : (S : Type ℓ → Type ℓ')
+            → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+            → SNS' S ι ≡ SNS'' S ι
+SNS'≡SNS'' S ι = refl
+
+
+
+-- A quick sanity-check that our definition is interchangeable with Escardó's.
+-- The direction SNS→SNS' corresponds more or less to an EquivJ formulation of Escardó's homomorphism-lemma.
+SNS'→SNS : (S : Type ℓ → Type ℓ')
+          → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+          → (SNS' S ι) → (SNS S ι)
+SNS'→SNS {ℓ = ℓ} {ℓ' = ℓ'} {ℓ'' = ℓ''} S ι θ {X = X} s t = subst (λ x → ((equivFun x) s ≡ t) ≃ ι (X , s) (X , t) (idEquiv X)) (⋆-idEquiv S X) θ-id
+  where
+   θ-id = θ (X , s) (X , t) (idEquiv X)
+
+SNS→SNS' : (S : Type ℓ → Type ℓ')
+          → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+          → (SNS S ι) → (SNS' S ι)
+SNS→SNS' {ℓ = ℓ} {ℓ' = ℓ'} {ℓ'' = ℓ''} S ι θ A B f = (EquivJ P C (B .fst) (A .fst) f) (B .snd) (A .snd)
+  where
+   P : (X Y : Type ℓ) → Y ≃ X → Type (ℓ-max ℓ' ℓ'')
+   P X Y g = (s : S X) (t : S Y) → ((equivFun (S ⋆ g)) t ≡ s) ≃ (ι (Y , t) (X , s) g)
+
+   C : (X : Type ℓ) → (s t : S X) → ((equivFun (S ⋆ (idEquiv X))) t ≡ s) ≃ (ι (X , t) (X , s) (idEquiv X))
+   C X s t = subst (λ u →  (u ≡ s) ≃ (ι (X , t) (X , s) (idEquiv X)))
+                   (sym ( cong (λ f → (equivFun f) t) (⋆-idEquiv S X))) (θ t s) 
+
+
+
+-- The following transport-free version of SNS'' is a bit easier to
+-- work with for the SIP, so we will use it for the proof of the SIP.
+SNS''' : (S : Type ℓ → Type ℓ')
+     → ((A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+     → Type (ℓ-max (ℓ-max(ℓ-suc ℓ) ℓ') ℓ'')
+SNS'''  {ℓ = ℓ} S ι = (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → (f : (A .fst) ≃ (B .fst))
+                  → (PathP (λ i → S (ua f i)) (A .snd) (B .snd)) ≃ (ι A B f)
+
+-- We can easily go between SNS'' (which is def. equal to SNS') and SNS'''
+-- We should be able to find are more direct version of PathP≃Path for the family (λ i → S (ua f i))
+-- using glue and unglue terms.
+SNS''→SNS''' : (S : Type ℓ → Type ℓ')
+             → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+             → SNS'' S ι
+             → SNS''' S ι
+SNS''→SNS''' S ι h A B f =   PathP (λ i → S (ua f i)) (A .snd) (B .snd)
+                          ≃⟨ PathP≃Path (λ i → S (ua f i)) (A .snd) (B .snd) ⟩
+                             h A B f 
+
+SNS'''→SNS'' : (S : Type ℓ → Type ℓ')
+             → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+             → SNS''' S ι
+             → SNS'' S ι
+SNS'''→SNS'' S ι h A B f =   transport (λ i → S (ua f i)) (A .snd) ≡ (B .snd)
+                          ≃⟨ invEquiv (PathP≃Path (λ i → S (ua f i)) (A .snd) (B .snd)) ⟩
+                             h A B f
+
+
+-- We can now directly define a function
+--    sip : A ≃[ ι ] B → A ≡ B
+-- and it's inverse.
+-- Here, these functions use SNS''' and are expressed using a Σ-type instead as it is a bit
+-- easier to work with
+sip : (S : Type ℓ → Type ℓ')
+    → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+    → (θ : SNS''' S ι)
+    → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+    → A ≃[ ι ] B
+    → Σ (A .fst ≡ B .fst) (λ p → PathP (λ i → S (p i)) (A .snd) (B .snd))
+sip S ι θ A B (e , p) = ua e , invEq (θ A B e) p
+
+-- The inverse to sip using the following little lemma
+lem : (S : Type ℓ → Type ℓ')
+         (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+         (e : A .fst ≡ B .fst)
+       → PathP (λ i → S (ua (pathToEquiv e) i)) (A .snd) (B .snd) ≡
+         PathP (λ i → S (e i)) (A .snd) (B .snd)
+lem S A B e i = PathP (λ j → S (ua-pathToEquiv (A .fst) (B .fst) e i j)) (A .snd) (B .snd)
+
+sip⁻ : (S : Type ℓ → Type ℓ')
+    → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+    → (θ : SNS''' S ι)
+    → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+    → Σ (A .fst ≡ B .fst) (λ p → PathP (λ i → S (p i)) (A .snd) (B .snd))
+    → A ≃[ ι ] B
+sip⁻ S ι θ A B (e , r) = pathToEquiv e , θ A B (pathToEquiv e) .fst q
+  where
+  q : PathP (λ i → S (ua (pathToEquiv e) i)) (A .snd) (B .snd)
+  q = transport (λ i → lem S A B e (~ i)) r
+
+
+-- we can rather directly show that sip and sip⁻ are mutually inverse:
+sip-sip⁻ : (S : Type ℓ → Type ℓ')
+           → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+           → (θ : SNS''' S ι)
+           → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+           → (r : Σ (A .fst ≡ B .fst) (λ p → PathP (λ i → S (p i)) (A .snd) (B .snd)))
+           → sip S ι θ A B (sip⁻ S ι θ A B r) ≡ r
+sip-sip⁻ S ι θ A B (p , q) =
+    sip S ι θ A B (sip⁻ S ι θ A B (p , q))
+  ≡⟨ refl ⟩
+    ua (pathToEquiv p) , invEq (θ A B (pathToEquiv p)) (θ A B (pathToEquiv p) .fst (transport (λ i → lem S A B p (~ i)) q))
+  ≡⟨ (λ i → ua (pathToEquiv p) , secEq (θ A B (pathToEquiv p)) (transport (λ i → lem S A B p (~ i)) q) i) ⟩
+    ua (pathToEquiv p) , transport (λ i → lem S A B p (~ i)) q
+  ≡⟨ (λ i → ua-pathToEquiv (A .fst) (B .fst) p i ,
+     transp (λ k →  (PathP (λ j → S (ua-pathToEquiv (A .fst) (B .fst) p (i ∧ k) j)) (A .snd) (B .snd))) (~ i)
+    (transport (λ i → lem S A B p (~ i)) q)) ⟩
+    p , transport (λ i → lem S A B p i) (transport (λ i → lem S A B p (~ i)) q)
+  ≡⟨ (λ i → p , transportTransport⁻ (lem S A B p) q i) ⟩
+    p , q ∎
+
+
+-- The trickier direction:
+sip⁻-sip : (S : Type ℓ → Type ℓ')
+           → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+           → (θ : SNS''' S ι)
+           → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+           → (r : A ≃[ ι ] B)
+           → sip⁻ S ι θ A B (sip S ι θ A B r) ≡ r
+sip⁻-sip S ι θ A B (e , p) =
+    sip⁻ S ι θ A B (sip S ι θ A B (e , p))
+  ≡⟨ refl ⟩
+     pathToEquiv (ua e) , θ A B (pathToEquiv (ua e)) .fst (f⁺ p')
+  ≡⟨ (λ i → pathToEquiv-ua (A . fst) (B .fst) e i , θ A B (pathToEquiv-ua (A . fst) (B .fst) e i) .fst (pth' i)) ⟩
+    e , θ A B e .fst (f⁻ (f⁺ p'))
+  ≡⟨ (λ i → e , θ A B e .fst (transportTransport⁻ (lem S A B (ua e)) p' i)) ⟩
+    e , θ A B e .fst (invEq (θ A B e) p)
+  ≡⟨ (λ i → e , (retEq (θ A B e) p i)) ⟩
+    e , p ∎
+  where
+  p' : PathP (λ i → S (ua e i)) (A .snd) (B .snd)
+  p' = invEq (θ A B e) p
+
+  f⁺ : PathP (λ i → S (ua e i)) (A .snd) (B .snd) → PathP (λ i → S (ua (pathToEquiv (ua e)) i)) (A .snd) (B .snd)
+  f⁺ = transport (λ i → PathP (λ j → S (ua-pathToEquiv (A .fst) (B. fst) (ua e) (~ i) j)) (A .snd) (B .snd))
+
+  f⁻ : PathP (λ i → S (ua (pathToEquiv (ua e)) i)) (A .snd) (B .snd) → PathP (λ i → S (ua e i)) (A .snd) (B .snd)
+  f⁻ = transport (λ i → PathP (λ j → S (ua-pathToEquiv (A .fst) (B. fst) (ua e) i j)) (A .snd) (B .snd))
+
+  -- We can prove the following as in sip∘pis-id, but the type is not
+  -- what we want as it should be "cong ua (pathToEquiv-ua e)"
+  pth : PathP (λ j → PathP (λ k → S (ua-pathToEquiv (A .fst) (B. fst) (ua e) j k)) (A .snd) (B .snd)) (f⁺ p') (f⁻ (f⁺ p'))
+  pth i = transp (λ k → PathP (λ j → S (ua-pathToEquiv (A .fst) (B. fst) (ua e) (i ∧ k) j)) (A .snd) (B .snd)) (~ i) (f⁺ p')
+
+  -- So we build an equality that we want to cast the types with
+  casteq : PathP (λ j → PathP (λ k → S (ua-pathToEquiv (A .fst) (B. fst) (ua e) j k)) (A .snd) (B .snd)) (f⁺ p') (f⁻ (f⁺ p'))
+         ≡ PathP (λ j → PathP (λ k → S (cong ua (pathToEquiv-ua (A .fst) (B .fst) e) j k)) (A .snd) (B .snd)) (f⁺ p') (f⁻ (f⁺ p'))
+  casteq i = PathP (λ j → PathP (λ k → S (eq i j k)) (A .snd) (B .snd)) (f⁺ p') (f⁻ (f⁺ p'))
+    where
+    -- This is where we need the half-adjoint equivalence property
+    eq : ua-pathToEquiv (A .fst) (B. fst) (ua e) ≡ cong ua (pathToEquiv-ua (A .fst) (B. fst) e)
+    eq = sym (uaHAEquiv (A .fst) (B .fst) .snd .com e)
+
+  -- We then get a term of the type we need
+  pth' : PathP (λ j → PathP (λ k → S (cong ua (pathToEquiv-ua (A .fst) (B. fst) e) j k)) (A .snd) (B .snd))  (f⁺ p') (f⁻ (f⁺ p'))
+  pth' = transport (λ i → casteq i) pth
+
+
+
+
+-- Finally package everything up to get the cubical SIP
+SIP : (S : Type ℓ → Type ℓ')
+    → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+    → (θ : SNS''' S ι)
+    → (A B : Σ[ X ∈ (Type ℓ) ] (S X))
+    → A ≃[ ι ] B ≃ (A ≡ B)
+SIP S ι θ A B = (A ≃[ ι ] B ) ≃⟨ eq ⟩ Σ≡
+  where
+  eq : A ≃[ ι ] B ≃ Σ (A .fst ≡ B .fst) (λ p → PathP (λ i → S (p i)) (A .snd) (B .snd))
+  eq = isoToEquiv (iso (sip S ι θ A B) (sip⁻ S ι θ A B)
+                       (sip-sip⁻ S ι θ A B) (sip⁻-sip S ι θ A B))
+
+
+
+
+
+
+-- Now, we want to add axioms (i.e. propositions) to our Structure S that don't affect the ι.
+-- For this and the remainder of this file we will work with SNS'
+-- We use a lemma due to Zesen Qian, which can now be found in Foundations.Prelude:
+-- https://github.com/riaqn/cubical/blob/hgroup/Cubical/Data/Group/Properties.agda#L83
+add-to-structure : (S : Type ℓ → Type ℓ')
+                   (axioms : (X : Type ℓ) → (S X) → Type ℓ''')
+                  → Type ℓ → Type (ℓ-max ℓ' ℓ''')
+add-to-structure S axioms X = Σ[ s ∈ S X ] (axioms X s)
+
+
+add-to-iso : (S : Type ℓ → Type ℓ')
+             (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+             (axioms : (X : Type ℓ) → (S X) → Type ℓ''')
+            → (A B : Σ[ X ∈ (Type ℓ) ] (add-to-structure S axioms X)) → ((A .fst) ≃ (B .fst)) → Type ℓ''
+add-to-iso S ι axioms (X , (s , a)) (Y , (t , b)) f = ι (X , s) (Y , t) f
+
+add-⋆-lemma : (S : Type ℓ → Type ℓ')
+              (axioms : (X : Type ℓ) → (S X) → Type ℓ''')
+              (axioms-are-Props : (X : Type ℓ) (s : S X) → isProp (axioms X s))
+              {X Y : Type ℓ} {s : S X} {t : S Y} {a : axioms X s} {b : axioms Y t}
+              (f : X ≃ Y) → (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b)) ≃ (equivFun (S ⋆ f) s ≡ t)
+add-⋆-lemma S axioms axioms-are-Props {Y = Y} {s = s} {t = t} {a = a} {b = b} f = isoToEquiv (iso φ ψ η ε)
+      where
+       φ : (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b)) → (equivFun (S ⋆ f) s ≡ t)
+       φ r i = (r i) .fst
+       
+       ψ : (equivFun (S ⋆ f) s ≡ t) → (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b))
+       ψ p i = p i , isProp-PathP-I (λ j → axioms-are-Props Y (p j)) (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) .snd) b i
+       
+       η : section φ ψ
+       η p = refl
+       
+       ε : retract φ ψ
+       ε r i j = r j .fst , isProp→isSet-PathP (λ k → axioms-are-Props Y (r k .fst)) _ _
+                  (λ k → isProp-PathP-I (λ j → axioms-are-Props Y (r j .fst)) (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) .snd) b k)
+                  (λ k → (r k) .snd) i j
+ 
+
+add-axioms-SNS' : (S : Type ℓ → Type ℓ')
+                  (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
+                  (axioms : (X : Type ℓ) → (S X) → Type ℓ''')
+                  (axioms-are-Props : (X : Type ℓ) (s : S X) → isProp (axioms X s))
+                  (θ : SNS' S ι) → SNS' (add-to-structure S axioms) (add-to-iso S ι axioms)
+
+add-axioms-SNS' S ι axioms axioms-are-Props θ (X , (s , a)) (Y , (t , b)) f =
+               equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b)    ≃⟨ add-⋆-lemma S axioms axioms-are-Props f ⟩
+               equivFun (S ⋆ f) s ≡ t                                          ≃⟨ θ (X , s) (Y , t) f ⟩
+               (add-to-iso S ι axioms) (X , (s , a)) (Y , (t , b)) f           ■
+
+
+
+-- Now, we want to join two structures.
+-- Together with the adding of axioms this will allow us to prove that a lot of mathematical structures are a standard notion of structure
+technical-×-lemma : {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄}
+                   → (A ≃ C) → (B ≃ D) → (A × B) ≃ (C × D)
+technical-×-lemma {A = A} {B = B} {C = C} {D = D} f g = isoToEquiv (iso φ ψ η ε)
+ where
+  φ : (A × B) → (C × D)
+  φ (a , b) = equivFun f a , equivFun g b
+  
+  ψ : (C × D) → (A × B)
+  ψ (c , d) = equivFun (invEquiv f) c , equivFun (invEquiv g) d
+
+  η : section φ ψ
+  η (c , d) i = retEq f c i , retEq g d i
+  
+  ε : retract φ ψ
+  ε (a , b) i = secEq f a i , secEq g b i
+
+
+join-structure : (S₁ : Type ℓ₁ → Type ℓ₂) (S₂ : Type ℓ₁ → Type ℓ₄)
+                → Type ℓ₁ → Type (ℓ-max ℓ₂ ℓ₄)
+join-structure S₁ S₂ X = (S₁ X) × (S₂ X)
+
+
+join-iso : {S₁ : Type ℓ₁ → Type ℓ₂}
+           (ι₁ : (A B : Σ[ X ∈ (Type ℓ₁) ] (S₁ X)) → ((A .fst) ≃ (B .fst)) → Type ℓ₃)
+           {S₂ : Type ℓ₁ → Type ℓ₄}
+           (ι₂ : (A B : Σ[ X ∈ (Type ℓ₁) ] (S₂ X)) → ((A .fst) ≃ (B .fst)) → Type ℓ₅)
+          → (A B : Σ[ X ∈ (Type ℓ₁) ] (join-structure S₁ S₂ X)) → ((A .fst) ≃ (B .fst)) → Type (ℓ-max ℓ₃ ℓ₅)
+join-iso ι₁ ι₂ (X , s₁ , s₂) (Y , t₁ , t₂) f = (ι₁ (X , s₁) (Y , t₁) f) × (ι₂ (X , s₂) (Y , t₂) f)
+
+
+join-⋆-lemma : (S₁ : Type ℓ₁ → Type ℓ₂) (S₂ : Type ℓ₁ → Type ℓ₄)
+               {X Y : Type ℓ₁} {s₁ : S₁ X} {s₂ : S₂ X} {t₁ : S₁ Y} {t₂ : S₂ Y} (f : X ≃ Y)
+              → (equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂)) ≃ (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂)
+join-⋆-lemma S₁ S₂ {Y = Y} {s₁ = s₁} {s₂ = s₂} {t₁ = t₁} {t₂ = t₂} f = isoToEquiv (iso φ ψ η ε)
+   where
+    φ : (equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂)) → (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂)
+    φ p = (λ i → (p i) .fst) , (λ i → (p i) .snd)
+    
+    ψ : (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂) → (equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂))
+    ψ (p , q) i = (p i) , (q i)
+    
+    η : section φ ψ
+    η (p , q) = refl
+    
+    ε : retract φ ψ
+    ε p = refl
+
+join-SNS' : (S₁ : Type ℓ₁ → Type ℓ₂)
+            (ι₁ : (A B : Σ[ X ∈ (Type ℓ₁) ] (S₁ X)) → ((A .fst) ≃ (B .fst)) → Type ℓ₃)
+            (θ₁ : SNS' S₁ ι₁)
+            (S₂ : Type ℓ₁ → Type ℓ₄)
+            (ι₂ : (A B : Σ[ X ∈ (Type ℓ₁) ] (S₂ X)) → ((A .fst) ≃ (B .fst)) → Type ℓ₅)
+            (θ₂ : SNS' S₂ ι₂)
+           → SNS' (join-structure S₁ S₂) (join-iso ι₁ ι₂)
+join-SNS' S₁ ι₁ θ₁ S₂ ι₂ θ₂ (X , s₁ , s₂) (Y , t₁ , t₂) f =
+ 
+  equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂) ≃⟨ join-⋆-lemma S₁ S₂ f ⟩
+  (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂)   ≃⟨ technical-×-lemma (θ₁ (X , s₁) (Y , t₁) f) (θ₂ (X , s₂) (Y , t₂) f)  ⟩
+  (join-iso ι₁ ι₂) (X , s₁ , s₂) (Y , t₁ , t₂) f              ■
+
+
+
+
+-- Now, we want to do Monoids as an example. We begin by showing SNS' for simple structures, i.e. pointed types and ∞-magmas.
+-- Pointed types with SNS'
+pointed-structure : Type ℓ → Type ℓ
+pointed-structure X = X
+
+Pointed-Type : Type (ℓ-suc ℓ)
+Pointed-Type {ℓ = ℓ} = Σ (Type ℓ) pointed-structure
+
+pointed-iso : (A B : Pointed-Type) → (A .fst) ≃ (B .fst) → Type ℓ
+pointed-iso A B f = (equivFun f) (A .snd) ≡ (B .snd)
+
+pointed-is-SNS' : SNS' {ℓ = ℓ} pointed-structure pointed-iso
+pointed-is-SNS' A B f = transportEquiv (λ i → transportRefl (equivFun f (A .snd)) i ≡ B .snd)
+
+
+-- ∞-Magmas with SNS'
+-- We need function extensionality for binary functions. This should be done in a separate file maybe.
+funExtBin : {A : Type ℓ} {B : A → Type ℓ'} {C : (x : A) → B x → Type ℓ''} {f g : (x : A) → (y : B x) → C x y}
+           → ((x : A) (y : B x) → f x y ≡ g x y) → f ≡ g
+funExtBin p i x y = p x y i
+module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : (x : A) → B x → Type ℓ''} {f g : (x : A) → (y : B x) → C x y} where
+  private
+    appl : f ≡ g → ∀ x y → f x y ≡ g x y
+    appl eq x y i = eq i x y
+
+    fib : (p : f ≡ g) → fiber funExtBin p
+    fib p = (appl p , refl)
+
+    funExtBin-fiber-isContr
+      : (p : f ≡ g)
+      → (fi : fiber funExtBin p)
+      → fib p ≡ fi
+    funExtBin-fiber-isContr p (h , eq) i = (appl (eq (~ i)) , λ j → eq (~ i ∨ j))
+
+  funExtBin-isEquiv : isEquiv funExtBin
+  equiv-proof funExtBin-isEquiv p = (fib p , funExtBin-fiber-isContr p)
+
+  funExtBinEquiv : (∀ x y → f x y ≡ g x y) ≃ (f ≡ g)
+  funExtBinEquiv = (funExtBin , funExtBin-isEquiv)
+
+-- ∞-Magmas
+∞-magma-structure : Type ℓ → Type ℓ
+∞-magma-structure X = X → X → X
+
+∞-Magma : Type (ℓ-suc ℓ)
+∞-Magma {ℓ = ℓ} = Σ (Type ℓ) ∞-magma-structure
+
+∞-magma-iso : (A B : ∞-Magma) → (A .fst) ≃ (B .fst) → Type ℓ
+∞-magma-iso (X , _·_) (Y , _∗_) f = (x x' : X) → equivFun f (x · x') ≡ (equivFun f x) ∗ (equivFun f x')
+
+∞-magma-is-SNS' : SNS' {ℓ = ℓ} ∞-magma-structure ∞-magma-iso
+∞-magma-is-SNS' (X , _·_) (Y , _∗_) f = SNS→SNS' ∞-magma-structure ∞-magma-iso C (X , _·_) (Y , _∗_) f
+ where 
+  C : {X : Type ℓ} (_·_ _∗_ : X → X → X) → (_·_ ≡ _∗_) ≃ ((x x' : X) → (x · x') ≡ (x ∗ x'))
+  C _·_ _∗_ = invEquiv funExtBinEquiv
+
+
+
+-- Now we're getting serious: Monoids
+monoid-structure : Type ℓ → Type ℓ
+monoid-structure X = X × (X → X → X)
+
+monoid-axioms : (X : Type ℓ) → monoid-structure X → Type ℓ
+monoid-axioms X (e , _·_ ) = isSet X
+                          × ((x y z : X) → (x · (y · z)) ≡ ((x · y) · z))
+                          × ((x : X) → (x · e) ≡ x)
+                          × ((x : X) → (e · x) ≡ x)
+
+monoid-iso : (M N : Σ (Type ℓ) monoid-structure) → (M .fst) ≃ (N .fst) → Type ℓ
+monoid-iso (M , e , _·_) (N , d , _∗_) f = (equivFun f e ≡ d)
+                        × ((x y : M) → equivFun f (x · y) ≡ (equivFun f x) ∗ (equivFun f y))
+
+-- If we ignore the axioms we something like a "raw" monoid, which essentially is the join of a pointed type and an ∞-magma
+Raw-Monoid-SNS' : SNS' {ℓ = ℓ} monoid-structure monoid-iso
+Raw-Monoid-SNS' = join-SNS' pointed-structure pointed-iso pointed-is-SNS' ∞-magma-structure ∞-magma-iso ∞-magma-is-SNS'
+
+Monoid : Type (ℓ-suc ℓ)
+Monoid {ℓ = ℓ} = Σ (Type ℓ) (λ X → Σ (monoid-structure X) (λ s → monoid-axioms X s))
+-- TODO: show that the monoid axioms are propositions...

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -114,7 +114,7 @@ S ⋆ f = pathToEquiv (cong S (ua f))
 PathP-⋆-lemma : (S : Type ℓ → Type ℓ') (A B : Σ[ X ∈ (Type ℓ) ] (S X)) (f : (A .fst) ≃ (B .fst))
     → (PathP (λ i →  ua (S ⋆ f) i) (A .snd) (B .snd)) ≡ (PathP (λ i → S ((ua f) i)) (A .snd) (B .snd))
 PathP-⋆-lemma S A B f i = PathP (λ j → (⋆-char S (A .fst) (B .fst) f) i j) (A .snd) (B .snd)
-     
+
 
 
 
@@ -160,7 +160,7 @@ SNS→SNS' {ℓ = ℓ} {ℓ' = ℓ'} {ℓ'' = ℓ''} S ι θ A B f = (EquivJ P C
 
    C : (X : Type ℓ) → (s t : S X) → ((equivFun (S ⋆ (idEquiv X))) t ≡ s) ≃ (ι (X , t) (X , s) (idEquiv X))
    C X s t = subst (λ u →  (u ≡ s) ≃ (ι (X , t) (X , s) (idEquiv X)))
-                   (sym ( cong (λ f → (equivFun f) t) (⋆-idEquiv S X))) (θ t s) 
+                   (sym ( cong (λ f → (equivFun f) t) (⋆-idEquiv S X))) (θ t s)
 
 
 
@@ -181,7 +181,7 @@ SNS''→SNS''' : (S : Type ℓ → Type ℓ')
              → SNS''' S ι
 SNS''→SNS''' S ι h A B f =   PathP (λ i → S (ua f i)) (A .snd) (B .snd)
                           ≃⟨ PathP≃Path (λ i → S (ua f i)) (A .snd) (B .snd) ⟩
-                             h A B f 
+                             h A B f
 
 SNS'''→SNS'' : (S : Type ℓ → Type ℓ')
              → (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
@@ -336,18 +336,18 @@ add-⋆-lemma S axioms axioms-are-Props {Y = Y} {s = s} {t = t} {a = a} {b = b} 
       where
        φ : (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b)) → (equivFun (S ⋆ f) s ≡ t)
        φ r i = (r i) .fst
-       
+
        ψ : (equivFun (S ⋆ f) s ≡ t) → (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) ≡ (t , b))
        ψ p i = p i , isProp-PathP-I (λ j → axioms-are-Props Y (p j)) (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) .snd) b i
-       
+
        η : section φ ψ
        η p = refl
-       
+
        ε : retract φ ψ
        ε r i j = r j .fst , isProp→isSet-PathP (λ k → axioms-are-Props Y (r k .fst)) _ _
                   (λ k → isProp-PathP-I (λ j → axioms-are-Props Y (r j .fst)) (equivFun ((add-to-structure S axioms) ⋆ f) (s , a) .snd) b k)
                   (λ k → (r k) .snd) i j
- 
+
 
 add-axioms-SNS' : (S : Type ℓ → Type ℓ')
                   (ι : (A B : Σ[ X ∈ (Type ℓ) ] (S X)) → ((A .fst) ≃ (B .fst)) → Type ℓ'')
@@ -370,13 +370,13 @@ technical-×-lemma {A = A} {B = B} {C = C} {D = D} f g = isoToEquiv (iso φ ψ �
  where
   φ : (A × B) → (C × D)
   φ (a , b) = equivFun f a , equivFun g b
-  
+
   ψ : (C × D) → (A × B)
   ψ (c , d) = equivFun (invEquiv f) c , equivFun (invEquiv g) d
 
   η : section φ ψ
   η (c , d) i = retEq f c i , retEq g d i
-  
+
   ε : retract φ ψ
   ε (a , b) i = secEq f a i , secEq g b i
 
@@ -401,13 +401,13 @@ join-⋆-lemma S₁ S₂ {Y = Y} {s₁ = s₁} {s₂ = s₂} {t₁ = t₁} {t₂
    where
     φ : (equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂)) → (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂)
     φ p = (λ i → (p i) .fst) , (λ i → (p i) .snd)
-    
+
     ψ : (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂) → (equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂))
     ψ (p , q) i = (p i) , (q i)
-    
+
     η : section φ ψ
     η (p , q) = refl
-    
+
     ε : retract φ ψ
     ε p = refl
 
@@ -419,7 +419,7 @@ join-SNS' : (S₁ : Type ℓ₁ → Type ℓ₂)
             (θ₂ : SNS' S₂ ι₂)
            → SNS' (join-structure S₁ S₂) (join-iso ι₁ ι₂)
 join-SNS' S₁ ι₁ θ₁ S₂ ι₂ θ₂ (X , s₁ , s₂) (Y , t₁ , t₂) f =
- 
+
   equivFun ((join-structure S₁ S₂) ⋆ f) (s₁ , s₂) ≡ (t₁ , t₂) ≃⟨ join-⋆-lemma S₁ S₂ f ⟩
   (equivFun (S₁ ⋆ f) s₁ ≡ t₁) × (equivFun (S₂ ⋆ f) s₂ ≡ t₂)   ≃⟨ technical-×-lemma (θ₁ (X , s₁) (Y , t₁) f) (θ₂ (X , s₂) (Y , t₂) f)  ⟩
   (join-iso ι₁ ι₂) (X , s₁ , s₂) (Y , t₁ , t₂) f              ■
@@ -479,7 +479,7 @@ module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : (x : A) → 
 
 ∞-magma-is-SNS' : SNS' {ℓ = ℓ} ∞-magma-structure ∞-magma-iso
 ∞-magma-is-SNS' (X , _·_) (Y , _∗_) f = SNS→SNS' ∞-magma-structure ∞-magma-iso C (X , _·_) (Y , _∗_) f
- where 
+ where
   C : {X : Type ℓ} (_·_ _∗_ : X → X → X) → (_·_ ≡ _∗_) ≃ ((x x' : X) → (x · x') ≡ (x ∗ x'))
   C _·_ _∗_ = invEquiv funExtBinEquiv
 


### PR DESCRIPTION
We give a cubical proof of the structure identity principle, as formulated in the lecture notes of Martin Escardó:

https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns

Hopefully, we can compute nice things with it. A first rather straightforward implementation of the original proof can be found in the Experiments folder in the file EscardoSIP, a more direct proof using more cubical methods is in the SIP file in the Foundations folder. This file also contains monoids as an example application.