### PR TITLE
Explanation of "A is constant on φ" in Cubical.Core.Primitives

### DIFF
--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -154,8 +154,15 @@ infix 4 _[_↦_]
 
 -- * Generalized transport and homogeneous composition [CHM 18].
 
--- When calling "transp A φ a" Agda makes sure that "A" is constant on "φ".
+-- When calling "transp A φ a" Agda makes sure that "A" is constant on "φ" (see below).
 -- transp : ∀ {ℓ} (A : I → Type ℓ) (φ : I) (a : A i0) → A i1
+
+-- "A" being constant on "φ" means that "A" should be a constant function whenever the
+-- constraint "φ = i1" is satisfied. For example:
+-- - If "φ" is "i0" then "A" can be anything, since this condition is vacuously true.
+-- - If "φ" is "i1" then "A" must be a constant function.
+-- - If "φ" is some in-scope variable "i" then "A" only needs to be a constant function
+--   when substituting "i1" for "i".
 
 -- When calling "hcomp A φ u a" Agda makes sure that "a" agrees with "u i0" on "φ".
 -- hcomp : ∀ {ℓ} {A : Type ℓ} {φ : I} (u : I → Partial φ A) (a : A) → A


### PR DESCRIPTION
The terminology "A is constant on φ" can be counterintuitive and confusing when seeing it for the first time. This PR adds an explanation and some examples, mostly taken from the docs, to `Cubical.Core.Primitives`.

The third example I added I think is particularly helpful in making clear what this phrase means, let me know if folks think this example should be added to the docs as well.