### PR TITLE
Fix naming in syntax declarations for ∃

### DIFF
--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -168,8 +168,8 @@ syntax ∀[]-syntax (λ a → P)          = ∀[ a ] P
 ∃[∶]-syntax : (A → hProp ℓ) → hProp _
 ∃[∶]-syntax {A = A} P = ∥ Σ A (fst ∘ P) ∥ₚ
 
-syntax ∃[]-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
-syntax ∃[∶]-syntax (λ x → P) = ∃[ x ] P
+syntax ∃[∶]-syntax {A = A} (λ x → P) = ∃[ x ∶ A ] P
+syntax ∃[]-syntax (λ x → P) = ∃[ x ] P
 --------------------------------------------------------------------------------
 -- Decidable mere proposition
 


### PR DESCRIPTION
It seemed to me that `∃[]-syntax` and `∃[∶]-syntax` were flipped in the syntax declarations.

https://github.com/agda/cubical/blob/acabbd9595ad4291fd6f4bd2b1e802d285f676ed/Cubical/Foundations/Logic.agda#L171-L172