### PR TITLE
Zigzag relations

### DIFF
--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -70,6 +70,10 @@ pred-≤-pred (k , p) = k , injSuc ((sym (+-suc k _)) ∙ p)
 ≤-suc : m ≤ n → m ≤ suc n
 ≤-suc (k , p) = suc k , cong suc p
 
+≤-predℕ : predℕ n ≤ n
+≤-predℕ {zero} = ≤-refl
+≤-predℕ {suc n} = ≤-suc ≤-refl
+
 ≤-trans : k ≤ m → m ≤ n → k ≤ n
 ≤-trans {k} {m} {n} (i , p) (j , q) = i + j , l2 ∙ (l1 ∙ q)
   where
@@ -108,6 +112,16 @@ pred-≤-pred (k , p) = k , injSuc ((sym (+-suc k _)) ∙ p)
 
 ¬m<m : ¬ m < m
 ¬m<m {m} = ¬-<-zero ∘ ≤-+k-cancel {k = m}
+
+≤0→≡0 : n ≤ 0 → n ≡ 0
+≤0→≡0 {zero} ineq = refl
+≤0→≡0 {suc n} ineq = ⊥.rec (¬-<-zero ineq)
+
+predℕ-≤-predℕ : m ≤ n → (predℕ m) ≤ (predℕ n)
+predℕ-≤-predℕ {zero} {zero}   ineq = ≤-refl
+predℕ-≤-predℕ {zero} {suc n}  ineq = zero-≤
+predℕ-≤-predℕ {suc m} {zero}  ineq = ⊥.rec (¬-<-zero ineq)
+predℕ-≤-predℕ {suc m} {suc n} ineq = pred-≤-pred ineq
 
 ¬m+n<m : ¬ m + n < m
 ¬m+n<m {m} {n} = ¬-<-zero ∘ <-k+-cancel ∘ subst (m + n <_) (sym (+-zero m))

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -36,6 +36,12 @@ discreteℕ (suc m) (suc n) with discreteℕ m n
 isSetℕ : isSet ℕ
 isSetℕ = Discrete→isSet discreteℕ
 
+-- Arithmetic facts about predℕ
+
+suc-predℕ : ∀ n → ¬ n ≡ 0 → n ≡ suc (predℕ n)
+suc-predℕ zero p = ⊥.rec (p refl)
+suc-predℕ (suc n) p = refl
+
 -- Arithmetic facts about +
 
 +-zero : ∀ m → m + 0 ≡ m

--- a/Cubical/HITs/AssocList/Base.agda
+++ b/Cubical/HITs/AssocList/Base.agda
@@ -7,14 +7,14 @@ open import Cubical.Data.Nat   using (ℕ; _+_)
 private
   variable
     ℓ : Level
-    A : Type₀
+    A : Type ℓ
 
 infixr 5 ⟨_,_⟩∷_
 
 
 
 
-data AssocList (A : Type₀) : Type₀ where
+data AssocList (A : Type ℓ) : Type ℓ where
  ⟨⟩ : AssocList A
  ⟨_,_⟩∷_ : (a : A) (n : ℕ) (xs : AssocList A) → AssocList A
  per : ∀ a b xs →   ⟨ a , 1 ⟩∷ ⟨ b , 1 ⟩∷ xs
@@ -31,7 +31,7 @@ pattern ⟨_⟩ a = ⟨ a , 1 ⟩∷ ⟨⟩
 
 
 --Elimination and recursion principle for association lists
-module Elim {ℓ} {B : AssocList A → Type ℓ}
+module Elim {ℓ'} {B : AssocList A → Type ℓ'}
        (⟨⟩* : B ⟨⟩) (⟨_,_⟩∷*_ : (x : A) (n : ℕ) {xs : AssocList A} → B xs → B (⟨ x , n ⟩∷ xs))
        (per* :  (x y : A) {xs : AssocList A} (b : B xs)
               → PathP (λ i → B (per x y xs i)) (⟨ x , 1 ⟩∷* ⟨ y , 1 ⟩∷* b) (⟨ y , 1 ⟩∷* ⟨ x , 1 ⟩∷* b))
@@ -51,7 +51,7 @@ module Elim {ℓ} {B : AssocList A → Type ℓ}
 
 
 
-module ElimProp {ℓ} {B : AssocList A → Type ℓ} (BProp : {xs : AssocList A} → isProp (B xs))
+module ElimProp {ℓ'} {B : AssocList A → Type ℓ'} (BProp : {xs : AssocList A} → isProp (B xs))
        (⟨⟩* : B ⟨⟩) (⟨_,_⟩∷*_ : (x : A) (n : ℕ) {xs : AssocList A} → B xs → B (⟨ x , n ⟩∷ xs)) where
 
  f : (xs : AssocList A) → B xs
