### PR TITLE
Reintroduce Truncation.rec and fix problems in ZCohomology related to it

### DIFF
--- a/Cubical/Codata/M/AsLimit/M/Properties.agda
+++ b/Cubical/Codata/M/AsLimit/M/Properties.agda
@@ -27,25 +27,35 @@ open import Cubical.Codata.M.AsLimit.Container
 
 open Iso
 
-in-inverse-out : ∀ {ℓ} {S : Container ℓ} -> (in-fun ∘ out-fun {S = S}) ≡ idfun (M S)
-in-inverse-out {S = S} = funExt (rightInv {A = P₀ S (M S)} {B = M S} (shift-iso S))
+in-inverse-out : ∀ {ℓ} {S : Container ℓ} → (in-fun {S = S} ∘ out-fun {S = S}) ≡ idfun (M S)
+in-inverse-out {S = S} = subst (λ inv → in-fun {S = S} ∘ inv ≡ idfun (M S)) idpath def where
+  -- substituting refl makes type-checking work a lot faster, but introduces a transport
+  -- TODO (2020-05-23): revisit this at some point to see if it's still needed in future versions of agda
+  def : (in-fun {S = S} ∘ inv (shift-iso S)) ≡ idfun (M S)
+  def = funExt (rightInv (shift-iso S))
+  idpath : inv (shift-iso S) ≡ out-fun {S = S}
+  idpath = refl
 
-out-inverse-in : ∀ {ℓ} {S : Container ℓ} -> (out-fun {S = S} ∘ in-fun {S = S}) ≡ idfun (P₀ S (M S))
-out-inverse-in {S = S} = funExt (leftInv {A = P₀ S (M S)} {B = M S} (shift-iso S))
+out-inverse-in : ∀ {ℓ} {S : Container ℓ} → (out-fun {S = S} ∘ in-fun {S = S}) ≡ idfun (P₀ S (M S))
+out-inverse-in {S = S} = subst (λ fun → out-fun {S = S} ∘ fun ≡ idfun (P₀ S (M S))) idpath def where
+  def : (out-fun {S = S} ∘ fun (shift-iso S)) ≡ idfun (P₀ S (M S))
+  def = funExt (leftInv (shift-iso S))
+  idpath : fun (shift-iso S) ≡ in-fun {S = S}
+  idpath = refl
 
-in-out-id : ∀ {ℓ} {S : Container ℓ} -> ∀ {x y} → (in-fun (out-fun {S = S} x) ≡ in-fun (out-fun {S = S} y)) ≡ (x ≡ y)
+in-out-id : ∀ {ℓ} {S : Container ℓ} -> ∀ {x y : M S} → (in-fun (out-fun x) ≡ in-fun (out-fun y)) ≡ (x ≡ y)
 in-out-id {x = x} {y} i = (in-inverse-out i x) ≡ (in-inverse-out i y)
 
 -- constructor properties
 
-in-inj : ∀ {ℓ} {S : Container ℓ} {Z : Type ℓ} -> ∀ {f g : Z → P₀ S (M S)} -> (in-fun ∘ f ≡ in-fun ∘ g) ≡ (f ≡ g)
+in-inj : ∀ {ℓ} {S : Container ℓ} {Z : Type ℓ} → ∀ {f g : Z → P₀ S (M S)} → (in-fun ∘ f ≡ in-fun ∘ g) ≡ (f ≡ g)
 in-inj {ℓ} {S = S} {Z = Z} {f = f} {g = g} = iso→fun-Injection-Path {ℓ = ℓ} {A = P₀ S (M S)} {B = M S} {C = Z} (shift-iso S) {f = f} {g = g}
 
-out-inj : ∀ {ℓ} {S : Container ℓ} {Z : Type ℓ} -> ∀ {f g : Z → M S} -> (out-fun ∘ f ≡ out-fun ∘ g) ≡ (f ≡ g)
+out-inj : ∀ {ℓ} {S : Container ℓ} {Z : Type ℓ} → ∀ {f g : Z → M S} → (out-fun ∘ f ≡ out-fun ∘ g) ≡ (f ≡ g)
 out-inj {ℓ} {S = S} {Z = Z} {f = f} {g = g} = iso→inv-Injection-Path {ℓ = ℓ} {A = P₀ S (M S)} {B = M S} {C = Z} (shift-iso S) {f = f} {g = g}
 
