### PR TITLE
Real projective spaces

### DIFF
--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -6,6 +6,7 @@ open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Empty
+open import Cubical.Data.Sum
 
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq
@@ -32,6 +33,11 @@ false and true  = false
 true  and false = false
 true  and true  = true
 
+-- xor / mod-2 addition
+_⊕_ : Bool → Bool → Bool
+false ⊕ x = x
+true  ⊕ x = not x
+
 caseBool : ∀ {ℓ} → {A : Type ℓ} → (a0 aS : A) → Bool → A
 caseBool att aff true  = att
 caseBool att aff false = aff
@@ -45,3 +51,7 @@ true  ≟ true  = yes refl
 Dec→Bool : ∀ {ℓ} {A : Type ℓ} → Dec A → Bool
 Dec→Bool (yes p) = true
 Dec→Bool (no ¬p) = false
+
+dichotomyBool : (x : Bool) → (x ≡ true) ⊎ (x ≡ false)
+dichotomyBool true  = inl refl
+dichotomyBool false = inr refl

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -45,6 +45,10 @@ true≢false p = subst (caseBool Bool ⊥) p true
 false≢true : ¬ false ≡ true
 false≢true p = subst (caseBool ⊥ Bool) p true
 
+not≢const : ∀ x → ¬ not x ≡ x
+not≢const false = true≢false
+not≢const true  = false≢true
+
 zeroˡ : ∀ x → true or x ≡ true
 zeroˡ false = refl
 zeroˡ true  = refl
@@ -85,3 +89,16 @@ or-assoc true y z  =
 or-idem      : ∀ x → x or x ≡ x
 or-idem false = refl
 or-idem true  = refl
+
+⊕-comm : ∀ x y → x ⊕ y ≡ y ⊕ x
+⊕-comm false false = refl
+⊕-comm false true  = refl
+⊕-comm true  false = refl
+⊕-comm true  true  = refl
+
+⊕-invol : ∀ x y → x ⊕ (x ⊕ y) ≡ y
+⊕-invol false x = refl
+⊕-invol true  x = notnot x
+
+isEquiv-⊕ : ∀ x → isEquiv (x ⊕_)
+isEquiv-⊕ x = isoToIsEquiv (iso _ (x ⊕_) (⊕-invol x) (⊕-invol x))

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -48,11 +48,17 @@ private
   testrefl = refl
 
 -- equivalence between the sigma-based definition and the inductive one
-A×B≡A×ΣB : A × B ≡ A ×Σ B
-A×B≡A×ΣB = isoToPath (iso (λ { (a , b) → (a , b)})
+A×B≃A×ΣB : A × B ≃ A ×Σ B
+A×B≃A×ΣB = isoToEquiv (iso (λ { (a , b) → (a , b)})
                           (λ { (a , b) → (a , b)})
                           (λ _ → refl)
                           (λ { (a , b) → refl }))
+
+A×B≡A×ΣB : A × B ≡ A ×Σ B
+A×B≡A×ΣB = ua A×B≃A×ΣB
+
+swapΣEquiv : (A : Type ℓ) (B : Type ℓ') → A ×Σ B ≃ B ×Σ A
+swapΣEquiv A B = compEquiv (compEquiv (invEquiv A×B≃A×ΣB) (swapEquiv A B)) A×B≃A×ΣB
 
 -- truncation for products
 isOfHLevelProd : (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -19,12 +19,14 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.CartesianKanOps
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq
+open import Cubical.Data.Unit.Base
 
 private
   variable
     ℓ : Level
     A : Type ℓ
-    B : (a : A) → Type ℓ
+    B B' : (a : A) → Type ℓ
+    C : (a : A) (b : B a) → Type ℓ
 
 
 ΣPathP : ∀ {x y}
@@ -143,3 +145,21 @@ discreteΣ {B = B} Adis Bdis (a0 , b0) (a1 , b1) = discreteΣ' (Adis a0 a1)
         ... | (yes q) = yes (transport (ua Σ≡) (refl , q))
         ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isSet Adis a0 a0 (cong fst r) refl) (cong snd r)))
     discreteΣ' (no ¬p) = no (λ r → ¬p (cong fst r))
