### PR TITLE
Vogt's lemma is iso→HAEquiv

### DIFF
--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -204,7 +204,7 @@ swapΣEquiv A B = isoToEquiv (iso (λ x → x .snd , x .fst) (λ z → z .snd , 
 Iso.fun (Σ-ap-iso₁ isom) x = (Iso.fun isom) (x .fst) , x .snd
 Iso.inv (Σ-ap-iso₁ {B = B} isom) x = (Iso.inv isom) (x .fst) , subst B (sym (ε' (x .fst))) (x .snd)
   where
-    ε' = fst (vogt isom)
+    ε' = isHAEquiv.ret (snd (iso→HAEquiv isom))
 Iso.rightInv (Σ-ap-iso₁ {B = B} isom) (x , y) = ΣPathP (ε' x ,
   transport
     (sym (PathP≡Path (λ j → cong B (ε' x) j) (subst B (sym (ε' x)) y) y))
@@ -216,7 +216,7 @@ Iso.rightInv (Σ-ap-iso₁ {B = B} isom) (x , y) = ΣPathP (ε' x ,
       ≡⟨ substRefl {B = B} y ⟩
     y ∎))
   where
-    ε' = fst (vogt isom)
+    ε' = isHAEquiv.ret (snd (iso→HAEquiv isom))
 Iso.leftInv (Σ-ap-iso₁ {A = A} {B = B} isom@(iso f g ε η)) (x , y) = ΣPathP (η x ,
   transport
     (sym (PathP≡Path (λ j → cong B (cong f (η x)) j) (subst B (sym (ε' (f x))) y) y))
@@ -228,8 +228,8 @@ Iso.leftInv (Σ-ap-iso₁ {A = A} {B = B} isom@(iso f g ε η)) (x , y) = ΣPath
       ≡⟨ substRefl {B = B} y ⟩
     y ∎))
   where
-    ε' = fst (vogt isom)
-    γ = snd (vogt isom)
+    ε' = isHAEquiv.ret (snd (iso→HAEquiv isom))
+    γ = isHAEquiv.com (snd (iso→HAEquiv isom))
 
     lem : (x : A) → sym (ε' (f x)) ∙ cong f (η x) ≡ refl
     lem x = cong (λ a → sym (ε' (f x)) ∙ a) (γ x) ∙ lCancel (ε' (f x))

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -89,25 +89,6 @@ iso→HAEquiv {A = A} {B = B} (iso f g ε η) = f , (record { g = g ; sec = η ;
                                ; (j = i1) → ε (f a) k})
                       (cong (cong f) (sym (Hfa≡fHa (λ x → g (f x)) η a)) i j)
 
--- Theorem 4.2.3. of HoTT book (similar to iso→HAEquiv)
-iso→HAEquiv' : Iso A B → HAEquiv A B
-fst (iso→HAEquiv' (iso f g ε η)) = f
-isHAEquiv.g (snd (iso→HAEquiv' (iso f g ε η))) = g
-isHAEquiv.sec (snd (iso→HAEquiv' (iso f g ε η))) = η
-isHAEquiv.ret (snd (iso→HAEquiv' (iso f g ε η))) b = sym (ε (f (g b))) ∙ (cong f (η (g b)) ∙ ε b)
-isHAEquiv.com (snd (iso→HAEquiv' (iso f g ε η))) a =
-  cong f (η a)
-    ≡⟨ lUnit (cong f (η a)) ⟩
-  refl ∙ cong f (η a)
-    ≡⟨ cong (λ m → m ∙ cong f (η a)) (sym (lCancel (ε (f (g (f a)))))) ⟩
-  (sym (ε (f (g (f a)))) ∙ ε (f (g (f a)))) ∙ cong f (η a)
-    ≡⟨ sym (assoc (sym (ε (f (g (f a))))) (ε (f (g (f a)))) (cong f (η a))) ⟩
-  sym (ε (f (g (f a)))) ∙ ε (f (g (f a))) ∙ cong f (η a)
-    ≡⟨ cong (λ m → sym (ε (f (g (f a)))) ∙ m) (homotopyNatural (ε ∘ f) (η a)) ⟩
-  sym (ε (f (g (f a)))) ∙ (cong (f ∘ g ∘ f) (η a)) ∙ ε (f a)
-    ≡⟨ cong (λ m → sym (ε (f (g (f a)))) ∙ cong f m ∙ ε (f a)) (sym (Hfa≡fHa (λ x → g (f x)) η a)) ⟩
-  sym (ε (f (g (f a)))) ∙ (cong f (η (g (f a)))) ∙ ε (f a) ∎
-
 equiv→HAEquiv : A ≃ B → HAEquiv A B
 equiv→HAEquiv e = iso→HAEquiv (equivToIso e)
 

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -102,17 +102,7 @@ congIso {A = A} {B} {x} {y} e = (iso intro elim intro-elim elim-intro)
     f : A → B
     f = e' .fst
 
-    g : B → A
-    g = isHAEquiv.g (e' .snd)
-
-    sec : ∀ a → g (f a) ≡ a
-    sec = isHAEquiv.sec (e' .snd)
-
-    ret : ∀ b → f (g b) ≡ b
-    ret = isHAEquiv.ret (e' .snd)
-
-    com : ∀ a → cong f (sec a) ≡ ret (f a)
-    com = isHAEquiv.com (e' .snd)
+    open isHAEquiv (e' .snd)
 
     intro : x ≡ y → f x ≡ f y
     intro = cong f

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -174,40 +174,10 @@ coherent : ∀ {ℓ} {A B : Type ℓ} (isom : Iso A B) → Type ℓ
 coherent (iso f g H K) = ∀ x → cong f (K x) ≡ H (f x)
 
 -- vogt's lemma (https://ncatlab.org/nlab/show/homotopy+equivalence#vogts_lemma)
-vogt : ∀ {ℓ} {X Y : Type ℓ} → (isom : Iso X Y) → Σ ((y : Y) → Iso.fun isom (Iso.inv isom y) ≡ y) λ iso' → coherent (iso (Iso.fun isom) (Iso.inv isom) iso' (Iso.leftInv isom))
-vogt {X = X} isom@(iso f g ε η) = ε' , γ
+vogt : ∀ {ℓ} {X Y : Type ℓ} (isom : Iso X Y)
+  → Σ ((y : Y) → Iso.fun isom (Iso.inv isom y) ≡ y)
+      (λ iso' → coherent (iso (Iso.fun isom) (Iso.inv isom) iso' (Iso.leftInv isom)))
+vogt {X = X} isom@(iso f g ε η) =
+  e .snd .isHAEquiv.ret , e .snd .isHAEquiv.com
   where
-    ε' : ∀ y → f (g y) ≡ y
-    ε' x = cong (f ∘ g) (sym (ε x)) ∙ cong f (η (g x)) ∙ ε x
-
-    lem : ∀ (x : X)
-      → cong f (η (g (f x))) ∙ ε (f x)
-      ≡ cong (f ∘ g) (ε (f x)) ∙ cong f (η x)
-    lem x =
-      cong f (η (g (f x))) ∙ ε (f x)
-        ≡⟨ lUnit (cong (f) (η (g (f x))) ∙ ε (f x)) ⟩
-      refl ∙ cong f (η (g (f x))) ∙ ε (f x)
-        ≡⟨ cong (λ a → a ∙ cong f (η (g (f x))) ∙ ε (f x)) (sym (rCancel (ε (f (g (f x)))))) ⟩
-      (ε (f (g (f x))) ∙ sym (ε (f (g (f x))))) ∙ cong f (η (g (f x))) ∙ ε (f x)
-        ≡⟨ sym (assoc (ε (f (g (f x)))) (sym (ε (f (g (f x))))) (cong f (η (g (f x))) ∙ ε (f x))) ⟩
-      ε (f (g (f x))) ∙ sym (ε (f (g (f x)))) ∙ cong f (η (g (f x))) ∙ ε (f x)
-        ≡⟨ cong (λ a → ε (f (g (f x))) ∙ a) (sym (isHAEquiv.com (iso→HAEquiv' isom .snd) x)) ⟩
-      ε (f (g (f x))) ∙ cong f (η x)
-        ≡⟨ cong (λ a → a ∙ cong f (η x)) (Hfa≡fHa (f ∘ g) ε (f x)) ⟩
-      cong (f ∘ g) (ε (f x)) ∙ cong f (η x) ∎
-
-    γ : coherent (iso f g ε' η)
-    γ x = sym
-      (ε' (f x)
-        ≡⟨ refl ⟩
-      cong (f ∘ g) (sym (ε (f x))) ∙ cong f (η (g (f x))) ∙ ε (f x)
-        ≡⟨ cong (λ a → cong (f ∘ g) (sym (ε (f x))) ∙ a) (lem x) ⟩
-      cong (f ∘ g) (sym (ε (f x))) ∙ cong (f ∘ g) (ε (f x)) ∙ cong f (η x)
-        ≡⟨ refl ⟩
-      sym (cong (f ∘ g) (ε (f x))) ∙ cong (f ∘ g) (ε (f x)) ∙ cong f (η x)
-        ≡⟨ assoc (sym (cong (f ∘ g) (ε (f x)))) (cong (f ∘ g) (ε (f x))) (cong f (η x)) ⟩
-      (sym (cong (f ∘ g) (ε (f x))) ∙ cong (f ∘ g) (ε (f x))) ∙ cong f (η x)
-        ≡⟨ cong (λ a → a ∙ cong f (η x)) (lCancel (cong (f ∘ g) (ε (f x)))) ⟩
-      refl ∙ cong f (η x)
-        ≡⟨ sym (lUnit (cong f (η x))) ⟩
-      cong f (η x) ∎)
+  e = iso→HAEquiv isom

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -90,8 +90,6 @@ iso→HAEquiv {A = A} {B = B} (iso f g ε η) = f , (record { g = g ; sec = η ;
                       (cong (cong f) (sym (Hfa≡fHa (λ x → g (f x)) η a)) i j)
 
 -- Theorem 4.2.3. of HoTT book (similar to iso→HAEquiv)
--- This exists to make the proof of vogt (see later in the file) easier,
--- since iso→HAEquiv does not reduce fully when applied.
 iso→HAEquiv' : Iso A B → HAEquiv A B
 fst (iso→HAEquiv' (iso f g ε η)) = f
 isHAEquiv.g (snd (iso→HAEquiv' (iso f g ε η))) = g

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -69,6 +69,7 @@ private
     A : Type ℓ
     B : Type ℓ'
 
+-- vogt's lemma (https://ncatlab.org/nlab/show/homotopy+equivalence#vogts_lemma)
 iso→HAEquiv : Iso A B → HAEquiv A B
 iso→HAEquiv {A = A} {B = B} (iso f g ε η) = f , (record { g = g ; sec = η ; ret = ret ; com = com })
   where
@@ -148,15 +149,3 @@ congIso {A = A} {B} {x} {y} e = (iso intro elim intro-elim elim-intro)
 
 congEquiv : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
 congEquiv {A = A} {B} {x} {y} e = isoToEquiv (congIso e)
-
-coherent : ∀ {ℓ} {A B : Type ℓ} (isom : Iso A B) → Type ℓ
-coherent (iso f g H K) = ∀ x → cong f (K x) ≡ H (f x)
-
--- vogt's lemma (https://ncatlab.org/nlab/show/homotopy+equivalence#vogts_lemma)
-vogt : ∀ {ℓ} {X Y : Type ℓ} (isom : Iso X Y)
-  → Σ ((y : Y) → Iso.fun isom (Iso.inv isom y) ≡ y)
-      (λ iso' → coherent (iso (Iso.fun isom) (Iso.inv isom) iso' (Iso.leftInv isom)))
-vogt {X = X} isom@(iso f g ε η) =
-  e .snd .isHAEquiv.ret , e .snd .isHAEquiv.com
-  where
-  e = iso→HAEquiv isom


### PR DESCRIPTION
Eliminating some duplication. There are also two proofs of `iso→HAEquiv` in this file, don't know if we want to keep both of them.