@@ -63,7 +63,7 @@ module ElimProp {ℓ} {B : AssocList A → Type ℓ} (BProp : {xs : AssocList A}
 
 
 
-module Rec {ℓ} {B : Type ℓ} (BType : isSet B)
+module Rec {ℓ'} {B : Type ℓ'} (BType : isSet B)
        (⟨⟩* : B) (⟨_,_⟩∷*_ : (x : A) (n : ℕ) → B → B)
        (per* :  (x y : A) (b : B) → (⟨ x , 1 ⟩∷* ⟨ y , 1 ⟩∷* b) ≡ (⟨ y , 1 ⟩∷* ⟨ x , 1 ⟩∷* b))
        (agg* :  (x : A) (m n : ℕ) (b : B) → (⟨ x , m ⟩∷* ⟨ x , n ⟩∷* b) ≡ (⟨ x , m + n ⟩∷* b))

--- a/Cubical/HITs/AssocList/Properties.agda
+++ b/Cubical/HITs/AssocList/Properties.agda
@@ -13,7 +13,7 @@ open import Cubical.Relation.Nullary.DecidableEq
 private
   variable
     ℓ : Level
-    A : Type₀
+    A : Type ℓ
 
 
 

--- a/Cubical/HITs/AssocList/Properties.agda
+++ b/Cubical/HITs/AssocList/Properties.agda
@@ -86,32 +86,32 @@ AssocList≡FMSet = ua AssocList≃FMSet
 
 
 
--- We want to define a multiset structure on AssocList A, we use the recursor to define the membership-function
-ALmember-⟨,⟩∷*-aux : (a x : A) → Dec (a ≡ x) → ℕ → ℕ → ℕ
-ALmember-⟨,⟩∷*-aux a x (yes a≡x) n xs = n + xs
-ALmember-⟨,⟩∷*-aux a x (no  a≢x) n xs = xs
+-- We want to define a multiset structure on AssocList A, we use the recursor to define the count-function
+ALcount-⟨,⟩∷*-aux : (a x : A) → Dec (a ≡ x) → ℕ → ℕ → ℕ
+ALcount-⟨,⟩∷*-aux a x (yes a≡x) n xs = n + xs
+ALcount-⟨,⟩∷*-aux a x (no  a≢x) n xs = xs
 
 
-ALmember-per*-aux :  (a x y : A) (xs : ℕ) (p : Dec (a ≡ x)) (q : Dec (a ≡ y))
-                   →  ALmember-⟨,⟩∷*-aux a x p 1 (ALmember-⟨,⟩∷*-aux a y q 1 xs)
-                    ≡ ALmember-⟨,⟩∷*-aux a y q 1 (ALmember-⟨,⟩∷*-aux a x p 1 xs)
-ALmember-per*-aux a x y xs (yes a≡x) (yes a≡y) = refl
-ALmember-per*-aux a x y xs (yes a≡x) (no  a≢y) = refl
-ALmember-per*-aux a x y xs (no  a≢x) (yes a≡y) = refl
-ALmember-per*-aux a x y xs (no  a≢x) (no  a≢y) = refl
+ALcount-per*-aux :  (a x y : A) (xs : ℕ) (p : Dec (a ≡ x)) (q : Dec (a ≡ y))
+                   →  ALcount-⟨,⟩∷*-aux a x p 1 (ALcount-⟨,⟩∷*-aux a y q 1 xs)
+                    ≡ ALcount-⟨,⟩∷*-aux a y q 1 (ALcount-⟨,⟩∷*-aux a x p 1 xs)
+ALcount-per*-aux a x y xs (yes a≡x) (yes a≡y) = refl
+ALcount-per*-aux a x y xs (yes a≡x) (no  a≢y) = refl
+ALcount-per*-aux a x y xs (no  a≢x) (yes a≡y) = refl
+ALcount-per*-aux a x y xs (no  a≢x) (no  a≢y) = refl
 
 
-ALmember-agg*-aux :  (a x : A) (m n xs : ℕ) (p : Dec (a ≡ x))
-                   →  ALmember-⟨,⟩∷*-aux a x p m (ALmember-⟨,⟩∷*-aux a x p n xs)
-                    ≡ ALmember-⟨,⟩∷*-aux a x p (m + n) xs
-ALmember-agg*-aux a x m n xs (yes x≡a) = +-assoc m n xs
-ALmember-agg*-aux a x m n xs (no  x≢a) = refl
+ALcount-agg*-aux :  (a x : A) (m n xs : ℕ) (p : Dec (a ≡ x))
+                   →  ALcount-⟨,⟩∷*-aux a x p m (ALcount-⟨,⟩∷*-aux a x p n xs)
+                    ≡ ALcount-⟨,⟩∷*-aux a x p (m + n) xs
+ALcount-agg*-aux a x m n xs (yes x≡a) = +-assoc m n xs
+ALcount-agg*-aux a x m n xs (no  x≢a) = refl
 
 
-ALmember-del*-aux :  (a x : A) (xs : ℕ) (p : Dec (a ≡ x))
-                   →  ALmember-⟨,⟩∷*-aux a x p 0 xs ≡ xs
-ALmember-del*-aux a x xs (yes a≡x) = refl
-ALmember-del*-aux a x xs (no  a≢x) = refl
+ALcount-del*-aux :  (a x : A) (xs : ℕ) (p : Dec (a ≡ x))
+                   →  ALcount-⟨,⟩∷*-aux a x p 0 xs ≡ xs
+ALcount-del*-aux a x xs (yes a≡x) = refl
+ALcount-del*-aux a x xs (no  a≢x) = refl
 
 
 
@@ -120,60 +120,60 @@ module _(discA : Discrete A) where
 
 
 
- ALmember-⟨,⟩∷* : A → A → ℕ → ℕ → ℕ
- ALmember-⟨,⟩∷* a x n xs = ALmember-⟨,⟩∷*-aux a x (discA a x) n xs
+ ALcount-⟨,⟩∷* : A → A → ℕ → ℕ → ℕ
+ ALcount-⟨,⟩∷* a x n xs = ALcount-⟨,⟩∷*-aux a x (discA a x) n xs
 
 
- ALmember-per* :  (a x y : A) (xs : ℕ)
-                →  ALmember-⟨,⟩∷* a x 1 (ALmember-⟨,⟩∷* a y 1 xs)
-                 ≡ ALmember-⟨,⟩∷* a y 1 (ALmember-⟨,⟩∷* a x 1 xs)
- ALmember-per* a x y xs = ALmember-per*-aux a x y xs (discA a x) (discA a y)
+ ALcount-per* :  (a x y : A) (xs : ℕ)
+                →  ALcount-⟨,⟩∷* a x 1 (ALcount-⟨,⟩∷* a y 1 xs)
+                 ≡ ALcount-⟨,⟩∷* a y 1 (ALcount-⟨,⟩∷* a x 1 xs)
+ ALcount-per* a x y xs = ALcount-per*-aux a x y xs (discA a x) (discA a y)
 
 
- ALmember-agg* :  (a x : A) (m n xs : ℕ)
-                →  ALmember-⟨,⟩∷* a x m (ALmember-⟨,⟩∷* a x n xs)
-                 ≡ ALmember-⟨,⟩∷* a x (m + n) xs
- ALmember-agg* a x m n xs = ALmember-agg*-aux a x m n xs (discA a x)
+ ALcount-agg* :  (a x : A) (m n xs : ℕ)
+                →  ALcount-⟨,⟩∷* a x m (ALcount-⟨,⟩∷* a x n xs)
+                 ≡ ALcount-⟨,⟩∷* a x (m + n) xs
+ ALcount-agg* a x m n xs = ALcount-agg*-aux a x m n xs (discA a x)
 
 
- ALmember-del* :  (a x : A) (xs : ℕ) → ALmember-⟨,⟩∷* a x 0 xs ≡ xs
- ALmember-del* a x xs = ALmember-del*-aux a x xs (discA a x)
+ ALcount-del* :  (a x : A) (xs : ℕ) → ALcount-⟨,⟩∷* a x 0 xs ≡ xs
+ ALcount-del* a x xs = ALcount-del*-aux a x xs (discA a x)
 
 
- ALmember : A → AssocList A → ℕ
- ALmember a = AL.Rec.f isSetℕ 0 (ALmember-⟨,⟩∷* a) (ALmember-per* a) (ALmember-agg* a) (ALmember-del* a)
+ ALcount : A → AssocList A → ℕ
+ ALcount a = AL.Rec.f isSetℕ 0 (ALcount-⟨,⟩∷* a) (ALcount-per* a) (ALcount-agg* a) (ALcount-del* a)
 
 
 
  AL-with-str : Multi-Set A setA
- AL-with-str = (AssocList A , ⟨⟩ , ⟨_, 1 ⟩∷_ , ALmember)
+ AL-with-str = (AssocList A , ⟨⟩ , ⟨_, 1 ⟩∷_ , ALcount)
 
 
 -- We want to show that Al-with-str ≅ FMS-with-str as multiset-structures
  FMS→AL-isIso : multi-set-iso A setA (FMS-with-str discA) (AL-with-str) FMSet≃AssocList
  FMS→AL-isIso = refl , (λ a xs → refl) , φ
   where
-  φ : ∀ a xs → FMSmember discA a xs ≡ ALmember a (FMS→AL xs)
+  φ : ∀ a xs → FMScount discA a xs ≡ ALcount a (FMS→AL xs)
   φ a = FMS.ElimProp.f (isSetℕ _ _) refl ψ
    where
    χ :  (x : A) (xs ys : ℕ) (p : Dec (a ≡ x))
       → xs ≡ ys
-      → FMSmember-∷*-aux a x p xs ≡ ALmember-⟨,⟩∷*-aux a x p 1 ys
+      → FMScount-∷*-aux a x p xs ≡ ALcount-⟨,⟩∷*-aux a x p 1 ys
    χ x xs ys (yes p) q = cong suc q
    χ x xs ys (no ¬p) q = q
 
    ψ :  (x : A) {xs : FMSet A}
-      → FMSmember discA a xs ≡ ALmember a (FMS→AL xs)
-      → FMSmember discA a (x ∷ xs) ≡ ALmember a (FMS→AL (x ∷ xs))
+      → FMScount discA a xs ≡ ALcount a (FMS→AL xs)
+      → FMScount discA a (x ∷ xs) ≡ ALcount a (FMS→AL (x ∷ xs))
    ψ x {xs} p = subst B α θ
     where
-    B = λ ys → FMSmember discA a (x ∷ xs) ≡ ALmember a ys
+    B = λ ys → FMScount discA a (x ∷ xs) ≡ ALcount a ys
 
     α : ⟨ x , 1 ⟩∷ FMS→AL xs ≡ FMS→AL (x ∷ xs)
     α = sym (multi-∷-id x 1 xs)
 
-    θ : FMSmember discA a (x ∷ xs) ≡ ALmember a (⟨ x , 1 ⟩∷ (FMS→AL xs))
-    θ = χ x (FMSmember discA a xs) (ALmember a (FMS→AL xs)) (discA a x) p
+    θ : FMScount discA a (x ∷ xs) ≡ ALcount a (⟨ x , 1 ⟩∷ (FMS→AL xs))
+    θ = χ x (FMScount discA a xs) (ALcount a (FMS→AL xs)) (discA a x) p
 
 
 

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -20,7 +20,7 @@ data FMSet (A : Type ℓ) : Type ℓ where
 
 pattern [_] x = x ∷ []
 
-module Elim {ℓ} {B : FMSet A → Type ℓ}
+module Elim {ℓ'} {B : FMSet A → Type ℓ'}
   ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs))
   (comm* : (x y : A) {xs : FMSet A} (b : B xs)
          → PathP (λ i → B (comm x y xs i)) (x ∷* (y ∷* b)) (y ∷* (x ∷* b)))
