### PR TITLE
Friendlier definitions of composition in Foundations.Prelude

### DIFF
--- a/Cubical/Data/Nat/Algebra.agda
+++ b/Cubical/Data/Nat/Algebra.agda
@@ -181,7 +181,7 @@ module AlgebraHInit→Ind (N : NatAlgebra ℓ') ℓ (hinit : isNatHInitial N (�
   Q-zero : α (N .alg-zero) ≡ N .alg-zero
   Q-zero = ζ
   Q-suc : ∀ n → α (N .alg-suc n) ≡ N .alg-suc n
-  Q-suc n = σ n □ cong (N .alg-suc) (P n)
+  Q-suc n = σ n ∙ cong (N .alg-suc) (P n)
 
   -- but P and Q are the same up to homotopy
   P-zero : P (N .alg-zero) ≡ Q-zero
@@ -194,7 +194,7 @@ module AlgebraHInit→Ind (N : NatAlgebra ℓ') ℓ (hinit : isNatHInitial N (�
   P-suc : ∀ n → P (N .alg-suc n) ≡ Q-suc n
   P-suc n i j = hcomp (λ k → λ where
       (i = i0) → lower (fst∘μ≡id j .comm-suc (~ k) n)
-      (i = i1) → compPath'-filler (σ n) (cong (N .alg-suc) (P n)) k j
+      (i = i1) → compPath-filler' (σ n) (cong (N .alg-suc) (P n)) k j
       (j = i0) → σ n (~ k)
       (j = i1) → N .alg-suc n
     ) (N .alg-suc (P n j))
@@ -212,7 +212,7 @@ module AlgebraHInit→Ind (N : NatAlgebra ℓ') ℓ (hinit : isNatHInitial N (�
     P (N .alg-suc n) ! α-h (N .alg-suc n)
       ≡[ i ]⟨ P-suc n i ! α-h _ ⟩
     Q-suc n ! α-h (N .alg-suc n)
-      ≡⟨ substComposite-□ (F .Fiber) (σ n) (cong (N .alg-suc) (P n)) _ ⟩
+      ≡⟨ substComposite (F .Fiber) (σ n) (cong (N .alg-suc) (P n)) _ ⟩
     cong (N .alg-suc) (P n) ! (σ n ! α-h (N .alg-suc n))
       ≡[ i ]⟨ cong (N .alg-suc) (P n) ! fromPathP (σ-h n) i ⟩
     cong (N .alg-suc) (P n) ! (F .fib-suc (α-h n))

--- a/Cubical/Foundations/BiInvEquiv.agda
+++ b/Cubical/Foundations/BiInvEquiv.agda
@@ -33,16 +33,16 @@ record BiInvEquiv {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') : Type (ℓ-max ℓ 
                 invl b              ∎
 
   invr-leftInv : retract fun invr
-  invr-leftInv a = invr≡invl (fun a) □ (invl-leftInv a)
+  invr-leftInv a = invr≡invl (fun a) ∙ (invl-leftInv a)
 
   invr≡invl-leftInv : ∀ a → PathP (λ j → invr≡invl (fun a) j ≡ a) (invr-leftInv a) (invl-leftInv a)
-  invr≡invl-leftInv a j i = compPath'-filler (invr≡invl (fun a)) (invl-leftInv a) (~ j) i
+  invr≡invl-leftInv a j i = compPath-filler' (invr≡invl (fun a)) (invl-leftInv a) (~ j) i
 
   invl-rightInv : section fun invl
-  invl-rightInv a = sym (cong fun (invr≡invl a)) □ (invr-rightInv a)
+  invl-rightInv a = sym (cong fun (invr≡invl a)) ∙ (invr-rightInv a)
 
   invr≡invl-rightInv : ∀ a → PathP (λ j → fun (invr≡invl a j) ≡ a) (invr-rightInv a) (invl-rightInv a)
-  invr≡invl-rightInv a j i = compPath'-filler (sym (cong fun (invr≡invl a))) (invr-rightInv a) j i
+  invr≡invl-rightInv a j i = compPath-filler' (sym (cong fun (invr≡invl a))) (invr-rightInv a) j i
 
 
 module _ {ℓ} {A B : Type ℓ} (e : BiInvEquiv A B) where

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -120,13 +120,9 @@ PropEquiv→Equiv Aprop Bprop f g = isoToEquiv (iso f g (λ b → Bprop (f (g b)
 
 homotopyNatural : {f g : A → B} (H : ∀ a → f a ≡ g a) {x y : A} (p : x ≡ y) →
                   H x ∙ cong g p ≡ cong f p ∙ H y
-homotopyNatural H p = homotopyNatural' H p ∙ □≡∙ _ _
-  where
-  homotopyNatural' : {f g : A → B} (H : ∀ a → f a ≡ g a) {x y : A} (p : x ≡ y) →
-                     H x ∙ cong g p ≡ cong f p □ H y
-  homotopyNatural' {f = f} {g = g} H {x} {y} p i j =
+homotopyNatural {f = f} {g = g} H {x} {y} p i j =
     hcomp (λ k → λ { (i = i0) → compPath-filler (H x) (cong g p) k j
-                   ; (i = i1) → compPath'-filler (cong f p) (H y) k j
+                   ; (i = i1) → compPath-filler' (cong f p) (H y) k j
                    ; (j = i0) → cong f p (i ∧ (~ k))
                    ; (j = i1) → cong g p (i ∨ k) })
           (H (p i) j)

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -104,7 +104,7 @@ preassoc {x = x} p q r j i = preassoc-filler p q r i1 j i
 
 assoc : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w) →
   p ∙ q ∙ r ≡ (p ∙ q) ∙ r
-assoc p q r = 3outof4 (compPath-filler p (q ∙ r)) ((p ∙ q) ∙ r) (preassoc p q r)
+assoc p q r = 3outof4 (λ j i → compPath-filler p (q ∙ r) j i) ((p ∙ q) ∙ r) (preassoc p q r)
 
 -- heterogeneous groupoid laws
 
@@ -114,7 +114,7 @@ symInvoP p = refl
 
 rUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
   PathP (λ j → PathP (λ i → rUnit (λ i → A i) j i) x y) p (compPathP p refl)
-rUnitP p j i = compPathP-filler p refl i j
+rUnitP p j i = compPathP-filler p refl j i
 
 lUnitP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → (p : PathP A x y) →
   PathP (λ j → PathP (λ i → lUnit (λ i → A i) j i) x y) p (compPathP refl p)
@@ -158,36 +158,20 @@ preassocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A
 preassocP {A = A} {x = x} {B = B} {C = C} p q r j i =
   comp (λ k → preassoc-filler (λ i → A i) B C k j i)
        (λ k → λ { (i = i0) → x
-                ; (i = i1) → compPathP-filler q r j k
+                ; (i = i1) → compPathP-filler q r k j
                 ; (j = i0) → p i
              -- ; (j = i1) → compPathP-filler (compPathP p q) r i k
-                }) (compPathP-filler p q i j)
+                }) (compPathP-filler p q j i)
 
 assocP : {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
   {C_i1 : Type ℓ} {C : (B i1) ≡ C_i1} {w : C i1} (p : PathP A x y) (q : PathP (λ i → B i) y z) (r : PathP (λ i → C i) z w) →
   PathP (λ j → PathP (λ i → assoc (λ i → A i) B C j i) x w) (compPathP p (compPathP q r)) (compPathP (compPathP p q) r)
 assocP p q r =
-  3outof4P (λ i j → compPathP-filler p (compPathP q r) j i) (compPathP (compPathP p q) r) (preassocP p q r)
+  3outof4P (λ j i → compPathP-filler p (compPathP q r) j i) (compPathP (compPathP p q) r) (preassocP p q r)
 
 
 
 -- Loic's code below
-
-
--- simultaneaous composition on both sides of a path
-
-doubleCompPath-filler : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z →
-                        I → I → A
-doubleCompPath-filler p q r i =
-  hfill (λ t → λ { (i = i0) → p (~ t)
-                 ; (i = i1) → r t })
-        (inS (q i))
-
-doubleCompPath : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
-doubleCompPath p q r i = doubleCompPath-filler p q r i i1
-
-_∙∙_∙∙_ : {ℓ : Level} {A : Type ℓ} {w x y z : A} → w ≡ x → x ≡ y → y ≡ z → w ≡ z
-p ∙∙ q ∙∙ r = doubleCompPath p q r
 
 -- some exchange law for doubleCompPath and refl
 
@@ -210,16 +194,16 @@ leftright p q i j =
 
 split-leftright : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
                   (p ∙∙ q ∙∙ r) ≡ (refl ∙∙ (p ∙∙ q ∙∙ refl) ∙∙ r)
-split-leftright p q r i j =
-  hcomp (λ t → λ { (j = i0) → p (~ i ∧ ~ t)
-                 ; (j = i1) → r t })
+split-leftright p q r j i =
+  hcomp (λ t → λ { (i = i0) → p (~ j ∧ ~ t)
+                 ; (i = i1) → r t })
         (doubleCompPath-filler p q refl j i)
 
 split-leftright' : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y) (r : y ≡ z) →
                   (p ∙∙ q ∙∙ r) ≡ (p ∙∙ (refl ∙∙ q ∙∙ r) ∙∙ refl)
-split-leftright' p q r i j =
-  hcomp (λ t → λ { (j = i0) → p (~ t)
-                 ; (j = i1) → r (i ∨ t) })
+split-leftright' p q r j i =
+  hcomp (λ t → λ { (i = i0) → p (~ t)
+                 ; (i = i1) → r (j ∨ t) })
         (doubleCompPath-filler refl q r j i)
 
 doubleCompPath-elim : {ℓ : Level} {A : Type ℓ} {w x y z : A} (p : w ≡ x) (q : x ≡ y)
@@ -240,7 +224,7 @@ cong-∙ f p q j i = hcomp (λ k → λ { (j = i0) → f (compPath-filler p q k 
 
 cong-∙∙ : ∀ {B : Type ℓ} (f : A → B) (p : w ≡ x) (q : x ≡ y) (r : y ≡ z)
           → cong f (p ∙∙ q ∙∙ r) ≡ (cong f p) ∙∙ (cong f q) ∙∙ (cong f r)
-cong-∙∙ f p q r j i = hcomp (λ k → λ { (j = i0) → f (doubleCompPath-filler p q r i k)
+cong-∙∙ f p q r j i = hcomp (λ k → λ { (j = i0) → f (doubleCompPath-filler p q r k i)
                                      ; (i = i0) → f (p (~ k))
                                      ; (i = i1) → f (r k) })
                             (f (q i))

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -82,12 +82,12 @@ PathP≡compPath p q r k = PathP (λ i → p i0 ≡ q (i ∨ k)) (λ j → compP
 PathP≡doubleCompPathˡ : ∀ {A : Type ℓ} {w x y z : A} (p : w ≡ y) (q : w ≡ x) (r : y ≡ z) (s : x ≡ z)
                         → (PathP (λ i → p i ≡ s i) q r) ≡ (p ⁻¹ ∙∙ q ∙∙ s ≡ r)
 PathP≡doubleCompPathˡ p q r s k = PathP (λ i → p (i ∨ k) ≡ s (i ∨ k))
-                                        (λ j → doubleCompPath-filler (p ⁻¹) q s j k) r
+                                        (λ j → doubleCompPath-filler (p ⁻¹) q s k j) r
 
 PathP≡doubleCompPathʳ : ∀ {A : Type ℓ} {w x y z : A} (p : w ≡ y) (q : w ≡ x) (r : y ≡ z) (s : x ≡ z)
                         → (PathP (λ i → p i ≡ s i) q r) ≡ (q ≡ p ∙∙ r ∙∙ s ⁻¹)
 PathP≡doubleCompPathʳ p q r s k  = PathP (λ i → p (i ∧ (~ k)) ≡ s (i ∧ (~ k)))
-                                         q (λ j → doubleCompPath-filler p r (s ⁻¹) j k)
+                                         q (λ j → doubleCompPath-filler p r (s ⁻¹) k j)
 
 compPathl-cancel : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : x ≡ z) → p ∙ (sym p ∙ q) ≡ q
 compPathl-cancel p q = p ∙ (sym p ∙ q) ≡⟨ assoc p (sym p) q ⟩

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -64,12 +64,12 @@ cong₂ f p q i = f (p i) (q i)
 {- The most natural notion of homogenous path composition
     in a cubical setting is double composition:
 
-     x ∙ ∙ ∙ > w
-     |         ^
-   p |         | r        ^
-     V         |        j |
-     y — — — > z          ∙ — >
-          q                 i
+       x ∙ ∙ ∙ > w
+       ^         ^
+   p⁻¹ |         | r        ^
+       |         |        j |
+       y — — — > z          ∙ — >
+            q                 i
 
    `p ∙∙ q ∙∙ r` gives the line at the top,
    `doubleCompPath-filler p q r` gives the whole square

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -38,7 +38,7 @@ private
     ℓ ℓ' : Level
     A : Type ℓ
     B : A → Type ℓ
-    x y z : A
+    x y z w : A
 
 refl : x ≡ x
 refl {x = x} = λ _ → x
@@ -61,34 +61,111 @@ cong₂ : ∀ {C : (a : A) → (b : B a) → Type ℓ} →
         PathP (λ i → C (p i) (q i)) (f x u) (f y v)
 cong₂ f p q i = f (p i) (q i)
 
--- The filler of homogeneous path composition:
--- compPath-filler p q = PathP (λ i → x ≡ q i) p (p ∙ q)
+{- The most natural notion of homogenous path composition
+    in a cubical setting is double composition:
 
-compPath-filler : ∀ {x y z : A} → x ≡ y → y ≡ z → I → I → A
-compPath-filler {x = x} p q j i =
-  hfill (λ j → λ { (i = i0) → x
-                  ; (i = i1) → q j }) (inS (p i)) j
+     x ∙ ∙ ∙ > w
+     |         ^
+   p |         | r        ^
+     V         |        j |
+     y — — — > z          ∙ — >
+          q                 i
+
+   `p ∙∙ q ∙∙ r` gives the line at the top,
+   `doubleCompPath-filler p q r` gives the whole square
+-}
+
+_∙∙_∙∙_ : w ≡ x → x ≡ y → y ≡ z → w ≡ z
+(p ∙∙ q ∙∙ r) i =
+  hcomp (λ j → λ { (i = i0) → p (~ j)
+                 ; (i = i1) → r j })
+        (q i)
+
+doubleCompPath-filler : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)
+                      → PathP (λ j → p (~ j) ≡ r j) q (p ∙∙ q ∙∙ r)
+doubleCompPath-filler p q r j i =
+  hfill (λ j → λ { (i = i0) → p (~ j)
+                 ; (i = i1) → r j })
+        (inS (q i)) j
+
+-- any two definitions of double composition are equal
+compPath-unique : ∀ (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)
+                  → (α β : Σ[ s ∈ x ≡ w ] PathP (λ j → p (~ j) ≡ r j) q s)
+                  → α ≡ β
+compPath-unique p q r (α , α-filler) (β , β-filler) t
+  = (λ i → cb i1 i) , (λ j i → cb j i)
+  where cb : I → I → _
+        cb j i = hfill (λ j → λ { (t = i0) → α-filler j i
+                                ; (t = i1) → β-filler j i
+                                ; (i = i0) → p (~ j)
+                                ; (i = i1) → r j })
+                       (inS (q i)) j
+
+{- For single homogenous path composition, we take `p = refl`:
+
+     x ∙ ∙ ∙ > z
+     ‖         ^
+     ‖         | r        ^
+     ‖         |        j |
+     x — — — > y          ∙ — >
+          q                 i
+
+   `q ∙ r` gives the line at the top,
+   `compPath-filler q r` gives the whole square
+-}
 
 _∙_ : x ≡ y → y ≡ z → x ≡ z
-(p ∙ q) j = compPath-filler p q i1 j
+p ∙ q = refl ∙∙ p ∙∙ q
 
--- The filler of heterogeneous path composition:
--- compPathP-filler p q = PathP (λ i → PathP (λ j → (compPath-filler (λ i → A i) B i j)) x (q i)) p (compPathP p q)
+compPath-filler : (p : x ≡ y) (q : y ≡ z) → PathP (λ j → x ≡ q j) p (p ∙ q)
+compPath-filler p q = doubleCompPath-filler refl p q
 
-compPathP-filler : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Type ℓ} {B : A i1 ≡ B_i1} → {z : B i1} →
-  (p : PathP A x y) → (q : PathP (λ i → B i) y z) → ∀ (i j : I) → compPath-filler (λ i → A i) B j i
-compPathP-filler {A = A} {x = x} {B = B} p q i =
+-- We could have also defined single composition by taking `r = refl`:
+
+_∙'_ : x ≡ y → y ≡ z → x ≡ z
+p ∙' q = p ∙∙ q ∙∙ refl
+
+compPath'-filler : (p : x ≡ y) (q : y ≡ z) → PathP (λ j → p (~ j) ≡ z) q (p ∙' q)
+compPath'-filler p q = doubleCompPath-filler p q refl
+
+-- It's easy to show that `p ∙ q` also has such a filler:
+compPath-filler' : (p : x ≡ y) (q : y ≡ z) → PathP (λ j → p (~ j) ≡ z) q (p ∙ q)
+compPath-filler' {z = z} p q j i =
+  hcomp (λ k → λ { (i = i0) → p (~ j)
+                 ; (i = i1) → q k
+                 ; (j = i0) → q (i ∧ k) })
+        (p (i ∨ ~ j))
+-- Note: We can omit a (j = i1) case here since when (j = i1), the whole expression is
+--  definitionally equal to `p ∙ q`. (Notice that `p ∙ q` is also an hcomp.) Nevertheless,
+--  we could have given `compPath-filler p q k i` as the (j = i1) case.
+
+-- From this, we can show that these two notions of composition are the same
+compPath≡compPath' : (p : x ≡ y) (q : y ≡ z) → p ∙ q ≡ p ∙' q
+compPath≡compPath' p q j =
+  compPath-unique p q refl (p ∙ q  , compPath-filler' p q)
+                           (p ∙' q , compPath'-filler p q) j .fst
+
+-- Heterogeneous path composition and its filler:
+
+compPathP : ∀ {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} {z : B i1}
+            → PathP A x y → PathP (λ i → B i) y z → PathP (λ j → ((λ i → A i) ∙ B) j) x z
+compPathP {A = A} {x = x} {B = B} p q i =
+  comp (λ j → compPath-filler (λ i → A i) B j i)
+       (λ j → λ { (i = i0) → x ;
+                  (i = i1) → q j })
+       (p i)
+
+compPathP-filler : ∀ {A : I → Type ℓ} {x : A i0} {y : A i1} {B_i1 : Type ℓ} {B : A i1 ≡ B_i1} {z : B i1}
+                   → (p : PathP A x y) (q : PathP (λ i → B i) y z)
+                   → PathP (λ j → PathP (λ k → (compPath-filler (λ i → A i) B j k)) x (q j)) p (compPathP p q)
+compPathP-filler {A = A} {x = x} {B = B} p q j i =
   fill (λ j → compPath-filler (λ i → A i) B j i)
        (λ j → λ { (i = i0) → x ;
-                   (i = i1) → q j }) (inS (p i))
-
-compPathP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} → {B_i1 : Type ℓ} {B : (A i1) ≡ B_i1} → {z : B i1} →
-  (p : PathP A x y) → (q : PathP (λ i → B i) y z) → PathP (λ j → ((λ i → A i) ∙ B) j) x z
-compPathP p q j = compPathP-filler p q j i1
+                  (i = i1) → q j })
+       (inS (p i)) j
 
 _≡⟨_⟩_ : (x : A) → x ≡ y → y ≡ z → x ≡ z
 _ ≡⟨ x≡y ⟩ y≡z = x≡y ∙ y≡z
-
 
 ≡⟨⟩-syntax : (x : A) → x ≡ y → y ≡ z → x ≡ z
 ≡⟨⟩-syntax = _≡⟨_⟩_
@@ -98,27 +175,6 @@ syntax ≡⟨⟩-syntax x (λ i → B) y = x ≡[ i ]⟨ B ⟩ y
 _∎ : (x : A) → x ≡ x
 _ ∎ = refl
 
--- another definition of composition, useful for some proofs
-compPath'-filler : ∀ {x y z : A} → x ≡ y → y ≡ z → I → I → A
-compPath'-filler {z = z} p q j i =
-  hfill (λ j → λ { (i = i0) → p (~ j)
-                 ; (i = i1) → z }) (inS (q i)) j
-
-_□_ : x ≡ y → y ≡ z → x ≡ z
-(p □ q) j = compPath'-filler p q i1 j
-
-□≡∙ : (p : x ≡ y) (q : y ≡ z) → p □ q ≡ p ∙ q
-□≡∙ {x = x} {y = y} {z = z} p q i j = hcomp (λ k → \ { (i = i0) → compPath'-filler p q k j
-                                             ; (i = i1) → compPath-filler p q k j
-                                             ; (j = i0) → p ( ~ i ∧ ~ k)
-                                             ; (j = i1) → q (k ∨ ~ i) }) (helper i j)
-  where
-    helper : PathP (λ i → p (~ i) ≡ q (~ i)) q p
-    helper i j = hcomp (λ k → \ { (i = i0) → q (k ∧ j)
-                                ; (i = i1) → p (~ k ∨ j)
-                                ; (j = i0) → p (~ i ∨ ~ k)
-                                ; (j = i1) → q (~ i ∧ k) })
-                       y
 
 -- Transport, subst and functional extensionality
 

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -66,13 +66,13 @@ isSet-subst : ∀ {ℓ ℓ′} {A : Type ℓ} {B : A → Type ℓ′}
 isSet-subst {B = B} isSet-A p x = subst (λ p′ → subst B p′ x ≡ x) (isSet-A _ _ refl p) (substRefl {B = B} x)
 
 -- substituting along a composite path is equivalent to substituting twice
-substComposite-□ : ∀ {ℓ ℓ′} {A : Type ℓ} → (B : A → Type ℓ′)
-                     → {x y z : A} (p : x ≡ y) (q : y ≡ z) (u : B x)
-                     → subst B (p □ q) u ≡ subst B q (subst B p u)
-substComposite-□ B p q Bx = sym (substRefl {B = B} _) ∙ helper where
+substComposite : ∀ {ℓ ℓ′} {A : Type ℓ} → (B : A → Type ℓ′)
+                   → {x y z : A} (p : x ≡ y) (q : y ≡ z) (u : B x)
+                   → subst B (p ∙ q) u ≡ subst B q (subst B p u)
+substComposite B p q Bx = sym (substRefl {B = B} _) ∙ helper where
   compSq : I → I → _
-  compSq = compPath'-filler p q
-  helper : subst B refl (subst B (p □ q) Bx) ≡ subst B q (subst B p Bx)
+  compSq j i = compPath-filler' p q j i
+  helper : subst B refl (subst B (p ∙ q) Bx) ≡ subst B q (subst B p Bx)
   helper i = subst B (λ k → compSq (~ i ∧ ~ k) (~ i ∨ k)) (subst B (λ k → compSq (~ i ∨ ~ k) (~ i ∧ k)) Bx)
 
 -- substitution commutes with morphisms in slices

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -179,12 +179,12 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         H1 : (x : 3x3-span.A□2 span) → proj₁ (A□2→A×join x) ≡ A□0→A (3x3-span.f□1 span x)
         H1 (inl (a , b)) = refl
         H1 (inr (a , c)) = refl
-        H1 (push (a , (b , c)) i) j = A□0→A (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
+        H1 (push (a , (b , c)) i) j = A□0→A (doubleCompPath-filler refl (λ i → push (a , c) i) refl j i)
 
         H2 : (x : 3x3-span.A□2 span) → proj₂ (A□2→A×join x) ≡ fst (joinPushout≃join _ _) (3x3-span.f□3 span x)
         H2 (inl (a , b)) = refl
         H2 (inr (a , c)) = refl
-        H2 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (b , c) i) refl i j)
+        H2 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (b , c) i) refl j i)
 
     -- the second span appearing in 3x3 lemma
     sp3 : 3-span
@@ -261,12 +261,12 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         H3 : (x : 3x3-span.A2□ span) → proj₂ (A2□→join×C x) ≡ A4□→C (3x3-span.f3□ span x)
         H3 (inl (a , c)) = refl
         H3 (inr (b , c)) = refl
-        H3 (push (a , (b , c)) i) j = A4□→C (doubleCompPath-filler refl (λ i → push (a , c) i) refl i j)
+        H3 (push (a , (b , c)) i) j = A4□→C (doubleCompPath-filler refl (λ i → push (a , c) i) refl j i)
 
         H4 : (x : 3x3-span.A2□ span) → proj₁ (A2□→join×C x) ≡ fst (joinPushout≃join _ _) (3x3-span.f1□ span x)
         H4 (inl (a , c)) = refl
         H4 (inr (b , c)) = refl
-        H4 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (a , b) i) refl i j)
+        H4 (push (a , (b , c)) i) j = fst (joinPushout≃join _ _) (doubleCompPath-filler refl (λ i → push (a , b) i) refl j i)
 
 {-
   Direct proof of an associativity-related property. Combined with

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -222,10 +222,10 @@ record 3x3-span : Type₁ where
       forward-r (push a i) = push (inr a) i
 
       forward-filler : A22 → I → I → I → A○□
-      forward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
-                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
-                                     ; (j = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t)
-                                     ; (j = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) })
+      forward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) (~ t) j)
+                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) (~ t) j)
+                                     ; (j = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) t i)
+                                     ; (j = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) t i) })
                             (inS (push (push a j) i))
 
       A□○→A○□ : A□○ → A○□