+
+
+-- some easy-to-prove equivalences of sigmas
+
+ΣUnit : ∀ {ℓ} (A : Unit → Type ℓ) → Σ Unit A ≃ A tt
+ΣUnit A = isoToEquiv (iso snd (λ { x → (tt , x) }) (λ _ → refl) (λ _ → refl))
+
+assocΣ : (Σ[ (a , b) ∈ Σ A B ] C a b) ≃ (Σ[ a ∈ A ] Σ[ b ∈ B a ] C a b)
+assocΣ = isoToEquiv (iso (λ { ((x , y) , z) → (x , (y , z)) })
+                         (λ { (x , (y , z)) → ((x , y) , z) })
+                         (λ _ → refl) (λ _ → refl))
+
+congΣEquiv : (∀ a → B a ≃ B' a) → Σ A B ≃ Σ A B'
+congΣEquiv h =
+  isoToEquiv (iso (λ { (x , y)   → (x , equivFun (h x) y) })
+                  (λ { (x , y)   → (x , invEq    (h x) y) })
+                  (λ { (x , y) i → (x , retEq    (h x) y i) })
+                  (λ { (x , y) i → (x , secEq    (h x) y i) }))

--- a/Cubical/Foundations/Bundle.agda
+++ b/Cubical/Foundations/Bundle.agda
@@ -1,0 +1,26 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Bundle where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Structure
+
+open import Cubical.Structures.TypeEqvTo
+
+module _ {ℓb ℓf} {B : Type ℓb} {F : Type ℓf} {ℓ} where
+
+{-
+    A fiber bundle with base space B and fibers F is a map `p⁻¹ : B → TypeEqvTo F`
+     taking points in the base space to their respective fibers.
+
+    e.g. a double cover is a map `B → TypeEqvTo Bool`
+-}
+
+  Total : (p⁻¹ : B → TypeEqvTo ℓ F) → Type (ℓ-max ℓb ℓ)
+  Total p⁻¹ = Σ[ x ∈ B ] p⁻¹ x .fst
+
+  pr : (p⁻¹ : B → TypeEqvTo ℓ F) → Total p⁻¹ → B
+  pr p⁻¹ = fst
+
+  inc : (p⁻¹ : B → TypeEqvTo ℓ F) (x : B) → p⁻¹ x .fst → Total p⁻¹
+  inc p⁻¹ x = (x ,_)

--- a/Cubical/Foundations/Bundle.agda
+++ b/Cubical/Foundations/Bundle.agda
@@ -2,7 +2,9 @@
 module Cubical.Foundations.Bundle where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Structure
 
 open import Cubical.Structures.TypeEqvTo
@@ -24,3 +26,30 @@ module _ {ℓb ℓf} {B : Type ℓb} {F : Type ℓf} {ℓ} where
 
   inc : (p⁻¹ : B → TypeEqvTo ℓ F) (x : B) → p⁻¹ x .fst → Total p⁻¹
   inc p⁻¹ x = (x ,_)
+
+  module FibPrIso (p⁻¹ : B → TypeEqvTo ℓ F) (x : B) where
+
+    fwd : fiber (pr p⁻¹) x → typ (p⁻¹ x)
+    fwd ((x' , y) , p) = subst (λ z → typ (p⁻¹ z)) p y
+
+    bwd : typ (p⁻¹ x) → fiber (pr p⁻¹) x
+    bwd y = (x , y) , refl
+
+    fwd-bwd : ∀ x → fwd (bwd x) ≡ x
+    fwd-bwd y = transportRefl y
+
+    bwd-fwd : ∀ x → bwd (fwd x) ≡ x
+    bwd-fwd ((x' , y) , p) i = h (q i)
+      where h : Σ[ s ∈ singl x ] typ (p⁻¹ (s .fst)) → fiber (pr p⁻¹) x
+            h ((x , p) , y) = (x , y) , sym p
+            q : Path (Σ[ s ∈ singl x ] typ (p⁻¹ (s .fst)))
+                     ((x  , refl ) , subst (λ z → typ (p⁻¹ z)) p y)
+                     ((x' , sym p) , y                            )
+            q i = (contrSingl (sym p) i) , toPathP {A = λ i → typ (p⁻¹ (p (~ i)))}
+                                           (transport⁻Transport (λ i → typ (p⁻¹ (p i))) y) i
+
+    isom : Iso (fiber (pr p⁻¹) x) (typ (p⁻¹ x))
+    isom = iso fwd bwd fwd-bwd bwd-fwd
+
+  fibPrEquiv : (p⁻¹ : B → TypeEqvTo ℓ F) (x : B) → fiber (pr p⁻¹) x ≃ p⁻¹ x .fst
+  fibPrEquiv p⁻¹ x = isoToEquiv (FibPrIso.isom p⁻¹ x)

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -142,6 +142,9 @@ Hfa≡fHa {A = A} f H a =
   cong f (H a) ∙ refl              ≡⟨ sym (rUnit _) ⟩
   cong f (H a) ∎
 
+invEq≡→equivFun≡ : ∀ (e : A ≃ B) {x y} → invEq e x ≡ y → equivFun e y ≡ x
+invEq≡→equivFun≡ e {x} p = cong (equivFun e) (sym p) ∙ retEq e x
+
 equivPi
   : ∀{F : A → Set ℓ} {G : A → Set ℓ'}
   → ((x : A) → F x ≃ G x) → (((x : A) → F x) ≃ ((x : A) → G x))

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -48,6 +48,7 @@ open import Cubical.Foundations.GroupoidLaws public
 open import Cubical.Foundations.Isomorphism public
 open import Cubical.Foundations.Surjection public
 open import Cubical.Foundations.TotalFiber public
+open import Cubical.Foundations.Bundle public
 open import Cubical.Foundations.Logic
 open import Cubical.Foundations.SIP
 open import Cubical.Foundations.HoTT-UF

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -20,6 +20,7 @@ open import Cubical.Relation.Nullary
 
 open import Cubical.Foundations.Pointed.Base
 open import Cubical.Foundations.Pointed.Properties
+open import Cubical.Structures.Pointed
 
 isHomogeneous : ∀ {ℓ} → Pointed ℓ → Type (ℓ-suc ℓ)
 isHomogeneous {ℓ} (A , x) = ∀ y → Path (Pointed ℓ) (A , x) (A , y)
@@ -34,8 +35,8 @@ isHomogeneousProd : ∀ {ℓ ℓ'} {A∙ : Pointed ℓ} {B∙ : Pointed ℓ'}
 isHomogeneousProd hA hB (a , b) i = (typ (hA a i)) × (typ (hB b i)) , (pt (hA a i) , pt (hB b i))
 
 isHomogeneousPath : ∀ {ℓ} (A : Type ℓ) {x y : A} (p : x ≡ y) → isHomogeneous ((x ≡ y) , p)
-isHomogeneousPath A {x} {y} p q i
-  = ua eqv i , ua-gluePath eqv (compPathr-cancel p q) i
+isHomogeneousPath A {x} {y} p q
+  = pointed-sip ((x ≡ y) , p) ((x ≡ y) , q) (eqv , compPathr-cancel p q)
   where eqv : (x ≡ y) ≃ (x ≡ y)
         eqv = ((q ∙ sym p) ∙_) , compPathl-isEquiv (q ∙ sym p)
 
@@ -77,6 +78,6 @@ module HomogeneousDiscrete {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙))
   switch-eqv = isoToEquiv (iso switch switch switch-idp switch-idp)
 
 isHomogeneousDiscrete : ∀ {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙)) → isHomogeneous A∙
-isHomogeneousDiscrete {ℓ} {A∙} dA y i
-  = ua switch-eqv i , ua-gluePath switch-eqv switch-ptA∙ i
+isHomogeneousDiscrete {ℓ} {A∙} dA y
+  = pointed-sip (typ A∙ , pt A∙) (typ A∙ , y) (switch-eqv , switch-ptA∙)
   where open HomogeneousDiscrete {ℓ} {A∙} dA y

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -186,6 +186,14 @@ isProp A = (x y : A) → x ≡ y
 isSet : Type ℓ → Type ℓ
 isSet A = (x y : A) → isProp (x ≡ y)
 
+SquareP :
+  (A : I → I → Type ℓ)
+  {a₀₀ : A i0 i0} {a₀₁ : A i0 i1} (a₀₋ : PathP (λ j → A i0 j) a₀₀ a₀₁)
+  {a₁₀ : A i1 i0} {a₁₁ : A i1 i1} (a₁₋ : PathP (λ j → A i1 j) a₁₀ a₁₁)
+  (a₋₀ : PathP (λ i → A i i0) a₀₀ a₁₀) (a₋₁ : PathP (λ i → A i i1) a₀₁ a₁₁)
+  → Type ℓ
+SquareP A a₀₋ a₁₋ a₋₀ a₋₁ = PathP (λ i → PathP (λ j → A i j) (a₋₀ i) (a₋₁ i)) a₀₋ a₁₋
+
 Square :
   {a₀₀ a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁)
   {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)

--- a/Cubical/Foundations/TotalFiber.agda
+++ b/Cubical/Foundations/TotalFiber.agda
@@ -57,9 +57,9 @@ module _ {A : Type ℓ} {B : Type ℓ'} (f : A → B) where
     LiftA→Total-fiber→LiftA)
 
   -- HoTT Lemma 4.8.2
-  A≃Total : Lift A ≃ Total-fiber
+  A≃Total : A ≃ Total-fiber
   A≃Total = isoToEquiv (iso
-    LiftA→Total-fiber
-    Total-fiber→LiftA
-    Total-fiber→LiftA→Total-fiber
-    LiftA→Total-fiber→LiftA)
+    A→Total-fiber
+    Total-fiber→A
+    Total-fiber→A→Total-fiber
+    (λ _ → refl))

--- a/Cubical/HITs/Everything.agda
+++ b/Cubical/HITs/Everything.agda
@@ -27,6 +27,7 @@ import Cubical.HITs.2GroupoidTruncation
 import Cubical.HITs.SetQuotients
 import Cubical.HITs.FiniteMultiset
 import Cubical.HITs.Sn
+import Cubical.HITs.RPn
 import Cubical.HITs.Truncation
 import Cubical.HITs.Colimit
 import Cubical.HITs.MappingCones

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -39,7 +39,7 @@ joinPushout-iso-join A B = iso joinPushout→join join→joinPushout join→join
     joinPushout→join : joinPushout A B → join A B
     joinPushout→join (inl x) = inl x
     joinPushout→join (inr x) = inr x
-    joinPushout→join (push y i) = push (proj₁ y) (proj₂ y) i
+    joinPushout→join (push x i) = push (proj₁ x) (proj₂ x) i
 
     join→joinPushout : join A B → joinPushout A B
     join→joinPushout (inl x) = inl x

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Unit
 
-open import Cubical.HITs.Susp
+open import Cubical.HITs.Susp.Base
 
 data Pushout {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
              (f : A → B) (g : A → C) : Type (ℓ-max ℓ (ℓ-max ℓ' ℓ'')) where

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -1,0 +1,78 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Pushout.Flattening where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+
+open import Cubical.Data.Sigma
+
+open import Cubical.HITs.Pushout.Base
+
+module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Type ℓc} (f : A → B) (g : A → C)
+                       {ℓ} (F : B → Type ℓ) (G : C → Type ℓ) (e : ∀ a → F (f a) ≃ G (g a)) where
+
+  E : Pushout f g → Type ℓ
+  E (inl x) = F x
+  E (inr x) = G x
+  E (push a i) = ua (e a) i
+
+  Σf : Σ[ a ∈ A ] F (f a) → Σ[ b ∈ B ] F b
+  Σf (a , x) = (f a , x)
+
+  Σg : Σ[ a ∈ A ] F (f a) → Σ[ c ∈ C ] G c
+  Σg (a , x) = (g a , (e a) .fst x)
+
+  module FlattenIso where
+
+    fwd : Σ (Pushout f g) E → Pushout Σf Σg
+    fwd (inl b , x) = inl (b , x)
+    fwd (inr c , x) = inr (c , x)
+    fwd (push a i , x) = hcomp (λ j → λ { (i = i0) → push (a , x) (~ j)
+                                        ; (i = i1) → inr (g a , x) })
+                               (inr (g a , unglue (i ∨ ~ i) x))
+
+    bwd : Pushout Σf Σg → Σ (Pushout f g) E
+    bwd (inl (b , x)) = (inl b , x)
+    bwd (inr (c , x)) = (inr c , x)
+    bwd (push (a , x) i) = (push a i , ua-gluePath (e a) {x = x} refl i)
+
+    -- this case follows trivially due to the definitional equalities below
+    fwd-bwd : ∀ x → fwd (bwd x) ≡ x
+    fwd-bwd (inl (b , x)) = refl
+    fwd-bwd (inr (c , x)) = refl
+    fwd-bwd (push (a , x) i) j =
+      hcomp (λ k → λ { (i = i0) → push (a , x) (~ k)       -- ua-gluePath (e a) {x = x} refl i0 := x
+                     ; (i = i1) → inr (g a , (e a) .fst x) -- ua-gluePath (e a) {x = x} refl i1 := (e a) .fst x
+                     ; (j = i1) → push (a , x) (i ∨ ~ k) })
+            (inr (g a , (e a) .fst x)) -- unglue (i ∨ ~ i) (ua-gluePath (e a) {x = x} refl i) := (e a) .fst x
+
+    sq : ∀ a → SquareP (λ i j → ua (e a) i → ua (e a) (i ∨ ~ j))
+          {- i = i0 -} (λ j x → glue (λ { ((~ j) = i0) → x ; ((~ j) = i1) → (e a) .fst x }) ((e a) .fst x))
+          {- i = i1 -} (λ j x → x)
+          {- j = i0 -} (λ i x → unglue (i ∨ ~ i) x)
+          {- j = i1 -} (λ i x → x)
+    sq a i j x = glue {φ = (i ∨ ~ j) ∨ ~ (i ∨ ~ j)}
+                      (λ { ((i ∨ ~ j) = i0) → x
+                         ;     ((~ j) = i1) → unglue (i ∨ ~ i) x
+                         ;         (i = i1) → x })
+                      (unglue (i ∨ ~ i) x)
+
+    bwd-fwd : ∀ x → bwd (fwd x) ≡ x
+    bwd-fwd (inl b , x) = refl
+    bwd-fwd (inr c , x) = refl
+    bwd-fwd (push a i , x) j =
+      hcomp (λ k → λ { (i = i0) → transp (λ _ → Σ (Pushout f g) E) (k ∨ j)
+                                         (push a (~ (k ∨ j)) , ua-gluePath (e a) {x = x} refl (~ (k ∨ j)))
+                     ; (i = i1) → transp (λ _ → Σ (Pushout f g) E) (k ∨ j)
+                                         (inr (g a) , x)
+                     ; (j = i1) → push a i , x })
+            (transp (λ _ → Σ (Pushout f g) E) j (push a (i ∨ ~ j) , sq a i j x))
+
+    isom : Iso (Σ (Pushout f g) E) (Pushout Σf Σg)
+    isom = iso fwd bwd fwd-bwd bwd-fwd
+
+  flatten : Σ (Pushout f g) E ≃ Pushout Σf Σg
+  flatten = isoToEquiv FlattenIso.isom

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -57,19 +57,21 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
                      ; (j = i1) → push (a , x) (i ∨ ~ k) })
             (inr (g a , ua-unglue (e a) i (ua-gluePt (e a) i x)))
       -- Note: the (j = i1) case typechecks because of the definitional equalities:
-      --  ua-gluePt e i0 x ≡ x, ua-gluePt e i1 x ≡ e .fst x,
-      --  ua-unglue e i (ua-gluePt e i x) ≡ e .fst x
+      --  ua-gluePt e i0 x ≡ x , ua-gluePt e i1 x ≡ e .fst x,
+      --  ua-unglue-glue : ua-unglue e i (ua-gluePt e i x) ≡ e .fst x
 
-    sq : ∀ a → SquareP (λ i k → ua (e a) i → ua (e a) (i ∨ k))
-          {- i = i0 -} (λ k x → glue (λ { (k = i0) → x ; (k = i1) → (e a) .fst x }) ((e a) .fst x))
-          {- i = i1 -} (λ k x → x)
-          {- k = i0 -} (λ i x → x {- ≡ glue (λ { (i = i0) → x ; (i = i1) → x }) (unglue (i ∨ ~ i) x) -})
-          {- k = i1 -} (λ i x → unglue (i ∨ ~ i) x)
-    sq a i k x = glue {φ = (i ∨ k) ∨ ~ (i ∨ k)}
-                      (λ { (i ∨ k = i0) → x
-                         ;     (k = i1) → unglue (i ∨ ~ i) x
-                         ;     (i = i1) → x })
-                      (unglue (i ∨ ~ i) x)
+    -- essentially: ua-glue e (i ∨ ~ k) ∘ ua-unglue e i
+    sq : ∀ {ℓ} {A B : Type ℓ} (e : A ≃ B)
+         → SquareP (λ i k → ua e i → ua e (i ∨ ~ k))
+      {- i = i0 -} (λ k x → ua-gluePt e (~ k) x)
+      {- i = i1 -} (λ k x → x)
+      {- k = i0 -} (λ i x → ua-unglue e i x)
+      {- k = i1 -} (λ i x → x)
+    sq e i k x = ua-glue e (i ∨ ~ k) (λ { ((i ∨ ~ k) = i0) → x })
+                                     (inS (ua-unglue e i x))
+      -- Note: this typechecks because of the definitional equalities:
+      --  ua-unglue e i0 x ≡ e .fst x, ua-glue e i1 _ (inS y) ≡ y, ua-unglue e i1 x ≡ x,
+      --  ua-glue-unglue : ua-glue e i (λ { (i = i0) → x }) (inS (ua-unglue e i x)) ≡ x
 
     fwd-bwd : ∀ x → fwd (bwd x) ≡ x
     fwd-bwd (inl b , x) = refl
@@ -79,7 +81,7 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
       comp (λ _ → Σ (Pushout f g) E)
            (λ k → λ { (i = i0) → push a (~ k) , ua-gluePt (e a) (~ k) x
                     ; (i = i1) → inr (g a) , x
-                    ; (j = i1) → push a (i ∨ ~ k) , sq a i (~ k) x })
+                    ; (j = i1) → push a (i ∨ ~ k) , sq (e a) i k x })
             (inr (g a) , ua-unglue (e a) i x)
 
     isom : Iso (Σ (Pushout f g) E) (Pushout Σf Σg)

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -37,6 +37,9 @@ record 3-span : Type₁ where
     f1 : A2 → A0
     f3 : A2 → A4
 
+3span : {A0 A2 A4 : Type₀} → (A2 → A0) → (A2 → A4) → 3-span
+3span f1 f3 = record { f1 = f1 ; f3 = f3 }
+
 spanPushout : (s : 3-span) → Type₀
 spanPushout s = Pushout (3-span.f1 s) (3-span.f3 s)
 

--- a/Cubical/HITs/RPn.agda
+++ b/Cubical/HITs/RPn.agda
@@ -1,0 +1,4 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.RPn where
+
+open import Cubical.HITs.RPn.Base public

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -276,6 +276,18 @@ TotalCov≃Sn (ℕ→ℕ₋₁ n) =
           Susp (Total (cov⁻¹ (-1+ n)))      ≃⟨ cong≃ Susp (TotalCov≃Sn (-1+ n)) ⟩
           S (ℕ→ℕ₋₁ n)                      ■
 
+-- the usual covering map S n → RP n, with fibers exactly cov⁻¹
+
+cov : (n : ℕ₋₁) → S n → RP n
+cov n = pr (cov⁻¹ n) ∘ invEq (TotalCov≃Sn n)
+
+fibcov≡cov⁻¹ : ∀ n (x : RP n) → fiber (cov n) x ≡ cov⁻¹ n x .fst
+fibcov≡cov⁻¹ n x =
+  fiber (cov n)        x ≡[ i ]⟨ fiber {A = ua e i} (pr (cov⁻¹ n) ∘ ua-unglue e i) x ⟩
+  fiber (pr (cov⁻¹ n)) x ≡⟨ ua (fibPrEquiv (cov⁻¹ n) x) ⟩
+  cov⁻¹ n x .fst         ∎
+  where e = invEquiv (TotalCov≃Sn n)
+
 
 --------------------------------------------------------------------------------
 

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -2,8 +2,8 @@
 
    A defintion of the real projective spaces following:
 
-    U. Buchholtz, E. Rijke, The real projective spaces in homotopy type theory.
-     (2017) https://arxiv.org/abs/1704.05770
+   [BR17] U. Buchholtz, E. Rijke, The real projective spaces in homotopy type theory.
+           (2017) https://arxiv.org/abs/1704.05770
 
 -}
 {-# OPTIONS --cubical --safe #-}
@@ -44,6 +44,8 @@ private
   variable
     ℓ ℓ' ℓ'' : Level
 
+-- Definition II.1 in [BR17], see also Cubical.Foundations.Bundle
+
 2-EltType₀    = TypeEqvTo    ℓ-zero Bool -- Σ[ X ∈ Type₀ ] ∥ X ≃ Bool ∥
 2-EltPointed₀ = PointedEqvTo ℓ-zero Bool -- Σ[ X ∈ Type₀ ] X × ∥ X ≃ Bool ∥
 
@@ -51,8 +53,13 @@ Bool* : 2-EltType₀
 Bool* = Bool , ∣ idEquiv _ ∣
 
 
--- Our first goal is to lift `_⊕_ : Bool → Bool ≃ Bool` to a function `_⊕_ : A → A ≃ Bool`
+-- Our first goal is to 'lift' `_⊕_ : Bool → Bool ≃ Bool` to a function `_⊕_ : A → A ≃ Bool`
 --  for any 2-element type (A, ∣e∣).
+
+-- `isContr-BoolPointedIso` and `isContr-2-EltPointed-iso` are contained in the proof
+--  of Lemma II.2 in [BR17], though we prove `isContr-BoolPointedIso` more directly
+--  with ⊕ -- [BR17] proves it for just the x = false case and uses notEquiv to get
+--  the x = true case.
 
 -- (λ y → x ⊕ y) is the unqiue pointed isomorphism (Bool , false) ≃ (Bool , x)
 isContr-BoolPointedIso : ∀ x → isContr ((Bool , false) ≃[ pointed-iso ] (Bool , x))
@@ -77,8 +84,9 @@ isContr-2-EltPointed-iso (X , x , ∣e∣)
                            (isContr-BoolPointedIso (e .fst x))
                            (sym (pointed-sip _ _ (e , refl))))
                   ∣e∣
-
--- This unique isomorphism must be _⊕_ 'lifted' to X
+                  
+-- This unique isomorphism must be _⊕_ 'lifted' to X. This idea is alluded to at the end of the
+--  proof of Theorem III.4 in [BR17], where the authors reference needing ⊕-comm.
 module ⊕* (X : 2-EltType₀) where
 
   _⊕*_ : typ X → typ X → Bool
@@ -93,7 +101,7 @@ module ⊕* (X : 2-EltType₀) where
   Equivʳ y = (y ⊕*_) , isEquivʳ y
 
   -- any mere proposition that holds for (Bool, _⊕_) holds for (typ X, _⊕*_)
-  -- this ammounts to just carefully unfolding the PropTrunc.elim and J in isContr-2-EltPointed-iso
+  -- this amounts to just carefully unfolding the PropTrunc.elim and J in isContr-2-EltPointed-iso
   elim : ∀ {ℓ'} (P : (A : Type₀) (_⊕'_ : A → A → Bool) → Type ℓ') (propP : ∀ A _⊕'_ → isProp (P A _⊕'_))
          → P Bool _⊕_ → P (typ X) _⊕*_
   elim {ℓ'} P propP r = PropTrunc.elim {P = λ ∣e∣ → P (typ X) (R₁ ∣e∣)} (λ _ → propP _ _)
@@ -119,7 +127,8 @@ module ⊕* (X : 2-EltType₀) where
   Equivˡ : typ X → typ X ≃ Bool
   Equivˡ y = (_⊕* y) , isEquivˡ y
 
--- the obvious consequence of isContr-2-EltPointed-iso, though it is not needed here
+-- Lemma II.2 in [BR17], though we do not use it here
+-- Note: Lemma II.3 is `pointed-sip`, used in `PointedEqvTo-sip`
 isContr-2-EltPointed : isContr (2-EltPointed₀)
 fst isContr-2-EltPointed = (Bool , false , ∣ idEquiv Bool ∣)
 snd isContr-2-EltPointed A∙ = PointedEqvTo-sip Bool _ A∙ (fst (isContr-2-EltPointed-iso A∙))
@@ -127,8 +136,8 @@ snd isContr-2-EltPointed A∙ = PointedEqvTo-sip Bool _ A∙ (fst (isContr-2-Elt
 
 --------------------------------------------------------------------------------
 
--- Now we mutually define RP n and its double cover, and show that the total
---  space of this double cover is S n.
+-- Now we mutually define RP n and its double cover (Definition III.1 in [BR17]),
+--  and show that the total space of this double cover is S n (Theorem III.4).
 
 RP  : ℕ₋₁ → Type₀
 cov⁻¹ : (n : ℕ₋₁) → RP n → 2-EltType₀ -- (see Cubical.Foundations.Bundle)
@@ -291,7 +300,7 @@ fibcov≡cov⁻¹ n x =
 
 --------------------------------------------------------------------------------
 
--- Finally, we state the trivial equivalences for RP 0 and RP 1
+-- Finally, we state the trivial equivalences for RP 0 and RP 1 (Example III.3 in [BR17])
 
 RP0≃Unit : RP 0 ≃ Unit
 RP0≃Unit = isoToEquiv (iso (λ _ → tt) (λ _ → inr tt) (λ _ → refl) (λ { (inr tt) → refl }))

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -1,0 +1,136 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.RPn.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Equiv
+
+open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
+
+open import Cubical.HITs.PropositionalTruncation as PropTrunc
+
+private
+  variable
+    ℓ ℓ' ℓ'' : Level
+
+-- Bundle : (F : Type ℓ) (E : Type ℓ') (B : Type ℓ'') → Type _
+-- Bundle F E B = Σ[ p ∈ (E → B) ] ∀ x → ∥ F ≃ fiber p x ∥
+
+TypeEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+TypeEqvTo ℓ X = TypeWithStr ℓ (λ Y → ∥ Y ≃ X ∥)
+
+PointedEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+PointedEqvTo ℓ X = TypeWithStr ℓ (λ Y → Y × ∥ Y ≃ X ∥)
+
+-- Bundle' : Type ℓ' → Type ℓ'' → (ℓ : Level) → Type (ℓ-max (ℓ-max ℓ' ℓ'') (ℓ-suc ℓ))
+-- Bundle' F X ℓ = X → TypeEqvTo ℓ F
+
+Total : ∀ {B : Type ℓ} {F : Type ℓ'} {ℓ''} → (B → TypeEqvTo ℓ'' F) → Type _
+Total {B = B} {F} p⁻¹ = Σ[ x ∈ B ] typ (p⁻¹ x)
+
+pr : ∀ {B : Type ℓ} {F : Type ℓ'} {ℓ''} (p⁻¹ : B → TypeEqvTo ℓ'' F) → Total p⁻¹ → B
+pr p⁻¹ = fst
+
+open import Cubical.Data.Bool
+open import Cubical.Data.Sigma.Properties
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.HLevels
+
+2-EltType : (ℓ : Level) → Type (ℓ-suc ℓ)
+2-EltType ℓ = TypeEqvTo ℓ Bool
+
+2-EltType₀ = 2-EltType ℓ-zero
+
+2-EltPointed : (ℓ : Level) → Type (ℓ-suc ℓ)
+2-EltPointed ℓ = PointedEqvTo ℓ Bool
+
+2-EltPointed₀ = 2-EltPointed ℓ-zero
+
+open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
+open import Cubical.Foundations.Pointed
+open import Cubical.Structures.Pointed
+
+2-EltPointed-structure : Type ℓ → Type ℓ
+2-EltPointed-structure = add-to-structure pointed-structure (λ Y _ → ∥ Y ≃ Bool ∥)
+
+2-EltPointed-iso : StrIso 2-EltPointed-structure ℓ''
+2-EltPointed-iso = add-to-iso pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ Bool ∥)
+
+2-EltPointed-SNS : SNS {ℓ} 2-EltPointed-structure 2-EltPointed-iso
+2-EltPointed-SNS = add-axioms-SNS pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ Bool ∥)
+                                  (λ _ _ → squash)
+                                  pointed-is-SNS
+
+2-EltPointed-SIP : (A B : 2-EltPointed ℓ) → A ≃[ 2-EltPointed-iso ] B ≃ (A ≡ B)
+2-EltPointed-SIP = SIP 2-EltPointed-structure 2-EltPointed-iso (SNS₂→SNS₄ 2-EltPointed-SNS)
+
+2-EltPointed-sip : (A B : 2-EltPointed ℓ) → A ≃[ 2-EltPointed-iso ] B → (A ≡ B)
+2-EltPointed-sip A B = equivFun (2-EltPointed-SIP A B)
+
+pointed-SIP : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B ≃ (A ≡ B)
+pointed-SIP = SIP pointed-structure pointed-iso (SNS₂→SNS₄ pointed-is-SNS)
+
+pointed-sip : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B → (A ≡ B)
+pointed-sip A B = equivFun (pointed-SIP A B)
+
+open import Cubical.Relation.Nullary
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Sum
+
+dichotomyBool : (x : Bool) → (x ≡ true) ⊎ (x ≡ false)
+dichotomyBool true  = inl refl
+dichotomyBool false = inr refl
+
+isContr-BoolPointedIso : ∀ x → isContr ((Bool , true) ≃[ pointed-iso ] (Bool , x))
+fst (isContr-BoolPointedIso true) = idEquiv _ , refl
+snd (isContr-BoolPointedIso true) (e , p)
+  = ΣProp≡ (λ e → isSetBool (equivFun e true) true)
+           {u = idEquiv _ , refl} {v = e , p}
+           (ΣProp≡ isPropIsEquiv λ { i true → p (~ i) ; i false → q (~ i) })
+  where q : equivFun e false ≡ false
+        q with dichotomyBool (invEq e false)
+        ... | (inr q) = cong (equivFun e) (sym q) ∙ retEq e false
+        ... | (inl q) = ⊥.rec (true≢false (sym p ∙ cong (equivFun e) (sym q) ∙ retEq e false))
+fst (isContr-BoolPointedIso false) = notEquiv , refl
+snd (isContr-BoolPointedIso false) (e , p)
+  = ΣProp≡ (λ e → isSetBool (equivFun e true) false)
+           {u = notEquiv , refl} {v = e , p}
+           (ΣProp≡ isPropIsEquiv λ { i true → p (~ i) ; i false → q (~ i) })
+  where q : equivFun e false ≡ true
+        q with dichotomyBool (invEq e true)
+        ... | (inr q) = cong (equivFun e) (sym q) ∙ retEq e true
+        ... | (inl q) = ⊥.rec (false≢true (sym p ∙ cong (equivFun e) (sym q) ∙ retEq e true))
+
+isContr-2-EltPointed-iso : (A∙ : 2-EltPointed₀)
+                         → isContr ((Bool , true , ∣ idEquiv Bool ∣) ≃[ 2-EltPointed-iso ] A∙)
+isContr-2-EltPointed-iso (A , x , ∣e∣)
+  = PropTrunc.rec isPropIsContr
+                  (λ e → J (λ A∙ _ → isContr ((Bool , true) ≃[ pointed-iso ] A∙))
+                           (isContr-BoolPointedIso (equivFun e x))
+                           (sym (pointed-sip _ _ (e , refl))))
+                  ∣e∣
+
+open import Cubical.Data.NatMinusOne
+open import Cubical.HITs.MappingCones
+
+RP  : ℕ₋₁ → Type₀
+cov⁻¹ : (n : ℕ₋₁) → RP n → 2-EltType₀
+
+RP neg1 = ⊥
+RP (ℕ→ℕ₋₁ n) = Cone (pr (cov⁻¹ (-1+ n)) {- : Total (cov⁻¹ (-1+ n)) → RP (-1+ n) -})
+
+cov⁻¹ neg1 x = Bool , ∣ idEquiv _ ∣
+cov⁻¹ (ℕ→ℕ₋₁ n) hub     = Bool , ∣ idEquiv _ ∣
+cov⁻¹ (ℕ→ℕ₋₁ n) (inj x) = cov⁻¹ (-1+ n) x
+cov⁻¹ (ℕ→ℕ₋₁ n) (spoke (x , y) i) = typ (eq i) , str (eq i) .snd
+  where eq : (Bool , true , ∣ idEquiv Bool ∣) ≡ (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))
+        eq = 2-EltPointed-sip _ _ (fst (isContr-2-EltPointed-iso (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))))
+
+open import Cubical.HITs.Susp
+open import Cubical.HITs.Sn
+open import Cubical.Foundations.Isomorphism
+
+thm : ∀ n → Total (cov⁻¹ n) ≡ S n
+thm neg1 = isoToPath (iso (λ { () }) (λ { () }) (λ { () }) (λ { () }))
+thm (ℕ→ℕ₋₁ n) = {!!} ∙ cong Susp (thm (-1+ n))

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -1,122 +1,62 @@
+{-
+
+   A defintion of the real projective spaces following:
+
+    U. Buchholtz, E. Rijke, The real projective spaces in homotopy type theory.
+     (2017) https://arxiv.org/abs/1704.05770
+
+-}
 {-# OPTIONS --cubical --safe #-}
 module Cubical.HITs.RPn.Base where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
-open import Cubical.Foundations.Structure
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Bundle
 
-open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Pointed
+open import Cubical.Structures.Pointed
+open import Cubical.Structures.TypeEqvTo
 
-open import Cubical.HITs.PropositionalTruncation as PropTrunc
+open import Cubical.Data.Bool
+open import Cubical.Data.Nat hiding (elim)
+open import Cubical.Data.NatMinusOne
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Data.Empty as ⊥ hiding (elim)
+open import Cubical.Data.Sum as ⊎ hiding (elim)
+
+open import Cubical.Data.Prod renaming (_×_ to _×'_; _×Σ_ to _×_; swapΣEquiv to swapEquiv)
+                              hiding (swapEquiv)
+
+open import Cubical.HITs.PropositionalTruncation as PropTrunc hiding (elim)
+open import Cubical.HITs.Sn
+open import Cubical.HITs.Susp
+open import Cubical.HITs.Join
+open import Cubical.HITs.Pushout
+open import Cubical.HITs.Pushout.Flattening
 
 private
   variable
     ℓ ℓ' ℓ'' : Level
 
--- Bundle : (F : Type ℓ) (E : Type ℓ') (B : Type ℓ'') → Type _
--- Bundle F E B = Σ[ p ∈ (E → B) ] ∀ x → ∥ F ≃ fiber p x ∥
+2-EltType₀    = TypeEqvTo    ℓ-zero Bool -- Σ[ X ∈ Type₀ ] ∥ X ≃ Bool ∥
+2-EltPointed₀ = PointedEqvTo ℓ-zero Bool -- Σ[ X ∈ Type₀ ] X × ∥ X ≃ Bool ∥
 
-TypeEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
-TypeEqvTo ℓ X = TypeWithStr ℓ (λ Y → ∥ Y ≃ X ∥)
+Bool* : 2-EltType₀
+Bool* = Bool , ∣ idEquiv _ ∣
 
-PointedEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
-PointedEqvTo ℓ X = TypeWithStr ℓ (λ Y → Y × ∥ Y ≃ X ∥)
 
--- Bundle' : Type ℓ' → Type ℓ'' → (ℓ : Level) → Type (ℓ-max (ℓ-max ℓ' ℓ'') (ℓ-suc ℓ))
--- Bundle' F X ℓ = X → TypeEqvTo ℓ F
+-- Our first goal is to lift `_⊕_ : Bool → Bool ≃ Bool` to a function `_⊕_ : A → A ≃ Bool`
+--  for any 2-element type (A, ∣e∣).
 
-Total : ∀ {B : Type ℓ} {F : Type ℓ'} {ℓ''} → (B → TypeEqvTo ℓ'' F) → Type _
-Total {B = B} {F} p⁻¹ = Σ[ x ∈ B ] typ (p⁻¹ x)
-
-pr : ∀ {B : Type ℓ} {F : Type ℓ'} {ℓ''} (p⁻¹ : B → TypeEqvTo ℓ'' F) → Total p⁻¹ → B
-pr p⁻¹ = fst
-
-open import Cubical.Data.Bool
-open import Cubical.Data.Sigma.Properties
-open import Cubical.Foundations.Univalence
-open import Cubical.Foundations.HLevels
-
-2-EltType : (ℓ : Level) → Type (ℓ-suc ℓ)
-2-EltType ℓ = TypeEqvTo ℓ Bool
-
-2-EltType₀ = 2-EltType ℓ-zero
-
-2-EltPointed : (ℓ : Level) → Type (ℓ-suc ℓ)
-2-EltPointed ℓ = PointedEqvTo ℓ Bool
-
-2-EltPointed₀ = 2-EltPointed ℓ-zero
-
-open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
-open import Cubical.Foundations.Pointed
-open import Cubical.Structures.Pointed
-
-2-EltPointed-structure : Type ℓ → Type ℓ
-2-EltPointed-structure = add-to-structure pointed-structure (λ Y _ → ∥ Y ≃ Bool ∥)
-
-2-EltPointed-iso : StrIso 2-EltPointed-structure ℓ''
-2-EltPointed-iso = add-to-iso pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ Bool ∥)
-
-2-EltPointed-SNS : SNS {ℓ} 2-EltPointed-structure 2-EltPointed-iso
-2-EltPointed-SNS = add-axioms-SNS pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ Bool ∥)
-                                  (λ _ _ → squash)
-                                  pointed-is-SNS
-
-2-EltPointed-SIP : (A B : 2-EltPointed ℓ) → A ≃[ 2-EltPointed-iso ] B ≃ (A ≡ B)
-2-EltPointed-SIP = SIP 2-EltPointed-structure 2-EltPointed-iso (SNS₂→SNS₄ 2-EltPointed-SNS)
-
-2-EltPointed-sip : (A B : 2-EltPointed ℓ) → A ≃[ 2-EltPointed-iso ] B → (A ≡ B)
-2-EltPointed-sip A B = equivFun (2-EltPointed-SIP A B)
-
-pointed-SIP : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B ≃ (A ≡ B)
-pointed-SIP = SIP pointed-structure pointed-iso (SNS₂→SNS₄ pointed-is-SNS)
-
-pointed-sip : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B → (A ≡ B)
-pointed-sip A B (e , p) i = ua e i , ua-gluePath e p i -- equivFun (pointed-SIP A B)
-
-open import Cubical.Relation.Nullary
-open import Cubical.Data.Empty as ⊥
-open import Cubical.Data.Sum
-
-dichotomyBool : (x : Bool) → (x ≡ true) ⊎ (x ≡ false)
-dichotomyBool true  = inl refl
-dichotomyBool false = inr refl
-
-_⊕_ : Bool → Bool → Bool
-false ⊕ x = x
-true  ⊕ x = not x
-
-⊕-invol : ∀ x y → x ⊕ (x ⊕ y) ≡ y
-⊕-invol false x = refl
-⊕-invol true  x = notnot x
-
-⊕-comm : ∀ x y → x ⊕ y ≡ y ⊕ x
-⊕-comm false false = refl
-⊕-comm false true  = refl
-⊕-comm true  false = refl
-⊕-comm true  true  = refl
-
-not≢const : ∀ x → ¬ not x ≡ x
-not≢const false = true≢false
-not≢const true  = false≢true
-
-open import Cubical.Foundations.Isomorphism
-
-isEquiv-⊕ : ∀ x → isEquiv (x ⊕_)
-isEquiv-⊕ x = isoToIsEquiv (iso _ (x ⊕_) (⊕-invol x) (⊕-invol x))
-
-invEq≡→equivFun≡ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) {x y} → invEq e x ≡ y → equivFun e y ≡ x
-invEq≡→equivFun≡ e {x} p = cong (equivFun e) (sym p) ∙ retEq e x
-
--- open import Cubical.Foundations.GroupoidLaws
-
--- wop : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) {x y} → (invEq e x ≡ y) ≃ (equivFun e y ≡ x)
--- wop e {x} {y} = isoToEquiv (iso (λ p → cong (equivFun e) (sym p) ∙ retEq e x)
---                                 (λ p → cong (invEq e) (sym p)    ∙ secEq e y)
---                                 (λ p → cong (_∙ retEq e x) {!!} ∙ {!!})
---                                 -- cong (equivFun e) (sym (cong (invEq e) (sym p) ∙ secEq e y)) ∙ retEq e x)
---                                 (λ p → {!!}))
-
+-- (λ y → x ⊕ y) is the unqiue pointed isomorphism (Bool , false) ≃ (Bool , x)
 isContr-BoolPointedIso : ∀ x → isContr ((Bool , false) ≃[ pointed-iso ] (Bool , x))
 fst (isContr-BoolPointedIso x) = ((λ y → x ⊕ y) , isEquiv-⊕ x) , ⊕-comm x false
 snd (isContr-BoolPointedIso x) (e , p)
@@ -128,200 +68,231 @@ snd (isContr-BoolPointedIso x) (e , p)
         ... | inl q = invEq≡→equivFun≡ e q
         ... | inr q = ⊥.rec (not≢const x (sym (invEq≡→equivFun≡ e q) ∙ p))
 
--- compPointedIso : ∀ {ℓ} {A : Pointed ℓ} {B : Pointed ℓ} {C : Pointed ℓ}
---                    (f : A ≃[ pointed-iso ] B) (g : B ≃[ pointed-iso ] C) → A ≃[ pointed-iso ] C
--- compPointedIso (f , p) (g , q) = compEquiv f g , cong (g .fst) p ∙ q
-
-                  -- (λ e →   compPointedIso (fst (isContr-BoolPointedIso (equivFun e x))) (invEquiv e , secEq e x)
-                  --        , λ { (f , p) → {!snd (isContr-BoolPointedIso (equivFun e x))!} })
-
-isContr-2-EltPointed-iso : (A∙ : 2-EltPointed₀)
-                         → isContr ((Bool , false , ∣ idEquiv Bool ∣) ≃[ 2-EltPointed-iso ] A∙)
-isContr-2-EltPointed-iso (A , x , ∣e∣)
+-- Since isContr is a mere proposition, we can eliminate a witness ∣e∣ : ∥ X ≃ Bool ∥ to get
+--  that there is therefore a unique pointed isomorphism (Bool , false) ≃ (X , x) for any
+--  2-element pointed type (X , x, ∣e∣).
+isContr-2-EltPointed-iso : (X∙ : 2-EltPointed₀)
+                         → isContr ((Bool , false , ∣ idEquiv Bool ∣) ≃[ PointedEqvTo-iso Bool ] X∙)
+isContr-2-EltPointed-iso (X , x , ∣e∣)
   = PropTrunc.rec isPropIsContr
-                  (λ e → J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
+                  (λ e → J (λ X∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] X∙))
                            (isContr-BoolPointedIso (e .fst x))
                            (sym (pointed-sip _ _ (e , refl))))
                   ∣e∣
 
+-- This unique isomorphism must be _⊕_ 'lifted' to X
+module ⊕* (X : 2-EltType₀) where
+
+  _⊕*_ : typ X → typ X → Bool
+  y ⊕* z = invEquiv (fst (fst (isContr-2-EltPointed-iso (fst X , y , snd X)))) .fst z
+
+  -- we've already shown that this map is an equivalence on the right
+
+  isEquivʳ : (y : typ X) → isEquiv (y ⊕*_)
+  isEquivʳ y = invEquiv (fst (fst (isContr-2-EltPointed-iso (fst X , y , snd X)))) .snd
+
+  Equivʳ : typ X → typ X ≃ Bool
+  Equivʳ y = (y ⊕*_) , isEquivʳ y
+
+  -- any mere proposition that holds for (Bool, _⊕_) holds for (typ X, _⊕*_)
+  -- this ammounts to just carefully unfolding the PropTrunc.elim and J in isContr-2-EltPointed-iso
+  elim : ∀ {ℓ'} (P : (A : Type₀) (_⊕'_ : A → A → Bool) → Type ℓ') (propP : ∀ A _⊕'_ → isProp (P A _⊕'_))
+         → P Bool _⊕_ → P (typ X) _⊕*_
+  elim {ℓ'} P propP r = PropTrunc.elim {P = λ ∣e∣ → P (typ X) (R₁ ∣e∣)} (λ _ → propP _ _)
+                                       (λ e → EquivJ' (λ A e → P A (R₂ A e)) r e)
+                                       (snd X)
+    where R₁ : ∥ fst X ≃ Bool ∥ → typ X → typ X → Bool
+          R₁ ∣e∣ y = invEq (fst (fst (isContr-2-EltPointed-iso (fst X , y , ∣e∣))))
+          R₂ : (B : Type₀) → B ≃ Bool → B → B → Bool
+          R₂ A e y = invEq (fst (fst (J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
+                                        (isContr-BoolPointedIso (e .fst y))
+                                        (sym (pointed-sip (A , y) (Bool , e .fst y) (e , refl))))))
+
+  -- as a consequence, we get that ⊕* is commutative, and is therefore also an equivalence on the left
+
+  comm : (y z : typ X) → y ⊕* z ≡ z ⊕* y
+  comm = elim (λ A _⊕'_ → (x y : A) → x ⊕' y ≡ y ⊕' x)
+              (λ _ _ → isPropPi (λ _ → isPropPi (λ _ → isSetBool _ _)))
+              ⊕-comm
+
+  isEquivˡ : (y : typ X) → isEquiv (_⊕* y)
+  isEquivˡ y = subst isEquiv (funExt (λ z → comm y z)) (isEquivʳ y)
+
+  Equivˡ : typ X → typ X ≃ Bool
+  Equivˡ y = (_⊕* y) , isEquivˡ y
+
+-- the obvious consequence of isContr-2-EltPointed-iso, though it is not needed here
 isContr-2-EltPointed : isContr (2-EltPointed₀)
 fst isContr-2-EltPointed = (Bool , false , ∣ idEquiv Bool ∣)
-snd isContr-2-EltPointed A∙ = 2-EltPointed-sip _ A∙ (fst (isContr-2-EltPointed-iso A∙))
+snd isContr-2-EltPointed A∙ = PointedEqvTo-sip Bool _ A∙ (fst (isContr-2-EltPointed-iso A∙))
 
--- toPointed : 2-EltType₀ → 2-EltPointed₀
--- toPointed (A , ∣e∣) = PropTrunc.rec (isContr→isProp isContr-2-EltPointed)
---                                     (λ e → A , invEq e false , ∣e∣)
---                                     ∣e∣
 
--- inhab : (A : 2-EltType₀) → typ A
--- inhab A = {!!}
+--------------------------------------------------------------------------------
 
--- qwe : (A : 2-EltType₀) → Bool ≡ typ A
--- qwe (A , ∣e∣) i = typ (snd isContr-2-EltPointed {!!} i)
-
--- _⊕*_ : ∀ {A : 2-EltType₀} → typ A → typ A → Bool
--- _⊕*_ {A , ∣e∣} x y = pathToEquiv (λ i → typ (snd isContr-2-EltPointed (A , x , ∣e∣) (~ i))) .fst y
-
-open import Cubical.Data.Sum
-
-R : ∀ {ℓ} {X : Type ℓ} (F : X → 2-EltType₀) (x : X) (y : typ (F x)) → Bool ≃ typ (F x)
-R F x y = fst (fst (isContr-2-EltPointed-iso (fst (F x) , y , snd (F x))))
-
--- Equivalence induction
-EquivJ' : {A B : Type ℓ} (P : (B : Type ℓ) → (e : B ≃ A) → Type ℓ')
-        → (r : P A (idEquiv A)) → (e : B ≃ A) → P B e
-EquivJ' P r e = subst (λ x → P (x .fst) (x .snd)) (contrSinglEquiv e) r
-
--- this lemma is just ⊕-comm wrapped up in two elims which unfold the elims in isContr-2-EltPointed-iso
-lemR : ∀ {ℓ} {X : Type ℓ} (F : X → 2-EltType₀) (x : X) (y z : typ (F x))
-     → invEq (R F x y) z ≡ invEq (R F x z) y
-lemR F x = PropTrunc.elim {P = λ ∣e∣ → (y z : typ (F x)) → invEq (fst (fst (isContr-2-EltPointed-iso (fst (F x) , y , ∣e∣)))) z
-                                                         ≡ invEq (fst (fst (isContr-2-EltPointed-iso (fst (F x) , z , ∣e∣)))) y}
-                          (λ _ → isPropPi (λ _ → isPropPi (λ _ → isSetBool _ _)))
-                          (EquivJ' (λ A e → (y z : A) → invEq (fst (fst (J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
-                                                                           (isContr-BoolPointedIso (e .fst y)) (sym (pointed-sip (A , y) (Bool , e .fst y) (e , refl)))))) z
-                                                      ≡ invEq (fst (fst (J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
-                                                                           (isContr-BoolPointedIso (e .fst z)) (sym (pointed-sip (A , z) (Bool , e .fst z) (e , refl)))))) y)
-                                   (λ y z → ⊕-comm y z))
-                          (snd (F x))
-
--- PropTrunc.rec isPropIsContr _ ∣e∣ ≡ PropTrunc.rec isPropIsContr _ ∣e∣
-
--- setA : (A : 2-EltType₀) → isSet (typ A)
--- setA A
-
--- mdec : (A : 2-EltType₀) → Discrete (typ A)
--- mdec (A , ∣e∣) = PropTrunc.elim {P = λ _ → Discrete A} (λ ∣e∣ → PropTrunc.elim (λ _ → isPropIsProp) (λ e → {!!}) ∣e∣) -- isPropPi (λ x → isPropPi (λ y → isPropDec {!!})))
---                                 {!!} ∣e∣
-
-open import Cubical.Data.NatMinusOne
-open import Cubical.HITs.Pushout
-open import Cubical.Data.Unit
+-- Now we mutually define RP n and its double cover, and show that the total
+--  space of this double cover is S n.
 
 RP  : ℕ₋₁ → Type₀
-cov⁻¹ : (n : ℕ₋₁) → RP n → 2-EltType₀
-
-α : ∀ {n} (x : Total (cov⁻¹ n)) → typ (cov⁻¹ n (x .fst)) ≃ Bool
-α {n} (x , y) = invEquiv (R (cov⁻¹ n) x y)
+cov⁻¹ : (n : ℕ₋₁) → RP n → 2-EltType₀ -- (see Cubical.Foundations.Bundle)
 
 RP neg1 = ⊥
 RP (ℕ→ℕ₋₁ n) = Pushout (pr (cov⁻¹ (-1+ n))) (λ _ → tt)
-             -- Cone (pr (cov⁻¹ (-1+ n)) {- : Total (cov⁻¹ (-1+ n)) → RP (-1+ n) -})
+{-
+                         tt
+   Total (cov⁻¹ (n-1)) — — — > Unit
+            |                    ∙
+        pr  |                    ∙  inr
+            |                    ∙
+            V                    V
+        RP (n-1) ∙ ∙ ∙ ∙ ∙ ∙ > RP n := Pushout pr (const tt)
+                      inl
+-}
 
-cov⁻¹ neg1 x = Bool , ∣ idEquiv _ ∣
-cov⁻¹ (ℕ→ℕ₋₁ n) (inl x) = cov⁻¹ (-1+ n) x
-cov⁻¹ (ℕ→ℕ₋₁ n) (inr _) = Bool , ∣ idEquiv _ ∣
-cov⁻¹ (ℕ→ℕ₋₁ n) (push (x,y) i) = ua (α (x,y)) i , isProp→PathP (λ i → squash {A = ua (α (x,y)) i ≃ _})
-                                                               (str (cov⁻¹ (-1+ n) (fst (x,y))))
-                                                               (∣ idEquiv Bool ∣)
-                                                               i
-  -- typ (eq i) , str (eq i) .snd
-  -- where eq : (Bool , true , ∣ idEquiv Bool ∣) ≡ (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))
-  --       eq = snd isContr-2-EltPointed _
+cov⁻¹ neg1 x = Bool*
+cov⁻¹ (ℕ→ℕ₋₁ n) (inl x)          = cov⁻¹ (-1+ n) x
+cov⁻¹ (ℕ→ℕ₋₁ n) (inr _)          = Bool*
+cov⁻¹ (ℕ→ℕ₋₁ n) (push (x , y) i) = ua ((λ z → y ⊕* z) , ⊕*.isEquivʳ (cov⁻¹ (-1+ n) x) y) i , ∣p∣ i
+  where open ⊕* (cov⁻¹ (-1+ n) x)
+        ∣p∣ = isProp→PathP (λ i → squash {A = ua (⊕*.Equivʳ (cov⁻¹ (-1+ n) x) y) i ≃ Bool})
+                           (str (cov⁻¹ (-1+ n) x)) (∣ idEquiv _ ∣)
+{-
+                         tt
+   Total (cov⁻¹ (n-1)) — — — > Unit
+            |                    |
+        pr  |     // ua α //     | Bool
+            |                    |
+            V                    V
+        RP (n-1) - - - - - - > Type
+                  cov⁻¹ (n-1)
 
--- module Wrong! (α-lem : ∀ {n} (x : RP n) (y : typ (cov⁻¹ n x)) → (α (x , y)) .fst ≡ const y) where
+   where α : ∀ (x : Total (cov⁻¹ (n-1))) → cov⁻¹ (n-1) (pr x) ≃ Bool
+         α (x , y) = (λ z → y ⊕* z) , ⊕*.isEquivʳ y
+-}
 
---   fact : ∀ n (x : RP n) (y : typ (cov⁻¹ n x)) → isEquiv (λ (_ : Bool) → y)
---   fact n x y = subst isEquiv (α-lem x y) (α (x , y) .snd)
+TotalCov≃Sn : ∀ n → Total (cov⁻¹ n) ≃ S n
+TotalCov≃Sn neg1 = isoToEquiv (iso (λ { () }) (λ { () }) (λ { () }) (λ { () }))
+TotalCov≃Sn (ℕ→ℕ₋₁ n) =
+  Total (cov⁻¹ (ℕ→ℕ₋₁ n))           ≃⟨ i ⟩
+  Pushout Σf Σg                      ≃⟨ ii ⟩
+  join (Total (cov⁻¹ (-1+ n))) Bool  ≃⟨ iii ⟩
+  S (ℕ→ℕ₋₁ n)                       ■
+  where
+{-
+    (i) First we want to show that `Total (cov⁻¹ (ℕ→ℕ₋₁ n))` is equivalent to a pushout.
+    We do this using the flattening lemma, which states:
 
---   contra : ⊥
---   contra = true≢false (retEq (_ , fact (ℕ→ℕ₋₁ 0) (inl tt) true) false)
+    Given f,g,F,G,e such that the following square commutes:
 
-open import Cubical.HITs.Susp
-open import Cubical.HITs.Sn
+             g
+       A — — — — > C                 Define:   E : Pushout f g → Type
+       |           |                           E (inl b) = F b
+    f  |   ua e    |  G                        E (inr c) = G c
+       V           V                           E (push a i) = ua (e a) i
+       B — — — — > Type
+             F
 
-open import Cubical.Data.Prod renaming (_×_ to _×'_ ; _×Σ_ to _×_)
+    Then, the total space `Σ (Pushout f g) E` is the following pushout:
 
-open import Cubical.HITs.Pushout.Flattening
+                                Σg := (g , e a)
+            Σ[ a ∈ A ] F (f a) — — — — — — — — > Σ[ c ∈ C ] G c
+                   |                                ∙
+    Σf := (f , id) |                                ∙
+                   V                                V
+            Σ[ b ∈ B ] F b ∙ ∙ ∙ ∙ ∙ ∙ ∙ ∙ ∙ ∙ > Σ (Pushout f g) E
 
-open import Cubical.HITs.Join
+    In our case, setting `f = pr (cov⁻¹ (n-1))`, `g = λ _ → tt`, `F = cov⁻¹ (n-1)`, `G = λ _ → Bool`,
+     and `e = λ (x , y) → ⊕*.Equivʳ (cov⁻¹ (n-1) x) y` makes E equal (up to funExt) to `cov⁻¹ n`.
 
--- Susp≡Join
+    Thus the flattening lemma gives us that `Total (cov⁻¹ n) ≃ Pushout Σf Σg`.
+-}
+    open FlatteningLemma {- f = -} (λ x → pr (cov⁻¹ (-1+ n)) x)  {- g = -} (λ _ → tt)
+                         {- F = -} (λ x → typ (cov⁻¹ (-1+ n) x)) {- G = -} (λ _ → Bool)
+                         {- e = -} (λ { (x , y) → ⊕*.Equivʳ (cov⁻¹ (-1+ n) x) y })
+                         hiding (Σf ; Σg)
 
-ΣUnit : ∀ {ℓ} (A : Unit → Type ℓ) → Σ Unit A ≃ A tt
-ΣUnit A = isoToEquiv (iso (λ { (tt , x) → x }) (λ { x → (tt , x) }) (λ _ → refl) (λ _ → refl))
+    cov⁻¹≃E : ∀ x → typ (cov⁻¹ (ℕ→ℕ₋₁ n) x) ≃ E x
+    cov⁻¹≃E (inl x) = idEquiv _
+    cov⁻¹≃E (inr x) = idEquiv _
+    cov⁻¹≃E (push a i) = idEquiv _
 
-private
-  e₁ : ∀ {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') → A × B ≃ B ×' A
-  e₁ A B = isoToEquiv (iso (λ { (x , y) → (y , x) }) (λ { (x , y) → (y , x) })
-                           (λ { (x , y) → refl })    (λ { (x , y) → refl }))
+    -- for easier reference, we copy these definitons here
+    Σf : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x)) → Total (cov⁻¹ (-1+ n))
+    Σg : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x)) → Unit × Bool
+    Σf ((x , y) , z) = (x , z)       -- ≡ (f a , x)
+    Σg ((x , y) , z) = (tt , y ⊕* z) -- ≡ (g a , (e a) .fst x)
+      where open ⊕* (cov⁻¹ (-1+ n) x)
 
-  e₁' : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A × B ≃ B × A
-  e₁' = isoToEquiv (iso (λ { (x , y) → (y , x) }) (λ { (x , y) → (y , x) })
-                        (λ _ → refl) (λ _ → refl))
+    i : Total (cov⁻¹ (ℕ→ℕ₋₁ n)) ≃ Pushout Σf Σg
+    i = (Σ[ x ∈ RP (ℕ→ℕ₋₁ n) ] typ (cov⁻¹ (ℕ→ℕ₋₁ n) x)) ≃⟨ congΣEquiv cov⁻¹≃E ⟩
+        (Σ[ x ∈ RP (ℕ→ℕ₋₁ n) ] E x)                     ≃⟨ flatten ⟩
+        Pushout Σf Σg                                   ■
+{-
+    (ii) Next we want to show that `Pushout Σf Σg` is equivalent to `join (Total (cov⁻¹ (n-1))) Bool`.
+    Since both are pushouts, this can be done by defining a diagram equivalence:
 
-  e₂ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : A → Type ℓ''}
-       → (Σ[ (a,b) ∈ Σ A B ] C (fst (a,b))) ≃ (Σ[ a ∈ A ] B a × C a)
-  e₂ = isoToEquiv (iso (λ { ((x , y) , z) → (x , (y , z)) }) (λ { (x , (y , z)) → ((x , y) , z) })
-                       (λ _ → refl) (λ _ → refl))
+                          Σf                                                  Σg
+    Total (cov⁻¹ (n-1)) < — — Σ[ x ∈ Total (cov⁻¹ (n-1)) ] cov⁻¹ (n-1) (pr x) — — > Unit × Bool
+            |                                        ∙                                   |
+        id  |≃                                    u  ∙≃                             snd  |≃
+            V                                        V                                   V
+    Total (cov⁻¹ (n-1)) < — — — — — — — Total (cov⁻¹ (n-1)) × Bool — — — — — — — — — > Bool
+                              proj₁                                      proj₂
 
-  e₃ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : A → Type ℓ''}
-       → (∀ a → B a ≃ C a) → Σ A B ≃ Σ A C
-  e₃ h = isoToEquiv (iso (λ { (x , y)   → (x , equivFun (h x) y) })
-                         (λ { (x , y)   → (x , invEq    (h x) y) })
-                         (λ { (x , y) i → (x , retEq    (h x) y i) })
-                         (λ { (x , y) i → (x , secEq    (h x) y i) }))
+    where the equivalence u above must therefore satisfy: `u .fst x ≡ (Σf x , snd (Σg x))`
+    Unfolding this, we get: `u .fst ((x , y) , z) ≡ ((x , z) , (y ⊕* z))`
 
-ui : ∀ {n} (x : RP n) → typ (cov⁻¹ n x) → typ (cov⁻¹ n x) → Bool
-ui x y z = α (x , z) .fst y
+    It suffices to show that the map y ↦ y ⊕* z is an equivalence, since we can then express u as
+     the following composition of equivalences:
+    ((x , y) , z) ↦ (x , (y , z)) ↦ (x , (z , y)) ↦ (x , (z , y ⊕* z)) ↦ ((x , z) , y ⊕* z)
 
-isEquiv-ui : ∀ {n} (x : RP n) (y : typ (cov⁻¹ n x)) → isEquiv (ui x y)
-isEquiv-ui {n} x y = subst isEquiv (funExt (λ z → lemR (cov⁻¹ n) x y z)) (α (x , y) .snd)
+    This was proved above by ⊕*.isEquivˡ.
+-}
+    u : ∀ {n} → (Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))) ≃ (Total (cov⁻¹ n) ×' Bool)
+    u {n} = Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))      ≃⟨ assocΣ ⟩
+            Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × (typ (cov⁻¹ n x)) ≃⟨ congΣEquiv (λ x → swapEquiv _ _) ⟩
+            Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × (typ (cov⁻¹ n x)) ≃⟨ congΣEquiv (λ x → congΣEquiv (λ y →
+                                                                             ⊕*.Equivˡ (cov⁻¹ n x) y)) ⟩
+            Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × Bool              ≃⟨ invEquiv assocΣ ⟩
+            Total (cov⁻¹ n) × Bool                              ≃⟨ invEquiv A×B≃A×ΣB ⟩
+            Total (cov⁻¹ n) ×' Bool                             ■
 
