### PR TITLE
removed unusable instance

### DIFF
--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -269,7 +269,7 @@ isProp→isSet h a b p q j i =
 -- Universe lifting
 
 record Lift {i j} (A : Type i) : Type (ℓ-max i j) where
-  instance constructor lift
+  constructor lift
   field
     lower : A
 


### PR DESCRIPTION
A recent update to agda means that this constructor gets a warning: 

> Instance declarations with explicit arguments are never considered
> by instance search, so making lift into an instance has no effect.
> when checking the definition of Lift

This pull request removes the instance.