### PR TITLE
[ travis ] Only reinstall agda when necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
       echo "cabal build-cache MISS";
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+      travis_wait 30 cabal install --only-dependencies;
     fi
   # only installing agda if we have to
   - touch $HOME/oldHEAD.txt
@@ -67,8 +68,7 @@ install:
     then
       echo "agda up to date";
     else
-      echo "**** cached agda behind remote - re-installing... ****";
-      travis_wait 30 cabal install --only-dependencies;
+      echo "**** cached build of agda is out of date, re-installing... ****";
       travis_wait 30 cabal install;
     fi
   - cd -
@@ -82,6 +82,7 @@ install:
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
   # snapshop agda dir on cache miss
+  - [ -d "$HOME/.cabsnap/agda" ] && rm -rf $HOME/.cabsnap/agda;
   - cp -a $HOME/agda $HOME/.cabsnap/agda;
   - yes | rm -R agda/
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,15 +62,14 @@ install:
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  # TODO: delete these lines once travis is working
-  - git rev-parse HEAD
-  - cat $HOME/agdaHEAD.txt
   # only install agda if we have to
+  - git rev-parse HEAD; cat $HOME/agdaHEAD.txt
   - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/agdaHEAD.txt)" ];
     then
       echo "skipping cabal install";
     else
       git rev-parse HEAD > $HOME/agdaHEAD.txt;
+      echo "starting cabal install";
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ install:
       cp -a $HOME/.cabsnap/agda $HOME/agda;
       cd agda;
       git rev-parse HEAD > $HOME/oldHEAD.txt;
-      git pull origin master --depth 1;
+      git fetch origin master --depth=1;
+      git reset --hard origin/master;
     else
       echo "agda dir cache MISS";
       git clone https://github.com/agda/agda --depth 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ dist: xenial
 cache:
   directories:
     - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+    - $HOME/.cabal/store
+    - $HOME/.cabal/bin
+    - $HOME/agda
 
 matrix:
   include:
@@ -31,7 +35,12 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
-  - git clone https://github.com/agda/agda --depth=1
+  - if [ -d "./agda" ];
+    then
+      git clone https://github.com/agda/agda --depth=1;
+    else
+      git fetch origin master;
+    fi
   - cd agda
   # checking whether .ghc is still valid
   - cabal install --only-dependencies --dry -v > $HOME/installplan.txt
@@ -49,8 +58,14 @@ install:
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  - travis_wait 30 cabal install --only-dependencies
-  - travis_wait 30 cabal install
+  # only install agda if we have to
+  - if [ $(git rev-parse HEAD) == $(git rev-parse master@{origin}) ];
+    then
+      echo "skipping cabal install";
+    else
+      travis_wait 30 cabal install --only-dependencies;
+      travis_wait 30 cabal install;
+    fi
   - cd -
   # installing fix-agda-whitespace
   - cd agda/src/fix-agda-whitespace

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,17 @@ install:
   - cd
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
-  # checking whether agda dir is cached and fetching the latest
+  # checking whether agda is cached and fetching the latest
   - if [ -d "$HOME/.cabsnap/agda" ];
     then
-      echo "agda dir cache HIT";
+      echo "agda cache HIT";
       cp -a $HOME/.cabsnap/agda $HOME/agda;
       cd agda;
       git rev-parse HEAD > $HOME/oldHEAD.txt;
       git fetch origin master --depth=1;
       git reset --hard origin/master;
     else
-      echo "agda dir cache MISS";
+      echo "agda cache MISS";
       git clone https://github.com/agda/agda --depth 1;
       cd agda;
     fi
@@ -81,9 +81,9 @@ install:
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
-  # snapshop agda dir on cache miss
-  - [ -d "$HOME/.cabsnap/agda" ] && rm -rf $HOME/.cabsnap/agda;
-  - cp -a $HOME/agda $HOME/.cabsnap/agda;
+  # snapshop agda on cache miss
+  - if [ -d "$HOME/.cabsnap/agda" ]; then rm -rf $HOME/.cabsnap/agda; fi
+  - cp -a $HOME/agda $HOME/.cabsnap/agda
   - yes | rm -R agda/
   - cd $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,13 @@ install:
   - cd agda/src/fix-agda-whitespace
   - cabal install fix-agda-whitespace.cabal
   - cd -