-ee : ∀ {n} → (Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))) ≃ (Total (cov⁻¹ n) × Bool)
-ee = compEquiv (compEquiv e₂ (e₃ (λ x → compEquiv e₁' (e₃ (λ z → ui x z , isEquiv-ui x z))))) (invEquiv e₂)
+    H : ∀ x → u .fst x ≡ (Σf x , snd (Σg x))
+    H x = refl
 
--- joinBool≃Susp : ∀ {A : Type ℓ} → join A Bool ≃ Susp A
--- joinBool≃Susp = {!isoc!}
+    nat : 3-span-equiv (3span Σf Σg) (3span {A2 = Total (cov⁻¹ (-1+ n)) ×' Bool} proj₁ proj₂)
+    nat = record { e0 = idEquiv _ ; e2 = u ; e4 = ΣUnit _
+                 ; H1 = λ x → cong proj₁ (H x)
+                 ; H3 = λ x → cong proj₂ (H x) }
 
-thm : ∀ n → Total (cov⁻¹ n) ≡ S n
-thm neg1 = isoToPath (iso (λ { () }) (λ { () }) (λ { () }) (λ { () }))
-thm (ℕ→ℕ₋₁ n) = Total (cov⁻¹ (ℕ→ℕ₋₁ n))                 ≡⟨ cong (Σ _) (funExt cov⁻¹≡E) ⟩
-                 Σ (Pushout _ _) E                        ≡⟨ ua flatten ⟩
-                 Pushout Σf Σg                            ≡⟨ spanEquivToPushoutPath nat ⟩
-                 joinPushout (Total (cov⁻¹ (-1+ n))) Bool ≡⟨ joinPushout≡join _ _ ⟩
-                 join (Total (cov⁻¹ (-1+ n))) Bool        ≡⟨ sym Susp≡joinBool ⟩
-                 Susp (Total (cov⁻¹ (-1+ n)))             ≡⟨ cong Susp (thm (-1+ n)) ⟩
-                 S (ℕ→ℕ₋₁ n)                              ∎
-  where open FlatteningLemma (λ x → pr (cov⁻¹ (-1+ n)) x) (λ _ → tt)
-                             (λ x → typ (cov⁻¹ (-1+ n) x)) (λ _ → Bool)
-                             (λ (x,y) → α (x,y))
-                             hiding (Σf ; Σg)
+    ii : Pushout Σf Σg ≃ join (Total (cov⁻¹ (-1+ n))) Bool
+    ii = compEquiv (pathToEquiv (spanEquivToPushoutPath nat)) (joinPushout≃join _ _)
 
-        cov⁻¹≡E : ∀ x → typ (cov⁻¹ (ℕ→ℕ₋₁ n) x) ≡ E x
-        cov⁻¹≡E (inl x) = refl
-        cov⁻¹≡E (inr x) = refl
-        cov⁻¹≡E (push a i) = refl
-        
-        Σf : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x))
-           → Σ[ x ∈ RP (-1+ n) ] typ (cov⁻¹ (-1+ n) x)
-        Σf (x , y) = (pr (cov⁻¹ (-1+ n)) x , y)
-        Σg : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x))
-           → Unit × Bool
-        Σg (x , y) = (tt , (α x) .fst y)
+{-
+    (iii) Finally, it's trivial to show that `join (Total (cov⁻¹ (n-1))) Bool` is equivalent to
+     `Susp (Total (cov⁻¹ (n-1)))`. Induction then gives us that `Susp (Total (cov⁻¹ (n-1)))`
+     is equivalent to `S n`, which completes the proof.
+-}
 
-        span₁ span₂ : 3-span
-        span₁ = record { f1 = Σf ; f3 = Σg }
-        span₂ = record { A2 = (Total (cov⁻¹ (-1+ n)) ×' Bool) ; f1 = proj₁ ; f3 = proj₂ }
+    iii : join (Total (cov⁻¹ (-1+ n))) Bool ≃ S (ℕ→ℕ₋₁ n)
+    iii = join (Total (cov⁻¹ (-1+ n))) Bool ≃⟨ invEquiv Susp≃joinBool ⟩
+          Susp (Total (cov⁻¹ (-1+ n)))      ≃⟨ cong≃ Susp (TotalCov≃Sn (-1+ n)) ⟩
+          S (ℕ→ℕ₋₁ n)                      ■
 
-        nat : 3-span-equiv span₁ span₂
-        nat = record { e0 = idEquiv _ ; e4 = ΣUnit _ ; e2 = compEquiv ee (pathToEquiv (sym A×B≡A×ΣB)) ;
-                       H1 = λ x → transportRefl _ ; H3 = λ x → refl }
 
-        
+--------------------------------------------------------------------------------
 
-        -- e₂ : ∀ (x : RP (-1+ n)) (b : Bool) → (typ (cov⁻¹ (-1+ n) x)) ≃ (typ (cov⁻¹ (-1+ n) x))
-        -- e₂ x b = isoToEquiv (iso (λ { y → α (x , y) .fst b }) {!!} {!!} {!!})
+-- Finally, we state the trivial equivalences for RP 0 and RP 1
 
-        -- eq : Pushout Σf Σg ≡ joinPushout Bool (Total (cov⁻¹ (-1+ n)))
-        -- eq i = Pushout {A = ua (e₁ (Total (cov⁻¹ (-1+ n))) Bool) i }
-        --                {B = ua (ΣUnit (λ _ → Bool)) i}
-        --                {C = {!!}} -- Σ[ x ∈ RP (-1+ n) ] typ (cov⁻¹ (-1+ n) x)}
-        --                (λ x → glue (λ { (i = i0) → tt , snd x
-        --                               ; (i = i1) → proj₁ x })
-        --                            (proj₁ (unglue (i ∨ ~ i) x)))
-        --                (λ x → glue (λ { (i = i0) → {!!} -- fst (fst x) , α (fst x) .fst (snd x)
-        --                               ; (i = i1) → proj₂ x })
-        --                            (proj₂ (unglue (i ∨ ~ i) x)))
-        --                -- want:   equivFun e₃ (fst (fst x) , α (fst x) .fst (snd x))
-        --                --        ≡ fst (fst x) , snd (fst x)
+RP0≃Unit : RP 0 ≃ Unit
+RP0≃Unit = isoToEquiv (iso (λ _ → tt) (λ _ → inr tt) (λ _ → refl) (λ { (inr tt) → refl }))
+
+RP1≡S1 : RP 1 ≡ S 1
+RP1≡S1 = Pushout {A = Total (cov⁻¹ 0)} {B = RP 0} (pr (cov⁻¹ 0)) (λ _ → tt) ≡⟨ i ⟩
+         Pushout {A = Total (cov⁻¹ 0)} {B = Unit} (λ _ → tt)     (λ _ → tt) ≡⟨ ii ⟩
+         Pushout {A = S 0}             {B = Unit} (λ _ → tt)     (λ _ → tt) ≡⟨ PushoutSusp≡Susp ⟩
+         S 1                                                                ∎
+  where i = λ i → Pushout {A = Total (cov⁻¹ 0)}
+                          {B = ua RP0≃Unit i}
+                          (λ x → ua-gluePt RP0≃Unit i (pr (cov⁻¹ 0) x))
+                          (λ _ → tt)
+        ii = λ j → Pushout {A = ua (TotalCov≃Sn 0) j} (λ _ → tt) (λ _ → tt)

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -72,7 +72,7 @@ pointed-SIP : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B ≃ (A ≡ B)
 pointed-SIP = SIP pointed-structure pointed-iso (SNS₂→SNS₄ pointed-is-SNS)
 
 pointed-sip : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B → (A ≡ B)
-pointed-sip A B = equivFun (pointed-SIP A B)
+pointed-sip A B (e , p) i = ua e i , ua-gluePath e p i -- equivFun (pointed-SIP A B)
 
 open import Cubical.Relation.Nullary
 open import Cubical.Data.Empty as ⊥
@@ -82,55 +82,246 @@ dichotomyBool : (x : Bool) → (x ≡ true) ⊎ (x ≡ false)
 dichotomyBool true  = inl refl
 dichotomyBool false = inr refl
 
-isContr-BoolPointedIso : ∀ x → isContr ((Bool , true) ≃[ pointed-iso ] (Bool , x))
-fst (isContr-BoolPointedIso true) = idEquiv _ , refl
-snd (isContr-BoolPointedIso true) (e , p)
-  = ΣProp≡ (λ e → isSetBool (equivFun e true) true)
-           {u = idEquiv _ , refl} {v = e , p}
-           (ΣProp≡ isPropIsEquiv λ { i true → p (~ i) ; i false → q (~ i) })
-  where q : equivFun e false ≡ false
-        q with dichotomyBool (invEq e false)
-        ... | (inr q) = cong (equivFun e) (sym q) ∙ retEq e false
-        ... | (inl q) = ⊥.rec (true≢false (sym p ∙ cong (equivFun e) (sym q) ∙ retEq e false))
-fst (isContr-BoolPointedIso false) = notEquiv , refl
-snd (isContr-BoolPointedIso false) (e , p)
-  = ΣProp≡ (λ e → isSetBool (equivFun e true) false)
-           {u = notEquiv , refl} {v = e , p}
-           (ΣProp≡ isPropIsEquiv λ { i true → p (~ i) ; i false → q (~ i) })
-  where q : equivFun e false ≡ true
-        q with dichotomyBool (invEq e true)
-        ... | (inr q) = cong (equivFun e) (sym q) ∙ retEq e true
-        ... | (inl q) = ⊥.rec (false≢true (sym p ∙ cong (equivFun e) (sym q) ∙ retEq e true))
+_⊕_ : Bool → Bool → Bool
+false ⊕ x = x
+true  ⊕ x = not x
+
+⊕-invol : ∀ x y → x ⊕ (x ⊕ y) ≡ y
+⊕-invol false x = refl
+⊕-invol true  x = notnot x
+
+⊕-comm : ∀ x y → x ⊕ y ≡ y ⊕ x
+⊕-comm false false = refl
+⊕-comm false true  = refl
+⊕-comm true  false = refl
+⊕-comm true  true  = refl
+
+not≢const : ∀ x → ¬ not x ≡ x
+not≢const false = true≢false
+not≢const true  = false≢true
+
+open import Cubical.Foundations.Isomorphism
+
+isEquiv-⊕ : ∀ x → isEquiv (x ⊕_)
+isEquiv-⊕ x = isoToIsEquiv (iso _ (x ⊕_) (⊕-invol x) (⊕-invol x))
+
+invEq≡→equivFun≡ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) {x y} → invEq e x ≡ y → equivFun e y ≡ x
+invEq≡→equivFun≡ e {x} p = cong (equivFun e) (sym p) ∙ retEq e x
+
+-- open import Cubical.Foundations.GroupoidLaws
+
+-- wop : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) {x y} → (invEq e x ≡ y) ≃ (equivFun e y ≡ x)
+-- wop e {x} {y} = isoToEquiv (iso (λ p → cong (equivFun e) (sym p) ∙ retEq e x)
+--                                 (λ p → cong (invEq e) (sym p)    ∙ secEq e y)
+--                                 (λ p → cong (_∙ retEq e x) {!!} ∙ {!!})
+--                                 -- cong (equivFun e) (sym (cong (invEq e) (sym p) ∙ secEq e y)) ∙ retEq e x)
+--                                 (λ p → {!!}))
+
+isContr-BoolPointedIso : ∀ x → isContr ((Bool , false) ≃[ pointed-iso ] (Bool , x))
+fst (isContr-BoolPointedIso x) = ((λ y → x ⊕ y) , isEquiv-⊕ x) , ⊕-comm x false
+snd (isContr-BoolPointedIso x) (e , p)
+  = ΣProp≡ (λ e → isSetBool (equivFun e false) x)
+           (ΣProp≡ isPropIsEquiv (funExt λ { false → ⊕-comm x false ∙ sym p
+                                           ; true  → ⊕-comm x true  ∙ sym q }))
+  where q : e .fst true ≡ not x
+        q with dichotomyBool (invEq e (not x))
+        ... | inl q = invEq≡→equivFun≡ e q
+        ... | inr q = ⊥.rec (not≢const x (sym (invEq≡→equivFun≡ e q) ∙ p))
+
+-- compPointedIso : ∀ {ℓ} {A : Pointed ℓ} {B : Pointed ℓ} {C : Pointed ℓ}
+--                    (f : A ≃[ pointed-iso ] B) (g : B ≃[ pointed-iso ] C) → A ≃[ pointed-iso ] C
+-- compPointedIso (f , p) (g , q) = compEquiv f g , cong (g .fst) p ∙ q
+
+                  -- (λ e →   compPointedIso (fst (isContr-BoolPointedIso (equivFun e x))) (invEquiv e , secEq e x)
+                  --        , λ { (f , p) → {!snd (isContr-BoolPointedIso (equivFun e x))!} })
 
 isContr-2-EltPointed-iso : (A∙ : 2-EltPointed₀)