@@ -247,10 +247,10 @@ record 3x3-span : Type₁ where
       backward-r (push a i) = push (inr a) i
 
       backward-filler : A22 → I → I → I → A□○
-      backward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
-                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
-                                     ; (j = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t)
-                                     ; (j = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) })
+      backward-filler a i j = hfill (λ t → λ { (i = i0) → inl (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) (~ t) j)
+                                     ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) (~ t) j)
+                                     ; (j = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) t i)
+                                     ; (j = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) t i) })
                             (inS (push (push a j) i))
 
       A○□→A□○ : A○□ → A□○
@@ -277,10 +277,10 @@ record 3x3-span : Type₁ where
       A○□→A□○→A○□ (push (inl x) i) k = push (inl x) i
       A○□→A□○→A○□ (push (inr x) i) k = push (inr x) i
       A○□→A□○→A○□ (push (push a i) j) k =
-        hcomp (λ t → λ { (i = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) j (~ t))
-                       ; (i = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) j (~ t))
-                       ; (j = i0) → homotopy1-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) i t) k
-                       ; (j = i1) → homotopy1-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) i t) k
+        hcomp (λ t → λ { (i = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) (~ t) j)
+                       ; (i = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) (~ t) j)
+                       ; (j = i0) → homotopy1-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) t i) k
+                       ; (j = i1) → homotopy1-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) t i) k
                        ; (k = i0) → A□○→A○□ (backward-filler a i j t)
                        ; (k = i1) → forward-filler a j i (~ t) })
               (forward-filler a j i i1)