@@ -33,7 +33,7 @@ module Elim {ℓ} {B : FMSet A → Type ℓ}
   f (trunc xs zs p q i j) =
     isOfHLevel→isOfHLevelDep 2 trunc*  (f xs) (f zs) (cong f p) (cong f q) (trunc xs zs p q) i j
 
-module ElimProp {ℓ} {B : FMSet A → Type ℓ} (BProp : {xs : FMSet A} → isProp (B xs))
+module ElimProp {ℓ'} {B : FMSet A → Type ℓ'} (BProp : {xs : FMSet A} → isProp (B xs))
   ([]* : B []) (_∷*_ : (x : A) {xs : FMSet A} → B xs → B (x ∷ xs)) where
 
   f : (xs : FMSet A) → B xs
@@ -42,7 +42,7 @@ module ElimProp {ℓ} {B : FMSet A → Type ℓ} (BProp : {xs : FMSet A} → isP
           toPathP (BProp (transp (λ i → B (comm x y xs i)) i0 (x ∷* (y ∷* b))) (y ∷* (x ∷* b))))
         (λ xs → isProp→isSet BProp)
 
-module Rec {ℓ} {B : Type ℓ} (BType : isSet B)
+module Rec {ℓ'} {B : Type ℓ'} (BType : isSet B)
   ([]* : B) (_∷*_ : A → B → B)
   (comm* : (x y : A) (b : B) → x ∷* (y ∷* b) ≡ y ∷* (x ∷* b)) where
 

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -7,11 +7,12 @@ open import Cubical.Foundations.HLevels
 
 private
   variable
-    A : Type₀
+    ℓ : Level
+    A : Type ℓ
 
 infixr 5 _∷_
 
-data FMSet (A : Type₀) : Type₀ where
+data FMSet (A : Type ℓ) : Type ℓ where
   []    : FMSet A
   _∷_   : (x : A) → (xs : FMSet A) → FMSet A
   comm  : ∀ x y xs → x ∷ y ∷ xs ≡ y ∷ x ∷ xs