-                         → isContr ((Bool , true , ∣ idEquiv Bool ∣) ≃[ 2-EltPointed-iso ] A∙)
+                         → isContr ((Bool , false , ∣ idEquiv Bool ∣) ≃[ 2-EltPointed-iso ] A∙)
 isContr-2-EltPointed-iso (A , x , ∣e∣)
   = PropTrunc.rec isPropIsContr
-                  (λ e → J (λ A∙ _ → isContr ((Bool , true) ≃[ pointed-iso ] A∙))
-                           (isContr-BoolPointedIso (equivFun e x))
+                  (λ e → J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
+                           (isContr-BoolPointedIso (e .fst x))
                            (sym (pointed-sip _ _ (e , refl))))
                   ∣e∣
 
+isContr-2-EltPointed : isContr (2-EltPointed₀)
+fst isContr-2-EltPointed = (Bool , false , ∣ idEquiv Bool ∣)
+snd isContr-2-EltPointed A∙ = 2-EltPointed-sip _ A∙ (fst (isContr-2-EltPointed-iso A∙))
+
+-- toPointed : 2-EltType₀ → 2-EltPointed₀
+-- toPointed (A , ∣e∣) = PropTrunc.rec (isContr→isProp isContr-2-EltPointed)
+--                                     (λ e → A , invEq e false , ∣e∣)
+--                                     ∣e∣
+
+-- inhab : (A : 2-EltType₀) → typ A
+-- inhab A = {!!}
+
+-- qwe : (A : 2-EltType₀) → Bool ≡ typ A
+-- qwe (A , ∣e∣) i = typ (snd isContr-2-EltPointed {!!} i)
+
+-- _⊕*_ : ∀ {A : 2-EltType₀} → typ A → typ A → Bool
+-- _⊕*_ {A , ∣e∣} x y = pathToEquiv (λ i → typ (snd isContr-2-EltPointed (A , x , ∣e∣) (~ i))) .fst y
+
+open import Cubical.Data.Sum
+
+R : ∀ {ℓ} {X : Type ℓ} (F : X → 2-EltType₀) (x : X) (y : typ (F x)) → Bool ≃ typ (F x)
+R F x y = fst (fst (isContr-2-EltPointed-iso (fst (F x) , y , snd (F x))))
+
+-- Equivalence induction
+EquivJ' : {A B : Type ℓ} (P : (B : Type ℓ) → (e : B ≃ A) → Type ℓ')
+        → (r : P A (idEquiv A)) → (e : B ≃ A) → P B e
+EquivJ' P r e = subst (λ x → P (x .fst) (x .snd)) (contrSinglEquiv e) r
+
+-- this lemma is just ⊕-comm wrapped up in two elims which unfold the elims in isContr-2-EltPointed-iso
+lemR : ∀ {ℓ} {X : Type ℓ} (F : X → 2-EltType₀) (x : X) (y z : typ (F x))
+     → invEq (R F x y) z ≡ invEq (R F x z) y
+lemR F x = PropTrunc.elim {P = λ ∣e∣ → (y z : typ (F x)) → invEq (fst (fst (isContr-2-EltPointed-iso (fst (F x) , y , ∣e∣)))) z
+                                                         ≡ invEq (fst (fst (isContr-2-EltPointed-iso (fst (F x) , z , ∣e∣)))) y}
+                          (λ _ → isPropPi (λ _ → isPropPi (λ _ → isSetBool _ _)))
+                          (EquivJ' (λ A e → (y z : A) → invEq (fst (fst (J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
+                                                                           (isContr-BoolPointedIso (e .fst y)) (sym (pointed-sip (A , y) (Bool , e .fst y) (e , refl)))))) z
+                                                      ≡ invEq (fst (fst (J (λ A∙ _ → isContr ((Bool , false) ≃[ pointed-iso ] A∙))
+                                                                           (isContr-BoolPointedIso (e .fst z)) (sym (pointed-sip (A , z) (Bool , e .fst z) (e , refl)))))) y)
+                                   (λ y z → ⊕-comm y z))
+                          (snd (F x))
+
+-- PropTrunc.rec isPropIsContr _ ∣e∣ ≡ PropTrunc.rec isPropIsContr _ ∣e∣
+
+-- setA : (A : 2-EltType₀) → isSet (typ A)
+-- setA A
+
+-- mdec : (A : 2-EltType₀) → Discrete (typ A)
+-- mdec (A , ∣e∣) = PropTrunc.elim {P = λ _ → Discrete A} (λ ∣e∣ → PropTrunc.elim (λ _ → isPropIsProp) (λ e → {!!}) ∣e∣) -- isPropPi (λ x → isPropPi (λ y → isPropDec {!!})))
+--                                 {!!} ∣e∣
+
 open import Cubical.Data.NatMinusOne