@@ -302,10 +302,10 @@ record 3x3-span : Type₁ where
       A□○→A○□→A□○ (push (inl x) i) k = push (inl x) i
       A□○→A○□→A□○ (push (inr x) i) k = push (inr x) i
       A□○→A○□→A□○ (push (push a i) j) k =
-        hcomp (λ t → λ { (i = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) j (~ t))
-                       ; (i = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) j (~ t))
-                       ; (j = i0) → homotopy2-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) i t) k
-                       ; (j = i1) → homotopy2-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) i t) k
+        hcomp (λ t → λ { (i = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) (~ t) j)
+                       ; (i = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) (~ t) j)
+                       ; (j = i0) → homotopy2-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) t i) k
+                       ; (j = i1) → homotopy2-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) t i) k
                        ; (k = i0) → A○□→A□○ (forward-filler a i j t)
                        ; (k = i1) → backward-filler a j i (~ t) })
               (backward-filler a j i i1)


### PR DESCRIPTION
This PR comes from the following ideas:
- As far as I can tell, the definition of `compPath-filler` doesn't need to come before the definition of `_∙_`, in fact I think it's more helpful to newcomers if it comes after:
   ```agda
   _∙_ : x ≡ y → y ≡ z → x ≡ z
   _∙_ {x = x} p q i =
     hcomp (λ j → λ { (i = i0) → x
                    ; (i = i1) → q j })
           (p i)
   
   compPath-filler : (p : x ≡ y) (q : y ≡ z) → PathP (λ j → x ≡ q j) p (p ∙ q)
   compPath-filler {x = x} p q j i =
     hfill (λ j → λ { (i = i0) → x
                    ; (i = i1) → q j })
           (inS (p i)) j
   ```
- The reason to use `_□_` over `_∙_` is because of `_□_`'s filler, but it's straightforward to define the analogous filler for `_∙_`:
   ```agda
   compPath-filler' : (p : x ≡ y) (q : y ≡ z) → PathP (λ j → p (~ j) ≡ z) q (p ∙ q)
   compPath-filler' {z = z} p q j i =
     hcomp (λ k → λ { (i = i0) → p (~ j)
                    ; (i = i1) → q k
                    ; (j = i0) → q (i ∧ k) })
           (p (i ∨ ~ j))
   ```
   Using this instead of `compPath'-filler` is much more convenient, and can simply things. See `homotopyNatural`, for example.

I ended up defining both versions of composition in terms of `_∙∙_∙∙_`, which makes for a nicer proof that they are equal and (in my opinion) makes for nicer exposition. In general, I focused on clarity of exposition, spelling out in comments a few things I wish I would've seen when I was first trying to grok cubical type theory.

My goal here is to make reading `Foundations.Prelude` and using `_∙_` a bit friendlier to new folks, so if this complicates things in other ways I'm very happy to greatly modify or close this PR.