### PR TITLE
[ fix #272 ] Defined _×_ in Data.Sigma and ported code over to it.

### DIFF
--- a/Cubical/Data/DescendingList/Strict/Properties.agda
+++ b/Cubical/Data/DescendingList/Strict/Properties.agda
@@ -116,7 +116,7 @@ module IsoToLFSet
     >-excluded : ∀ x xs → x >ᴴ xs → exclude x (Memʰ (x ∷ unsort xs)) ≡ Memˡ xs
     >-excluded x xs x>xs = funExt (λ a → ⇔toPath (to a) (from a)) where
 
-     import Cubical.Data.Prod  as D
+     import Cubical.Data.Sigma as D
      import Cubical.Data.Sum   as D
 
      from : ∀ a → [ a ∈ˡ xs ] → [ ¬ a ≡ₚ x ⊓ (a ≡ₚ x ⊔ a ∈ˡ xs) ]

--- a/Cubical/Data/DiffInt/Base.agda
+++ b/Cubical/Data/DiffInt/Base.agda
@@ -5,14 +5,13 @@ open import Cubical.Foundations.Prelude
 
 open import Cubical.HITs.SetQuotients.Base
 
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 open import Cubical.Data.Nat
 
-rel : (ℕ ×Σ ℕ) → (ℕ ×Σ ℕ) → Type₀
+rel : (ℕ × ℕ) → (ℕ × ℕ) → Type₀
 rel (a₀ , b₀) (a₁ , b₁) = x ≡ y
   where
     x = a₀ + b₁
     y = a₁ + b₀
 
-ℤ = (ℕ ×Σ ℕ) / rel
-
+ℤ = (ℕ × ℕ) / rel

--- a/Cubical/Data/DiffInt/Properties.agda
+++ b/Cubical/Data/DiffInt/Properties.agda
@@ -7,7 +7,6 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Data.DiffInt.Base
 open import Cubical.Data.Nat
 open import Cubical.Data.Sigma
-open import Cubical.Data.Prod
 open import Cubical.Data.Bool
 
 open import Cubical.Relation.Binary.Base
@@ -18,7 +17,7 @@ open import Cubical.HITs.SetQuotients
 open BinaryRelation
 
 relIsEquiv : isEquivRel rel
-relIsEquiv = EquivRel {A = ℕ ×Σ ℕ} relIsRefl relIsSym relIsTrans
+relIsEquiv = EquivRel {A = ℕ × ℕ} relIsRefl relIsSym relIsTrans
   where
     relIsRefl : isRefl rel
     relIsRefl (a0 , a1) = refl

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -17,7 +17,6 @@ open import Cubical.Data.Nat.Order
 open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
 
 open import Cubical.Induction.WellFounded
 

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -12,7 +12,7 @@ open import Cubical.Data.SumFin
 open import Cubical.Relation.Nullary
 
 open import Cubical.Data.Sum
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 
 open import Cubical.Data.Graph.Base
 
@@ -159,4 +159,3 @@ module _ {ℓv ℓe ℓv' ℓe'} where
     _<$>_ asDiag {x , x'} {y , y'} (inr f) | yes p | yes _  = subst _ p  (×Hom₂ x f )
     _<$>_ asDiag {x , x'} {y , y'} f | yes p | no  _  = subst _ p  (×Hom₂ x (lower f) )
     _<$>_ asDiag {x , x'} {y , y'} f | no  _ | yes p' = subst _ p' (×Hom₁ (lower f) x')
-

--- a/Cubical/Data/List/Properties.agda
+++ b/Cubical/Data/List/Properties.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Prelude
 open import Cubical.Data.Empty as ⊥
 open import Cubical.Data.Nat
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 open import Cubical.Data.Unit
 open import Cubical.Relation.Nullary
 
@@ -76,7 +76,7 @@ module ListPath {ℓ} {A : Type ℓ} where
   isOfHLevelCover n p (x ∷ xs) [] =
     isOfHLevelLift (suc n) (isProp→isOfHLevelSuc n isProp⊥)
   isOfHLevelCover n p (x ∷ xs) (y ∷ ys) =
-    isOfHLevelProd (suc n) (p x y) (isOfHLevelCover n p xs ys)
+    isOfHLevelΣ (suc n) (p x y) (\ _ → isOfHLevelCover n p xs ys)
 
 isOfHLevelList : ∀ {ℓ} (n : ℕ) {A : Type ℓ}
   → isOfHLevel (suc (suc n)) A → isOfHLevel (suc (suc n)) (List A)

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -8,7 +8,6 @@ open import Cubical.Foundations.HLevels
 
 open import Cubical.Data.Empty as ⊥
 open import Cubical.Data.Sigma
-open import Cubical.Data.Prod
 open import Cubical.Data.Sum as ⊎
 
 open import Cubical.Data.Nat.Base
@@ -87,7 +86,7 @@ pred-≤-pred (k , p) = k , injSuc ((sym (+-suc k _)) ∙ p)
   l2 : j + i ≡ 0
   l2 = m+n≡n→m≡0 l1
   l3 : 0 ≡ i
-  l3 = sym (proj₂ (m+n≡0→m≡0×n≡0 l2))
+  l3 = sym (snd (m+n≡0→m≡0×n≡0 l2))
 
 ≤-k+-cancel : k + m ≤ k + n → m ≤ n
 ≤-k+-cancel {k} {m} (l , p) = l , inj-m+ (sub k m ∙ p)
@@ -153,7 +152,7 @@ suc m ≟ zero = gt (m , +-comm m 1)
 suc m ≟ suc n = Trichotomy-suc (m ≟ n)
 
 <-split : m < suc n → (m < n) ⊎ (m ≡ n)
-<-split {n = zero} = inr ∘ proj₂ ∘ m+n≡0→m≡0×n≡0 ∘ snd ∘ pred-≤-pred
+<-split {n = zero} = inr ∘ snd ∘ m+n≡0→m≡0×n≡0 ∘ snd ∘ pred-≤-pred
 <-split {zero} {suc n} = λ _ → inl (suc-≤-suc zero-≤)
 <-split {suc m} {suc n} = ⊎.map suc-≤-suc (cong suc) ∘ <-split ∘ pred-≤-pred
 

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Nat.Base
 open import Cubical.Data.Empty as ⊥
-open import Cubical.Data.Prod.Base
+open import Cubical.Data.Sigma
 
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -6,11 +6,16 @@ open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 
+-- Here we define an inductive version of the product type, see below
+-- for its uses.
+
+-- See `Cubical.Data.Sigma` for `_×_` defined as a special case of
+-- sigma types, which is the generally preferred one.
+
 -- If × is defined using Σ then transp/hcomp will be compute
 -- "negatively", that is, they won't reduce unless we project out the
--- first of second component. This is not always what we want so the
--- default implementation is done using a datatype which computes
--- positively.
+-- first of second component. This is not always what we want so this
+-- implementation is done using a datatype which computes positively.
 
 
 private
@@ -28,11 +33,6 @@ proj₁ (x , _) = x
 proj₂ : {A : Type ℓ} {B : Type ℓ'} → A × B → B
 proj₂ (_ , x) = x
 
--- We still export the version using Σ
-_×Σ_ : (A : Type ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
-A ×Σ B = Σ A (λ _ → B)
-
-infixr 5 _×Σ_
 
 private
   variable

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -4,7 +4,7 @@ module Cubical.Data.Prod.Properties where
 open import Cubical.Core.Everything
 
 open import Cubical.Data.Prod.Base
-open import Cubical.Data.Sigma
+open import Cubical.Data.Sigma renaming (_×_ to _×Σ_)
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
@@ -56,9 +56,6 @@ A×B≃A×ΣB = isoToEquiv (iso (λ { (a , b) → (a , b)})
 
 A×B≡A×ΣB : A × B ≡ A ×Σ B
 A×B≡A×ΣB = ua A×B≃A×ΣB
-
-swapΣEquiv : (A : Type ℓ) (B : Type ℓ') → A ×Σ B ≃ B ×Σ A
-swapΣEquiv A B = compEquiv (compEquiv (invEquiv A×B≃A×ΣB) (swapEquiv A B)) A×B≃A×ΣB
 
 -- truncation for products
 isOfHLevelProd : (n : ℕ) → isOfHLevel n A → isOfHLevel n B → isOfHLevel n (A × B)

--- a/Cubical/Data/Queue/Base.agda
+++ b/Cubical/Data/Queue/Base.agda
@@ -9,7 +9,7 @@ open import Cubical.Structures.Queue
 open import Cubical.Data.Unit
 open import Cubical.Data.Sum
 open import Cubical.Data.List
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 module _ (A : Type ℓ) (Aset : isSet A) where
  open Queues-on A Aset

--- a/Cubical/Data/Sigma/Base.agda
+++ b/Cubical/Data/Sigma/Base.agda
@@ -4,3 +4,9 @@ module Cubical.Data.Sigma.Base where
 open import Cubical.Core.Primitives public
 
 -- Σ-types are defined in Core/Primitives as they are needed for Glue types.
+
+
+_×_ : ∀ {ℓ ℓ'} (A : Type ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
+A × B = Σ A (λ _ → B)
+
+infixr 5 _×_

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -184,3 +184,6 @@ PiΣ : ((a : A) → Σ[ b ∈ B a ] C a b) ≃ (Σ[ f ∈ ((a : A) → B a) ] �
 PiΣ = isoToEquiv (iso (λ f → fst ∘ f , snd ∘ f)
                       (λ (f , g) → (λ x → f x , g x))
                       (λ _ → refl) (λ _ → refl))
+
+swapΣEquiv : ∀ {ℓ'} (A : Type ℓ) (B : Type ℓ') → A × B ≃ B × A
+swapΣEquiv A B = isoToEquiv (iso (λ x → x .snd , x .fst) (λ z → z .snd , z .fst) (\ _ → refl) (\ _ → refl))

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -3,16 +3,15 @@
 module Cubical.Foundations.Logic where
 
 import Cubical.Data.Empty as ⊥
-open import Cubical.Data.Prod as × using (_×_; _,_; proj₁; proj₂)
 open import Cubical.Data.Sum as ⊎ using (_⊎_)
 open import Cubical.Data.Unit
-open import Cubical.Data.Sigma hiding (_×_)
+open import Cubical.Data.Sigma
 
 open import Cubical.Foundations.Prelude
 
 open import Cubical.HITs.PropositionalTruncation as PropTrunc
 
-open import Cubical.Foundations.HLevels using (hProp; isPropΠ) public
+open import Cubical.Foundations.HLevels using (hProp; isPropΠ; isOfHLevelΣ) public
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Function
 
@@ -131,11 +130,11 @@ _⊓′_ : Type ℓ → Type ℓ' → Type _
 A ⊓′ B = A × B
 
 _⊓_ : hProp ℓ → hProp ℓ' → hProp _
-A ⊓ B = [ A ] ⊓′ [ B ] , ×.isOfHLevelProd 1 (A .snd) (B .snd)
+A ⊓ B = [ A ] ⊓′ [ B ] , isOfHLevelΣ 1 (A .snd) (\ _ → B .snd)
 
 ⊓-intro : (P : hProp ℓ) (Q : [ P ] → hProp ℓ') (R : [ P ] → hProp ℓ'')
        → (∀ a → [ Q a ]) → (∀ a → [ R a ]) → (∀ (a : [ P ]) → [ Q a ⊓ R a ] )
-⊓-intro _ _ _ = ×.intro
+⊓-intro _ _ _ = \ f g a → f a , g a
 
 --------------------------------------------------------------------------------
 -- Logical bi-implication of mere propositions
@@ -229,16 +228,16 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
   ⇐∶ (λ {((x , y) , z) → x , (y , z) })
 
 ⊓-comm : (P : hProp ℓ) (Q : hProp ℓ') → P ⊓ Q ≡ Q ⊓ P
-⊓-comm _ _ = ⇔toPath ×.swap ×.swap
+⊓-comm _ _ = ⇔toPath (\ p → p .snd , p .fst) (\ p → p .snd , p .fst)
 
 ⊓-idem : (P : hProp ℓ) → P ⊓ P ≡ P
-⊓-idem _ = ⇔toPath proj₁ (λ x → x , x)
+⊓-idem _ = ⇔toPath fst (λ x → x , x)
 
 ⊓-identityˡ : (P : hProp ℓ) → ⊤ ⊓ P ≡ P
-⊓-identityˡ _ = ⇔toPath proj₂ λ x → tt , x
+⊓-identityˡ _ = ⇔toPath snd λ x → tt , x
 
 ⊓-identityʳ : (P : hProp ℓ) → P ⊓ ⊤ ≡ P
-⊓-identityʳ _ = ⇔toPath proj₁ λ x → x , tt
+⊓-identityʳ _ = ⇔toPath fst λ x → x , tt
 
 --------------------------------------------------------------------------------
 -- Distributive laws
@@ -246,7 +245,7 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
 ⇒-⊓-distrib : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
   → P ⇒ (Q ⊓ R) ≡ (P ⇒ Q) ⊓ (P ⇒ R)
 ⇒-⊓-distrib _ _ _ =
-  ⇒∶ (λ f → (proj₁ ∘ f) , (proj₂ ∘ f))
+  ⇒∶ (λ f → (fst ∘ f) , (snd ∘ f))
   ⇐∶ (λ { (f , g) x → f x , g x})
 
 ⊓-⊔-distribˡ : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
@@ -257,14 +256,14 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
         (λ z → ∣ ⊎.inr (x , z) ∣ ) a })
 
   ⇐∶ ⊔-elim (P ⊓ Q) (P ⊓ R) (λ _ → P ⊓ Q ⊔ R)
-       (λ y → proj₁ y , inl (proj₂ y))
-       (λ z → proj₁ z , inr (proj₂ z))
+       (λ y → fst y , inl (snd y))
+       (λ z → fst z , inr (snd z))
 
 ⊔-⊓-distribˡ : (P : hProp ℓ) (Q : hProp ℓ')(R : hProp ℓ'')
   → P ⊔ (Q ⊓ R) ≡ (P ⊔ Q) ⊓ (P ⊔ R)
 ⊔-⊓-distribˡ P Q R =
   ⇒∶ ⊔-elim P (Q ⊓ R) (λ _ → (P ⊔ Q) ⊓ (P ⊔ R) )
-    (×.intro inl inl) (×.map inr inr)
+    (\ x → inl x , inl x) (\ p → inr (p .fst) , inr (p .snd))
 
   ⇐∶ (λ { (x , y) → ⊔-elim P R (λ _ → P ⊔ Q ⊓ R) inl
       (λ z → ⊔-elim P Q (λ _ → P ⊔ Q ⊓ R) inl (λ y → inr (y , z)) x) y })
@@ -273,4 +272,4 @@ Decₚ P = Dec [ P ] , isPropDec (snd P)
   → (∀[ a ∶ A ] P a) ⊓ (∀[ a ∶ A ] Q a) ≡ (∀[ a ∶ A ] (P a ⊓ Q a))
 ⊓-∀-distrib P Q =
   ⇒∶ (λ {(p , q) a → p a , q a})
-  ⇐∶ λ pq → (proj₁ ∘ pq ) , (proj₂ ∘ pq)
+  ⇐∶ λ pq → (fst ∘ pq ) , (snd ∘ pq)

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -6,7 +6,7 @@ import Cubical.Data.Empty as ⊥
 open import Cubical.Data.Prod as × using (_×_; _,_; proj₁; proj₂)
 open import Cubical.Data.Sum as ⊎ using (_⊎_)
 open import Cubical.Data.Unit
-open import Cubical.Data.Sigma
+open import Cubical.Data.Sigma hiding (_×_)
 
 open import Cubical.Foundations.Prelude
 

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -14,7 +14,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Path
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 open import Cubical.Data.Empty as ⊥
 open import Cubical.Relation.Nullary
 

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -3,7 +3,7 @@ module Cubical.Foundations.Pointed.Properties where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Pointed.Base
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 
 Π∙ : ∀ {ℓ ℓ'} (A : Type ℓ) (B∙ : A → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
 Π∙ A B∙ = (∀ a → typ (B∙ a)) , (λ a → pt (B∙ a))

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -17,7 +17,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.Properties renaming (cong≃ to _⋆_)
 open import Cubical.Foundations.Equiv.HalfAdjoint
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 open import Cubical.Foundations.Structure public
 

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -2,7 +2,7 @@
 module Cubical.Functions.Surjection where
 
 open import Cubical.Core.Everything
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
@@ -49,5 +49,5 @@ isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjectio
 isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
-  (λ _ → isOfHLevelProd 1 isEmbeddingIsProp isSurjectionIsProp _ _)
+  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isSurjectionIsProp) _ _)
   (λ _ → isPropIsEquiv _ _ _))

--- a/Cubical/HITs/Cylinder/Base.agda
+++ b/Cubical/HITs/Cylinder/Base.agda
@@ -6,7 +6,7 @@ open import Cubical.Core.Everything
 
 open import Cubical.Foundations.Everything
 
-open import Cubical.Data.Prod using (_×_; _,_)
+open import Cubical.Data.Sigma
 open import Cubical.Data.Unit
 open import Cubical.Data.Sum using (_⊎_; inl; inr)
 
@@ -263,4 +263,3 @@ module Push {ℓ} {A : Type ℓ} where
            Cylinder→Pushout
            Cylinder→Pushout→Cylinder
            Pushout→Cylinder→Pushout)
-

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -8,7 +8,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Int
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma
 
 open import Cubical.HITs.S1
 open import Cubical.HITs.S2

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -19,7 +19,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws
 
-open import Cubical.Data.Prod
+open import Cubical.Data.Sigma renaming (fst to proj₁; snd to proj₂)
 
 open import Cubical.HITs.Join.Base
 open import Cubical.HITs.Pushout

--- a/Cubical/HITs/KleinBottle/Properties.agda
+++ b/Cubical/HITs/KleinBottle/Properties.agda
@@ -17,7 +17,6 @@ open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Univalence
 open import Cubical.Data.Nat
 open import Cubical.Data.Int public renaming (_+_ to _+Int_ ; +-assoc to +Int-assoc; +-comm to +Int-comm)
-open import Cubical.Data.Prod
 open import Cubical.Data.Sigma
 open import Cubical.HITs.S1
 open import Cubical.HITs.PropositionalTruncation as PropTrunc
@@ -124,8 +123,6 @@ isGroupoidKleinBottle =
     ≡⟨ sym (ua Σ≡) ⟩
   Σ ΩS¹ (λ p → PathP (λ j → invS¹Loop (p j)) base base)
     ≡⟨ (λ i → Σ ΩS¹ (λ p → PathP (λ j → invS¹Loop (p (j ∨ i))) (twistBaseLoop (p i)) base)) ⟩
-  Σ ΩS¹ (λ _ → ΩS¹)
-    ≡⟨ sym A×B≡A×ΣB ⟩
   ΩS¹ × ΩS¹
     ≡⟨ (λ i → ΩS¹≡Int i × ΩS¹≡Int i) ⟩
   Int × Int ∎

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -22,7 +22,7 @@ open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Transport
 
-open import Cubical.Data.Prod.Base
+open import Cubical.Data.Sigma
 open import Cubical.Data.Unit
 
 open import Cubical.HITs.Pushout.Base

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -30,9 +30,6 @@ open import Cubical.Data.Unit
 open import Cubical.Data.Empty as ⊥ hiding (elim)
 open import Cubical.Data.Sum as ⊎ hiding (elim)
 
-open import Cubical.Data.Prod renaming (_×_ to _×'_; _×Σ_ to _×_; swapΣEquiv to swapEquiv)
-                              hiding (swapEquiv)
-
 open import Cubical.HITs.PropositionalTruncation as PropTrunc hiding (elim)
 open import Cubical.HITs.Sn
 open import Cubical.HITs.Susp
@@ -254,22 +251,21 @@ TotalCov≃Sn (ℕ→ℕ₋₁ n) =
 
     This was proved above by ⊕*.isEquivˡ.
 -}
-    u : ∀ {n} → (Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))) ≃ (Total (cov⁻¹ n) ×' Bool)
+    u : ∀ {n} → (Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))) ≃ (Total (cov⁻¹ n) × Bool)
     u {n} = Σ[ x ∈ Total (cov⁻¹ n) ] typ (cov⁻¹ n (fst x))      ≃⟨ assocΣ ⟩
-            Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × (typ (cov⁻¹ n x)) ≃⟨ congΣEquiv (λ x → swapEquiv _ _) ⟩
+            Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × (typ (cov⁻¹ n x)) ≃⟨ congΣEquiv (λ x → swapΣEquiv _ _) ⟩
             Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × (typ (cov⁻¹ n x)) ≃⟨ congΣEquiv (λ x → congΣEquiv (λ y →
                                                                              ⊕*.Equivˡ (cov⁻¹ n x) y)) ⟩
             Σ[ x ∈ RP n ] (typ (cov⁻¹ n x)) × Bool              ≃⟨ invEquiv assocΣ ⟩
-            Total (cov⁻¹ n) × Bool                              ≃⟨ invEquiv A×B≃A×ΣB ⟩
-            Total (cov⁻¹ n) ×' Bool                             ■
+            Total (cov⁻¹ n) × Bool                              ■
 
     H : ∀ x → u .fst x ≡ (Σf x , snd (Σg x))
     H x = refl
 
-    nat : 3-span-equiv (3span Σf Σg) (3span {A2 = Total (cov⁻¹ (-1+ n)) ×' Bool} proj₁ proj₂)
+    nat : 3-span-equiv (3span Σf Σg) (3span {A2 = Total (cov⁻¹ (-1+ n)) × Bool} fst snd)
     nat = record { e0 = idEquiv _ ; e2 = u ; e4 = ΣUnit _
-                 ; H1 = λ x → cong proj₁ (H x)
-                 ; H3 = λ x → cong proj₂ (H x) }
+                 ; H1 = λ x → cong fst (H x)
+                 ; H3 = λ x → cong snd (H x) }
 
     ii : Pushout Σf Σg ≃ join (Total (cov⁻¹ (-1+ n))) Bool
     ii = compEquiv (pathToEquiv (spanEquivToPushoutPath nat)) (joinPushout≃join _ _)

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -14,7 +14,7 @@ open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Nat
 open import Cubical.Data.Int
-open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 open import Cubical.HITs.S1
 

--- a/Cubical/Structures/Monoid.agda
+++ b/Cubical/Structures/Monoid.agda
@@ -4,7 +4,7 @@ module Cubical.Structures.Monoid where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.HLevels
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 open import Cubical.Foundations.SIP renaming (SNS-PathP to SNS)
 

--- a/Cubical/Structures/MultiSet.agda
+++ b/Cubical/Structures/MultiSet.agda
@@ -14,7 +14,7 @@ open import Cubical.Structures.Queue
 open import Cubical.Data.Unit
 open import Cubical.Data.Sum
 open import Cubical.Data.Nat
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 
 module _(A : Type ℓ)

--- a/Cubical/Structures/Queue.agda
+++ b/Cubical/Structures/Queue.agda
@@ -12,7 +12,7 @@ open import Cubical.Structures.Pointed
 
 open import Cubical.Data.Unit
 open import Cubical.Data.Sum
-open import Cubical.Data.Prod.Base hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 
 -- Developing Queues as a standard notion of structure, see

--- a/Cubical/Structures/TypeEqvTo.agda
+++ b/Cubical/Structures/TypeEqvTo.agda
@@ -5,7 +5,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 
 open import Cubical.HITs.PropositionalTruncation
-open import Cubical.Data.Prod hiding (_×_) renaming (_×Σ_ to _×_)
+open import Cubical.Data.Sigma
 
 open import Cubical.Foundations.SIP renaming (SNS-PathP to SNS)
 open import Cubical.Foundations.Pointed

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -13,7 +13,6 @@ open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Data.NatMinusTwo.Base
 open import Cubical.Data.Empty
 open import Cubical.Data.Sigma
-open import Cubical.Data.Prod.Base
 open import Cubical.HITs.Susp
 open import Cubical.HITs.SetTruncation
 open import Cubical.HITs.Nullification


### PR DESCRIPTION
I decided we did not need to rename `_×_` in `Cubical.Data.Prod`.

There's more parts of the library that should be converted to `Cubicla.Data.Sigma`, not sure if in this PR.
