### PR TITLE
Clean up and improve the `Poset` module in various ways

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -289,6 +289,10 @@ isPropΠ3 h = isPropΠ λ x → isPropΠ λ y → isPropΠ λ z → h x y z
 isSetΠ : ((x : A) → isSet (B x)) → isSet ((x : A) → B x)
 isSetΠ = isOfHLevelΠ 2
 
+isSetΠ2 : (h : (x : A) (y : B x) → isSet (C x y))
+        → isSet ((x : A) (y : B x) → C x y)
+isSetΠ2 h = isSetΠ λ x → isSetΠ λ y → h x y
+
 isGroupoidΠ : ((x : A) → isGroupoid (B x)) → isGroupoid ((x : A) → B x)
 isGroupoidΠ = isOfHLevelΠ 3
 

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -57,8 +57,7 @@ Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv
 -- We now write down the axioms for a partial order.
 
 isReflexive : {A : Type ℓ₀} → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
-isReflexive {A = X} _⊑_ =
-  ((x : X) → [ x ⊑ x ]) , isPropΠ (λ x → snd (x ⊑ x))
+isReflexive {A = X} _⊑_ = ((x : X) → [ x ⊑ x ]) , isPropΠ λ x → snd (x ⊑ x)
 
 isTransitive : {A : Type ℓ₀} → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
 isTransitive {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} _⊑_ = φ , φ-prop

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -178,10 +178,10 @@ poset-SIP : (A : Type ℓ₀) (B : Type ℓ₀) (eqv : A ≃ B)
             (P : PosetStr ℓ₁ A) (Q : PosetStr ℓ₁ B)
           → poset-iso (A , P) (B , Q) eqv
           → (A , P) ≡ (B , Q)
-poset-SIP {ℓ₁ = ℓ₁} A B eqv P Q i = foo (eqv , i)
+poset-SIP {ℓ₁ = ℓ₁} A B eqv P Q i = φ (eqv , i)
   where
-    foo : (A , P) ≃[ poset-iso ] (B , Q) → (A , P) ≡ (B , Q)
-    foo = equivFun (SIP poset-is-SNS-PathP (A , P) (B , Q))
+    φ : (A , P) ≃[ poset-iso ] (B , Q) → (A , P) ≡ (B , Q)
+    φ = equivFun (SIP poset-is-SNS-PathP (A , P) (B , Q))
 
 ≃ₚ→≡ : (P Q : Poset ℓ₀ ℓ₁) → P ≃ₚ Q → P ≡ Q
 ≃ₚ→≡ (A , A-pos) (B , B-pos) (eqv , i) = poset-SIP A B eqv A-pos B-pos i

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -143,7 +143,7 @@ module PosetReasoning (P : Poset ℓ₀ ℓ₁) where
 RP-iso-prop : (P Q : Σ (Type ℓ₀) (Order ℓ₁))
             → (eqv : fst P ≃ fst Q) → isProp (order-iso P Q eqv)
 RP-iso-prop (A , _⊑₀_) (B , _⊑₁_) (f , _) =