--- a/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
+++ b/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
@@ -1,5 +1,5 @@
 {-# OPTIONS --cubical --safe #-}
-module Cubical.HITs.FiniteMultiset.Order where
+module Cubical.HITs.FiniteMultiset.CountExtensionality where
 
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/FiniteMultiset/Order.agda
+++ b/Cubical/HITs/FiniteMultiset/Order.agda
@@ -25,16 +25,16 @@ module _(discA : Discrete A) where
 
  ≼-refl : ∀ xs → xs ≼ xs
  ≼-refl xs a  = ≤-refl
- 
+
  ≼-trans : ∀ xs ys zs → xs ≼ ys → ys ≼ zs → xs ≼ zs
  ≼-trans xs ys zs xs≼ys ys≼zs a = ≤-trans (xs≼ys a) (ys≼zs a)
 
- 
+
  ≼[]→≡[] : ∀ xs → xs ≼ [] → xs ≡ []
  ≼[]→≡[] xs xs≼[] = FMScount-0-lemma discA xs λ a → ≤0→≡0 (xs≼[] a)
 
 
- 
+
 
  ≼-remove1 : ∀ a xs → remove1 discA a xs ≼ xs
  ≼-remove1 a xs b with discA a b
@@ -42,15 +42,8 @@ module _(discA : Discrete A) where
   where
   path : FMScount discA b (remove1 discA a xs) ≡ predℕ (FMScount discA b xs)
   path = cong (λ c → FMScount discA b (remove1 discA c xs)) a≡b ∙ remove1-predℕ-lemma discA b xs
- ...              | no  a≢b = subst (λ n → n ≤ FMScount discA b xs) (sym path) ≤-refl
-  where
-  path : FMScount discA b (remove1 discA a xs) ≡ FMScount discA b xs
-  path with discreteℕ (FMScount discA a xs) zero
-  path | yes p = cong (FMScount discA b) (sym (remove1-zero-lemma discA a xs p))
-  path | no ¬p = sym (FMScount-≢-lemma discA  (remove1 discA a xs) λ b≡a → a≢b (sym b≡a)) ∙ cong (FMScount discA b) eq₁
-   where
-   eq₁ : (a ∷ remove1 discA a xs) ≡ xs
-   eq₁ = sym (remove1-suc-lemma discA a (predℕ (FMScount discA a xs)) xs (suc-predℕ (FMScount discA a xs) ¬p))
+ ...              | no  a≢b = subst (λ n → n ≤ FMScount discA b xs)
+                                    (sym (FMScount-remove1-≢-lemma discA xs λ b≡a → a≢b (sym b≡a))) ≤-refl
 
 
  ≼-remove1-lemma : ∀ x xs ys → ys ≼ (x ∷ xs) → (remove1 discA x ys) ≼ xs
@@ -60,18 +53,8 @@ module _(discA : Discrete A) where
   where
   p₁ : FMScount discA a (remove1 discA x ys) ≡ predℕ (FMScount discA a ys)
   p₁ = subst (λ b →  FMScount discA a (remove1 discA b ys) ≡ predℕ (FMScount discA a ys)) a≡x (remove1-predℕ-lemma discA a ys)
-  
- ...                               | no  a≢x = ≤-trans (≤-trans (0 , p₁) (ys≼x∷xs a)) (0 , FMScount-≢-lemma discA  xs a≢x) -- extra lemma ≡→≤?
-  where
-  -- have as extra lemma!!
-  p₁ : FMScount discA a (remove1 discA x ys) ≡ FMScount discA a ys
-  p₁ with discreteℕ (FMScount discA x ys) zero
-  p₁ | yes p = cong (FMScount discA a) (sym (remove1-zero-lemma discA x ys p))
-  p₁ | no ¬p = sym (FMScount-≢-lemma discA (remove1 discA x ys) a≢x) ∙ cong (FMScount discA a) eq₁
-   where
-   eq₁ : (x ∷ remove1 discA x ys) ≡ ys
-   eq₁ = sym (remove1-suc-lemma discA x (predℕ (FMScount discA x ys)) ys (suc-predℕ (FMScount discA x ys) ¬p))
-
+ ...                               | no  a≢x = ≤-trans (≤-trans (0 ,  FMScount-remove1-≢-lemma discA ys a≢x) (ys≼x∷xs a))
+                                                                (0 , FMScount-≢-lemma discA  xs a≢x)
 
 
  ≼-Dichotomy : ∀ x xs ys → ys ≼ (x ∷ xs) → (ys ≼ xs) ⊎ (ys ≡ x ∷ (remove1 discA x ys))
@@ -90,8 +73,8 @@ module _(discA : Discrete A) where
 
 
 
-
- module FMS-≼-ElimProp {ℓ} {B : FMSet A → Type ℓ}
+ -- proving a strong elimination principle for finite multisets
+ module ≼-ElimProp {ℓ} {B : FMSet A → Type ℓ}
                        (BisProp : ∀ {xs} → isProp (B xs)) (b₀ : B [])
                        (B-≼-hyp : ∀ x xs → (∀ ys → ys ≼ xs → B ys) → B (x ∷ xs)) where
 
@@ -120,3 +103,85 @@ module _(discA : Discrete A) where
   f = obs g
 
 
+
+ ≼-ElimPropBin :  ∀ {ℓ} {B : FMSet A → FMSet A → Type ℓ}
+                   → (∀ {xs} {ys} → isProp (B xs ys))
+                   → (B [] [])
+                   → (∀ x xs ys → (∀ vs ws → vs ≼ xs → ws ≼ ys → B vs ws) → B (x ∷ xs) ys)
+                   → (∀ x xs ys → (∀ vs ws → vs ≼ xs → ws ≼ ys → B vs ws) → B xs (x ∷ ys))
+                   -------------------------------------------------------------------------------
+                   → (∀ xs ys → B xs ys)
+ ≼-ElimPropBin {B = B} BisProp b₀₀ left-hyp right-hyp = ≼-ElimProp.f (isPropΠ (λ _ → BisProp)) θ χ
+  where
+  θ : ∀ ys → B [] ys
+  θ = ≼-ElimProp.f BisProp b₀₀ h₁
+   where
+   h₁ : ∀ x ys → (∀ ws → ws ≼ ys → B [] ws) → B [] (x ∷ ys)
+   h₁ x ys mini-h = right-hyp x [] ys h₂
+    where
+    h₂ : ∀ vs ws → vs ≼ [] → ws ≼ ys → B vs ws
+    h₂ vs ws vs≼[] ws≼ys = subst (λ zs → B zs ws) (sym (≼[]→≡[] vs vs≼[])) (mini-h ws ws≼ys)
+
+  χ : ∀ x xs → (∀ zs → zs ≼ xs → (∀ ys → B zs ys)) → ∀ ys → B (x ∷ xs) ys
+  χ x xs h ys = left-hyp x xs ys λ vs ws vs≼xs _ → h vs vs≼xs ws
+
+
+
+ ≼-ElimPropBinSym :  ∀ {ℓ} {B : FMSet A → FMSet A → Type ℓ}
+                      → (∀ {xs} {ys} → isProp (B xs ys))
+                      → (∀ {xs} {ys} → B xs ys → B ys xs)
+                      → (B [] [])
+                      → (∀ x xs ys → (∀ vs ws → vs ≼ xs → ws ≼ ys → B vs ws) → B (x ∷ xs) ys)
+                      ----------------------------------------------------------------------------
+                      → (∀ xs ys → B xs ys)
+ ≼-ElimPropBinSym {B = B} BisProp BisSym b₀₀ left-hyp = ≼-ElimPropBin BisProp b₀₀ left-hyp right-hyp
+  where
+  right-hyp : ∀ x xs ys → (∀ vs ws → vs ≼ xs → ws ≼ ys → B vs ws) → B xs (x ∷ ys)
+  right-hyp x xs ys h₁ = BisSym (left-hyp x ys xs (λ vs ws vs≼ys ws≼xs → BisSym (h₁ ws vs ws≼xs vs≼ys)))
+
+
+
+ module FMScountExt where
+  B : FMSet A → FMSet A → Type₀
+  B xs ys = (∀ a → FMScount discA a xs ≡ FMScount discA a ys) → xs ≡ ys
+
+  BisProp : ∀ {xs} {ys} → isProp (B xs ys)
+  BisProp = isPropΠ λ _ → trunc _ _
+
+  BisSym : ∀ {xs} {ys} → B xs ys → B ys xs
+  BisSym {xs} {ys} b h = sym (b (λ a → sym (h a)))
+
+  b₀₀ : B [] []
+  b₀₀ _ = refl
+
+  left-hyp : ∀ x xs ys → (∀ vs ws → vs ≼ xs → ws ≼ ys → B vs ws) → B (x ∷ xs) ys
+  left-hyp x xs ys hyp h₁ = (λ i → x ∷ (hyp-path i)) ∙ sym path
+   where
+   eq₁ : FMScount discA x ys ≡ suc (FMScount discA x xs)
+   eq₁ = sym (h₁ x) ∙ FMScount-≡-lemma-refl discA xs
+
+   path : ys ≡ x ∷ (remove1 discA x ys)
+   path = remove1-suc-lemma discA x (FMScount discA x xs) ys eq₁
+
+   hyp-path : xs ≡ remove1 discA x ys
+   hyp-path = hyp xs (remove1 discA x ys) (≼-refl xs) (≼-remove1 x ys) θ
+    where
+    θ : ∀ a → FMScount discA a xs ≡ FMScount discA a (remove1 discA x ys)
+    θ a with discA a x
+    ... | yes a≡x = subst (λ b → FMScount discA b xs ≡ FMScount discA b (remove1 discA x ys)) (sym a≡x) eq₂
+     where
+     eq₂ : FMScount discA x xs ≡ FMScount discA x (remove1 discA x ys)
+     eq₂ = FMScount discA x xs                     ≡⟨ cong predℕ (sym (FMScount-≡-lemma-refl discA xs)) ⟩
+           predℕ (FMScount discA x (x ∷ xs))       ≡⟨ cong predℕ (h₁ x) ⟩
+           predℕ (FMScount discA x ys)             ≡⟨ sym (remove1-predℕ-lemma discA x ys) ⟩
+           FMScount discA x (remove1 discA x ys)   ∎
+    ... | no  a≢x =
+           FMScount discA a xs                         ≡⟨ sym (FMScount-≢-lemma discA  xs a≢x) ⟩
+           FMScount discA a (x ∷ xs)                   ≡⟨ h₁ a ⟩
+           FMScount discA a ys                         ≡⟨ cong (FMScount discA a) path ⟩
+           FMScount discA a (x ∷ (remove1 discA x ys)) ≡⟨ FMScount-≢-lemma discA (remove1 discA x ys) a≢x ⟩
+           FMScount discA a (remove1 discA x ys)       ∎
+
+
+  Thm : ∀ xs ys → (∀ a → FMScount discA a xs ≡ FMScount discA a ys) → xs ≡ ys
+  Thm = ≼-ElimPropBinSym BisProp BisSym b₀₀ left-hyp

--- a/Cubical/HITs/FiniteMultiset/Order.agda
+++ b/Cubical/HITs/FiniteMultiset/Order.agda
@@ -1,0 +1,122 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.FiniteMultiset.Order where
+
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Sum
+open import Cubical.Relation.Nullary
+open import Cubical.HITs.FiniteMultiset.Base
+open import Cubical.HITs.FiniteMultiset.Properties as FMS
+open import Cubical.Structures.MultiSet
+open import Cubical.Relation.Nullary.DecidableEq
+
+
+private
+ variable
+  A : Type₀
+
+module _(discA : Discrete A) where
+ _≼_ : FMSet A → FMSet A → Type₀ --\preceq
+ xs ≼ ys = ∀ a → FMScount discA a xs ≤ FMScount discA a ys
+
+ ≼-refl : ∀ xs → xs ≼ xs
+ ≼-refl xs a  = ≤-refl
+ 
+ ≼-trans : ∀ xs ys zs → xs ≼ ys → ys ≼ zs → xs ≼ zs
+ ≼-trans xs ys zs xs≼ys ys≼zs a = ≤-trans (xs≼ys a) (ys≼zs a)
+
+ 
+ ≼[]→≡[] : ∀ xs → xs ≼ [] → xs ≡ []
+ ≼[]→≡[] xs xs≼[] = FMScount-0-lemma discA xs λ a → ≤0→≡0 (xs≼[] a)
+
+
+ 
+
+ ≼-remove1 : ∀ a xs → remove1 discA a xs ≼ xs
+ ≼-remove1 a xs b with discA a b
+ ...              | yes a≡b = subst (λ n → n ≤ FMScount discA b xs) (sym path) (≤-predℕ)
+  where
+  path : FMScount discA b (remove1 discA a xs) ≡ predℕ (FMScount discA b xs)
+  path = cong (λ c → FMScount discA b (remove1 discA c xs)) a≡b ∙ remove1-predℕ-lemma discA b xs
+ ...              | no  a≢b = subst (λ n → n ≤ FMScount discA b xs) (sym path) ≤-refl
+  where
+  path : FMScount discA b (remove1 discA a xs) ≡ FMScount discA b xs
+  path with discreteℕ (FMScount discA a xs) zero
+  path | yes p = cong (FMScount discA b) (sym (remove1-zero-lemma discA a xs p))
+  path | no ¬p = sym (FMScount-≢-lemma discA  (remove1 discA a xs) λ b≡a → a≢b (sym b≡a)) ∙ cong (FMScount discA b) eq₁
+   where
+   eq₁ : (a ∷ remove1 discA a xs) ≡ xs
+   eq₁ = sym (remove1-suc-lemma discA a (predℕ (FMScount discA a xs)) xs (suc-predℕ (FMScount discA a xs) ¬p))
+
+
+ ≼-remove1-lemma : ∀ x xs ys → ys ≼ (x ∷ xs) → (remove1 discA x ys) ≼ xs
+ ≼-remove1-lemma x xs ys ys≼x∷xs a with discA a x
+ ...                               | yes a≡x = ≤-trans (≤-trans (0 , p₁) (predℕ-≤-predℕ (ys≼x∷xs a)))
+                                                                (0 , cong predℕ (FMScount-≡-lemma discA xs a≡x))
+  where
+  p₁ : FMScount discA a (remove1 discA x ys) ≡ predℕ (FMScount discA a ys)
+  p₁ = subst (λ b →  FMScount discA a (remove1 discA b ys) ≡ predℕ (FMScount discA a ys)) a≡x (remove1-predℕ-lemma discA a ys)
+  
+ ...                               | no  a≢x = ≤-trans (≤-trans (0 , p₁) (ys≼x∷xs a)) (0 , FMScount-≢-lemma discA  xs a≢x) -- extra lemma ≡→≤?
+  where
+  -- have as extra lemma!!
+  p₁ : FMScount discA a (remove1 discA x ys) ≡ FMScount discA a ys
+  p₁ with discreteℕ (FMScount discA x ys) zero
+  p₁ | yes p = cong (FMScount discA a) (sym (remove1-zero-lemma discA x ys p))
+  p₁ | no ¬p = sym (FMScount-≢-lemma discA (remove1 discA x ys) a≢x) ∙ cong (FMScount discA a) eq₁
+   where
+   eq₁ : (x ∷ remove1 discA x ys) ≡ ys
+   eq₁ = sym (remove1-suc-lemma discA x (predℕ (FMScount discA x ys)) ys (suc-predℕ (FMScount discA x ys) ¬p))
+
+
+
+ ≼-Dichotomy : ∀ x xs ys → ys ≼ (x ∷ xs) → (ys ≼ xs) ⊎ (ys ≡ x ∷ (remove1 discA x ys))
+ ≼-Dichotomy x xs ys ys≼x∷xs with (FMScount discA x ys) ≟ suc (FMScount discA x xs)
+ ...                         | lt <suc = inl ys≼xs
+  where
+  ys≼xs : ys ≼ xs
+  ys≼xs a with discA a x
+  ...     | yes a≡x = pred-≤-pred (subst (λ b → (FMScount discA b ys) < suc (FMScount discA b xs)) (sym a≡x) <suc)
+  ...     | no  a≢x = ≤-trans (ys≼x∷xs a) (subst (λ n → FMScount discA a (x ∷ xs) ≤ n) (FMScount-≢-lemma discA xs a≢x) ≤-refl)
+ ...                         | eq ≡suc = inr (remove1-suc-lemma discA x (FMScount discA x xs) ys ≡suc)
+ ...                         | gt >suc = ⊥.rec (¬m<m strict-ineq)
+  where
+  strict-ineq : suc (FMScount discA x xs) < suc (FMScount discA x xs)
+  strict-ineq =  <≤-trans (<≤-trans >suc (ys≼x∷xs x)) (0 , FMScount-≡-lemma-refl discA xs)
+
+
+
+
+ module FMS-≼-ElimProp {ℓ} {B : FMSet A → Type ℓ}
+                       (BisProp : ∀ {xs} → isProp (B xs)) (b₀ : B [])
+                       (B-≼-hyp : ∀ x xs → (∀ ys → ys ≼ xs → B ys) → B (x ∷ xs)) where
+
+  C : FMSet A → Type ℓ
+  C xs = ∀ ys → ys ≼ xs → B ys
+
+  obs : (∀ xs → C xs) → (∀ xs → B xs)
+  obs C-hyp xs = C-hyp xs xs (≼-refl xs)
+
+  g : ∀ xs → C xs
+  g = ElimProp.f (isPropΠ2 (λ _ _ → BisProp)) c₀ θ
+   where
+   c₀ : C []
+   c₀ ys ys≼[] = subst B (sym (≼[]→≡[] ys ys≼[])) b₀
+
+   θ : ∀ x {xs} → C xs → C (x ∷ xs)
+   θ x {xs} hyp ys ys≼x∷xs with ≼-Dichotomy x xs ys ys≼x∷xs
+   ...                     | inl ys≼xs   = hyp ys ys≼xs
+   ...                     | inr ys≡x∷zs = subst B (sym ys≡x∷zs) (B-≼-hyp x zs χ)
+    where
+    zs = remove1 discA x ys
+    χ : ∀ vs → vs ≼ zs → B vs
+    χ vs vs≼zs = hyp vs (≼-trans vs zs xs vs≼zs (≼-remove1-lemma x xs ys ys≼x∷xs))
+
+  f : ∀ xs → B xs
+  f = obs g
+
+

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -218,3 +218,12 @@ module _(discA : Discrete A) where
   θ x {xs} hyp p with discA a x
   ...            | yes a≡x = (λ i → (sym a≡x i) ∷ xs)
   ...            | no  a≢x = cong (x ∷_) (hyp p) ∙ comm x a (remove1 a xs)
+
+
+ FMScount-remove1-≢-lemma : ∀ {a} {x} xs → ¬ a ≡ x → FMScount a (remove1 x xs) ≡ FMScount a xs
+ FMScount-remove1-≢-lemma {a} {x} xs a≢x with discreteℕ (FMScount x xs) zero
+ ...                     | yes p = cong (FMScount a) (sym (remove1-zero-lemma x xs p))
+ ...                     | no ¬p = sym (FMScount-≢-lemma (remove1 x xs) a≢x) ∙ cong (FMScount a) eq₁
+   where
+   eq₁ : (x ∷ remove1 x xs) ≡ xs
+   eq₁ = sym (remove1-suc-lemma x (predℕ (FMScount x xs)) xs (suc-predℕ (FMScount x xs) ¬p))

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -12,7 +12,8 @@ open import Cubical.Relation.Nullary.DecidableEq
 
 private
   variable
-    A : Type₀
+    ℓ : Level
+    A : Type ℓ
 
 infixr 30 _++_
 

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -80,36 +80,36 @@ module FMSetUniversal {ℓ} {M : Type ℓ} (MSet : isSet M)
 
 
 -- We want to construct a multiset-structure on FMSet A, the empty set and insertion are given by the constructors,
--- for the membership part we use the recursor
+-- for the count part we use the recursor
 
 -- Is there a way around the auxillary functions with the with-syntax?
-FMSmember-∷*-aux : (a x : A) → Dec (a ≡ x) → ℕ → ℕ
-FMSmember-∷*-aux a x (yes a≡x) n = suc n
-FMSmember-∷*-aux a x (no  a≢x) n = n
+FMScount-∷*-aux : (a x : A) → Dec (a ≡ x) → ℕ → ℕ
+FMScount-∷*-aux a x (yes a≡x) n = suc n
+FMScount-∷*-aux a x (no  a≢x) n = n
 
 
-FMSmember-comm*-aux :  (a x y : A) (n : ℕ) (p : Dec (a ≡ x)) (q : Dec (a ≡ y))
-                     →  FMSmember-∷*-aux a x p (FMSmember-∷*-aux a y q n)
-                      ≡ FMSmember-∷*-aux a y q (FMSmember-∷*-aux a x p n)
-FMSmember-comm*-aux a x y n (yes a≡x) (yes a≡y) = refl
-FMSmember-comm*-aux a x y n (yes a≡x) (no  a≢y) = refl
-FMSmember-comm*-aux a x y n (no  a≢x) (yes a≡y) = refl
-FMSmember-comm*-aux a x y n (no  a≢x) (no  a≢y) = refl
+FMScount-comm*-aux :  (a x y : A) (n : ℕ) (p : Dec (a ≡ x)) (q : Dec (a ≡ y))
+                     →  FMScount-∷*-aux a x p (FMScount-∷*-aux a y q n)
+                      ≡ FMScount-∷*-aux a y q (FMScount-∷*-aux a x p n)
+FMScount-comm*-aux a x y n (yes a≡x) (yes a≡y) = refl
+FMScount-comm*-aux a x y n (yes a≡x) (no  a≢y) = refl
+FMScount-comm*-aux a x y n (no  a≢x) (yes a≡y) = refl
+FMScount-comm*-aux a x y n (no  a≢x) (no  a≢y) = refl
 
 
--- If A has decidable equality we can define the member-function:
+-- If A has decidable equality we can define the count-function:
 module _(discA : Discrete A) where
- FMSmember-∷* : A → A → ℕ → ℕ
- FMSmember-∷* a x n = FMSmember-∷*-aux a x (discA a x) n
+ FMScount-∷* : A → A → ℕ → ℕ
+ FMScount-∷* a x n = FMScount-∷*-aux a x (discA a x) n
 
- FMSmember-comm* :  (a x y : A) (n : ℕ)
-                  →  FMSmember-∷* a x (FMSmember-∷* a y n)
-                   ≡ FMSmember-∷* a y (FMSmember-∷* a x n)
- FMSmember-comm* a x y n = FMSmember-comm*-aux a x y n (discA a x) (discA a y)
+ FMScount-comm* :  (a x y : A) (n : ℕ)
+                  →  FMScount-∷* a x (FMScount-∷* a y n)
+                   ≡ FMScount-∷* a y (FMScount-∷* a x n)
+ FMScount-comm* a x y n = FMScount-comm*-aux a x y n (discA a x) (discA a y)
 
- FMSmember : A → FMSet A → ℕ
- FMSmember a = Rec.f isSetℕ 0 (FMSmember-∷* a) (FMSmember-comm* a)
+ FMScount : A → FMSet A → ℕ
+ FMScount a = Rec.f isSetℕ 0 (FMScount-∷* a) (FMScount-comm* a)
 
 
  FMS-with-str : Multi-Set A (Discrete→isSet discA)
- FMS-with-str = (FMSet A , [] , _∷_ , FMSmember)
+ FMS-with-str = (FMSet A , [] , _∷_ , FMScount)

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -14,7 +14,7 @@ open import Cubical.Structures.MultiSet
 open import Cubical.HITs.SetQuotients.Base
 open import Cubical.HITs.SetQuotients.Properties
 open import Cubical.HITs.FiniteMultiset as FMS hiding ([_])
-open import Cubical.HITs.FiniteMultiset.Order
+open import Cubical.HITs.FiniteMultiset.CountExtensionality
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq
 open import Cubical.Relation.ZigZag.Base as ZigZag

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -14,7 +14,7 @@ open import Cubical.Structures.MultiSet
 open import Cubical.HITs.SetQuotients.Base
 open import Cubical.HITs.SetQuotients.Properties
 open import Cubical.HITs.FiniteMultiset as FMS hiding ([_])
-open import Cubical.HITs.FiniteMultiset.Order as FMSO
+open import Cubical.HITs.FiniteMultiset.Order
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Nullary.DecidableEq
 open import Cubical.Relation.ZigZag.Base as ZigZag
@@ -22,11 +22,11 @@ open import Cubical.Relation.ZigZag.Base as ZigZag
 private
  variable
   ℓ : Level
-  A : Type₀
+  A : Type ℓ
 
 
 -- we define simple association lists without any higher constructors
-data AList (A : Type₀) : Type₀ where
+data AList (A : Type ℓ) : Type ℓ where
  ⟨⟩ : AList A
  ⟨_,_⟩∷_ : A → ℕ → AList A → AList A
 
@@ -34,15 +34,15 @@ infixr 5 ⟨_,_⟩∷_
 
 
 -- We have a count-structure on List and AList and use these to get a bisimulation between the two
-module Lists&ALists (discA : Discrete A) where
+module Lists&ALists {A : Type ℓ} (discA : Discrete A) where
  -- the relation we're interested in
  S = count-structure A (Discrete→isSet discA)
- R : {A B : TypeWithStr ℓ-zero S} → (A .fst) → (B .fst) → Type₀
+ R : {A B : TypeWithStr ℓ S} → (A .fst) → (B .fst) → Type ℓ
  R {X , count₁} {Y , count₂} x y = ∀ a → count₁ a x ≡ count₂ a y
 
  -- relation between R and ι
  ι = count-iso A (Discrete→isSet discA)
- ι-R-char : {X Y : TypeWithStr ℓ-zero S} (e : (X .fst) ≃ (Y .fst))
+ ι-R-char : {X Y : TypeWithStr ℓ S} (e : (X .fst) ≃ (Y .fst))
           → (∀ x → R {X} {Y} x (e .fst x)) ≃ (ι X Y e)
  ι-R-char e = isoToEquiv (iso (λ f → λ a x → f x a) (λ g → λ x a → g a x) (λ _ → refl) λ _ → refl)
 
@@ -150,8 +150,8 @@ module Lists&ALists (discA : Discrete A) where
   where
   r' : Rᴸ (a ∷ xs) (a ∷ xs')
   r' =  ⟨ a , 1 ⟩∷ (r .fst)
