### PR TITLE
Fix uncaught problem with addition of Powersets

### DIFF
--- a/Cubical/Algebra/Everything.agda
+++ b/Cubical/Algebra/Everything.agda
@@ -1,5 +1,0 @@
-{-# OPTIONS --cubical --safe #-}
-module Cubical.Algebra.Everything where
-
-open import Cubical.Algebra.BasicProp public
-open import Cubical.Algebra.SymmetricGroup public

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -2,7 +2,7 @@
 module Cubical.HITs.ListedFiniteSet.Base where
 
 open import Cubical.Core.Everything
-open import Cubical.Foundations.Logic
+open import Cubical.Foundations.Logic hiding (_∈_)
 open import Cubical.Foundations.Everything
 
 private

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -42,7 +42,7 @@ check-README:
 
 .PHONY : check
 check: $(wildcard Cubical/**/*.agda)
-	$(foreach f, $(shell $(EVERYTHINGS) get-imports-README), $(AGDA) $(f);)
+	$(foreach f, $(shell $(EVERYTHINGS) get-imports-README), $(AGDA) "$(f)" && ) true
 	$(AGDA) Cubical/WithK.agda
 
 .PHONY: listings


### PR DESCRIPTION
7b8739cc4cd843bb46c2e27501b1dc22a8a079ed introduced a regression in ListedFiniteSets that was not caught by the CI due to ignoring the result of checking the files. This fixes both the CI process and the problem in LFS. Also removes Algebra/Everything.agda since that file is overwritten anyway when running `make`.