-  - yes | rm -R agda/
   # snapshot package-db on cache miss
   - echo "snapshotting package-db to build-cache";
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
-    cp -a $HOME/agda $HOME/.cabsnap/agda;
+  - cp -a $HOME/agda $HOME/.cabsnap/agda;
+  - yes | rm -R agda/
   - cd $TRAVIS_BUILD_DIR
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
-  - if [ $(git rev-parse HEAD) == $(git rev-parse master@{origin}) ];
+  - if [ $(git rev-parse HEAD) == $(git rev-parse origin/master) ];
     then
       echo "skipping cabal install";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - git rev-parse HEAD
   - cat $HOME/agdaHEAD.txt
   # only install agda if we have to
-  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat $HOME/agdaHEAD.txt) ];
+  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/agdaHEAD.txt)" ];
     then
       echo "skipping cabal install";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ install:
       echo "cabal build-cache MISS";
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-      travis_wait 30 cabal install --only-dependencies;
     fi
   # only installing agda if we have to
   - touch $HOME/oldHEAD.txt
@@ -69,6 +68,7 @@ install:
       echo "agda up to date";
     else
       echo "**** cached build of agda is out of date, re-installing... ****";
+      travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi
   - cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     then
       cd agda;
       git fetch origin master --depth 1;
-      git rev-parse HEAD > $HOME/agdaHEAD.txt
+      git rev-parse HEAD > $HOME/agdaHEAD.txt;
     else
       git clone https://github.com/agda/agda --depth 1;
       cd agda;

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
-  - if [ $(git rev-parse HEAD) == $(git rev-parse origin/master) ];
+  - if [ agda ] && [ $(git rev-parse master) == $(git rev-parse origin/master) ];
     then
       echo "skipping cabal install";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ dist: xenial
 cache:
   directories:
     - $HOME/.cabsnap
-    - $HOME/agda
 
 matrix:
   include:
@@ -31,13 +30,16 @@ install:
   - cd
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
-  # get master Agda
-  - if [ -d "./agda/src" ];
+  # getting the latest agda
+  - if [ -d "$HOME/.cabsnap/agda" ];
     then
+      echo "agda git cache HIT";
+      cp -a $HOME/.cabsnap/agda $HOME/agda;
       cd agda;
-      git rev-parse HEAD > oldHEAD.txt;
+      git rev-parse HEAD > $HOME/oldHEAD.txt;
       git pull origin master --depth 1;
     else
+      echo "agda git cache MISS";
       git clone https://github.com/agda/agda --depth 1;
       cd agda;
     fi
@@ -58,13 +60,15 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
-  - touch oldHEAD.txt
-  - git rev-parse HEAD; cat oldHEAD.txt
-  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat oldHEAD.txt)" ];
+  - touch $HOME/oldHEAD.txt
+  - git rev-parse HEAD; cat $HOME/oldHEAD.txt
+  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/oldHEAD.txt)" ];
     then
+      echo "agda build-cache HIT";
       echo "skipping cabal install";
     else
-      echo "starting cabal install";
+      echo "agda build-cache MISS";
+      echo "running cabal install";
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi
@@ -79,6 +83,7 @@ install:
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
+    cp -a $HOME/agda $HOME/.cabsnap/agda;
   - cd $TRAVIS_BUILD_DIR
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,11 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
+  - touch ./agdaHEAD
   - if [ -d "./agda/src" ];
     then
       cd agda;
       git fetch origin master --depth 1;
-      touch ./agdaHEAD;
       git rev-parse HEAD > agdaHEAD;
     else
       git clone https://github.com/agda/agda --depth 1;
@@ -67,7 +67,7 @@ install:
   - git rev-parse HEAD
   - cat agdaHEAD
   # only install agda if we have to
-  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat agdaHEAD) ];
+  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat $HOME/agdaHEAD) ];
     then
       echo "skipping cabal install";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,9 @@ install:
   - cd
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
-  # checking whether agda is cached and fetching the latest
-  - if [ -d "$HOME/.cabsnap/agda" ];
-    then
-      echo "agda cache HIT";
-      cp -a $HOME/.cabsnap/agda $HOME/agda;
-      cd agda;
-      git rev-parse HEAD > $HOME/oldHEAD.txt;
-      git fetch origin master --depth=1;
-      git reset --hard origin/master;
-    else
-      echo "agda cache MISS";
-      git clone https://github.com/agda/agda --depth 1;
-      cd agda;
-    fi
+  # get master Agda
+  - git clone https://github.com/agda/agda --depth=1
+  - cd agda
   # checking whether .ghc is still valid
   - cabal install --only-dependencies --dry -v > $HOME/installplan.txt
   - sed -i -e '1,/^Resolving /d' $HOME/installplan.txt; cat $HOME/installplan.txt
@@ -57,23 +46,22 @@ install:
       cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
     else
       echo "cabal build-cache MISS";
