### PR TITLE
[ perfomance ] improved normal forms of isoToPath and compIso

### DIFF
--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -22,8 +22,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws
 
-open import Cubical.Core.Glue public
-  using ( isEquiv ; equiv-proof ; _≃_ ; equivFun ; equivProof )
+open import Cubical.Foundations.Equiv.Base public
 
 private
   variable
@@ -43,13 +42,6 @@ equivCtrPath : ∀ {A : Type ℓ} {B : Type ℓ'} (e : A ≃ B) (y : B) →
   (v : fiber (equivFun e) y) → Path _ (equivCtr e y) v
 equivCtrPath e y = e .snd .equiv-proof y .snd
 
--- The identity equivalence
-idIsEquiv : ∀ (A : Type ℓ) → isEquiv (idfun A)
-equiv-proof (idIsEquiv A) y =
-  ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
-
-idEquiv : ∀ (A : Type ℓ) → A ≃ A
-idEquiv A = (idfun A , idIsEquiv A)
 
 -- Proof using isPropIsContr. This is slow and the direct proof below is better
 

--- a/Cubical/Foundations/Equiv/Base.agda
+++ b/Cubical/Foundations/Equiv/Base.agda
@@ -13,4 +13,5 @@ equiv-proof (idIsEquiv A) y =
   ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
 
 idEquiv : ∀ {ℓ} (A : Type ℓ) → A ≃ A
-idEquiv A = record {fst = idfun A; snd = idIsEquiv A }
+idEquiv A .fst = idfun A
+idEquiv A .snd = idIsEquiv A

--- a/Cubical/Foundations/Equiv/Base.agda
+++ b/Cubical/Foundations/Equiv/Base.agda
@@ -1,0 +1,16 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Foundations.Equiv.Base where
+
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Core.Glue public
+  using ( isEquiv ; equiv-proof ; _≃_ ; equivFun ; equivProof )
+
+-- The identity equivalence
+idIsEquiv : ∀ {ℓ} (A : Type ℓ) → isEquiv (idfun A)
+equiv-proof (idIsEquiv A) y =
+  ((y , refl) , λ z i → z .snd (~ i) , λ j → z .snd (~ i ∨ j))
+
+idEquiv : ∀ {ℓ} (A : Type ℓ) → A ≃ A
+idEquiv A = record {fst = idfun A; snd = idIsEquiv A }

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -14,6 +14,7 @@ open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv.Base
 
 private
   variable
@@ -88,18 +89,19 @@ module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (i : Iso A B) where
 
 
 isoToEquiv : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → Iso A B → A ≃ B
-isoToEquiv i = _ , isoToIsEquiv i
+isoToEquiv i .fst = _
+isoToEquiv i .snd = isoToIsEquiv i
 
 isoToPath : ∀ {ℓ} {A B : Type ℓ} → (Iso A B) → A ≡ B
 isoToPath {A = A} {B = B} f i =
-  Glue B (λ { (i = i0) → (A , (Iso.fun f , isoToIsEquiv f))
-            ; (i = i1) → (B , (λ x → x) ,
-                              record { equiv-proof = λ y → (y , refl)
-                                                          , λ z i → z .snd (~ i)
-                                                                  , λ j → z .snd (~ i ∨ j)})})
+  Glue B (λ { (i = i0) → (A , isoToEquiv f)
+            ; (i = i1) → (B , idEquiv B) })
 
 compIso : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
           → Iso A B → Iso B C → Iso A C
-compIso (iso fun inv rightInv leftInv) (iso fun₁ inv₁ rightInv₁ leftInv₁) = iso (fun₁ ∘ fun) (inv ∘ inv₁)
-        (λ b → cong fun₁ (rightInv (inv₁ b)) ∙ (rightInv₁ b))
-        (λ a → cong inv (leftInv₁ (fun a) ) ∙ leftInv a )
+compIso (iso fun inv rightInv leftInv) (iso fun₁ inv₁ rightInv₁ leftInv₁) .Iso.fun = fun₁ ∘ fun
+compIso (iso fun inv rightInv leftInv) (iso fun₁ inv₁ rightInv₁ leftInv₁) .Iso.inv = inv ∘ inv₁
+compIso (iso fun inv rightInv leftInv) (iso fun₁ inv₁ rightInv₁ leftInv₁) .Iso.rightInv b
+  = cong fun₁ (rightInv (inv₁ b)) ∙ (rightInv₁ b)
+compIso (iso fun inv rightInv leftInv) (iso fun₁ inv₁ rightInv₁ leftInv₁) .Iso.leftInv a
+  = cong inv (leftInv₁ (fun a) ) ∙ leftInv a


### PR DESCRIPTION
Core functions like `isoToPath` and `compIso` should really use copatterns as much as possible to keep normal forms small.