-open import Cubical.HITs.MappingCones
+open import Cubical.HITs.Pushout
+open import Cubical.Data.Unit
 
 RP  : ℕ₋₁ → Type₀
 cov⁻¹ : (n : ℕ₋₁) → RP n → 2-EltType₀
 
+α : ∀ {n} (x : Total (cov⁻¹ n)) → typ (cov⁻¹ n (x .fst)) ≃ Bool
+α {n} (x , y) = invEquiv (R (cov⁻¹ n) x y)
+
 RP neg1 = ⊥
-RP (ℕ→ℕ₋₁ n) = Cone (pr (cov⁻¹ (-1+ n)) {- : Total (cov⁻¹ (-1+ n)) → RP (-1+ n) -})
+RP (ℕ→ℕ₋₁ n) = Pushout (pr (cov⁻¹ (-1+ n))) (λ _ → tt)
+             -- Cone (pr (cov⁻¹ (-1+ n)) {- : Total (cov⁻¹ (-1+ n)) → RP (-1+ n) -})
 
 cov⁻¹ neg1 x = Bool , ∣ idEquiv _ ∣
-cov⁻¹ (ℕ→ℕ₋₁ n) hub     = Bool , ∣ idEquiv _ ∣
-cov⁻¹ (ℕ→ℕ₋₁ n) (inj x) = cov⁻¹ (-1+ n) x
-cov⁻¹ (ℕ→ℕ₋₁ n) (spoke (x , y) i) = typ (eq i) , str (eq i) .snd
-  where eq : (Bool , true , ∣ idEquiv Bool ∣) ≡ (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))
-        eq = 2-EltPointed-sip _ _ (fst (isContr-2-EltPointed-iso (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))))
+cov⁻¹ (ℕ→ℕ₋₁ n) (inl x) = cov⁻¹ (-1+ n) x
+cov⁻¹ (ℕ→ℕ₋₁ n) (inr _) = Bool , ∣ idEquiv _ ∣
+cov⁻¹ (ℕ→ℕ₋₁ n) (push (x,y) i) = ua (α (x,y)) i , isProp→PathP (λ i → squash {A = ua (α (x,y)) i ≃ _})
+                                                               (str (cov⁻¹ (-1+ n) (fst (x,y))))
+                                                               (∣ idEquiv Bool ∣)
+                                                               i
+  -- typ (eq i) , str (eq i) .snd
+  -- where eq : (Bool , true , ∣ idEquiv Bool ∣) ≡ (typ (cov⁻¹ (-1+ n) x) , y , str (cov⁻¹ (-1+ n) x))
+  --       eq = snd isContr-2-EltPointed _
+
+-- module Wrong! (α-lem : ∀ {n} (x : RP n) (y : typ (cov⁻¹ n x)) → (α (x , y)) .fst ≡ const y) where
+
+--   fact : ∀ n (x : RP n) (y : typ (cov⁻¹ n x)) → isEquiv (λ (_ : Bool) → y)
+--   fact n x y = subst isEquiv (α-lem x y) (α (x , y) .snd)
+
+--   contra : ⊥
+--   contra = true≢false (retEq (_ , fact (ℕ→ℕ₋₁ 0) (inl tt) true) false)
 
 open import Cubical.HITs.Susp
 open import Cubical.HITs.Sn