-      , (λ a' → cong (λ n →  aux a' a (discA a' a) n) (r .snd .fst a'))
-      , (λ a' → cong (λ n →  aux a' a (discA a' a) n) (r .snd .snd a'))
+      , (λ a' → cong (aux a' a (discA a' a)) (r .snd .fst a'))
+      , (λ a' → cong (aux a' a (discA a' a)) (r .snd .snd a'))
  a ∷/ squash/ xs xs₁ p q i j = squash/ (a ∷/ xs) (a ∷/ xs₁) (cong (a ∷/_) p) (cong (a ∷/_) q) i j
 
  infixr 5 _∷/_
@@ -198,7 +198,7 @@ module Lists&ALists (discA : Discrete A) where
    θ a = sym (List→FMSet-count a xs) ∙∙ ρ a ∙∙ List→FMSet-count a ys
 
    path : List→FMSet xs ≡ List→FMSet ys
-   path = FMSO.FMScountExt.Thm discA _ _ θ
+   path = FMScountExt.Thm discA _ _ θ
  ν (squash/ xs/ xs/' p q i j) = trunc (ν xs/) (ν xs/') (cong ν p) (cong ν q) i j
 
 

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -1,0 +1,216 @@
+-- We apply the theory of zigzag complete relations to finite multisets and association lists.
+-- See discussion at the end of the file.
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Relation.ZigZag.Applications.MultiSet where
+
+open import Cubical.Core.Everything
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+open import Cubical.Data.Nat
+open import Cubical.Data.List hiding ([_])
+open import Cubical.Structures.MultiSet renaming (count-structure to S)
+open import Cubical.HITs.SetQuotients.Base
+open import Cubical.HITs.SetQuotients.Properties
+open import Cubical.HITs.FiniteMultiset as FMS hiding ([_])
+open import Cubical.HITs.FiniteMultiset.Order as FMSO
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Nullary.DecidableEq
+open import Cubical.Relation.ZigZag.Base as ZigZag
+
+private
+ variable
+  ℓ : Level
+  A : Type₀
+
+
+-- we define simple association lists without any higher constructors
+data AList (A : Type₀) : Type₀ where
+ ⟨⟩ : AList A
+ ⟨_,_⟩∷_ : A → ℕ → AList A → AList A
+
+infixr 5 ⟨_,_⟩∷_
+
+
+-- We have a count-structure on List and AList and use these to get a bisimulation between the two
+module Lists&ALists (discA : Discrete A) where
+ -- the relation we're interested in
+ R : {A B : TypeWithStr ℓ-zero (S A (Discrete→isSet discA))} → (A .fst) → (B .fst) → Type₀
+ R {X , count₁} {Y , count₂} x y = ∀ a → count₁ a x ≡ count₂ a y
+
+
+ aux : (a x : A) → Dec (a ≡ x) → ℕ → ℕ
+ aux a x (yes a≡x) n = suc n
+ aux a x (no  a≢x) n = n
+
+
+ -- the count-structures
+ Lcount : S A (Discrete→isSet discA) (List A)
+ Lcount a [] = zero
+ Lcount a (x ∷ xs) = aux a x (discA a x) (Lcount a xs)
+
+ ALcount : S A (Discrete→isSet discA) (AList A)
+ ALcount a ⟨⟩ = zero
+ ALcount a (⟨ x , zero ⟩∷ xs) = ALcount a xs
+ ALcount a (⟨ x , suc n ⟩∷ xs) = aux a x (discA a x) (ALcount a (⟨ x , n ⟩∷ xs))
+
+
+ -- now for the bisimulation between List and Alist
+ φ : List A → AList A
+ φ [] = ⟨⟩
+ φ (x ∷ xs) = ⟨ x , 1 ⟩∷ φ xs
+
+ ψ : AList A → List A
+ ψ ⟨⟩ = []
+ ψ (⟨ x , zero ⟩∷ xs) = ψ xs
+ ψ (⟨ x , suc n ⟩∷ xs) = x ∷ ψ (⟨ x , n ⟩∷ xs)
+
+
+ η : ∀ x → R {List A , Lcount} {AList A , ALcount} x (φ x)
+ η [] a = refl
+ η (x ∷ xs) a  with (discA a x)
+ ...           | yes a≡x = cong suc (η xs a)
+ ...           | no  a≢x = η xs a
+
+
+ -- for the other direction we need a little helper function
+ ε : ∀ y → R {List A , Lcount} {AList A , ALcount} (ψ y) y
+ ε' : (x : A) (n : ℕ) (xs : AList A) (a : A)
+    → Lcount a (ψ (⟨ x , n ⟩∷ xs)) ≡ ALcount a (⟨ x , n ⟩∷ xs)
+
+ ε ⟨⟩ a = refl
+ ε (⟨ x , n ⟩∷ xs) a = ε' x n xs a
+
+ ε' x zero xs a = ε xs a
+ ε' x (suc n) xs a with discA a x
+ ...                 | yes a≡x = cong suc (ε' x n xs a)
+ ...                 | no  a≢x = ε' x n xs a
+
+
+ -- R {List A , Lcount} {AList A , ALcount} is zigzag-complete
+ zigzagR : isZigZagComplete (R {List A , Lcount} {AList A , ALcount})
+ zigzagR _ _ _ _ r r' r'' a = (r a) ∙∙ sym (r' a) ∙∙ (r'' a)
+
+
+ -- now we can apply the main result about zigzag-complete relations:
+ Rᴸ  = ZigZag.Bisimulation→Equiv.Rᴬ (List A) (AList A) (R {List A , Lcount} {AList A , ALcount}) φ ψ (zigzagR , η , ε)
+ Rᴬᴸ = ZigZag.Bisimulation→Equiv.Rᴮ (List A) (AList A) (R {List A , Lcount} {AList A , ALcount}) φ ψ (zigzagR , η , ε)
+
+ List/Rᴸ = (List A) / Rᴸ
+ AList/Rᴬᴸ = (AList A) / Rᴬᴸ
+
+ List/Rᴸ≃AList/Rᴬᴸ : List/Rᴸ ≃ AList/Rᴬᴸ
+ List/Rᴸ≃AList/Rᴬᴸ = ZigZag.Bisimulation→Equiv.Thm (List A) (AList A)
+                                                   (R {List A , Lcount} {AList A , ALcount}) φ ψ (zigzagR , η , ε)
+
+
+ -- We now show that List/Rᴸ≃FMSet
+ _∷/_ : A → List/Rᴸ → List/Rᴸ
+ a ∷/ [ xs ] = [ a ∷ xs ]
+ a ∷/ eq/ xs xs' r i = eq/ (a ∷ xs) (a ∷ xs') r' i
+  where
+  r' : Rᴸ (a ∷ xs) (a ∷ xs')
+  r' =  ⟨ a , 1 ⟩∷ (r .fst)
+      , (λ a' → cong (λ n →  aux a' a (discA a' a) n) (r .snd .fst a'))
+      , (λ a' → cong (λ n →  aux a' a (discA a' a) n) (r .snd .snd a'))
+ a ∷/ squash/ xs xs₁ p q i j = squash/ (a ∷/ xs) (a ∷/ xs₁) (cong (a ∷/_) p) (cong (a ∷/_) q) i j
+
+ infixr 5 _∷/_
+
+ μ : FMSet A → List/Rᴸ
+ μ = FMS.Rec.f squash/ [ [] ] _∷/_ β
+  where
+  β : ∀ a b [xs] → a ∷/ b ∷/ [xs] ≡ b ∷/ a ∷/ [xs]
+  β a b = elimProp (λ _ → squash/ _ _) (λ xs → eq/ _ _ (γ xs))
+   where
+     γ : ∀ xs → Rᴸ (a ∷ b ∷ xs) (b ∷ a ∷ xs)
+     γ xs = φ (a ∷ b ∷ xs) , η (a ∷ b ∷ xs) , λ c → sym (δ c) ∙ η (a ∷ b ∷ xs) c
+      where
+      δ : ∀ c → Lcount c (a ∷ b ∷ xs) ≡ Lcount c (b ∷ a ∷ xs)
+      δ c with discA c a | discA c b
+      δ c | yes _        | yes _ = refl
+      δ c | yes _        | no  _ = refl
+      δ c | no  _        | yes _ = refl
+      δ c | no  _        | no  _ = refl
+
+
+ -- The inverse is induced by the standard projection of lists into finite multisets,
+ -- which is a morphism of count-structures
+ -- Moreover, we need 'count-extensionality' for finite multisets
+ List→FMSet : List A → FMSet A
+ List→FMSet [] = []
+ List→FMSet (x ∷ xs) = x ∷ List→FMSet xs
+
+ List→FMSet-count : ∀ a xs → Lcount a xs ≡ FMScount discA a (List→FMSet xs)
+ List→FMSet-count a [] = refl
+ List→FMSet-count a (x ∷ xs) with discA a x
+ ...                         | yes _ = cong suc (List→FMSet-count a xs)
+ ...                         | no  _ = List→FMSet-count a xs
+
+
+ ν : List/Rᴸ → FMSet A
+ ν [ xs ] = List→FMSet xs
+ ν (eq/ xs ys r i) = path i
+  where
+   ρ : ∀ a → Lcount a xs ≡ Lcount a ys
+   ρ = λ a → (r .snd .fst a) ∙ sym (r .snd .snd a)
+
+   θ : ∀ a → FMScount discA a (List→FMSet xs) ≡ FMScount discA a (List→FMSet ys)
+   θ a = sym (List→FMSet-count a xs) ∙∙ ρ a ∙∙ List→FMSet-count a ys
+
+   path : List→FMSet xs ≡ List→FMSet ys
+   path = FMSO.FMScountExt.Thm discA _ _ θ
+ ν (squash/ xs/ xs/' p q i j) = trunc (ν xs/) (ν xs/') (cong ν p) (cong ν q) i j
+
+
+ σ : section μ ν
+ σ = elimProp (λ _ → squash/ _ _) θ
+  where
+  θ : (xs : List A) → μ (ν [ xs ]) ≡ [ xs ]
+  θ [] = refl
+  θ (x ∷ xs) = cong (x ∷/_) (θ xs)
+
+
+ ν-∷/-commute : (x : A) (ys : List/Rᴸ) → ν (x ∷/ ys) ≡ x ∷ ν ys
+ ν-∷/-commute x = elimProp (λ _ → FMS.trunc _ _) λ xs → refl
+
+ τ : retract μ ν
+ τ = FMS.ElimProp.f (FMS.trunc _ _) refl θ
+  where
+  θ : ∀ x {xs} → ν (μ xs) ≡ xs → ν (μ (x ∷ xs)) ≡ x ∷ xs
+  θ x {xs} p = ν-∷/-commute x (μ xs) ∙ cong (x ∷_) p
+
+
+ FMSet≃List/Rᴸ : FMSet A ≃ List/Rᴸ
+ FMSet≃List/Rᴸ = isoToEquiv (iso μ ν σ τ)
+
+ {-
+ Putting everything together we get:
+
+               ≃
+ List/Rᴸ ------------> AList/Rᴬᴸ
+
+   |
+   |≃
+   |
+   ∨
+               ≃
+ FMSet A ------------> AssocList A
+
+
+ We thus get that AList/Rᴬᴸ≃AssocList.
+ Constructing such an equivalence directly requires count extensionality for association lists,
+ which should be even harder to prove than for finite multisets.
+
+ This strategy should work for all implementations of multisets with HITs.
+ We just have to show that:
+
+  ∙ The HIT is equivalent to FMSet (like AssocList)
+  ∙ There is a bisimulation between lists and the basic data type of the HIT
+    with the higher constructors removed (like AList)
+
+ Then we get that this HIT is equivalent to the corresponding set quotient that identifies elements
+ that give the same count on each a : A.
+
+ TODO: Show that all the equivalences are indeed isomorphisms of multisets!
+ -}

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -14,14 +14,14 @@ open import Cubical.HITs.SetQuotients.Properties
 
 private
  variable