-in-inj-x : ∀ {ℓ} {S : Container ℓ} -> ∀ {x y : P₀ S (M S)} -> (in-fun x ≡ in-fun y) ≡ (x ≡ y)
-in-inj-x {ℓ} {S = S} {x = x} {y} = iso→fun-Injection-Path-x (shift-iso S)
+in-inj-x : ∀ {ℓ} {S : Container ℓ} → ∀ {x y : P₀ S (M S)} → (in-fun x ≡ in-fun y) ≡ (x ≡ y)
+in-inj-x {ℓ} {S = S} {x = x} {y} = iso→fun-Injection-Path-x (shift-iso S) {x} {y}
 
-out-inj-x : ∀ {ℓ} {S : Container ℓ} -> ∀ {x y : M S} -> (out-fun x ≡ out-fun y) ≡ (x ≡ y)
-out-inj-x {ℓ} {S = S} {x = x} {y} = iso→inv-Injection-Path-x (shift-iso S)
+out-inj-x : ∀ {ℓ} {S : Container ℓ} → ∀ {x y : M S} → (out-fun x ≡ out-fun y) ≡ (x ≡ y)
+out-inj-x {ℓ} {S = S} {x = x} {y} = iso→inv-Injection-Path-x (shift-iso S) {x} {y}

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -114,25 +114,13 @@ isOfHLevelTrunc (suc n) = isSphereFilled→isOfHLevelSuc isSphereFilledTrunc
 
 -- hLevelTrunc n is a modality
 