-      rm -rf $HOME/.cabsnap;
+      rm -rf $HOME/.cabsnap/*;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  # only installing agda if we have to
-  - touch $HOME/oldHEAD.txt
-  - git rev-parse HEAD; cat $HOME/oldHEAD.txt # for logging purposes
-  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/oldHEAD.txt)" ];
+  # only install agda if we have to
+  - touch $HOME/.cabsnap/oldHEAD.txt
+  - git rev-parse HEAD; cat $HOME/.cabsnap/oldHEAD.txt # for logging purposes
+  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/.cabsnap/oldHEAD.txt)" ];
     then
       echo "agda up to date";
     else
-      echo "**** cached build of agda is out of date, re-installing... ****";
+      echo "**** cached build of agda is out of date, re-installing (this will take 20-30m) ****";
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi
-  - cd -
   # installing fix-agda-whitespace
-  - cd agda/src/fix-agda-whitespace
+  - cd src/fix-agda-whitespace
   - cabal install fix-agda-whitespace.cabal
   - cd -
   # snapshot package-db on cache miss
@@ -81,9 +69,8 @@ install:
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
-  # snapshop agda on cache miss
-  - if [ -d "$HOME/.cabsnap/agda" ]; then rm -rf $HOME/.cabsnap/agda; fi
-  - cp -a $HOME/agda $HOME/.cabsnap/agda
+    git rev-parse HEAD > $HOME/.cabsnap/oldHEAD.txt;
+  - cd
   - yes | rm -R agda/
   - cd $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ install:
   - cd agda/src/fix-agda-whitespace
   - cabal install fix-agda-whitespace.cabal
   - cd -
-  # snapshot package-db on cache miss
+  # snapshot package-db and agda dir
   - echo "snapshotting package-db to build-cache";
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
-  - touch ./agdaHEAD
+  - touch $HOME/agdaHEAD.txt
   - if [ -d "./agda/src" ];
     then
       cd agda;
       git fetch origin master --depth 1;
-      git rev-parse HEAD > agdaHEAD;
+      git rev-parse HEAD > $HOME/agdaHEAD.txt
     else
       git clone https://github.com/agda/agda --depth 1;
       cd agda;
@@ -63,15 +63,14 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # TODO: delete these lines once travis is working
-  - if [ agda ]; then echo "has agda"; else echo "no agda"; fi
   - git rev-parse HEAD
-  - cat agdaHEAD
+  - cat $HOME/agdaHEAD.txt
   # only install agda if we have to
-  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat $HOME/agdaHEAD) ];
+  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat $HOME/agdaHEAD.txt) ];
     then
       echo "skipping cabal install";
     else
-      git rev-parse HEAD > agdaHEAD;
+      git rev-parse HEAD > $HOME/agdaHEAD.txt;
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,14 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
-  - if [ -d "./agda" ];
+  - if [ -d "agda/src" ];
     then
       git clone https://github.com/agda/agda --depth=1;
+      cd agda;
     else
+      cd agda;
       git fetch origin master;
     fi
-  - cd agda
   # checking whether .ghc is still valid
   - cabal install --only-dependencies --dry -v > $HOME/installplan.txt
   - sed -i -e '1,/^Resolving /d' $HOME/installplan.txt; cat $HOME/installplan.txt
@@ -59,6 +60,7 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
+  - if [ agda ]; then echo "has agda"; else echo "no agda"; fi
   - if [ agda ] && [ $(git rev-parse master) == $(git rev-parse origin/master) ];
     then
       echo "skipping cabal install";

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ install:
   - cd
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
-  # getting the latest agda
+  # checking whether agda dir is cached and fetching the latest
   - if [ -d "$HOME/.cabsnap/agda" ];
     then
-      echo "agda git cache HIT";
+      echo "agda dir cache HIT";
       cp -a $HOME/.cabsnap/agda $HOME/agda;
       cd agda;
       git rev-parse HEAD > $HOME/oldHEAD.txt;
       git pull origin master --depth 1;
     else
-      echo "agda git cache MISS";
+      echo "agda dir cache MISS";
       git clone https://github.com/agda/agda --depth 1;
       cd agda;
     fi
@@ -59,16 +59,14 @@ install:
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  # only install agda if we have to
+  # only installing agda if we have to
   - touch $HOME/oldHEAD.txt
-  - git rev-parse HEAD; cat $HOME/oldHEAD.txt
+  - git rev-parse HEAD; cat $HOME/oldHEAD.txt # for logging purposes
   - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/oldHEAD.txt)" ];
     then
-      echo "agda build-cache HIT";
-      echo "skipping cabal install";
+      echo "agda up to date";
     else
-      echo "agda build-cache MISS";
-      echo "running cabal install";
+      echo "**** cached agda behind remote - re-installing... ****";
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi
@@ -77,11 +75,12 @@ install:
   - cd agda/src/fix-agda-whitespace
   - cabal install fix-agda-whitespace.cabal
   - cd -
-  # snapshot package-db and agda dir
+  # snapshot package-db on cache miss
   - echo "snapshotting package-db to build-cache";
     mkdir -p $HOME/.cabsnap;
     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin $HOME/installplan.txt $HOME/.cabsnap/;
+  # snapshop agda dir on cache miss
   - cp -a $HOME/agda $HOME/.cabsnap/agda;
   - yes | rm -R agda/
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     - $HOME/.cabal/store
     - $HOME/.cabal/bin
     - $HOME/agda
+    - $HOME/agdaHEAD
 
 matrix:
   include:
@@ -35,13 +36,15 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
-  - if [ -d "agda/src" ];
+  - if [ -d "./agda/src" ];
     then
-      git clone https://github.com/agda/agda --depth=1;
       cd agda;
+      git fetch origin master --depth 1;
+      touch ./agdaHEAD;
+      git rev-parse HEAD > agdaHEAD;
     else
+      git clone https://github.com/agda/agda --depth 1;
       cd agda;
-      git fetch origin master;
     fi
   # checking whether .ghc is still valid
   - cabal install --only-dependencies --dry -v > $HOME/installplan.txt
@@ -59,12 +62,16 @@ install:
       rm -rf $HOME/.cabsnap;
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
-  # only install agda if we have to
+  # TODO: delete these lines once travis is working
   - if [ agda ]; then echo "has agda"; else echo "no agda"; fi
-  - if [ agda ] && [ $(git rev-parse master) == $(git rev-parse origin/master) ];
+  - git rev-parse HEAD
+  - cat agdaHEAD
+  # only install agda if we have to
+  - if [ agda ] && [ $(git rev-parse HEAD) == $(cat agdaHEAD) ];
     then
       echo "skipping cabal install";
     else
+      git rev-parse HEAD > agdaHEAD;
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ dist: xenial
 cache:
   directories:
     - $HOME/.cabsnap
-    - $HOME/.cabal/packages
-    - $HOME/.cabal/store
-    - $HOME/.cabal/bin
     - $HOME/agda
-    - $HOME/agdaHEAD
 
 matrix:
   include:
@@ -36,12 +32,11 @@ install:
   - cabal update
   - sed -i 's/^jobs:/-- jobs:/' $HOME/.cabal/config
   # get master Agda
-  - touch $HOME/agdaHEAD.txt
   - if [ -d "./agda/src" ];
     then
       cd agda;
-      git fetch origin master --depth 1;
-      git rev-parse HEAD > $HOME/agdaHEAD.txt;
+      git rev-parse HEAD > oldHEAD.txt;
+      git pull origin master --depth 1;
     else
       git clone https://github.com/agda/agda --depth 1;
       cd agda;
@@ -63,12 +58,11 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
-  - git rev-parse HEAD; cat $HOME/agdaHEAD.txt
-  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat $HOME/agdaHEAD.txt)" ];
+  - git rev-parse HEAD; cat oldHEAD.txt
+  - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat oldHEAD.txt)" ];
     then
       echo "skipping cabal install";
     else
-      git rev-parse HEAD > $HOME/agdaHEAD.txt;
       echo "starting cabal install";
       travis_wait 30 cabal install --only-dependencies;
       travis_wait 30 cabal install;

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ install:
       mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
     fi
   # only install agda if we have to
+  - touch oldHEAD.txt
   - git rev-parse HEAD; cat oldHEAD.txt
   - if [ agda ] && [ "$(git rev-parse HEAD)" == "$(cat oldHEAD.txt)" ];
     then


### PR DESCRIPTION
In this PR travis now caches the tag of the commit used to build the (already cached) agda executable, and does not re-build this executable if the cached tag matches the current one.

The result is that travis now takes only **4-5m** if the master branch of agda has not been updated since the last build, and the usual **20-30m** otherwise.

See below for the results of some experimenting. All the builds there shared the same `travis.yml` file and were triggered with empty commits to my `travis` branch – my comments are just describing what happened automatically. (Also, the commit tags I reference are commits in [agda/agda](https://github.com/agda/agda/commits/master).)

<img width="812" alt="empty-commit-testing" src="https://user-images.githubusercontent.com/15842547/78503578-93828d00-7735-11ea-990c-1ed3131d81f9.png">

I'm still a noob with CI/travis, so @phadej / @Saizan / anyone else, is what I've done reasonable?