-open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Prod renaming (_×_ to _×'_ ; _×Σ_ to _×_)
+
+open import Cubical.HITs.Pushout.Flattening
+
+open import Cubical.HITs.Join
+
+-- Susp≡Join
+
+ΣUnit : ∀ {ℓ} (A : Unit → Type ℓ) → Σ Unit A ≃ A tt
+ΣUnit A = isoToEquiv (iso (λ { (tt , x) → x }) (λ { x → (tt , x) }) (λ _ → refl) (λ _ → refl))
+
+private
+  e₁ : ∀ {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') → A × B ≃ B ×' A
+  e₁ A B = isoToEquiv (iso (λ { (x , y) → (y , x) }) (λ { (x , y) → (y , x) })
+                           (λ { (x , y) → refl })    (λ { (x , y) → refl }))
+
+  e₁' : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A × B ≃ B × A
+  e₁' = isoToEquiv (iso (λ { (x , y) → (y , x) }) (λ { (x , y) → (y , x) })
+                        (λ _ → refl) (λ _ → refl))
+
+  e₂ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : A → Type ℓ''}
+       → (Σ[ (a,b) ∈ Σ A B ] C (fst (a,b))) ≃ (Σ[ a ∈ A ] B a × C a)
+  e₂ = isoToEquiv (iso (λ { ((x , y) , z) → (x , (y , z)) }) (λ { (x , (y , z)) → ((x , y) , z) })
+                       (λ _ → refl) (λ _ → refl))
+
+  e₃ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : A → Type ℓ''}
+       → (∀ a → B a ≃ C a) → Σ A B ≃ Σ A C
+  e₃ h = isoToEquiv (iso (λ { (x , y)   → (x , equivFun (h x) y) })
+                         (λ { (x , y)   → (x , invEq    (h x) y) })
+                         (λ { (x , y) i → (x , retEq    (h x) y i) })
+                         (λ { (x , y) i → (x , secEq    (h x) y i) }))
+
+ui : ∀ {n} (x : RP n) → typ (cov⁻¹ n x) → typ (cov⁻¹ n x) → Bool
+ui x y z = α (x , z) .fst y
+
+isEquiv-ui : ∀ {n} (x : RP n) (y : typ (cov⁻¹ n x)) → isEquiv (ui x y)
+isEquiv-ui {n} x y = subst isEquiv (funExt (λ z → lemR (cov⁻¹ n) x y z)) (α (x , y) .snd)
+
+ee : ∀ {n} → (Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))) ≃ (Total (cov⁻¹ n) × Bool)
+ee = compEquiv (compEquiv e₂ (e₃ (λ x → compEquiv e₁' (e₃ (λ z → ui x z , isEquiv-ui x z))))) (invEquiv e₂)
+
+-- joinBool≃Susp : ∀ {A : Type ℓ} → join A Bool ≃ Susp A
+-- joinBool≃Susp = {!isoc!}
 
 thm : ∀ n → Total (cov⁻¹ n) ≡ S n
 thm neg1 = isoToPath (iso (λ { () }) (λ { () }) (λ { () }) (λ { () }))
-thm (ℕ→ℕ₋₁ n) = {!!} ∙ cong Susp (thm (-1+ n))
+thm (ℕ→ℕ₋₁ n) = Total (cov⁻¹ (ℕ→ℕ₋₁ n))                 ≡⟨ cong (Σ _) (funExt cov⁻¹≡E) ⟩
+                 Σ (Pushout _ _) E                        ≡⟨ ua flatten ⟩
+                 Pushout Σf Σg                            ≡⟨ spanEquivToPushoutPath nat ⟩
+                 joinPushout (Total (cov⁻¹ (-1+ n))) Bool ≡⟨ joinPushout≡join _ _ ⟩
+                 join (Total (cov⁻¹ (-1+ n))) Bool        ≡⟨ sym Susp≡joinBool ⟩
+                 Susp (Total (cov⁻¹ (-1+ n)))             ≡⟨ cong Susp (thm (-1+ n)) ⟩
+                 S (ℕ→ℕ₋₁ n)                              ∎
+  where open FlatteningLemma (λ x → pr (cov⁻¹ (-1+ n)) x) (λ _ → tt)
+                             (λ x → typ (cov⁻¹ (-1+ n) x)) (λ _ → Bool)
+                             (λ (x,y) → α (x,y))
+                             hiding (Σf ; Σg)
+
+        cov⁻¹≡E : ∀ x → typ (cov⁻¹ (ℕ→ℕ₋₁ n) x) ≡ E x
+        cov⁻¹≡E (inl x) = refl
+        cov⁻¹≡E (inr x) = refl
+        cov⁻¹≡E (push a i) = refl
+        
+        Σf : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x))
+           → Σ[ x ∈ RP (-1+ n) ] typ (cov⁻¹ (-1+ n) x)
+        Σf (x , y) = (pr (cov⁻¹ (-1+ n)) x , y)
+        Σg : Σ[ x ∈ Total (cov⁻¹ (-1+ n)) ] typ (cov⁻¹ (-1+ n) (fst x))
+           → Unit × Bool
+        Σg (x , y) = (tt , (α x) .fst y)
+
+        span₁ span₂ : 3-span
+        span₁ = record { f1 = Σf ; f3 = Σg }
+        span₂ = record { A2 = (Total (cov⁻¹ (-1+ n)) ×' Bool) ; f1 = proj₁ ; f3 = proj₂ }
+
+        nat : 3-span-equiv span₁ span₂
+        nat = record { e0 = idEquiv _ ; e4 = ΣUnit _ ; e2 = compEquiv ee (pathToEquiv (sym A×B≡A×ΣB)) ;
+                       H1 = λ x → transportRefl _ ; H3 = λ x → refl }
+
+        
+
+        -- e₂ : ∀ (x : RP (-1+ n)) (b : Bool) → (typ (cov⁻¹ (-1+ n) x)) ≃ (typ (cov⁻¹ (-1+ n) x))
+        -- e₂ x b = isoToEquiv (iso (λ { y → α (x , y) .fst b }) {!!} {!!} {!!})
+
+        -- eq : Pushout Σf Σg ≡ joinPushout Bool (Total (cov⁻¹ (-1+ n)))
+        -- eq i = Pushout {A = ua (e₁ (Total (cov⁻¹ (-1+ n))) Bool) i }
+        --                {B = ua (ΣUnit (λ _ → Bool)) i}
+        --                {C = {!!}} -- Σ[ x ∈ RP (-1+ n) ] typ (cov⁻¹ (-1+ n) x)}
+        --                (λ x → glue (λ { (i = i0) → tt , snd x
+        --                               ; (i = i1) → proj₁ x })
+        --                            (proj₁ (unglue (i ∨ ~ i) x)))
+        --                (λ x → glue (λ { (i = i0) → {!!} -- fst (fst x) , α (fst x) .fst (snd x)
+        --                               ; (i = i1) → proj₂ x })
+        --                            (proj₂ (unglue (i ∨ ~ i) x)))
+        --                -- want:   equivFun e₃ (fst (fst x) , α (fst x) .fst (snd x))
+        --                --        ≡ fst (fst x) , snd (fst x)

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -282,7 +282,7 @@ TotalCov≃Sn (ℕ→ℕ₋₁ n) =
 
     iii : join (Total (cov⁻¹ (-1+ n))) Bool ≃ S (ℕ→ℕ₋₁ n)
     iii = join (Total (cov⁻¹ (-1+ n))) Bool ≃⟨ invEquiv Susp≃joinBool ⟩
-          Susp (Total (cov⁻¹ (-1+ n)))      ≃⟨ cong≃ Susp (TotalCov≃Sn (-1+ n)) ⟩
+          Susp (Total (cov⁻¹ (-1+ n)))      ≃⟨ congSuspEquiv (TotalCov≃Sn (-1+ n)) ⟩
           S (ℕ→ℕ₋₁ n)                      ■
 
 -- the usual covering map S n → RP n, with fibers exactly cov⁻¹

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -84,7 +84,7 @@ isContr-2-EltPointed-iso (X , x , ∣e∣)
                            (isContr-BoolPointedIso (e .fst x))
                            (sym (pointed-sip _ _ (e , refl))))
                   ∣e∣
-                  
+
 -- This unique isomorphism must be _⊕_ 'lifted' to X. This idea is alluded to at the end of the
 --  proof of Theorem III.4 in [BR17], where the authors reference needing ⊕-comm.
 module ⊕* (X : 2-EltType₀) where

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -18,9 +18,7 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Bundle
 
-open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
-open import Cubical.Foundations.Structure
-open import Cubical.Foundations.Pointed
+open import Cubical.Foundations.SIP
 open import Cubical.Structures.Pointed
 open import Cubical.Structures.TypeEqvTo
 

--- a/Cubical/HITs/Susp.agda
+++ b/Cubical/HITs/Susp.agda
@@ -3,4 +3,4 @@ module Cubical.HITs.Susp where
 
 open import Cubical.HITs.Susp.Base public
 
--- open import Cubical.HITs.Susp.Properties public
+open import Cubical.HITs.Susp.Properties public

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -1,0 +1,38 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Susp.Properties where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Bool
+open import Cubical.HITs.Join
+open import Cubical.HITs.Susp.Base
+
+Susp-iso-joinBool : ∀ {ℓ} {A : Type ℓ} → Iso (Susp A) (join A Bool)
+Iso.fun Susp-iso-joinBool north = inr true
+Iso.fun Susp-iso-joinBool south = inr false
+Iso.fun Susp-iso-joinBool (merid a i) = (sym (push a true) ∙ push a false) i
+Iso.inv Susp-iso-joinBool (inr true ) = north
+Iso.inv Susp-iso-joinBool (inr false) = south
+Iso.inv Susp-iso-joinBool (inl _) = north
+Iso.inv Susp-iso-joinBool (push a true  i) = north
+Iso.inv Susp-iso-joinBool (push a false i) = merid a i
+Iso.rightInv Susp-iso-joinBool (inr true ) = refl
+Iso.rightInv Susp-iso-joinBool (inr false) = refl
+Iso.rightInv Susp-iso-joinBool (inl a) = sym (push a true)
+Iso.rightInv Susp-iso-joinBool (push a true  i) j = push a true (i ∨ ~ j)
+Iso.rightInv Susp-iso-joinBool (push a false i) j
+  = hcomp (λ k → λ { (i = i0) → push a true (~ j)
+                   ; (i = i1) → push a false k
+                   ; (j = i1) → push a false (i ∧ k) })
+          (push a true (~ i ∧ ~ j))
+Iso.leftInv Susp-iso-joinBool north = refl
+Iso.leftInv Susp-iso-joinBool south = refl
+Iso.leftInv (Susp-iso-joinBool {A = A}) (merid a i) j
+  = hcomp (λ k → λ { (i = i0) → transp (λ _ → Susp A) (k ∨ j) north
+                   ; (i = i1) → transp (λ _ → Susp A) (k ∨ j) (merid a k)
+                   ; (j = i1) → merid a (i ∧ k) })
+          (transp (λ _ → Susp A) j north)
+
+Susp≡joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≡ join A Bool
+Susp≡joinBool = isoToPath Susp-iso-joinBool

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -40,3 +40,19 @@ Susp≃joinBool = isoToEquiv Susp-iso-joinBool
 
 Susp≡joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≡ join A Bool
 Susp≡joinBool = isoToPath Susp-iso-joinBool
+
+congSuspEquiv : ∀ {ℓ} {A B : Type ℓ} → A ≃ B → Susp A ≃ Susp B
+congSuspEquiv {ℓ} {A} {B} h = isoToEquiv isom
+  where isom : Iso (Susp A) (Susp B)
+        Iso.fun isom north = north
+        Iso.fun isom south = south
+        Iso.fun isom (merid a i) = merid (fst h a) i
+        Iso.inv isom north = north
+        Iso.inv isom south = south
+        Iso.inv isom (merid a i) = merid (invEq h a) i
+        Iso.rightInv isom north = refl
+        Iso.rightInv isom south = refl
+        Iso.rightInv isom (merid a i) j = merid (retEq h a j) i
+        Iso.leftInv isom north = refl
+        Iso.leftInv isom south = refl
+        Iso.leftInv isom (merid a i) j = merid (secEq h a j) i

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -3,6 +3,7 @@ module Cubical.HITs.Susp.Properties where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
 
 open import Cubical.Data.Bool
 open import Cubical.HITs.Join
@@ -33,6 +34,9 @@ Iso.leftInv (Susp-iso-joinBool {A = A}) (merid a i) j
                    ; (i = i1) → transp (λ _ → Susp A) (k ∨ j) (merid a k)
                    ; (j = i1) → merid a (i ∧ k) })
           (transp (λ _ → Susp A) j north)