--- This more direct definition should behave better than recElim
--- below. Commented for now as it breaks some cohomology code if we
--- use it instead of recElim.
--- rec : {n : ℕ}
---       {B : Type ℓ'} →
---       isOfHLevel n B →
---       (A → B) →
---       hLevelTrunc n A →
---       B
--- rec h = Null.rec (isOfHLevel→isSnNull h)
-
--- TODO: remove this
-recElim : {n : ℕ}
+rec : {n : ℕ}
       {B : Type ℓ'} →
       isOfHLevel n B →
       (A → B) →
       hLevelTrunc n A →
       B
-recElim {B = B} h = Null.elim {B = λ _ → B} λ x → isOfHLevel→isSnNull h
+rec h = Null.rec (isOfHLevel→isSnNull h)
 
 elim : {n : ℕ}
        {B : hLevelTrunc n A → Type ℓ'}
@@ -192,11 +180,11 @@ Iso.leftInv (univTrunc n {B , lev}) b = funExt (elim (λ x → isOfHLevelPath _ 
 
 map : {n : ℕ} {B : Type ℓ'} (g : A → B)
   → hLevelTrunc n A → hLevelTrunc n B
-map g = recElim (isOfHLevelTrunc _) (λ a → ∣ g a ∣)
+map g = rec (isOfHLevelTrunc _) (λ a → ∣ g a ∣)
 
 mapCompIso : {n : ℕ} {B : Type ℓ'} → (Iso A B) → Iso (hLevelTrunc n A) (hLevelTrunc n B)
-Iso.fun (mapCompIso g) = recElim (isOfHLevelTrunc _) λ a → ∣ Iso.fun g a ∣
-Iso.inv (mapCompIso g) = recElim (isOfHLevelTrunc _) λ b → ∣ Iso.inv g b ∣
+Iso.fun (mapCompIso g) = map (Iso.fun g)
+Iso.inv (mapCompIso g) = map (Iso.inv g)
 Iso.rightInv (mapCompIso g) = elim (λ x → isOfHLevelPath _ (isOfHLevelTrunc _) _ _) λ b → cong ∣_∣ (Iso.rightInv g b)
 Iso.leftInv (mapCompIso g) = elim (λ x → isOfHLevelPath _ (isOfHLevelTrunc _) _ _) λ a → cong ∣_∣ (Iso.leftInv g a)
 
@@ -284,10 +272,10 @@ module ΩTrunc where
       decode* : ∀ {n : ℕ₋₂} (u v : B)
               → P {n = n} ∣ u ∣ ∣ v ∣ → Path (∥ B ∥ (suc₋₂ n)) ∣ u ∣ ∣ v ∣
       decode* {B = B} {n = neg2} u v =
-        recElim ( isOfHLevelTrunc 1 ∣ u ∣ ∣ v ∣
+        rec ( isOfHLevelTrunc 1 ∣ u ∣ ∣ v ∣
             , λ _ → isOfHLevelSuc 1 (isOfHLevelTrunc 1) _ _ _ _) (cong ∣_∣)
       decode* {n = ℕ₋₂.-1+ n} u v =
-        recElim (isOfHLevelTrunc (suc (suc n)) ∣ u ∣ ∣ v ∣) (cong ∣_∣)
+        rec (isOfHLevelTrunc (suc (suc n)) ∣ u ∣ ∣ v ∣) (cong ∣_∣)
 
   {- auxiliary function r used to define encode -}
   r : {m : ℕ₋₂} (u : ∥ B ∥ (suc₋₂ m)) → P u u

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -77,7 +77,7 @@ module elim {ℓ ℓ' : Level} {A : Type ℓ} {B : Type ℓ'} (f : A → B) (n :
        where
     inv : ((a : A) → P (f a) .fst) → (b : B) → hLevelTrunc n (fiber f b) → P b .fst
     inv t b =
-      Trunc.recElim
+      Trunc.rec
         (P b .snd)
         (λ {(a , p) → subst (fst ∘ P) p (t a)})
 
@@ -225,9 +225,9 @@ connectedTruncIso {A = A} {B = B} (suc n) f con = g
   back y = map fst ((con y) .fst)
 
   backSection :  (b : B) → Path (hLevelTrunc (suc n) B)
-                                 (Trunc.recElim (isOfHLevelTrunc (suc n))
+                                 (Trunc.rec (isOfHLevelTrunc (suc n))
                                             (λ a → ∣ f a ∣)
-                                            (Trunc.recElim {n = suc n }
+                                            (Trunc.rec {n = suc n }
                                                        {B = hLevelTrunc (suc n) A} (isOfHLevelTrunc (suc n)) back ∣ b ∣))
                                ∣ b ∣
   backSection b = helper (λ p → map f p ≡ ∣ b ∣)
@@ -248,7 +248,7 @@ connectedTruncIso {A = A} {B = B} (suc n) f con = g
 
   g : Iso (hLevelTrunc (suc n) A) (hLevelTrunc (suc n) B)
   Iso.fun g = map f
-  Iso.inv g = Trunc.recElim (isOfHLevelTrunc _) back
+  Iso.inv g = Trunc.rec (isOfHLevelTrunc _) back
   Iso.leftInv g = Trunc.elim (λ x → isOfHLevelPath (suc n) (isOfHLevelTrunc _) _ _)
                                λ a → cong (map fst) (con (f a) .snd  ∣ a , refl ∣)
   Iso.rightInv g = Trunc.elim (λ x → isOfHLevelPath (suc n) (isOfHLevelTrunc _) _ _)

--- a/Cubical/Homotopy/Freudenthal.agda
+++ b/Cubical/Homotopy/Freudenthal.agda
@@ -42,7 +42,7 @@ module _ {ℓ} (n : ℕ) {A : Pointed ℓ} (connA : isHLevelConnected (suc (suc 
     fwd : (p : north ≡ north) (a : typ A)
       → hLevelTrunc 2n+2 (fiber σ p)
       → hLevelTrunc 2n+2 (fiber (λ x → merid x ∙ merid a ⁻¹) p)
-    fwd p a = Trunc.recElim (isOfHLevelTrunc 2n+2) (uncurry (WC.extension p a))
+    fwd p a = Trunc.rec (isOfHLevelTrunc 2n+2) (uncurry (WC.extension p a))
 
     isEquivFwd : (p : north ≡ north) (a : typ A) → isEquiv (fwd p a)
     isEquivFwd p a .equiv-proof =
@@ -58,7 +58,7 @@ module _ {ℓ} (n : ℕ) {A : Pointed ℓ} (connA : isHLevelConnected (suc (suc 
           (λ _ → isProp→isOfHLevelSuc (n + suc n) isPropIsContr)
           (λ fib →
             subst (λ k → isContr (fiber k ∣ fib ∣))
-              (cong (Trunc.recElim (isOfHLevelTrunc 2n+2) ∘ uncurry)
+              (cong (Trunc.rec (isOfHLevelTrunc 2n+2) ∘ uncurry)
                 (funExt (WC.right p) ⁻¹))
               (subst isEquiv
                 (funExt (Trunc.mapId) ⁻¹)

--- a/Cubical/ZCohomology/KcompPrelims.agda
+++ b/Cubical/ZCohomology/KcompPrelims.agda
@@ -7,7 +7,7 @@ open import Cubical.HITs.Hopf
 open import Cubical.Homotopy.Freudenthal hiding (encode)
 open import Cubical.HITs.Sn
 open import Cubical.HITs.S1
-open import Cubical.HITs.Truncation renaming (elim to trElim ; recElim to trRec ; map to trMap)
+open import Cubical.HITs.Truncation renaming (elim to trElim ; rec to trRec ; map to trMap)
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
@@ -175,23 +175,12 @@ private
   d-iso2 : Iso (hLevelTrunc 3 (typ (Ω (Susp S¹ , north)))) (hLevelTrunc 3 S¹)
   d-iso2 = connectedTruncIso _ d-map is1Connected-dmap
 
-  d-iso : isIso {A = ∥  typ (Ω (Susp S¹ , north)) ∥ (ℕ→ℕ₋₂ 1)} {B = ∥ S¹ ∥ (ℕ→ℕ₋₂ 1)} (trElim (λ x → isOfHLevelTrunc 3) λ x → ∣ d-map x ∣ )
-  d-iso = (Iso.inv (connectedTruncIso _ d-map is1Connected-dmap)) , (Iso.rightInv (connectedTruncIso _ d-map is1Connected-dmap)
-                                                                  , Iso.leftInv (connectedTruncIso _ d-map is1Connected-dmap))
-
   {- We show that composing (λ a → ∣ ϕ base a ∣) and (λ x → ∣ d-map x ∣) gives us the identity function.  -}
 
-  d-mapId2 : (λ (x : hLevelTrunc 3 S¹) → (trRec {n = 3} {B = hLevelTrunc 3 S¹} (isOfHLevelTrunc 3) λ x → ∣ d-map x ∣)
-                                               (trRec (isOfHLevelTrunc 3) (λ a → ∣ ϕ base a ∣) x)) ≡ λ x → x
-  d-mapId2 = funExt (trElim (λ x → isOfHLevelSuc 2 (isOfHLevelTrunc 3 ((trElim {n = 3}
-                                                                                {B = λ _ → ∥ S¹ ∥ (ℕ→ℕ₋₂ 1)}
-                                                                                (λ x → isOfHLevelTrunc 3) λ x → ∣ d-map x ∣)
-                                                                                (trElim (λ _ → isOfHLevelTrunc 3)
-                                                                                        (λ a → ∣ ϕ base a ∣) x)) x))
-                            λ a i → ∣ d-mapId a i ∣)
+  d-mapId2 : Iso.fun d-iso2 ∘ trMap (ϕ base) ≡ idfun (hLevelTrunc 3 S¹)
+  d-mapId2 = funExt (trElim (λ _ → isOfHLevelPath 3 (isOfHLevelTrunc 3) _ _) (λ a → cong ∣_∣ (d-mapId a)))
 
   {- This means that (λ a → ∣ ϕ base a ∣) is an equivalence -}
-
 
   Iso∣ϕ-base∣ : Iso (hLevelTrunc 3 S¹) (hLevelTrunc 3 (typ (Ω (Susp S¹ , north))))
   Iso∣ϕ-base∣ = composesToId→Iso d-iso2 (trMap (ϕ base)) d-mapId2

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -22,7 +22,7 @@ open import Cubical.HITs.Nullification
 open import Cubical.Data.Int hiding (_+_)
 open import Cubical.Data.Nat
 open import Cubical.Data.Prod
-open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; recElim to trRec ; elim3 to trElim3)
+open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; rec to trRec ; elim3 to trElim3)
 open import Cubical.Homotopy.Loopspace
 open import Cubical.Homotopy.Connected
 open import Cubical.Homotopy.Freudenthal


### PR DESCRIPTION
Additionally, a workaround in Codata.M.AsLimit.M.Properties is provided that speeds
up type checking. The workaround might not be the best since it introduces a "useless" transport over reflexivity but it forces typechecking to do the morally correct thing.

@Saizan might have additional input for that before this is merged.