-  isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
+  isPropΠ2 λ x y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
 
 poset-iso : (P Q : Poset ℓ₀ ℓ₁) → ∣ P ∣ₚ ≃ ∣ Q ∣ₚ → Type (ℓ-max ℓ₀ ℓ₁)
 poset-iso {ℓ₁ = ℓ₁} = add-to-iso order-iso (λ A _⊑_ → [ satPosetAx ℓ₁ A _⊑_ ])

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -108,6 +108,8 @@ Poset : (ℓ₀ ℓ₁ : Level) → Type (ℓ-max (ℓ-suc ℓ₀) (ℓ-suc ℓ�
 Poset ℓ₀ ℓ₁ = Σ (Type ℓ₀) (PosetStr ℓ₁)
 
 -- Some projections for syntactic convenience.
+
+-- Carrier set of a poset.
 ∣_∣ₚ : Poset ℓ₀ ℓ₁ → Type ℓ₀
 ∣ X , _ ∣ₚ = X
 

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -3,9 +3,9 @@
 module Cubical.Structures.Poset where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Equiv       hiding (_■)
 open import Cubical.Foundations.Logic
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv        hiding   (_■)
 open import Cubical.Foundations.SIP          renaming (SNS-≡ to SNS)
 open import Cubical.Core.Primitives
 open import Cubical.Foundations.HLevels

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -22,10 +22,7 @@ Order : (ℓ₁ : Level) → Type ℓ₀ → Type (ℓ-max ℓ₀ (ℓ-suc ℓ�
 Order ℓ₁ A = A → A → hProp ℓ₁
 
 order-iso : (M N : Σ (Type ℓ₀) (Order ℓ₁)) →  fst M ≃ fst N → Type (ℓ-max ℓ₀ ℓ₁)
-order-iso (A , _⊑₀_) (B , _⊑₁_) eqv =
-  (x y : A) → [ x ⊑₀ y ⇔ f x ⊑₁ f y ]
-  where
-    f = equivFun eqv
+order-iso (A , _⊑₀_) (B , _⊑₁_) (f , _) = (x y : A) → [ x ⊑₀ y ⇔ f x ⊑₁ f y ]
 
 isSetOrder : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (Order ℓ₁ A)
 isSetOrder ℓ₁ A = isSetΠ (λ _ → isSetΠ λ _ → isSetHProp)

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -51,10 +51,7 @@ Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv
         h : (p : _⊑₀_ ≡ _⊑₁_) → (fib : fiber f p) → (g p , sec p) ≡ fib
         h p (i , _) = ΣProp≡ A-prop B-prop
           where
-            A-prop : _
             A-prop = λ i′ → isOfHLevelSuc 2 (isSetOrder ℓ₁ X) _⊑₀_ _⊑₁_ (f i′) p
-
-            B-prop : _
             B-prop = ⇔-prop (g p) i
 
 -- We now write down the axioms for a partial order.

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -34,7 +34,7 @@ Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv
     f i = funExt λ x → funExt λ y → ⇔toPath (fst (i x y)) (snd (i x y))
 
     ⇔-prop : isProp ((x y : X) → [ x ⊑₀ y ⇔ x ⊑₁ y ])
-    ⇔-prop = isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ x ⊑₁ y)
+    ⇔-prop = isPropΠ2 λ x y → snd (x ⊑₀ y ⇔ x ⊑₁ y)
 
     f-equiv : isEquiv f
     f-equiv = record { equiv-proof = λ eq → (g eq , sec eq) , h eq }

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -29,13 +29,13 @@ isSetOrder ℓ₁ A = isSetΠ2 λ _ _ → isSetHProp
 -- We first start by defining what it means a for a function to be
 -- order-preserving. The name "monotonic" is reserved for partial orders.
 
-isOrderPreserving : (M : Σ (Type ℓ₀) (Order ℓ₁)) (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+isOrderPreserving : (M : TypeWithStr ℓ₀ (Order ℓ₁)) (N : TypeWithStr ℓ₀′ (Order ℓ₁′))
                   → (fst M → fst N) → Type _
 isOrderPreserving (A , _⊑₀_) (B , _⊑₁_) f =
   (x y : A) → [ x ⊑₀ y ] → [ f x ⊑₁ f y ]
 
-isPropIsOrderPreserving : (M : Σ(Type ℓ₀)  (Order ℓ₁))
-                          (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+isPropIsOrderPreserving : (M : TypeWithStr ℓ₀  (Order ℓ₁))
+                          (N : TypeWithStr ℓ₀′ (Order ℓ₁′))
                         → (f : fst M → fst N)
                         → isProp (isOrderPreserving M N f)
 isPropIsOrderPreserving M (_ , _⊑₁_) f = isPropΠ3 λ x y p → snd (f x ⊑₁ f y)
@@ -44,8 +44,8 @@ isPropIsOrderPreserving M (_ , _⊑₁_) f = isPropΠ3 λ x y p → snd (f x ⊑
 -- nothing but the property that both directions of the equivalence are
 -- order-preserving.
 
-isAnOrderPreservingEqv : (M : Σ (Type ℓ₀) (Order ℓ₁))
-                         (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+isAnOrderPreservingEqv : (M : TypeWithStr ℓ₀  (Order ℓ₁))
+                         (N : TypeWithStr ℓ₀′ (Order ℓ₁′))
                        → fst M ≃ fst N → Type _
 isAnOrderPreservingEqv M N e@(f , _) =
   isOrderPreserving M N f × isOrderPreserving N M g

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -5,8 +5,10 @@ module Cubical.Structures.Poset where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Logic
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Equiv        hiding   (_■)
+open import Cubical.Foundations.Equiv        renaming (_■ to _QED)
 open import Cubical.Foundations.SIP          renaming (SNS-≡ to SNS)
+open import Cubical.Functions.FunExtEquiv
+open import Cubical.Foundations.Function
 open import Cubical.Core.Primitives
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
@@ -16,45 +18,83 @@ open import Cubical.Data.Sigma.Properties
 -- set by ℓ₀ and the level of the relation result by ℓ₁.
 private
   variable
-    ℓ₀ ℓ₁ : Level
+    ℓ ℓ₀ ℓ₁ ℓ₀′ ℓ₁′ ℓ₀′′ ℓ₁′′ : Level
 
 Order : (ℓ₁ : Level) → Type ℓ₀ → Type (ℓ-max ℓ₀ (ℓ-suc ℓ₁))
 Order ℓ₁ A = A → A → hProp ℓ₁
 
-order-iso : (M N : Σ (Type ℓ₀) (Order ℓ₁)) →  fst M ≃ fst N → Type (ℓ-max ℓ₀ ℓ₁)
-order-iso (A , _⊑₀_) (B , _⊑₁_) (f , _) = (x y : A) → [ x ⊑₀ y ⇔ f x ⊑₁ f y ]
-
 isSetOrder : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (Order ℓ₁ A)
 isSetOrder ℓ₁ A = isSetΠ2 λ _ _ → isSetHProp
 
-Order-is-SNS : SNS {ℓ₀} (Order ℓ₁) order-iso
-Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv
+-- We first start by defining what it means a for a function to be
+-- order-preserving. The name "monotonic" is reserved for partial orders.
+
+isOrderPreserving : (M : Σ (Type ℓ₀) (Order ℓ₁)) (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+                  → (fst M → fst N) → Type _
+isOrderPreserving (A , _⊑₀_) (B , _⊑₁_) f =
+  (x y : A) → [ x ⊑₀ y ] → [ f x ⊑₁ f y ]
+
+isPropIsOrderPreserving : (M : Σ(Type ℓ₀)  (Order ℓ₁))
+                          (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+                        → (f : fst M → fst N)
+                        → isProp (isOrderPreserving M N f)
+isPropIsOrderPreserving M (_ , _⊑₁_) f = isPropΠ3 λ x y p → snd (f x ⊑₁ f y)
+
+-- We then define what it means for an equivalence to order-preserving which is
+-- nothing but the property that both directions of the equivalence are
+-- order-preserving.
+
+isAnOrderPreservingEqv : (M : Σ (Type ℓ₀) (Order ℓ₁))
+                         (N : Σ (Type ℓ₀′) (Order ℓ₁′))
+                       → fst M ≃ fst N → Type _
+isAnOrderPreservingEqv M N e@(f , _) =
+  isOrderPreserving M N f × isOrderPreserving N M g
   where
-    f : order-iso (X , _⊑₀_) (X , _⊑₁_) (idEquiv X) → _⊑₀_ ≡ _⊑₁_
-    f i = funExt λ x → funExt λ y → ⇔toPath (fst (i x y)) (snd (i x y))
+    g = equivFun (invEquiv e)
 
-    ⇔-prop : isProp ((x y : X) → [ x ⊑₀ y ⇔ x ⊑₁ y ])
-    ⇔-prop = isPropΠ2 λ x y → snd (x ⊑₀ y ⇔ x ⊑₁ y)
+Order-is-SNS : SNS {ℓ} (Order ℓ₁) isAnOrderPreservingEqv
+Order-is-SNS {ℓ = ℓ} {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ =
+  f , record { equiv-proof = f-equiv }
+  where
+    f : isAnOrderPreservingEqv (X , _⊑₀_) (X , _⊑₁_) (idEquiv X) → _⊑₀_ ≡ _⊑₁_
+    f e@(φ , ψ) = funExt₂ λ x y → ⇔toPath (φ x y) (ψ x y)
 
-    f-equiv : isEquiv f
-    f-equiv = record { equiv-proof = λ eq → (g eq , sec eq) , h eq }
+    g : _⊑₀_ ≡ _⊑₁_ → isAnOrderPreservingEqv (X , _⊑₀_) (X , _⊑₁_) (idEquiv X)
+    g p =
+      subst
+        (λ _⊑_ → isAnOrderPreservingEqv (X , _⊑₀_) (X , _⊑_) (idEquiv X))
+        p
+        ((λ _ _ x⊑₁y → x⊑₁y) , λ _ _ x⊑₁y → x⊑₁y)
+
+    ret-f-g : retract f g
+    ret-f-g (φ , ψ) =
+      isPropΣ
+        (isPropIsOrderPreserving (X , _⊑₀_) (X , _⊑₁_) (idfun X))
+        (λ _ → isPropIsOrderPreserving (X , _⊑₁_) (X , _⊑₀_) (idfun X))
+        (g (f (φ , ψ))) (φ , ψ)
+
+    f-equiv : (p : _⊑₀_ ≡ _⊑₁_) → isContr (fiber f p)
+    f-equiv p = ((to , from) , eq) , NTS
       where
-        g : (eq : _⊑₀_ ≡ _⊑₁_)
-          → (x y : X)
-          → ([ x ⊑₀ y ] → [ x ⊑₁ y ]) × ([ x ⊑₁ y ] → [ x ⊑₀ y ])
-        g eq x y = subst (λ { _⊑⋆_ → [ x ⊑⋆ y ] }) eq
-                 , subst (λ { _⊑⋆_ → [ x ⊑⋆ y ] }) (sym eq)
+        to : isOrderPreserving (X , _⊑₀_) (X , _⊑₁_) (idfun _)
+        to x y = subst (λ _⊑_ → [ x ⊑₀ y ] → [ x ⊑ y ]) p (idfun _)
 
-        sec : section f g
-        sec p = isSetOrder _ X _⊑₀_ _⊑₁_ (f (g p)) p
+        from : isOrderPreserving (X , _⊑₁_) (X , _⊑₀_) (idfun _)
+        from x y = subst (λ _⊑_ → [ x ⊑ y ] → [ x ⊑₀ y ]) p (idfun _)
 
-        h : (p : _⊑₀_ ≡ _⊑₁_) → (fib : fiber f p) → (g p , sec p) ≡ fib
-        h p (i , _) = ΣProp≡ A-prop B-prop
-          where
-            A-prop = λ i′ → isOfHLevelSuc 2 (isSetOrder ℓ₁ X) _⊑₀_ _⊑₁_ (f i′) p
-            B-prop = ⇔-prop (g p) i
+        eq : f (to , from) ≡ p
+        eq = isSetOrder ℓ₁ X _⊑₀_ _⊑₁_ (f (to , from)) p
 
--- We now write down the axioms for a partial order.
+        NTS : (fib : fiber f p) → ((to , from) , eq) ≡ fib
+        NTS ((φ , ψ) , eq) =
+          ΣProp≡
+            (λ i′ → isOfHLevelSuc 2 (isSetOrder ℓ₁ X) _⊑₀_ _⊑₁_ (f i′) p)
+            (ΣProp≡
+               (λ _ → isPropIsOrderPreserving (X , _⊑₁_) (X , _⊑₀_) (idfun _))
+               (isPropIsOrderPreserving (X , _⊑₀_) (X , _⊑₁_) (idfun _) to φ))
+
+-- We now write down the axioms for a partial order and define posets on top of
+-- raw ordered structures.
 
 isReflexive : {A : Type ℓ₀} → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
 isReflexive {A = X} _⊑_ = ((x : X) → [ x ⊑ x ]) , isPropΠ λ x → snd (x ⊑ x)
@@ -127,6 +167,39 @@ syntax rel P x y = x ⊑[ P ] y
 carrier-is-set : (P : Poset ℓ₀ ℓ₁) → isSet ∣ P ∣ₚ
 carrier-is-set (_ , _ , is-set , _) = is-set
 
+-- Definition of a monotonic map amounts to forgetting the partial order axioms.
+isMonotonic : (P : Poset ℓ₀ ℓ₁) (Q : Poset ℓ₀′ ℓ₁′) → (∣ P ∣ₚ → ∣ Q ∣ₚ) → Type _
+isMonotonic (A , (_⊑₀_ , _)) (B , (_⊑₁_ , _)) =
+  isOrderPreserving (A , _⊑₀_) (B , _⊑₁_)
+
+isPropIsMonotonic : (P : Poset ℓ₀ ℓ₁) (Q : Poset ℓ₀′ ℓ₁′)
+                  → (f : ∣ P ∣ₚ → ∣ Q ∣ₚ)
+                  → isProp (isMonotonic P Q f)
+isPropIsMonotonic (A , (_⊑₀_ , _)) (B , (_⊑₁_ , _)) f =
+  isPropIsOrderPreserving (A , _⊑₀_) (B , _⊑₁_) f
+
+-- We collect the type of monotonic maps between two posets in the following
+-- type.
+
+_─m→_ : Poset ℓ₀ ℓ₁ → Poset ℓ₀′ ℓ₁′ → Type _
+_─m→_ P Q = Σ[ f ∈ (∣ P ∣ₚ → ∣ Q ∣ₚ) ] (isMonotonic P Q f)
+
+-- The identity monotonic map and composition of monotonic maps.
+
+𝟏m : (P : Poset ℓ₀ ℓ₁) → P ─m→ P
+𝟏m P = idfun ∣ P ∣ₚ , (λ x y x⊑y → x⊑y)
+
+_∘m_ : {P : Poset ℓ₀ ℓ₁} {Q : Poset ℓ₀′ ℓ₁′} {R : Poset ℓ₀′′ ℓ₁′′}
+     → (Q ─m→ R) → (P ─m→ Q) → (P ─m→ R)
+(g , pg) ∘m (f , pf) = g ∘ f , λ x y p → pg (f x) (f y) (pf x y p)
+
+forget-mono : (P : Poset ℓ₀ ℓ₁) (Q : Poset ℓ₀′ ℓ₁′)
+              ((f , f-mono) (g , g-mono) : P ─m→ Q)
+            → f ≡ g
+            → (f , f-mono) ≡ (g , g-mono)
+forget-mono P Q (f , f-mono) (g , g-mono) =
+  ΣProp≡ (λ f → isPropΠ3 λ x y x⊑y → snd (f x ⊑[ Q ] f y))
+
 module PosetReasoning (P : Poset ℓ₀ ℓ₁) where
 
   _⊑⟨_⟩_ : (x : ∣ P ∣ₚ) {y z : ∣ P ∣ₚ}
@@ -139,41 +212,109 @@ module PosetReasoning (P : Poset ℓ₀ ℓ₁) where
   infixr 0 _⊑⟨_⟩_
   infix  1 _■
 
--- Poset univalence.
-RP-iso-prop : (P Q : Σ (Type ℓ₀) (Order ℓ₁))
-            → (eqv : fst P ≃ fst Q) → isProp (order-iso P Q eqv)
-RP-iso-prop (A , _⊑₀_) (B , _⊑₁_) (f , _) =
-  isPropΠ2 λ x y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
+-- Univalence for posets.
 
-poset-iso : (P Q : Poset ℓ₀ ℓ₁) → ∣ P ∣ₚ ≃ ∣ Q ∣ₚ → Type (ℓ-max ℓ₀ ℓ₁)
-poset-iso {ℓ₁ = ℓ₁} = add-to-iso order-iso (λ A _⊑_ → [ satPosetAx ℓ₁ A _⊑_ ])
+isAMonotonicEqv : (P : Poset ℓ₀ ℓ₁) (Q : Poset ℓ₀′ ℓ₁′)
+                → ∣ P ∣ₚ ≃ ∣ Q ∣ₚ → Type _
+isAMonotonicEqv (A , (_⊑₀_ , _)) (B , (_⊑₁_ , _)) =
+  isAnOrderPreservingEqv (A , _⊑₀_) (B , _⊑₁_)
 
--- We collect poset isomorphisms in the following type.
-_≃ₚ_ : Poset ℓ₀ ℓ₁ → Poset ℓ₀ ℓ₁ → Type (ℓ-max ℓ₀ ℓ₁)
-_≃ₚ_ P Q = Σ[ i ∈ (∣ P ∣ₚ ≃ ∣ Q ∣ₚ) ] poset-iso P Q i
+isPropIsAMonotonicEqv : (P : Poset ℓ₀ ℓ₁) (Q : Poset ℓ₀ ℓ₁′)
+                      → (eqv : ∣ P ∣ₚ ≃ ∣ Q ∣ₚ)
+                      → isProp (isAMonotonicEqv P Q eqv)
+isPropIsAMonotonicEqv P Q e@(f , _) =
+  isPropΣ (isPropIsMonotonic P Q f) λ _ → isPropIsMonotonic Q P g
+  where
+    g = equivFun (invEquiv e)
 
-poset-ax-props : (A : Type ℓ₀) (str : Order ℓ₁ A)
-                   → isProp [ satPosetAx ℓ₁ A str ]
-poset-ax-props {ℓ₁ = ℓ₁} A str = snd (satPosetAx ℓ₁ A str)
+-- We denote by `_≃ₚ_` the type of monotonic poset equivalences.
 
-poset-is-SNS : SNS {ℓ₀} (PosetStr ℓ₁) poset-iso
+_≃ₚ_ : Poset ℓ₀ ℓ₁ → Poset ℓ₀ ℓ₁ → Type _
+_≃ₚ_ P Q = Σ[ i ∈ ∣ P ∣ₚ ≃ ∣ Q ∣ₚ ] isAMonotonicEqv P Q i
+
+-- From this, we can already establish that posets form an SNS and prove that
+-- the category of posets is univalent.
+
+poset-is-SNS : SNS {ℓ} (PosetStr ℓ₁) isAMonotonicEqv
 poset-is-SNS {ℓ₁ = ℓ₁} =
-    SNS-PathP→SNS-≡ _ poset-iso (add-axioms-SNS _ poset-ax-props isSNS-PathP)
+  SNS-PathP→SNS-≡
+    (PosetStr ℓ₁)
+    isAMonotonicEqv
+    (add-axioms-SNS _ NTS (SNS-≡→SNS-PathP isAnOrderPreservingEqv Order-is-SNS))
   where
-    isSNS-PathP : SNS-PathP (Order ℓ₁) order-iso
-    isSNS-PathP = SNS-≡→SNS-PathP order-iso Order-is-SNS
+    NTS : (A : Type ℓ) (_⊑_ : Order ℓ₁ A) → isProp [ satPosetAx ℓ₁ A _⊑_ ]
+    NTS A _⊑_ = snd (satPosetAx ℓ₁ A _⊑_)
 
-poset-is-SNS-PathP : SNS-PathP {ℓ₀} (PosetStr ℓ₁) poset-iso
-poset-is-SNS-PathP = SNS-≡→SNS-PathP poset-iso poset-is-SNS
+poset-univ₀ : (P Q : Poset ℓ₀ ℓ₁) → (P ≃ₚ Q) ≃ (P ≡ Q)
+poset-univ₀ = SIP (SNS-≡→SNS-PathP isAMonotonicEqv poset-is-SNS)
 
-poset-SIP : (A : Type ℓ₀) (B : Type ℓ₀) (eqv : A ≃ B)
-            (P : PosetStr ℓ₁ A) (Q : PosetStr ℓ₁ B)
-          → poset-iso (A , P) (B , Q) eqv
-          → (A , P) ≡ (B , Q)
-poset-SIP {ℓ₁ = ℓ₁} A B eqv P Q i = φ (eqv , i)
+-- This result is almost what we want but it is better talk directly about poset
+-- _isomorphisms_ rather than equivalences. In the case when types `A` and `B`
+-- are sets, the type of isomorphisms between `A` and `B` is equivalent to the
+-- type of equivalences betwee them.
+
+-- Let us start by writing down what a poset isomorphisms is.
+
+isPosetIso : (P Q : Poset ℓ₀ ℓ₁) → (P ─m→ Q) → Type _
+isPosetIso P Q (f , _) = Σ[ (g , _) ∈ (Q ─m→ P) ] section f g × retract f g
+
+isPosetIso-prop : (P Q : Poset ℓ₀ ℓ₁) (f : P ─m→ Q)
+                → isProp (isPosetIso P Q f)
+isPosetIso-prop P Q (f , f-mono) (g₀ , sec₀ , ret₀) (g₁ , sec₁ , ret₁) =
+  ΣProp≡ NTS g₀=g₁
   where
-    φ : (A , P) ≃[ poset-iso ] (B , Q) → (A , P) ≡ (B , Q)
-    φ = equivFun (SIP poset-is-SNS-PathP (A , P) (B , Q))
+    NTS : ((g , _) : Q ─m→ P) → isProp (section f g × retract f g)
+    NTS (g , g-mono) = isPropΣ
+                         (isPropΠ λ x → carrier-is-set Q (f (g x)) x) λ _ →
+                          isPropΠ λ x → carrier-is-set P (g (f x)) x
 
-≃ₚ→≡ : (P Q : Poset ℓ₀ ℓ₁) → P ≃ₚ Q → P ≡ Q
-≃ₚ→≡ (A , A-pos) (B , B-pos) (eqv , i) = poset-SIP A B eqv A-pos B-pos i
+    g₀=g₁ : g₀ ≡ g₁
+    g₀=g₁ =
+      forget-mono Q P g₀ g₁ (funExt λ x →
+        fst g₀ x              ≡⟨ sym (cong (λ - → fst g₀ -) (sec₁ x)) ⟩
+        fst g₀ (f (fst g₁ x)) ≡⟨ ret₀ (fst g₁ x) ⟩
+        fst g₁ x              ∎)
+
+-- We will denote by `P ≅ₚ Q` the type of isomorphisms between posets `P` and
+-- `Q`.
+
+_≅ₚ_ : Poset ℓ₀ ℓ₁ → Poset ℓ₀ ℓ₁ → Type _
+P ≅ₚ Q = Σ[ f ∈ P ─m→ Q ] isPosetIso P Q f
+
+-- ≅ₚ is equivalent to ≃ₚ.
+
+≃ₚ≃≅ₚ : (P Q : Poset ℓ₀ ℓ₁) → (P ≅ₚ Q) ≃ (P ≃ₚ Q)
+≃ₚ≃≅ₚ P Q = isoToEquiv (iso from to ret sec)
+  where
+    to : P ≃ₚ Q → P ≅ₚ Q
+    to (e@(f , _) , (f-mono , g-mono)) =
+      (f , f-mono) , (g , g-mono) , sec-f-g , ret-f-g
+      where
+        is = equivToIso e
+        g  = equivFun (invEquiv e)
+
+        sec-f-g : section f g
+        sec-f-g = Iso.rightInv (equivToIso e)
+
+        ret-f-g : retract f g
+        ret-f-g = Iso.leftInv (equivToIso e)
+
+    from : P ≅ₚ Q → P ≃ₚ Q
+    from ((f , f-mono) , ((g , g-mono) , sec , ret)) =
+      isoToEquiv is , f-mono , g-mono
+      where
+        is : Iso ∣ P ∣ₚ ∣ Q ∣ₚ
+        is = iso f g sec ret
+
+    sec : section to from
+    sec (f , _) = ΣProp≡ (isPosetIso-prop P Q) refl
+
+    ret : retract to from
+    ret (e , _) = ΣProp≡ (isPropIsAMonotonicEqv P Q) (ΣProp≡ isPropIsEquiv refl)
+
+-- Once we have this equivalence, the main result is then: the type of poset
+-- isomorphisms between `P` and `Q` is equivalent to the type of identity proofs
+-- between `P` and `Q`
+
+poset-univ : (P Q : Poset ℓ₀ ℓ₁) → (P ≅ₚ Q) ≃ (P ≡ Q)
+poset-univ P Q = P ≅ₚ Q ≃⟨ ≃ₚ≃≅ₚ P Q ⟩ P ≃ₚ Q ≃⟨ poset-univ₀ P Q ⟩ P ≡ Q QED

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -25,7 +25,7 @@ order-iso : (M N : Σ (Type ℓ₀) (Order ℓ₁)) →  fst M ≃ fst N → Typ
 order-iso (A , _⊑₀_) (B , _⊑₁_) (f , _) = (x y : A) → [ x ⊑₀ y ⇔ f x ⊑₁ f y ]
 
 isSetOrder : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (Order ℓ₁ A)
-isSetOrder ℓ₁ A = isSetΠ (λ _ → isSetΠ λ _ → isSetHProp)
+isSetOrder ℓ₁ A = isSetΠ2 λ _ _ → isSetHProp
 
 Order-is-SNS : SNS {ℓ₀} (Order ℓ₁) order-iso
 Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -146,11 +146,9 @@ module PosetReasoning (P : Poset ℓ₀ ℓ₁) where
 
 -- Poset univalence.
 RP-iso-prop : (P Q : Σ (Type ℓ₀) (Order ℓ₁))
-            → (i : fst P ≃ fst Q) → isProp (order-iso P Q i)
-RP-iso-prop (A , _⊑₀_) (B , _⊑₁_) i =
-    isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
-  where
-    f = equivFun i
+            → (eqv : fst P ≃ fst Q) → isProp (order-iso P Q eqv)
+RP-iso-prop (A , _⊑₀_) (B , _⊑₁_) (f , _) =
+  isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
 
 poset-iso : (P Q : Poset ℓ₀ ℓ₁) → ∣ P ∣ₚ ≃ ∣ Q ∣ₚ → Type (ℓ-max ℓ₀ ℓ₁)
 poset-iso {ℓ₁ = ℓ₁} = add-to-iso order-iso (λ A _⊑_ → [ satPosetAx ℓ₁ A _⊑_ ])

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -185,8 +185,3 @@ poset-SIP {ℓ₁ = ℓ₁} A B eqv P Q i = foo (eqv , i)
 
 ≃ₚ→≡ : (P Q : Poset ℓ₀ ℓ₁) → P ≃ₚ Q → P ≡ Q
 ≃ₚ→≡ (A , A-pos) (B , B-pos) (eqv , i) = poset-SIP A B eqv A-pos B-pos i
-
-
--- --}
--- --}
--- --}

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -78,7 +78,7 @@ isAntisym {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} A-set _⊑_ = φ , φ-prop
     φ      : Type (ℓ-max ℓ₀ ℓ₁)
     φ      = ((x y : X) → [ x ⊑ y ] → [ y ⊑ x ] → x ≡ y)
     φ-prop : isProp φ
-    φ-prop = isPropΠ λ x → isPropΠ λ y → isPropΠ λ _ → isPropΠ λ _ → A-set x y
+    φ-prop = isPropΠ3 λ x y z → isPropΠ λ _ → A-set x y
 
 -- The predicate expressing that a given order satisfies the partial order
 -- axioms.

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -66,8 +66,7 @@ isTransitive {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} _⊑_ = φ , φ-prop
     φ      : Type (ℓ-max ℓ₀ ℓ₁)
     φ      = ((x y z : X) → [ x ⊑ y ⇒ y ⊑ z ⇒ x ⊑ z ])
     φ-prop : isProp φ
-    φ-prop = isPropΠ λ x → isPropΠ λ y → isPropΠ λ z →
-               snd (x ⊑ y ⇒ y ⊑ z ⇒ x ⊑ z)
+    φ-prop = isPropΠ3 λ x y z → snd (x ⊑ y ⇒ y ⊑ z ⇒ x ⊑ z)
 
 isAntisym : {A : Type ℓ₀} → isSet A → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
 isAntisym {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} A-set _⊑_ = φ , φ-prop

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -1,0 +1,192 @@
+{-# OPTIONS --cubical --safe #-}
+
+module Cubical.Structures.Poset where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv       hiding (_■)
+open import Cubical.Foundations.Logic
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.SIP          renaming (SNS-≡ to SNS)
+open import Cubical.Core.Primitives
+open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sigma.Properties
+
+-- We will adopt the convention of denoting the level of the carrier
+-- set by ℓ₀ and the level of the relation result by ℓ₁.
+private
+  variable
+    ℓ₀ ℓ₁ : Level
+
+Order : (ℓ₁ : Level) → Type ℓ₀ → Type (ℓ-max ℓ₀ (ℓ-suc ℓ₁))
+Order ℓ₁ A = A → A → hProp ℓ₁
+
+order-iso : (M N : Σ (Type ℓ₀) (Order ℓ₁)) →  fst M ≃ fst N → Type (ℓ-max ℓ₀ ℓ₁)
+order-iso (A , _⊑₀_) (B , _⊑₁_) eqv =
+  (x y : A) → [ x ⊑₀ y ⇔ f x ⊑₁ f y ]
+  where
+    f = equivFun eqv
+
+isSetOrder : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (Order ℓ₁ A)
+isSetOrder ℓ₁ A = isSetΠ (λ _ → isSetΠ λ _ → isSetHProp)
+
+Order-is-SNS : SNS {ℓ₀} (Order ℓ₁) order-iso
+Order-is-SNS {ℓ₁ = ℓ₁} {X = X}  _⊑₀_ _⊑₁_ = f , f-equiv
+  where
+    f : order-iso (X , _⊑₀_) (X , _⊑₁_) (idEquiv X) → _⊑₀_ ≡ _⊑₁_
+    f i = funExt λ x → funExt λ y → ⇔toPath (fst (i x y)) (snd (i x y))
+
+    ⇔-prop : isProp ((x y : X) → [ x ⊑₀ y ⇔ x ⊑₁ y ])
+    ⇔-prop = isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ x ⊑₁ y)
+
+    f-equiv : isEquiv f
+    f-equiv = record { equiv-proof = λ eq → (g eq , sec eq) , h eq }
+      where
+        g : (eq : _⊑₀_ ≡ _⊑₁_)
+          → (x y : X)
+          → ([ x ⊑₀ y ] → [ x ⊑₁ y ]) × ([ x ⊑₁ y ] → [ x ⊑₀ y ])
+        g eq x y = subst (λ { _⊑⋆_ → [ x ⊑⋆ y ] }) eq
+                 , subst (λ { _⊑⋆_ → [ x ⊑⋆ y ] }) (sym eq)
+
+        sec : section f g
+        sec p = isSetOrder _ X _⊑₀_ _⊑₁_ (f (g p)) p
+
+        h : (p : _⊑₀_ ≡ _⊑₁_) → (fib : fiber f p) → (g p , sec p) ≡ fib
+        h p (i , _) = ΣProp≡ A-prop B-prop
+          where
+            A-prop : _
+            A-prop = λ i′ → isOfHLevelSuc 2 (isSetOrder ℓ₁ X) _⊑₀_ _⊑₁_ (f i′) p
+
+            B-prop : _
+            B-prop = ⇔-prop (g p) i
+
+-- We now write down the axioms for a partial order.
+
+isReflexive : {A : Type ℓ₀} → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
+isReflexive {A = X} _⊑_ =
+  ((x : X) → [ x ⊑ x ]) , isPropΠ (λ x → snd (x ⊑ x))
+
+isTransitive : {A : Type ℓ₀} → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
+isTransitive {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} _⊑_ = φ , φ-prop
+  where
+    φ      : Type (ℓ-max ℓ₀ ℓ₁)
+    φ      = ((x y z : X) → [ x ⊑ y ⇒ y ⊑ z ⇒ x ⊑ z ])
+    φ-prop : isProp φ
+    φ-prop = isPropΠ λ x → isPropΠ λ y → isPropΠ λ z →
+               snd (x ⊑ y ⇒ y ⊑ z ⇒ x ⊑ z)
+
+isAntisym : {A : Type ℓ₀} → isSet A → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
+isAntisym {ℓ₀ = ℓ₀} {ℓ₁ = ℓ₁} {A = X} A-set _⊑_ = φ , φ-prop
+  where
+    φ      : Type (ℓ-max ℓ₀ ℓ₁)
+    φ      = ((x y : X) → [ x ⊑ y ] → [ y ⊑ x ] → x ≡ y)
+    φ-prop : isProp φ
+    φ-prop = isPropΠ λ x → isPropΠ λ y → isPropΠ λ _ → isPropΠ λ _ → A-set x y
+
+-- The predicate expressing that a given order satisfies the partial order
+-- axioms.
+satPosetAx : (ℓ₁ : Level) (A : Type ℓ₀) → Order ℓ₁ A → hProp (ℓ-max ℓ₀ ℓ₁)
+satPosetAx {ℓ₀ = ℓ₀} ℓ₁ A _⊑_ = φ , φ-prop
+  where
+    isPartial : isSet A → hProp (ℓ-max ℓ₀ ℓ₁)
+    isPartial A-set = isReflexive _⊑_ ⊓ isTransitive _⊑_ ⊓ isAntisym A-set _⊑_
+
+    φ         = Σ[ A-set ∈ isSet A ] [ isPartial A-set ]
+    φ-prop    = isOfHLevelΣ 1 isPropIsSet (λ x → snd (isPartial x))
+
+-- The poset structure.
+PosetStr : (ℓ₁ : Level) → Type ℓ₀ → Type (ℓ-max ℓ₀ (ℓ-suc ℓ₁))
+PosetStr ℓ₁ = add-to-structure (Order ℓ₁) λ A _⊑_ → [ satPosetAx ℓ₁ A _⊑_ ]
+
+PosetStr-set : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (PosetStr ℓ₁ A)
+PosetStr-set ℓ₁ A =
+  isSetΣ
+    (isSetΠ λ _ → isSetΠ λ _ → isSetHProp) λ _⊑_ →
+      isProp→isSet (snd (satPosetAx ℓ₁ A _⊑_))
+
+Poset : (ℓ₀ ℓ₁ : Level) → Type (ℓ-max (ℓ-suc ℓ₀) (ℓ-suc ℓ₁))
+Poset ℓ₀ ℓ₁ = Σ (Type ℓ₀) (PosetStr ℓ₁)
+
+-- Some projections for syntactic convenience.
+∣_∣ₚ : Poset ℓ₀ ℓ₁ → Type ℓ₀
+∣ X , _ ∣ₚ = X
+
+strₚ : (P : Poset ℓ₀ ℓ₁) → PosetStr ℓ₁ ∣ P ∣ₚ
+strₚ (_ , s) = s
+
+rel : (P : Poset ℓ₀ ℓ₁) → ∣ P ∣ₚ → ∣ P ∣ₚ → hProp ℓ₁
+rel (_ , _⊑_ , _) = _⊑_
+
+syntax rel P x y = x ⊑[ P ] y
+
+⊑[_]-refl : (P : Poset ℓ₀ ℓ₁) → (x : ∣ P ∣ₚ) → [ x ⊑[ P ] x ]
+⊑[_]-refl (_ , _ , _ , ⊑-refl , _) = ⊑-refl
+
+⊑[_]-trans : (P : Poset ℓ₀ ℓ₁) (x y z : ∣ P ∣ₚ)
+           → [ x ⊑[ P ] y ] → [ y ⊑[ P ] z ] → [ x ⊑[ P ] z ]
+⊑[_]-trans (_ , _ , _ , _ , ⊑-trans , _) = ⊑-trans
+
+⊑[_]-antisym : (P : Poset ℓ₀ ℓ₁) (x y : ∣ P ∣ₚ)
+             → [ x ⊑[ P ] y ] → [ y ⊑[ P ] x ] → x ≡ y
+⊑[_]-antisym (_ , _ , _ , _ , _ , ⊑-antisym) = ⊑-antisym
+
+carrier-is-set : (P : Poset ℓ₀ ℓ₁) → isSet ∣ P ∣ₚ
+carrier-is-set (_ , _ , is-set , _) = is-set
+
+module PosetReasoning (P : Poset ℓ₀ ℓ₁) where
+
+  _⊑⟨_⟩_ : (x : ∣ P ∣ₚ) {y z : ∣ P ∣ₚ}
+         → [ x ⊑[ P ] y ] → [ y ⊑[ P ] z ] → [ x ⊑[ P ] z ]
+  _ ⊑⟨ p ⟩ q = ⊑[ P ]-trans _ _ _ p q
+
+  _■ : (x : ∣ P ∣ₚ) → [ x ⊑[ P ] x ]
+  _■ = ⊑[ P ]-refl
+
+  infixr 0 _⊑⟨_⟩_
+  infix  1 _■
+
+-- Poset univalence.
+RP-iso-prop : (P Q : Σ (Type ℓ₀) (Order ℓ₁))
+            → (i : fst P ≃ fst Q) → isProp (order-iso P Q i)
+RP-iso-prop (A , _⊑₀_) (B , _⊑₁_) i =
+    isPropΠ λ x → isPropΠ λ y → snd (x ⊑₀ y ⇔ f x ⊑₁ f y)
+  where
+    f = equivFun i
+
+poset-iso : (P Q : Poset ℓ₀ ℓ₁) → ∣ P ∣ₚ ≃ ∣ Q ∣ₚ → Type (ℓ-max ℓ₀ ℓ₁)
+poset-iso {ℓ₁ = ℓ₁} = add-to-iso order-iso (λ A _⊑_ → [ satPosetAx ℓ₁ A _⊑_ ])
+
+-- We collect poset isomorphisms in the following type.
+_≃ₚ_ : Poset ℓ₀ ℓ₁ → Poset ℓ₀ ℓ₁ → Type (ℓ-max ℓ₀ ℓ₁)
+_≃ₚ_ P Q = Σ[ i ∈ (∣ P ∣ₚ ≃ ∣ Q ∣ₚ) ] poset-iso P Q i
+
+poset-ax-props : (A : Type ℓ₀) (str : Order ℓ₁ A)
+                   → isProp [ satPosetAx ℓ₁ A str ]
+poset-ax-props {ℓ₁ = ℓ₁} A str = snd (satPosetAx ℓ₁ A str)
+
+poset-is-SNS : SNS {ℓ₀} (PosetStr ℓ₁) poset-iso
+poset-is-SNS {ℓ₁ = ℓ₁} =
+    SNS-PathP→SNS-≡ _ poset-iso (add-axioms-SNS _ poset-ax-props isSNS-PathP)
+  where
+    isSNS-PathP : SNS-PathP (Order ℓ₁) order-iso
+    isSNS-PathP = SNS-≡→SNS-PathP order-iso Order-is-SNS
+
+poset-is-SNS-PathP : SNS-PathP {ℓ₀} (PosetStr ℓ₁) poset-iso
+poset-is-SNS-PathP = SNS-≡→SNS-PathP poset-iso poset-is-SNS
+
+poset-SIP : (A : Type ℓ₀) (B : Type ℓ₀) (eqv : A ≃ B)
+            (P : PosetStr ℓ₁ A) (Q : PosetStr ℓ₁ B)
+          → poset-iso (A , P) (B , Q) eqv
+          → (A , P) ≡ (B , Q)
+poset-SIP {ℓ₁ = ℓ₁} A B eqv P Q i = foo (eqv , i)
+  where
+    foo : (A , P) ≃[ poset-iso ] (B , Q) → (A , P) ≡ (B , Q)
+    foo = equivFun (SIP poset-is-SNS-PathP (A , P) (B , Q))
+
+≃ₚ→≡ : (P Q : Poset ℓ₀ ℓ₁) → P ≃ₚ Q → P ≡ Q
+≃ₚ→≡ (A , A-pos) (B , B-pos) (eqv , i) = poset-SIP A B eqv A-pos B-pos i
+
+
+-- --}
+-- --}
+-- --}

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -97,7 +97,7 @@ PosetStr-set ℓ₁ A =
       isProp→isSet (snd (satPosetAx ℓ₁ A _⊑_))
 
 Poset : (ℓ₀ ℓ₁ : Level) → Type (ℓ-max (ℓ-suc ℓ₀) (ℓ-suc ℓ₁))
-Poset ℓ₀ ℓ₁ = Σ (Type ℓ₀) (PosetStr ℓ₁)
+Poset ℓ₀ ℓ₁ = TypeWithStr ℓ₀ (PosetStr ℓ₁)
 
 -- Some projections for syntactic convenience.
 

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -93,7 +93,7 @@ PosetStr ℓ₁ = add-to-structure (Order ℓ₁) λ A _⊑_ → [ satPosetAx �
 PosetStr-set : (ℓ₁ : Level) (A : Type ℓ₀) → isSet (PosetStr ℓ₁ A)
 PosetStr-set ℓ₁ A =
   isSetΣ
-    (isSetΠ λ _ → isSetΠ λ _ → isSetHProp) λ _⊑_ →
+    (isSetΠ2 λ _ _ → isSetHProp) λ _⊑_ →
       isProp→isSet (snd (satPosetAx ℓ₁ A _⊑_))
 
 Poset : (ℓ₀ ℓ₁ : Level) → Type (ℓ-max (ℓ-suc ℓ₀) (ℓ-suc ℓ₁))


### PR DESCRIPTION
I have done a couple of things.
- Cleaned up the definition poset isomorphism so that it coincides more directly with the categorical notion.
- Introduced a distinction between the type of monotonic poset equivalences and poset isomorphisms and proved them to be equivalent. These are denoted `≃ₚ` and `≅ₚ` respectively.
- Defined monotonic maps between posets and their composition.

I will finish #303 once this is merged.