### PR TITLE
Give a name to the second projection from `hProp`

### DIFF
--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -70,11 +70,11 @@ hProp≡ p = ΣProp≡ (\ _ → isPropIsProp) p
 -- Logical implication of mere propositions
 
 _⇒_ : (A : hProp ℓ) → (B : hProp ℓ') → hProp _
-A ⇒ B = ([ A ] → [ B ]) , isPropΠ λ _ → B .snd
+A ⇒ B = ([ A ] → [ B ]) , isPropΠ λ _ → isProp[] B
 
 ⇔toPath : [ P ⇒ Q ] → [ Q ⇒ P ] → P ≡ Q
 ⇔toPath {P = P} {Q = Q} P⇒Q Q⇒P = hProp≡ (isoToPath
-  (iso P⇒Q Q⇒P (λ b → Q .snd (P⇒Q (Q⇒P b)) b) λ a → P .snd (Q⇒P (P⇒Q a)) a))
+  (iso P⇒Q Q⇒P (λ b → isProp[] Q (P⇒Q (Q⇒P b)) b) λ a → isProp[] P (Q⇒P (P⇒Q a)) a))
 
 pathTo⇒ : P ≡ Q → [ P ⇒ Q ]
 pathTo⇒ p x = subst fst  p x
@@ -83,7 +83,7 @@ pathTo⇐ : P ≡ Q → [ Q ⇒ P ]
 pathTo⇐ p x = subst fst (sym p) x
 
 substₚ : {x y : A} (B : A → hProp ℓ) → [ x ≡ₚ y ⇒ B x ⇒ B y ]
-substₚ {x = x} {y = y} B = PropTrunc.elim (λ _ → isPropΠ λ _ → B y .snd) (subst (fst ∘ B))
+substₚ {x = x} {y = y} B = PropTrunc.elim (λ _ → isPropΠ λ _ → isProp[] (B y)) (subst (fst ∘ B))
 
 --------------------------------------------------------------------------------
 -- Mixfix notations for ⇔-toPath
@@ -137,7 +137,7 @@ _⊓′_ : Type ℓ → Type ℓ' → Type _
 A ⊓′ B = A × B
 
 _⊓_ : hProp ℓ → hProp ℓ' → hProp _
-A ⊓ B = [ A ] ⊓′ [ B ] , isOfHLevelΣ 1 (A .snd) (\ _ → B .snd)
+A ⊓ B = [ A ] ⊓′ [ B ] , isOfHLevelΣ 1 (isProp[] A) (\ _ → isProp[] B)
 
 ⊓-intro : (P : hProp ℓ) (Q : [ P ] → hProp ℓ') (R : [ P ] → hProp ℓ'')
        → (∀ a → [ Q a ]) → (∀ a → [ R a ]) → (∀ (a : [ P ]) → [ Q a ⊓ R a ] )
@@ -154,10 +154,10 @@ A ⇔ B = (A ⇒ B) ⊓ (B ⇒ A)
 
 
 ∀[∶]-syntax : (A → hProp ℓ) → hProp _
-∀[∶]-syntax {A = A} P = (∀ x → [ P x ]) , isPropΠ (snd ∘ P)
+∀[∶]-syntax {A = A} P = (∀ x → [ P x ]) , isPropΠ (isProp[] ∘ P)
 
 ∀[]-syntax : (A → hProp ℓ) → hProp _
-∀[]-syntax {A = A} P = (∀ x → [ P x ]) , isPropΠ (snd ∘ P)
+∀[]-syntax {A = A} P = (∀ x → [ P x ]) , isPropΠ (isProp[] ∘ P)
 
 syntax ∀[∶]-syntax {A = A} (λ a → P) = ∀[ a ∶ A ] P
 syntax ∀[]-syntax (λ a → P)          = ∀[ a ] P
@@ -177,7 +177,7 @@ syntax ∃[∶]-syntax (λ x → P) = ∃[ x ] P
 -- Decidable mere proposition
 
 Decₚ : (P : hProp ℓ) → hProp ℓ
-Decₚ P = Dec [ P ] , isPropDec (snd P)
+Decₚ P = Dec [ P ] , isPropDec (isProp[] P)
 
 --------------------------------------------------------------------------------
 -- Negation commutes with truncation
@@ -295,7 +295,7 @@ _⊆_ : {X : Type ℓ} → ℙ X → ℙ X → Type ℓ
 A ⊆ B = ∀ x → x ∈ A → x ∈ B
 
 ∈-isProp : {X : Type ℓ} (A : ℙ X) (x : X) → isProp (x ∈ A)
-∈-isProp A x = (A x) .snd
+∈-isProp A = isProp[] ∘ A
 
 ⊆-isProp : {X : Type ℓ} (A B : ℙ X) → isProp (A ⊆ B)
 ⊆-isProp A B = isPropΠ2 (λ x _ → ∈-isProp B x)

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -54,6 +54,9 @@ private
 [_] : hProp ℓ → Type ℓ
 [_] = fst
 
+isProp[] : (A : hProp ℓ) → isProp [ A ]
+isProp[] = snd
+
 ∥_∥ₚ : Type ℓ → hProp ℓ
 ∥ A ∥ₚ = ∥ A ∥ , propTruncIsProp
 

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -166,10 +166,10 @@ syntax ∀[]-syntax (λ a → P)          = ∀[ a ] P
 
 
 ∃[]-syntax : (A → hProp ℓ) → hProp _
-∃[]-syntax {A = A} P = ∥ Σ A (fst ∘ P) ∥ₚ
+∃[]-syntax {A = A} P = ∥ Σ A ([_] ∘ P) ∥ₚ
 
 ∃[∶]-syntax : (A → hProp ℓ) → hProp _
-∃[∶]-syntax {A = A} P = ∥ Σ A (fst ∘ P) ∥ₚ
+∃[∶]-syntax {A = A} P = ∥ Σ A ([_] ∘ P) ∥ₚ
 
 syntax ∃[]-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
 syntax ∃[∶]-syntax (λ x → P) = ∃[ x ] P


### PR DESCRIPTION
The first projection from `hProp` has a name: `[_]`. I think it would be nice to have a name for the second projection as well. This is called [`holds-is-subsingleton`](https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#249731) in the [HoTT/UF development of Martín Escardó](https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/).