+
+Susp≃joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≃ join A Bool
+Susp≃joinBool = isoToEquiv Susp-iso-joinBool
 
 Susp≡joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≡ join A Bool
 Susp≡joinBool = isoToPath Susp-iso-joinBool

--- a/Cubical/Structures/Everything.agda
+++ b/Cubical/Structures/Everything.agda
@@ -5,3 +5,5 @@ open import Cubical.Structures.Pointed public
 open import Cubical.Structures.InftyMagma public
 open import Cubical.Structures.Monoid public
 open import Cubical.Structures.Queue public
+
+open import Cubical.Structures.TypeEqvTo public

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Path
 
-open import Cubical.Foundations.Pointed
+open import Cubical.Foundations.Pointed.Base
 
 open import Cubical.Foundations.SIP renaming (SNS-PathP to SNS)
 

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -27,3 +27,10 @@ pointed-is-SNS : SNS {ℓ} pointed-structure pointed-iso
 pointed-is-SNS {A = A} {B = B} f =
   transportEquiv ( (λ j → transportRefl (equivFun f (pt A)) (~ j) ≡ pt B)
                  ∙ sym (PathP≡Path (λ i → ua f i) (pt A) (pt B)))
+
+
+pointed-SIP : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B ≃ (A ≡ B)
+pointed-SIP = SIP pointed-structure pointed-iso (SNS₂→SNS₄ pointed-is-SNS)
+
+pointed-sip : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B → (A ≡ B)
+pointed-sip A B = equivFun (pointed-SIP A B) -- ua e i , ua-gluePath e p i

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -24,13 +24,10 @@ pointed-iso : StrIso pointed-structure ℓ
 pointed-iso A B f = equivFun f (pt A) ≡ pt B
 
 pointed-is-SNS : SNS {ℓ} pointed-structure pointed-iso