-  ℓ : Level
+  ℓ ℓ' : Level
 
 
-isZigZagComplete : {A B : Type ℓ} (R : A → B → Type ℓ) → Type ℓ
+isZigZagComplete : {A B : Type ℓ} (R : A → B → Type ℓ') → Type (ℓ-max ℓ ℓ')
 isZigZagComplete R = ∀ a b a' b' → R a b → R a' b → R a' b' → R a b'
 
 
-isBisimulation : {A B : Type ℓ} (R : A → B → Type ℓ) (f : A → B) (g : B → A) → Type ℓ
+isBisimulation : {A B : Type ℓ} (R : A → B → Type ℓ') (f : A → B) (g : B → A) → Type (ℓ-max ℓ ℓ')
 isBisimulation R f g =  isZigZagComplete R
                       × (∀ a → R a (f a))
                       × (∀ b → R (g b) b)
@@ -29,7 +29,7 @@ isBisimulation R f g =  isZigZagComplete R
 
 -- The following result is due to Carlo Angiuli
 module Bisimulation→Equiv (A B : Type ℓ)
-                          (R : A → B → Type ℓ)
+                          (R : A → B → Type ℓ')
                           (f : A → B) (g : B → A)
                           (isBisimRfg : isBisimulation R f g) where
 
@@ -44,10 +44,10 @@ module Bisimulation→Equiv (A B : Type ℓ)
  β = isBisimRfg .snd .snd
 
  -- using R we can define binary relations on A and B
- Rᴬ : A → A → Type ℓ
+ Rᴬ : A → A → Type (ℓ-max ℓ ℓ')
  Rᴬ a a' = Σ[ b ∈ B ] (R a b × R a' b)
 
- Rᴮ : B → B → Type ℓ
+ Rᴮ : B → B → Type (ℓ-max ℓ ℓ')
  Rᴮ b b' = Σ[ a ∈ A ] (R a b × R a b')
 
  -- Rᴬ and Rᴮ are equivalence relations

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -1,0 +1,98 @@
+-- We define ZigZag-complete relations and prove that bisimulations
+-- give rise to equivalences on the set quotients.
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Relation.ZigZag.Base where
+
+open import Cubical.Core.Everything
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.Sigma using (_×_; ΣProp≡)
+open import Cubical.HITs.SetQuotients.Base
+open import Cubical.HITs.SetQuotients.Properties
+
+
+
+private
+ variable
+  ℓ : Level
+
+
+isZigZagComplete : {A B : Type ℓ} (R : A → B → Type ℓ) → Type ℓ
+isZigZagComplete R = ∀ a b a' b' → R a b → R a' b → R a' b' → R a b'
+
+
+isBisimulation : {A B : Type ℓ} (R : A → B → Type ℓ) (f : A → B) (g : B → A) → Type ℓ
+isBisimulation R f g =  isZigZagComplete R
+                      × (∀ a → R a (f a))
+                      × (∀ b → R (g b) b)
+
+
+-- The following result is due to Carlo Angiuli
+module Bisimulation→Equiv (A B : Type ℓ)
+                          (R : A → B → Type ℓ)
+                          (f : A → B) (g : B → A)
+                          (isBisimRfg : isBisimulation R f g) where
+
+ -- first we fix some notation
+ zigzag : isZigZagComplete R
+ zigzag = isBisimRfg .fst
+
+ α : ∀ a → R a (f a)
+ α = isBisimRfg .snd .fst
+
+ β : ∀ b → R (g b) b
+ β = isBisimRfg .snd .snd
+
+ -- using R we can define binary relations on A and B
+ Rᴬ : A → A → Type ℓ
+ Rᴬ a a' = Σ[ b ∈ B ] (R a b × R a' b)
+
+ Rᴮ : B → B → Type ℓ
+ Rᴮ b b' = Σ[ a ∈ A ] (R a b × R a b')
+
+ -- Rᴬ and Rᴮ are equivalence relations
+ Rᴬ-reflexive : ∀ a → Rᴬ a a
+ Rᴬ-reflexive a = f a , α a , α a
+
+ Rᴬ-symmetric : ∀ a a' → Rᴬ a a' → Rᴬ a' a
+ Rᴬ-symmetric a a' (b , r , s) = b , s , r
+
+ Rᴬ-transitive : ∀ a a' a'' → Rᴬ a a' → Rᴬ a' a'' → Rᴬ a a''
+ Rᴬ-transitive a a' a'' (b , r , s) (b' , r' , s') = b' , zigzag _ _ _ _ r s r' , s'
+
+
+ Rᴮ-reflexive : ∀ b → Rᴮ b b
+ Rᴮ-reflexive b = g b , β b , β b
+
+ Rᴮ-symmetric : ∀ b b' → Rᴮ b b' → Rᴮ b' b
+ Rᴮ-symmetric b b' (a , r , s) = a , s , r
+
+ Rᴮ-transitive : ∀ b b' b'' → Rᴮ b b' → Rᴮ b' b'' → Rᴮ b b''
+ Rᴮ-transitive b b' b'' (a , r , s) (a' , r' , s') = a , r , zigzag _ _ _ _ s r' s'
+
+
+ -- proof of A / Rᴬ ≃ B / Rᴮ
+ φ : A / Rᴬ → B / Rᴮ
+ φ [ a ] = [ f a ]
+ φ (eq/ a a' r i) = eq/ (f a) (f a') s i
+  where
+  s : Rᴮ (f a) (f a')
+  s = a , α a , zigzag _ _ _ _ (r .snd .fst) (r .snd .snd) (α a')
+ φ (squash/ x x₁ p q i j) = squash/ (φ x) (φ x₁) (cong φ p) (cong φ q) i j
+
+ ψ : B / Rᴮ → A / Rᴬ
+ ψ [ b ] = [ g b ]
+ ψ (eq/ b b' s i) = eq/ (g b) (g b') r i
+  where
+  r : Rᴬ (g b) (g b')
+  r = b' , zigzag _ _ _ _ (β b) (s .snd .fst) (s .snd .snd) , β b'
+ ψ (squash/ y y₁ p q i j) =  squash/ (ψ y) (ψ y₁) (cong ψ p) (cong ψ q) i j
+
+ η : section φ ψ
+ η y = elimProp (λ y → squash/ (φ (ψ y)) y) (λ b → eq/ _ _ (g b , α (g b) , β b)) y
+
+ ε : retract φ ψ
+ ε x = elimProp (λ x → squash/ (ψ (φ x)) x) (λ a → eq/ _ _ (f a , β (f a) , α a)) x
+
+ Thm : (A / Rᴬ) ≃ (B / Rᴮ)
+ Thm = isoToEquiv (iso φ ψ η ε)

--- a/Cubical/Structures/MultiSet.agda
+++ b/Cubical/Structures/MultiSet.agda
@@ -22,17 +22,17 @@ module _(A : Type ℓ)
 
  open Queues-on A Aset
 
- member-structure : Type ℓ → Type ℓ
- member-structure X = A → X → ℕ
+ count-structure : Type ℓ → Type ℓ
+ count-structure X = A → X → ℕ
 
- Member : Type (ℓ-suc ℓ)
- Member = TypeWithStr ℓ member-structure
+ Count : Type (ℓ-suc ℓ)
+ Count = TypeWithStr ℓ count-structure
 
- member-iso : StrIso member-structure ℓ
- member-iso (X , f) (Y , g) e = ∀ a x → f a x ≡ g a (e .fst x)
+ count-iso : StrIso count-structure ℓ
+ count-iso (X , f) (Y , g) e = ∀ a x → f a x ≡ g a (e .fst x)
 
- Member-is-SNS : SNS {ℓ} member-structure member-iso
- Member-is-SNS = SNS-≡→SNS-PathP member-iso ((λ _ _ → funExt₂Equiv))
+ Count-is-SNS : SNS {ℓ} count-structure count-iso
+ Count-is-SNS = SNS-≡→SNS-PathP count-iso ((λ _ _ → funExt₂Equiv))
 
  -- a multi set structure inspired bei Okasaki
  multi-set-structure : Type ℓ → Type ℓ
@@ -51,8 +51,7 @@ module _(A : Type ℓ)
  Multi-Set-is-SNS : SNS {ℓ₁ = ℓ} multi-set-structure multi-set-iso
  Multi-Set-is-SNS =
    join-SNS pointed-iso pointed-is-SNS
-            {S₂ = λ X → (left-action-structure X) × (member-structure X)}
+            {S₂ = λ X → (left-action-structure X) × (count-structure X)}
             (λ B C e →  (∀ a q → e .fst (B .snd .fst a q) ≡ C .snd .fst a (e .fst q))
                       × (∀ a x → (B .snd .snd a x) ≡ (C .snd .snd a (e .fst x))))
-            (join-SNS left-action-iso Left-Action-is-SNS member-iso Member-is-SNS)
-
+            (join-SNS left-action-iso Left-Action-is-SNS count-iso Count-is-SNS)


### PR DESCRIPTION
We introduce zigzag-complete relations and apply them to finite multisets  and association lists.
In particular we prove that two finite multisets are equal if their count-functions are equal and with the help of zigzag-complete relations we get the same result for association lists.