### PR TITLE
Different levels of objects and morphisms in categories

### DIFF
--- a/Cubical/Categories/Category.agda
+++ b/Cubical/Categories/Category.agda
@@ -4,11 +4,11 @@ module Cubical.Categories.Category where
 
 open import Cubical.Foundations.Prelude
 
-record Precategory ℓ : Type (ℓ-suc ℓ) where
+record Precategory ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   no-eta-equality
   field
     ob : Type ℓ
-    hom : ob → ob → Type ℓ
+    hom : ob → ob → Type ℓ'
     idn : ∀ x → hom x x
     seq : ∀ {x y z} (f : hom x y) (g : hom y z) → hom x z
     seq-λ : ∀ {x y : ob} (f : hom x y) → seq (idn x) f ≡ f
@@ -17,14 +17,14 @@ record Precategory ℓ : Type (ℓ-suc ℓ) where
 
 open Precategory public
 
-record isCategory {ℓ} (𝒞 : Precategory ℓ) : Type ℓ where
+record isCategory {ℓ ℓ'} (𝒞 : Precategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
   field
     homIsSet : ∀ {x y} → isSet (𝒞 .hom x y)
 
 open isCategory public
 
 
-_^op : ∀ {ℓ} → Precategory ℓ → Precategory ℓ
+_^op : ∀ {ℓ ℓ'} → Precategory ℓ ℓ' → Precategory ℓ ℓ'
 (𝒞 ^op) .ob = 𝒞 .ob
 (𝒞 ^op) .hom x y = 𝒞 .hom y x
 (𝒞 ^op) .idn = 𝒞 .idn

--- a/Cubical/Categories/Category.agda
+++ b/Cubical/Categories/Category.agda
@@ -23,7 +23,6 @@ record isCategory {ℓ ℓ'} (𝒞 : Precategory ℓ ℓ') : Type (ℓ-max ℓ �
 
 open isCategory public
 
-
 _^op : ∀ {ℓ ℓ'} → Precategory ℓ ℓ' → Precategory ℓ ℓ'
 (𝒞 ^op) .ob = 𝒞 .ob
 (𝒞 ^op) .hom x y = 𝒞 .hom y x

--- a/Cubical/Categories/Functor.agda
+++ b/Cubical/Categories/Functor.agda
@@ -8,9 +8,9 @@ open import Cubical.Categories.Category
 
 private
   variable
-    ℓ𝒞 ℓ𝒟 : Level
+    ℓ𝒞 ℓ𝒞' ℓ𝒟 ℓ𝒟' : Level
 
-record Functor (𝒞 : Precategory ℓ𝒞) (𝒟 : Precategory ℓ𝒟) : Type (ℓ-max ℓ𝒞 ℓ𝒟) where
+record Functor (𝒞 : Precategory ℓ𝒞 ℓ𝒞') (𝒟 : Precategory ℓ𝒟 ℓ𝒟') : Type (ℓ-max (ℓ-max ℓ𝒞 ℓ𝒞') (ℓ-max ℓ𝒟 ℓ𝒟')) where
   no-eta-equality
   open Precategory
 

--- a/Cubical/Categories/NaturalTransformation.agda
+++ b/Cubical/Categories/NaturalTransformation.agda
@@ -8,10 +8,10 @@ open import Cubical.Categories.Functor
 
 private
   variable
-    ℓ𝒞 ℓ𝒟 : Level
+    ℓ𝒞 ℓ𝒞' ℓ𝒟 ℓ𝒟' : Level
 
-module _ {𝒞 : Precategory ℓ𝒞} {𝒟 : Precategory ℓ𝒟} where
-  record NatTrans (F G : Functor 𝒞 𝒟) : Type (ℓ-max ℓ𝒞 ℓ𝒟) where
+module _ {𝒞 : Precategory ℓ𝒞 ℓ𝒞'} {𝒟 : Precategory ℓ𝒟 ℓ𝒟'} where
+  record NatTrans (F G : Functor 𝒞 𝒟) : Type (ℓ-max (ℓ-max ℓ𝒞 ℓ𝒞') (ℓ-max ℓ𝒟 ℓ𝒟')) where
     open Precategory
     open Functor
 
@@ -64,12 +64,12 @@ module _ {𝒞 : Precategory ℓ𝒞} {𝒟 : Precategory ℓ𝒟} where
         rem = toPathP (𝒟-category .homIsSet _ _ _ _)
 
 
-module _ (𝒞 : Precategory ℓ𝒞) (𝒟 : Precategory ℓ𝒟) ⦃ _ : isCategory 𝒟 ⦄ where
+module _ (𝒞 : Precategory ℓ𝒞 ℓ𝒞') (𝒟 : Precategory ℓ𝒟 ℓ𝒟') ⦃ _ : isCategory 𝒟 ⦄ where
   open Precategory
   open NatTrans
   open Functor
 
-  FUNCTOR : Precategory (ℓ-max ℓ𝒞 ℓ𝒟)
+  FUNCTOR : Precategory (ℓ-max (ℓ-max ℓ𝒞 ℓ𝒞') (ℓ-max ℓ𝒟 ℓ𝒟')) (ℓ-max (ℓ-max ℓ𝒞 ℓ𝒞') (ℓ-max ℓ𝒟 ℓ𝒟'))
   FUNCTOR .ob = Functor 𝒞 𝒟
   FUNCTOR .hom = NatTrans
   FUNCTOR .idn = id-trans

--- a/Cubical/Categories/Presheaves.agda
+++ b/Cubical/Categories/Presheaves.agda
@@ -12,54 +12,54 @@ open import Cubical.Categories.Functor
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Sets
 
-module _ (ℓ : Level) where
-  PSH : Precategory ℓ → Precategory (ℓ-suc ℓ)
+module _ (ℓ ℓ' : Level) where
+  PSH : Precategory ℓ ℓ' → Precategory (ℓ-max (ℓ-suc ℓ) ℓ') (ℓ-max (ℓ-suc ℓ) ℓ')
   PSH 𝒞 = FUNCTOR (𝒞 ^op) (SET ℓ)
 
 private
   variable
     ℓ : Level
 
-module Yoneda (𝒞 : Precategory ℓ) ⦃ 𝒞-cat : isCategory 𝒞 ⦄ where
+module Yoneda (𝒞 : Precategory ℓ ℓ) ⦃ 𝒞-cat : isCategory 𝒞 ⦄ where
   open Functor
   open NatTrans
 
   yo : 𝒞 .ob → Functor (𝒞 ^op) (SET ℓ)
   yo x .F-ob y .fst = 𝒞 .hom y x
   yo x .F-ob y .snd = 𝒞-cat .homIsSet
-  yo x .F-hom f .lower g = 𝒞 .seq f g
-  yo x .F-idn i .lower f = 𝒞 .seq-λ f i
-  yo x .F-seq f g i .lower h = 𝒞 .seq-α g f h i
+  yo x .F-hom f g = 𝒞 .seq f g
+  yo x .F-idn i f = 𝒞 .seq-λ f i
+  yo x .F-seq f g i h = 𝒞 .seq-α g f h i
 
-  YO : Functor 𝒞 (PSH ℓ 𝒞)
+  YO : Functor 𝒞 (PSH ℓ ℓ 𝒞)
   YO .F-ob = yo
-  YO .F-hom f .N-ob z .lower g = 𝒞 .seq g f
-  YO .F-hom f .N-hom g i .lower h = 𝒞 .seq-α g h f i
-  YO .F-idn = make-nat-trans-path λ i _ → lift λ f → 𝒞 .seq-ρ f i
-  YO .F-seq f g = make-nat-trans-path λ i _ → lift λ h → 𝒞 .seq-α h f g (~ i)
+  YO .F-hom f .N-ob z g = 𝒞 .seq g f
+  YO .F-hom f .N-hom g i h = 𝒞 .seq-α g h f i
+  YO .F-idn = make-nat-trans-path λ i _ → λ f → 𝒞 .seq-ρ f i
+  YO .F-seq f g = make-nat-trans-path λ i _ → λ h → 𝒞 .seq-α h f g (~ i)
 
 
   module _ {x} (F : Functor (𝒞 ^op) (SET ℓ)) where
     yo-yo-yo : NatTrans (yo x) F → F .F-ob x .fst
-    yo-yo-yo α = α .N-ob _ .lower (𝒞 .idn _)
+    yo-yo-yo α = α .N-ob _ (𝒞 .idn _)
 
     no-no-no : F .F-ob x .fst → NatTrans (yo x) F
-    no-no-no a .N-ob y .lower f = F .F-hom f .lower a
-    no-no-no a .N-hom f = liftExt (funExt λ g i → F .F-seq g f i .lower a)
+    no-no-no a .N-ob y f = F .F-hom f a
+    no-no-no a .N-hom f = funExt λ g i → F .F-seq g f i a
 
     yo-iso : Iso (NatTrans (yo x) F) (F .F-ob x .fst)
     yo-iso .Iso.fun = yo-yo-yo
     yo-iso .Iso.inv = no-no-no
-    yo-iso .Iso.rightInv b i = F .F-idn i .lower b
-    yo-iso .Iso.leftInv a = make-nat-trans-path (funExt λ _ → liftExt (funExt rem))
+    yo-iso .Iso.rightInv b i = F .F-idn i b
+    yo-iso .Iso.leftInv a = make-nat-trans-path (funExt λ _ → funExt rem)
       where
-        rem : ∀ {z} (x₁ : 𝒞 .hom z x) → F .F-hom x₁ .lower (yo-yo-yo a) ≡ lower (a .N-ob z) x₁
+        rem : ∀ {z} (x₁ : 𝒞 .hom z x) → F .F-hom x₁ (yo-yo-yo a) ≡ (a .N-ob z) x₁
         rem g =
-          F .F-hom g .lower (yo-yo-yo a)
-            ≡[ i ]⟨ a .N-hom g (~ i) .lower (𝒞 .idn x) ⟩
-          a .N-hom g i0 .lower (𝒞 .idn x)
-            ≡[ i ]⟨ a .N-ob _ .lower (𝒞 .seq-ρ g i) ⟩
-          lower (a .N-ob _) g
+          F .F-hom g (yo-yo-yo a)
+            ≡[ i ]⟨ a .N-hom g (~ i) (𝒞 .idn x) ⟩
+          a .N-hom g i0 (𝒞 .idn x)
+            ≡[ i ]⟨ a .N-ob _ (𝒞 .seq-ρ g i) ⟩
+          (a .N-ob _) g
             ∎
 
     yo-equiv : NatTrans (yo x) F ≃ F .F-ob x .fst

--- a/Cubical/Categories/Sets.agda
+++ b/Cubical/Categories/Sets.agda
@@ -7,11 +7,11 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Categories.Category
 
 module _ ℓ where
-  SET : Precategory (ℓ-suc ℓ)
+  SET : Precategory (ℓ-suc ℓ) ℓ
   SET .ob = Σ (Type ℓ) isSet
-  SET .hom (A , _) (B , _) = Lift (A → B)
-  SET .idn _ .lower x = x
-  SET .seq (lift f) (lift g) .lower x = g (f x)
+  SET .hom (A , _) (B , _) = A → B
+  SET .idn _  = λ x → x
+  SET .seq f g = λ x → g (f x)
   SET .seq-λ f = refl
   SET .seq-ρ f = refl
   SET .seq-α f g h = refl
@@ -25,4 +25,4 @@ module _ {ℓ} where
 
   instance
     SET-category : isCategory (SET ℓ)
-    SET-category .homIsSet {_} {B , B/set} = isSetLift (isSetExpIdeal B/set)
+    SET-category .homIsSet {_} {B , B/set} = isSetExpIdeal B/set

--- a/Cubical/Categories/Type.agda
+++ b/Cubical/Categories/Type.agda
@@ -6,11 +6,11 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Categories.Category
 
 module _ ℓ where
-  TYPE : Precategory (ℓ-suc ℓ)
-  TYPE .ob = Type _
-  TYPE .hom A B = Lift (A → B)
-  TYPE .idn A .lower x = x
-  TYPE .seq (lift f) (lift g) .lower x = g (f x)
+  TYPE : Precategory (ℓ-suc ℓ) ℓ
+  TYPE .ob = Type ℓ
+  TYPE .hom A B = A → B
+  TYPE .idn A  = λ x → x
+  TYPE .seq f g = λ x → g (f x)
   TYPE .seq-λ f = refl
   TYPE .seq-ρ f = refl
   TYPE .seq-α f g h = refl


### PR DESCRIPTION
This PR adds another level argument to the record Precategory such that the ob and hom may take values in different universes.

This has the advantage that the lifting of morphisms, as seen for instance in Presheaves.agda, can be omitted.