-pointed-is-SNS {A = A} {B = B} f =
-  transportEquiv ( (λ j → transportRefl (equivFun f (pt A)) (~ j) ≡ pt B)
-                 ∙ sym (PathP≡Path (λ i → ua f i) (pt A) (pt B)))
-
+pointed-is-SNS f = invEquiv (ua-ungluePath-Equiv f)
 
 pointed-SIP : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B ≃ (A ≡ B)
-pointed-SIP = SIP pointed-structure pointed-iso (SNS₂→SNS₄ pointed-is-SNS)
+pointed-SIP = SIP pointed-structure pointed-iso pointed-is-SNS
 
 pointed-sip : (A B : Pointed ℓ) → A ≃[ pointed-iso ] B → (A ≡ B)
-pointed-sip A B = equivFun (pointed-SIP A B) -- ua e i , ua-gluePath e p i
+pointed-sip A B = equivFun (pointed-SIP A B) -- ≡ λ (e , p) i → ua e i , ua-gluePath e p i

--- a/Cubical/Structures/TypeEqvTo.agda
+++ b/Cubical/Structures/TypeEqvTo.agda
@@ -1,0 +1,41 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Structures.TypeEqvTo where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+
+open import Cubical.HITs.PropositionalTruncation
+open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
+
+open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
+open import Cubical.Foundations.Pointed
+open import Cubical.Structures.Pointed
+
+private
+  variable
+    ℓ ℓ' ℓ'' : Level
+
+TypeEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+TypeEqvTo ℓ X = TypeWithStr ℓ (λ Y → ∥ Y ≃ X ∥)
+
+PointedEqvTo : (ℓ : Level) (X : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+PointedEqvTo ℓ X = TypeWithStr ℓ (λ Y → Y × ∥ Y ≃ X ∥)
+
+module _ (X : Type ℓ') where
+
+  PointedEqvTo-structure : Type ℓ → Type (ℓ-max ℓ ℓ')
+  PointedEqvTo-structure = add-to-structure pointed-structure (λ Y _ → ∥ Y ≃ X ∥)
+
+  PointedEqvTo-iso : StrIso PointedEqvTo-structure ℓ''
+  PointedEqvTo-iso = add-to-iso pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ X ∥)
+
+  PointedEqvTo-SNS : SNS {ℓ} PointedEqvTo-structure PointedEqvTo-iso
+  PointedEqvTo-SNS = add-axioms-SNS pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ X ∥)
+                                    (λ _ _ → squash)
+                                    pointed-is-SNS
+
+  PointedEqvTo-SIP : (A B : PointedEqvTo ℓ X) → A ≃[ PointedEqvTo-iso ] B ≃ (A ≡ B)
+  PointedEqvTo-SIP = SIP PointedEqvTo-structure PointedEqvTo-iso (SNS₂→SNS₄ PointedEqvTo-SNS)
+
+  PointedEqvTo-sip : (A B : PointedEqvTo ℓ X) → A ≃[ PointedEqvTo-iso ] B → (A ≡ B)
+  PointedEqvTo-sip A B = equivFun (PointedEqvTo-SIP A B)

--- a/Cubical/Structures/TypeEqvTo.agda
+++ b/Cubical/Structures/TypeEqvTo.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
 
-open import Cubical.Foundations.SIP renaming (SNS₂ to SNS)
+open import Cubical.Foundations.SIP renaming (SNS-PathP to SNS)
 open import Cubical.Foundations.Pointed
 open import Cubical.Structures.Pointed
 
@@ -29,13 +29,13 @@ module _ (X : Type ℓ') where
   PointedEqvTo-iso : StrIso PointedEqvTo-structure ℓ''
   PointedEqvTo-iso = add-to-iso pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ X ∥)
 
-  PointedEqvTo-SNS : SNS {ℓ} PointedEqvTo-structure PointedEqvTo-iso
-  PointedEqvTo-SNS = add-axioms-SNS pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ X ∥)
-                                    (λ _ _ → squash)
-                                    pointed-is-SNS
+  PointedEqvTo-is-SNS : SNS {ℓ} PointedEqvTo-structure PointedEqvTo-iso
+  PointedEqvTo-is-SNS = add-axioms-SNS pointed-structure pointed-iso (λ Y _ → ∥ Y ≃ X ∥)
+                                       (λ _ _ → squash)
+                                       pointed-is-SNS
 
   PointedEqvTo-SIP : (A B : PointedEqvTo ℓ X) → A ≃[ PointedEqvTo-iso ] B ≃ (A ≡ B)
-  PointedEqvTo-SIP = SIP PointedEqvTo-structure PointedEqvTo-iso (SNS₂→SNS₄ PointedEqvTo-SNS)
+  PointedEqvTo-SIP = SIP PointedEqvTo-structure PointedEqvTo-iso PointedEqvTo-is-SNS
 
   PointedEqvTo-sip : (A B : PointedEqvTo ℓ X) → A ≃[ PointedEqvTo-iso ] B → (A ≡ B)
   PointedEqvTo-sip A B = equivFun (PointedEqvTo-SIP A B)


### PR DESCRIPTION
This PR defines the real projective spaces following the paper:

- U. Buchholtz, E. Rijke, The real projective spaces in homotopy type theory. (2017) https://arxiv.org/abs/1704.05770

The core addition of this PR is the file `Cubical.HITs.RPn.Base`, which defines `RP n`, it's double cover, and proves that the total space of this double cover is `S n`. It also adds: 
- `HITs.Pushout.Flattening`: the flattening lemma for pushouts, used in `HITs.RPn`. This file ended up being a pretty good example of using `glue`/`unglue`, as well as how to deal with terms of the form `f (hcomp ...)` – the latter is something I've struggled with in the past.
- in `Foundations.Univalence`: since they keep coming up for me more and more (e.g. in `HITs.Pushout.Flattening`) I gave `ua-unglue` and `ua-glue` easier types to use and added a few other nice definitions about / related to these functions
- `Foundations.Bundle` and `Structures.TypeEqvTo`
- lots of small lemmas in lots of different files (sorry @mortberg !)

Eventually someone (possibly me) should add the long exact fiber sequence, from which computing the homotopy groups for `RP n` follows easily.