### PR TITLE
Rename Set to Type

### DIFF
--- a/Cubical/Algebra/BasicProp.agda
+++ b/Cubical/Algebra/BasicProp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Algebra.BasicProp where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Matrix.agda
+++ b/Cubical/Algebra/Matrix.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Algebra.Matrix where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/SymmetricGroup.agda
+++ b/Cubical/Algebra/SymmetricGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Algebra.SymmetricGroup where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Categories/Category.agda
+++ b/Cubical/Categories/Category.agda
@@ -16,7 +16,7 @@
 
 -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 
 module Cubical.Categories.Category where

--- a/Cubical/Categories/Functor.agda
+++ b/Cubical/Categories/Functor.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Categories.Functor where
 

--- a/Cubical/Categories/NaturalTransformation.agda
+++ b/Cubical/Categories/NaturalTransformation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Categories.NaturalTransformation where
 

--- a/Cubical/Categories/Presheaves.agda
+++ b/Cubical/Categories/Presheaves.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --postfix-projections --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --postfix-projections --safe #-}
 
 module Cubical.Categories.Presheaves where
 

--- a/Cubical/Categories/Pullback.agda
+++ b/Cubical/Categories/Pullback.agda
@@ -1,7 +1,7 @@
 {-
   This file contains cospans, cones, pullbacks and maps of cones in precategories.
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Categories.Pullback where
 

--- a/Cubical/Categories/Sets.agda
+++ b/Cubical/Categories/Sets.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Categories.Sets where
 

--- a/Cubical/Categories/Type.agda
+++ b/Cubical/Categories/Type.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Categories.Type where
 

--- a/Cubical/Codata/Conat.agda
+++ b/Cubical/Codata/Conat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Conat where
 
 open import Cubical.Codata.Conat.Base public

--- a/Cubical/Codata/Conat/Base.agda
+++ b/Cubical/Codata/Conat/Base.agda
@@ -18,7 +18,7 @@ The first approach is chosen to exploit guarded recursion and to avoid the use
 of Sized Types.
 -}
 
-{-# OPTIONS --cubical --safe --guardedness #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
 module Cubical.Codata.Conat.Base where
 
 open import Cubical.Data.Unit

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -20,7 +20,7 @@ The standard library also defines bisimulation on conaturals:
 https://github.com/agda/agda-stdlib/blob/master/src/Codata/Conat/Bisimilarity.agda
 -}
 
-{-# OPTIONS --cubical --safe --guardedness #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
 module Cubical.Codata.Conat.Properties where
 
 open import Cubical.Data.Unit

--- a/Cubical/Codata/Everything.agda
+++ b/Cubical/Codata/Everything.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Everything where
 
 open import Cubical.Codata.EverythingSafe public

--- a/Cubical/Codata/EverythingSafe.agda
+++ b/Cubical/Codata/EverythingSafe.agda
@@ -1,2 +1,2 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Codata.EverythingSafe where

--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --guardedness #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
 module Cubical.Codata.M where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Codata/M/AsLimit/Coalg.agda
+++ b/Cubical/Codata/M/AsLimit/Coalg.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Coalg where
 

--- a/Cubical/Codata/M/AsLimit/Coalg/Base.agda
+++ b/Cubical/Codata/M/AsLimit/Coalg/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Coalg.Base where
 

--- a/Cubical/Codata/M/AsLimit/Container.agda
+++ b/Cubical/Codata/M/AsLimit/Container.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Container where
 

--- a/Cubical/Codata/M/AsLimit/M.agda
+++ b/Cubical/Codata/M/AsLimit/M.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.M where
 

--- a/Cubical/Codata/M/AsLimit/M/Base.agda
+++ b/Cubical/Codata/M/AsLimit/M/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 -- Construction of M-types from
 -- https://arxiv.org/pdf/1504.02949.pdf

--- a/Cubical/Codata/M/AsLimit/M/Properties.agda
+++ b/Cubical/Codata/M/AsLimit/M/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.M.Properties where
 

--- a/Cubical/Codata/M/AsLimit/helper.agda
+++ b/Cubical/Codata/M/AsLimit/helper.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.helper where
 

--- a/Cubical/Codata/M/AsLimit/itree.agda
+++ b/Cubical/Codata/M/AsLimit/itree.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.itree where
 

--- a/Cubical/Codata/M/AsLimit/stream.agda
+++ b/Cubical/Codata/M/AsLimit/stream.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --guardedness --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.stream where
 

--- a/Cubical/Codata/M/Bisimilarity.agda
+++ b/Cubical/Codata/M/Bisimilarity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --postfix-projections #-}
+{-# OPTIONS --cubical --no-import-sorts --postfix-projections #-}
 module Cubical.Codata.M.Bisimilarity where
 
 open import Cubical.Core.Everything

--- a/Cubical/Codata/Stream.agda
+++ b/Cubical/Codata/Stream.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Stream where
 
 open import Cubical.Codata.Stream.Base public

--- a/Cubical/Codata/Stream/Base.agda
+++ b/Cubical/Codata/Stream/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --guardedness #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
 module Cubical.Codata.Stream.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Codata/Stream/Properties.agda
+++ b/Cubical/Codata/Stream/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --guardedness #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
 module Cubical.Codata.Stream.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Core/Everything.agda
+++ b/Cubical/Core/Everything.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Core.Everything where
 
 -- Basic primitives (some are from Agda.Primitive)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -7,7 +7,7 @@ This file contains:
 - Glue types
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Core.Glue where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Core/Id.agda
+++ b/Cubical/Core/Id.agda
@@ -1,5 +1,5 @@
 {- This file exports the primitives of cubical Id types -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Core.Id where
 
 open import Cubical.Core.Primitives hiding ( _≡_ )

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -4,7 +4,7 @@ This file document and export the main primitives of Cubical Agda. It
 also defines some basic derived operations (composition and filling).
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Core.Primitives where
 
 open import Agda.Builtin.Cubical.Path public
@@ -34,17 +34,9 @@ open import Agda.Primitive public
   renaming ( lzero to ℓ-zero
            ; lsuc  to ℓ-suc
            ; _⊔_   to ℓ-max
+           ; Set   to Type
            ; Setω  to Typeω )
 open import Agda.Builtin.Sigma public
-
-Type : (ℓ : Level) → Set (ℓ-suc ℓ)
-Type ℓ = Set ℓ
-
-Type₀ : Type (ℓ-suc ℓ-zero)
-Type₀ = Type ℓ-zero
-
-Type₁ : Type (ℓ-suc (ℓ-suc ℓ-zero))
-Type₁ = Type (ℓ-suc ℓ-zero)
 
 -- This file document the Cubical Agda primitives. The primitives
 -- themselves are bound by the Agda files imported above.

--- a/Cubical/Data/BinNat.agda
+++ b/Cubical/Data/BinNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.BinNat where
 
 open import Cubical.Data.BinNat.BinNat public

--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -58,7 +58,7 @@ but it has the virtue of being a bit simpler to prove equivalent to
 http://www.cs.bham.ac.uk/~mhe/agda-new/BinaryNaturals.html
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.BinNat.BinNat where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Bool.agda
+++ b/Cubical/Data/Bool.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Bool where
 
 open import Cubical.Data.Bool.Base public

--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Bool.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Bool.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/DescendingList.agda
+++ b/Cubical/Data/DescendingList.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.DescendingList where
 
 open import Cubical.Data.DescendingList.Base public

--- a/Cubical/Data/DescendingList/Base.agda
+++ b/Cubical/Data/DescendingList/Base.agda
@@ -2,7 +2,7 @@
 -- Descending lists
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 open import Cubical.Foundations.Everything
 

--- a/Cubical/Data/DescendingList/Examples.agda
+++ b/Cubical/Data/DescendingList/Examples.agda
@@ -9,7 +9,7 @@
 -- 2. "sorting" finite multisets by converting into sorted lists.
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.DescendingList.Examples where
 
@@ -31,11 +31,11 @@ open import Cubical.HITs.FiniteMultiset
 
 infix 4 _≤_ _≥_
 
-data _≤_ : ℕ → ℕ → Set where
+data _≤_ : ℕ → ℕ → Type where
  z≤n : ∀ {n}                 → zero  ≤ n
  s≤s : ∀ {m n} (m≤n : m ≤ n) → suc m ≤ suc n
 
-_≥_ : ℕ → ℕ → Set
+_≥_ : ℕ → ℕ → Type
 m ≥ n = n ≤ m
 
 ≤pred : {n m : ℕ} → suc n ≤ suc m → n ≤ m

--- a/Cubical/Data/DescendingList/Properties.agda
+++ b/Cubical/Data/DescendingList/Properties.agda
@@ -10,7 +10,7 @@
 -- properties by transporting those on finite multisets.
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 open import Cubical.Foundations.Everything
 

--- a/Cubical/Data/DescendingList/Strict.agda
+++ b/Cubical/Data/DescendingList/Strict.agda
@@ -2,7 +2,7 @@
 -- Strictly descending lists
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 open import Cubical.Core.Everything
 

--- a/Cubical/Data/DescendingList/Strict/Properties.agda
+++ b/Cubical/Data/DescendingList/Strict/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 open import Cubical.Core.Everything
 open import Cubical.Foundations.Everything
@@ -22,7 +22,7 @@ unsort (cons x xs x>xs) = x ∷ unsort xs
 
 module _ where
   open import Cubical.Relation.Nullary
-  data Tri (A B C : Set) : Set where
+  data Tri (A B C : Type) : Type where
     tri-< : A → ¬ B → ¬ C → Tri A B C
     tri-≡ : ¬ A → B → ¬ C → Tri A B C
     tri-> : ¬ A → ¬ B → C → Tri A B C
@@ -35,7 +35,7 @@ module IsoToLFSet
    (>-irreflexive : ∀ {x} → Type¬ x > x)
   where
 
-  Tri' : A → A → Set
+  Tri' : A → A → Type
   Tri' x y = Tri (y > x) (x ≡ y) (x > y)
 
   open import Cubical.Foundations.Logic
@@ -58,7 +58,7 @@ module IsoToLFSet
   >ᴴ-trans x y [] x>y y>zs = >ᴴ[]
   >ᴴ-trans x y (cons z zs _) x>y (>ᴴcons y>z) = >ᴴcons (>-trans x>y y>z)
 
-  ≡ₚ-sym : ∀ {A : Set} {x y : A} → [ x ≡ₚ y ] → [ y ≡ₚ x ]
+  ≡ₚ-sym : ∀ {A : Type} {x y : A} → [ x ≡ₚ y ] → [ y ≡ₚ x ]
   ≡ₚ-sym p = PropTrunc.rec squash (λ p → ∣ sym p ∣) p
 
   >-all : ∀ x l → x >ᴴ l → ∀ a → [ a ∈ˡ l ] → x > a

--- a/Cubical/Data/DiffInt.agda
+++ b/Cubical/Data/DiffInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.DiffInt where
 
 open import Cubical.Data.DiffInt.Base public

--- a/Cubical/Data/DiffInt/Base.agda
+++ b/Cubical/Data/DiffInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.DiffInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/DiffInt/Properties.agda
+++ b/Cubical/Data/DiffInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.DiffInt.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Empty.agda
+++ b/Cubical/Data/Empty.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Empty where
 
 open import Cubical.Data.Empty.Base public

--- a/Cubical/Data/Empty/Base.agda
+++ b/Cubical/Data/Empty/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Empty.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Empty/Properties.agda
+++ b/Cubical/Data/Empty/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Empty.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Equality.agda
+++ b/Cubical/Data/Equality.agda
@@ -8,7 +8,7 @@ and the inductively define equality types.
 
 TODO: reconsider naming scheme.
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Equality where
 
@@ -24,7 +24,7 @@ open import Cubical.Foundations.Isomorphism
 private
  variable
   ℓ : Level
-  A : Set ℓ
+  A : Type ℓ
   x y z : A
 
 ptoc : x ≡p y → x ≡c y

--- a/Cubical/Data/Fin.agda
+++ b/Cubical/Data/Fin.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Fin where
 

--- a/Cubical/Data/Fin/Base.agda
+++ b/Cubical/Data/Fin/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Fin.Base where
 

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Fin.Properties where
 

--- a/Cubical/Data/FinData.agda
+++ b/Cubical/Data/FinData.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.FinData where
 
 open import Cubical.Data.FinData.Base public

--- a/Cubical/Data/FinData/Base.agda
+++ b/Cubical/Data/FinData/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.FinData.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Graph.agda
+++ b/Cubical/Data/Graph.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Graph where
 
 open import Cubical.Data.Graph.Base public

--- a/Cubical/Data/Graph/Base.agda
+++ b/Cubical/Data/Graph/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Graph.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Graph.Examples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Group.agda
+++ b/Cubical/Data/Group.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Group where
 
 open import Cubical.Data.Group.Base public

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Group.Base where
 

--- a/Cubical/Data/HomotopyGroup.agda
+++ b/Cubical/Data/HomotopyGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.HomotopyGroup where
 
 open import Cubical.Data.HomotopyGroup.Base public

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.HomotopyGroup.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/InfNat.agda
+++ b/Cubical/Data/InfNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.InfNat where
 
 open import Cubical.Data.InfNat.Base public

--- a/Cubical/Data/InfNat/Base.agda
+++ b/Cubical/Data/InfNat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 module Cubical.Data.InfNat.Base where
 

--- a/Cubical/Data/InfNat/Properties.agda
+++ b/Cubical/Data/InfNat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 module Cubical.Data.InfNat.Properties where
 

--- a/Cubical/Data/Int.agda
+++ b/Cubical/Data/Int.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Int where
 
 open import Cubical.Data.Int.Base public

--- a/Cubical/Data/Int/Base.agda
+++ b/Cubical/Data/Int/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Int.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 {-
 

--- a/Cubical/Data/List.agda
+++ b/Cubical/Data/List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.List where
 
 open import Cubical.Data.List.Base       public

--- a/Cubical/Data/List/Base.agda
+++ b/Cubical/Data/List/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.List.Base where
 
 open import Agda.Builtin.List        public

--- a/Cubical/Data/List/Properties.agda
+++ b/Cubical/Data/List/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.List.Properties where
 
 open import Agda.Builtin.List

--- a/Cubical/Data/Maybe.agda
+++ b/Cubical/Data/Maybe.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Maybe where
 
 open import Cubical.Data.Maybe.Base public

--- a/Cubical/Data/Maybe/Base.agda
+++ b/Cubical/Data/Maybe/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Maybe.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Maybe/Properties.agda
+++ b/Cubical/Data/Maybe/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Maybe.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Nat.agda
+++ b/Cubical/Data/Nat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Nat where
 
 open import Cubical.Data.Nat.Base public

--- a/Cubical/Data/Nat/Algebra.agda
+++ b/Cubical/Data/Nat/Algebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 {-
 

--- a/Cubical/Data/Nat/Base.agda
+++ b/Cubical/Data/Nat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Nat.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/Nat/Coprime.agda
+++ b/Cubical/Data/Nat/Coprime.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Nat.Coprime where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Divisibility.agda
+++ b/Cubical/Data/Nat/Divisibility.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Nat.Divisibility where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/GCD.agda
+++ b/Cubical/Data/Nat/GCD.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Nat.GCD where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Literals.agda
+++ b/Cubical/Data/Nat/Literals.agda
@@ -4,7 +4,7 @@
    and negative integer literals for any type (e.g. Int, ℕ₋₁, ℕ₋₂, ℕ₊₁).
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Nat.Literals where
 
 open import Agda.Builtin.FromNat public

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Nat.Order where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Nat.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/NatMinusOne.agda
+++ b/Cubical/Data/NatMinusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.NatMinusOne where
 
 open import Cubical.Data.NatMinusOne.Base public

--- a/Cubical/Data/NatMinusOne/Base.agda
+++ b/Cubical/Data/NatMinusOne/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatMinusOne.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/NatMinusOne/Properties.agda
+++ b/Cubical/Data/NatMinusOne/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatMinusOne.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/NatMinusTwo.agda
+++ b/Cubical/Data/NatMinusTwo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.NatMinusTwo where
 
 open import Cubical.Data.NatMinusTwo.Base public

--- a/Cubical/Data/NatMinusTwo/Base.agda
+++ b/Cubical/Data/NatMinusTwo/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatMinusTwo.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/NatMinusTwo/Properties.agda
+++ b/Cubical/Data/NatMinusTwo/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatMinusTwo.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/NatMinusTwo/ToNatMinusOne.agda
+++ b/Cubical/Data/NatMinusTwo/ToNatMinusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatMinusTwo.ToNatMinusOne where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/NatPlusOne.agda
+++ b/Cubical/Data/NatPlusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.NatPlusOne where
 
 open import Cubical.Data.NatPlusOne.Base public

--- a/Cubical/Data/NatPlusOne/Base.agda
+++ b/Cubical/Data/NatPlusOne/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatPlusOne.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/NatPlusOne/Properties.agda
+++ b/Cubical/Data/NatPlusOne/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.NatPlusOne.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Prod.agda
+++ b/Cubical/Data/Prod.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Prod where
 
 open import Cubical.Data.Prod.Base public

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Prod.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Prod.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Queue.agda
+++ b/Cubical/Data/Queue.agda
@@ -1,5 +1,5 @@
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.Queue where
 

--- a/Cubical/Data/Queue/1List.agda
+++ b/Cubical/Data/Queue/1List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Queue.1List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Base.agda
+++ b/Cubical/Data/Queue/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Queue.Base where
 
 open import Cubical.Data.Queue.1List public

--- a/Cubical/Data/Queue/Finite.agda
+++ b/Cubical/Data/Queue/Finite.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Queue.Finite where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Truncated2List.agda
+++ b/Cubical/Data/Queue/Truncated2List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Queue.Truncated2List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Untruncated2List.agda
+++ b/Cubical/Data/Queue/Untruncated2List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Queue.Untruncated2List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Sigma.agda
+++ b/Cubical/Data/Sigma.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sigma where
 
 open import Cubical.Data.Sigma.Base public

--- a/Cubical/Data/Sigma/Base.agda
+++ b/Cubical/Data/Sigma/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sigma.Base where
 
 open import Cubical.Core.Primitives public

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -5,7 +5,7 @@ Basic properties about Σ-types
 - Characterization of equality in Σ-types using transport ([pathSigma≡sigmaPath])
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sigma.Properties where
 
 open import Cubical.Data.Sigma.Base

--- a/Cubical/Data/Sum.agda
+++ b/Cubical/Data/Sum.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sum where
 
 open import Cubical.Data.Sum.Base public

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sum.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Sum.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/SumFin.agda
+++ b/Cubical/Data/SumFin.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.SumFin where
 
 open import Cubical.Data.SumFin.Base public

--- a/Cubical/Data/SumFin/Base.agda
+++ b/Cubical/Data/SumFin/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.SumFin.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/SumFin/Properties.agda
+++ b/Cubical/Data/SumFin/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.SumFin.Properties where
 

--- a/Cubical/Data/Unit.agda
+++ b/Cubical/Data/Unit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Unit where
 
 open import Cubical.Data.Unit.Base       public

--- a/Cubical/Data/Unit/Base.agda
+++ b/Cubical/Data/Unit/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Unit.Base where
 
 -- Obtain Unit

--- a/Cubical/Data/Unit/Properties.agda
+++ b/Cubical/Data/Unit/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Unit.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Vec.agda
+++ b/Cubical/Data/Vec.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Vec where
 
 open import Cubical.Data.Vec.Base public

--- a/Cubical/Data/Vec/Base.agda
+++ b/Cubical/Data/Vec/Base.agda
@@ -1,6 +1,6 @@
 {- Definition of vectors. Inspired by the Agda Standard Library -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Vec.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Vec/NAry.agda
+++ b/Cubical/Data/Vec/NAry.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Vec.NAry where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Vec/Properties.agda
+++ b/Cubical/Data/Vec/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Data.Vec.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Experiments.Brunerie where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -8,7 +8,7 @@ It would be interesting to compare the proves with the one in Cubical.Foundation
 
 
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Experiments.EscardoSIP where
 
 open import Cubical.Core.Everything

--- a/Cubical/Experiments/Everything.agda
+++ b/Cubical/Experiments/Everything.agda
@@ -1,6 +1,6 @@
 -- Export only the experiments that are expected to compile (without
 -- any holes)
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Experiments.Everything where
 
 open import Cubical.Experiments.Brunerie public

--- a/Cubical/Experiments/FunExtFromUA.agda
+++ b/Cubical/Experiments/FunExtFromUA.agda
@@ -1,6 +1,6 @@
 {- Voevodsky's proof that univalence implies funext -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Experiments.FunExtFromUA where
 

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -1,6 +1,6 @@
 -- Two fun examples of generic programming using univalence
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Experiments.Generic where
 
 open import Agda.Builtin.String

--- a/Cubical/Experiments/HInt.agda
+++ b/Cubical/Experiments/HInt.agda
@@ -17,7 +17,7 @@ https://github.com/RedPRL/redtt/blob/master/library/cool/biinv-int.red
 It might be interesting to port that example one day.
 
 -}
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Experiments.HInt where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/HoTT-UF.agda
+++ b/Cubical/Experiments/HoTT-UF.agda
@@ -11,7 +11,7 @@ For the moment, this requires the development version of Agda.
 
 -}
 
-{-# OPTIONS --cubical --exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --exact-split --safe #-}
 
 module Cubical.Experiments.HoTT-UF where
 

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -1,5 +1,5 @@
 -- An example of something where normalization is surprisingly slow
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Experiments.Problem where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -1,5 +1,5 @@
 -- This file derives some of the Cartesian Kan operations using transp
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.CartesianKanOps where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -14,7 +14,7 @@ There are more statements about equivalences in Equiv/Properties.agda:
 - if f is an equivalence then postcomposition with f is an equivalence
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv where
 
 open import Cubical.Foundations.Function
@@ -147,7 +147,7 @@ invEq≡→equivFun≡ : ∀ (e : A ≃ B) {x y} → invEq e x ≡ y → equivFu
 invEq≡→equivFun≡ e {x} p = cong (equivFun e) (sym p) ∙ retEq e x
 
 equivPi
-  : ∀{F : A → Set ℓ} {G : A → Set ℓ'}
+  : ∀{F : A → Type ℓ} {G : A → Type ℓ'}
   → ((x : A) → F x ≃ G x) → (((x : A) → F x) ≃ ((x : A) → G x))
 equivPi k .fst f x = k x .fst (f x)
 equivPi k .snd .equiv-proof f

--- a/Cubical/Foundations/Equiv/Base.agda
+++ b/Cubical/Foundations/Equiv/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.Base where
 
 open import Cubical.Foundations.Function

--- a/Cubical/Foundations/Equiv/BiInvertible.agda
+++ b/Cubical/Foundations/Equiv/BiInvertible.agda
@@ -8,7 +8,7 @@ Some theory about Bi-Invertible Equivalences
 - Iso to BiInvEquiv
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.BiInvertible where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/Fiberwise.agda
+++ b/Cubical/Foundations/Equiv/Fiberwise.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.Fiberwise where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -7,7 +7,7 @@ Half adjoint equivalences ([HAEquiv])
 - Cong is an equivalence ([congEquiv])
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.HalfAdjoint where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/PathSplit.agda
+++ b/Cubical/Foundations/Equiv/PathSplit.agda
@@ -15,7 +15,7 @@ The module starts with a couple of general facts about equivalences:
 
 (those are not in 'Equiv.agda' because they need Univalence.agda (which imports Equiv.agda))
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.PathSplit where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -8,7 +8,7 @@ A couple of general facts about equivalences:
 
 (these are not in 'Equiv.agda' because they need Univalence.agda (which imports Equiv.agda))
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Equiv.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Everything where
 
 -- Basic cubical prelude

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -1,7 +1,7 @@
 {-
   Definitions for functions
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Function where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -4,7 +4,7 @@ This file proves the higher groupoid structure of types
 for homogeneous and heterogeneous paths
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.GroupoidLaws where
 
 open import Cubical.Foundations.Prelude
@@ -205,7 +205,7 @@ cong-∙∙ f p q r j i = hcomp (λ k → λ { (j = i0) → f (doubleCompPath-fi
                                      ; (i = i1) → f (r k) })
                             (f (q i))
 
-hcomp-unique : ∀ {ℓ} {A : Set ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
+hcomp-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
                (h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
                → (hcomp u (outS u0) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
 hcomp-unique {φ = φ} u u0 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
@@ -213,7 +213,7 @@ hcomp-unique {φ = φ} u u0 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u
                                                    (outS u0))
 
 
-lid-unique : ∀ {ℓ} {A : Set ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
+lid-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
                (h1 h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
                → (outS (h1 i1) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
 lid-unique {φ = φ} u u0 h1 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
@@ -222,8 +222,8 @@ lid-unique {φ = φ} u u0 h1 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → 
                                                    (outS u0))
 
 
-transp-hcomp : ∀ {ℓ} (φ : I) {A' : Set ℓ}
-                     (A : (i : I) → Set ℓ [ φ ↦ (λ _ → A') ]) (let B = \ (i : I) → outS (A i))
+transp-hcomp : ∀ {ℓ} (φ : I) {A' : Type ℓ}
+                     (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A') ]) (let B = \ (i : I) → outS (A i))
                  → ∀ {ψ} (u : I → Partial ψ (B i0)) → (u0 : B i0 [ ψ ↦ u i0 ]) →
                  (transp B φ (hcomp u (outS u0)) ≡ hcomp (\ i o → transp B φ (u i o)) (transp B φ (outS u0)))
                    [ ψ ↦ (\ { (ψ = i1) → (\ i → transp B φ (u i1 1=1))}) ]
@@ -234,9 +234,8 @@ transp-hcomp φ A u u0 = inS (sym (outS (hcomp-unique
     B = \ (i : I) → outS (A i)
 
 
-hcomp-cong : ∀ {ℓ} {A : Set ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
-                                    (u' : I → Partial φ A) → (u0' : A [ φ ↦ u' i0 ]) →
-
+hcomp-cong : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
+                                     (u' : I → Partial φ A) → (u0' : A [ φ ↦ u' i0 ]) →
              (ueq : ∀ i → PartialP φ (\ o → u i o ≡ u' i o)) → (outS u0 ≡ outS u0') [ φ ↦ (\ { (φ = i1) → ueq i0 1=1}) ]
              → (hcomp u (outS u0) ≡ hcomp u' (outS u0')) [ φ ↦ (\ { (φ = i1) → ueq i1 1=1 }) ]
 hcomp-cong u u0 u' u0' ueq 0eq = inS (\ j → hcomp (\ i o → ueq i o j) (outS 0eq j))

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -7,7 +7,7 @@ Basic theory about h-levels/n-types:
 - Hedberg's theorem can be found in Cubical/Relation/Nullary/DecidableEq
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.HLevels where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -17,7 +17,7 @@ This file contains:
 - Propositional truncation and its elimination principle
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Id where
 
 open import Cubical.Foundations.Prelude public

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -7,7 +7,7 @@ Theory about isomorphisms
 - Any isomorphism is an equivalence ([isoToEquiv])
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Isomorphism where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Foundations.Logic where
 

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Path where
 
 open import Cubical.Foundations.Prelude
@@ -27,7 +27,7 @@ PathP≃Path : ∀ (P : I → Type ℓ) (p : P i0) (q : P i1) →
 PathP≃Path P p q = transportEquiv (PathP≡Path P p q)
 
 -- Alternative more unfolded proof
-toPathP-isEquiv : ∀ (A : I → Set ℓ) {x y} → isEquiv (toPathP {A = A} {x} {y})
+toPathP-isEquiv : ∀ (A : I → Type ℓ) {x y} → isEquiv (toPathP {A = A} {x} {y})
 toPathP-isEquiv A {x} {y} = isoToIsEquiv (iso toPathP fromPathP to-from from-to)
  where
    to-from : ∀ (p : PathP A x y) → toPathP (fromPathP p) ≡ p

--- a/Cubical/Foundations/Pointed.agda
+++ b/Cubical/Foundations/Pointed.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Pointed where
 
 open import Cubical.Foundations.Pointed.Base public

--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Pointed.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -6,7 +6,7 @@ Portions of this file adapted from Nicolai Kraus' code here:
   https://bitbucket.org/nicolaikraus/agda/src/e30d70c72c6af8e62b72eefabcc57623dd921f04/trunc-inverse.lagda
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Pointed.Homogeneous where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Pointed.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -20,7 +20,7 @@ This file proves a variety of basic results about paths:
 - Export universe lifting
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Prelude where
 
 open import Cubical.Core.Primitives public
@@ -311,7 +311,7 @@ Cube :
 Cube a₀₋₋ a₁₋₋ a₋₀₋ a₋₁₋ a₋₋₀ a₋₋₁ =
   PathP (λ i → Square (a₋₀₋ i) (a₋₁₋ i) (a₋₋₀ i) (a₋₋₁ i)) a₀₋₋ a₁₋₋
 
-isGroupoid' : Set ℓ → Set ℓ
+isGroupoid' : Type ℓ → Type ℓ
 isGroupoid' A =
   {a₀₀₀ a₀₀₁ : A} {a₀₀₋ : a₀₀₀ ≡ a₀₀₁}
   {a₀₁₀ a₀₁₁ : A} {a₀₁₋ : a₀₁₀ ≡ a₀₁₁}

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -6,7 +6,7 @@ structure identity principle:
 https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.SIP where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Structure.agda
+++ b/Cubical/Foundations/Structure.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Structure where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -4,7 +4,7 @@
 - transport is an equivalence ([transportEquiv])
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Transport where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -12,7 +12,7 @@ various consequences of univalence
 - Isomorphism induction ([elimIso])
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Foundations.Univalence where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Univalence/Universe.agda
+++ b/Cubical/Foundations/Univalence/Universe.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --postfix-projections #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
 
 open import Cubical.Core.Everything
 

--- a/Cubical/Functions/Bundle.agda
+++ b/Cubical/Functions/Bundle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Functions.Bundle where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Functions.Embedding where
 

--- a/Cubical/Functions/Fibration.agda
+++ b/Cubical/Functions/Fibration.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Functions.Fibration where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/FunExtEquiv.agda
+++ b/Cubical/Functions/FunExtEquiv.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Functions.FunExtEquiv where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Functions.Surjection where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/2GroupoidTruncation.agda
+++ b/Cubical/HITs/2GroupoidTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.2GroupoidTruncation where
 
 open import Cubical.HITs.2GroupoidTruncation.Base public

--- a/Cubical/HITs/2GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of 2-groupoid truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.2GroupoidTruncation.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of 2-groupoid truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.2GroupoidTruncation.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/AssocList.agda
+++ b/Cubical/HITs/AssocList.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.AssocList where
 
 

--- a/Cubical/HITs/AssocList/Base.agda
+++ b/Cubical/HITs/AssocList/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.AssocList.Base where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/HITs/AssocList/Properties.agda
+++ b/Cubical/HITs/AssocList/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.AssocList.Properties where
 
 open import Cubical.HITs.AssocList.Base as AL

--- a/Cubical/HITs/Colimit.agda
+++ b/Cubical/HITs/Colimit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Colimit where
 
 open import Cubical.HITs.Colimit.Base public

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -3,7 +3,7 @@
   Homotopy colimits of graphs
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Colimit.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Colimit.Examples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Cylinder.agda
+++ b/Cubical/HITs/Cylinder.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Cylinder where
 
 open import Cubical.HITs.Cylinder.Base public

--- a/Cubical/HITs/Cylinder/Base.agda
+++ b/Cubical/HITs/Cylinder/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Cylinder.Base where
 

--- a/Cubical/HITs/DunceCap.agda
+++ b/Cubical/HITs/DunceCap.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.DunceCap where
 

--- a/Cubical/HITs/DunceCap/Base.agda
+++ b/Cubical/HITs/DunceCap/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.DunceCap.Base where
 

--- a/Cubical/HITs/DunceCap/Properties.agda
+++ b/Cubical/HITs/DunceCap/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.DunceCap.Properties where
 

--- a/Cubical/HITs/FiniteMultiset.agda
+++ b/Cubical/HITs/FiniteMultiset.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.FiniteMultiset where
 
 

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.FiniteMultiset.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
+++ b/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.FiniteMultiset.CountExtensionality where
 
 

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.FiniteMultiset.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/GroupoidTruncation.agda
+++ b/Cubical/HITs/GroupoidTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.GroupoidTruncation where
 
 open import Cubical.HITs.GroupoidTruncation.Base public

--- a/Cubical/HITs/GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/GroupoidTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of groupoid truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.GroupoidTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of groupoid truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.GroupoidTruncation.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Hopf where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/InfNat.agda
+++ b/Cubical/HITs/InfNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat where
 

--- a/Cubical/HITs/InfNat/Base.agda
+++ b/Cubical/HITs/InfNat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat.Base where
 

--- a/Cubical/HITs/InfNat/Properties.agda
+++ b/Cubical/HITs/InfNat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat.Properties where
 

--- a/Cubical/HITs/Interval.agda
+++ b/Cubical/HITs/Interval.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Interval where
 
 open import Cubical.HITs.Interval.Base public

--- a/Cubical/HITs/Interval/Base.agda
+++ b/Cubical/HITs/Interval/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Interval.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/BiInvInt.agda
+++ b/Cubical/HITs/Ints/BiInvInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.BiInvInt where
 
 open import Cubical.HITs.Ints.BiInvInt.Base public

--- a/Cubical/HITs/Ints/BiInvInt/Base.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Base.agda
@@ -13,7 +13,7 @@ This file contains:
 - versions of the point constructors of BiInvInt which satisfy the path constructors judgmentally
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.BiInvInt.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/BiInvInt/Properties.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.BiInvInt.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/DeltaInt.agda
+++ b/Cubical/HITs/Ints/DeltaInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.DeltaInt where
 
 open import Cubical.HITs.Ints.DeltaInt.Base public

--- a/Cubical/HITs/Ints/DeltaInt/Base.agda
+++ b/Cubical/HITs/Ints/DeltaInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 {-
 

--- a/Cubical/HITs/Ints/DeltaInt/Properties.agda
+++ b/Cubical/HITs/Ints/DeltaInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 {-
 

--- a/Cubical/HITs/Ints/HAEquivInt.agda
+++ b/Cubical/HITs/Ints/HAEquivInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.HAEquivInt where
 
 open import Cubical.HITs.Ints.HAEquivInt.Base public

--- a/Cubical/HITs/Ints/HAEquivInt/Base.agda
+++ b/Cubical/HITs/Ints/HAEquivInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.HAEquivInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/IsoInt.agda
+++ b/Cubical/HITs/Ints/IsoInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.IsoInt where
 
 open import Cubical.HITs.Ints.IsoInt.Base public

--- a/Cubical/HITs/Ints/IsoInt/Base.agda
+++ b/Cubical/HITs/Ints/IsoInt/Base.agda
@@ -6,7 +6,7 @@ This file mainly contains a proof that IsoInt ≢ Int, and ends with a
  demonstration of how the same proof strategy fails for BiInvInt.
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.IsoInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/QuoInt.agda
+++ b/Cubical/HITs/Ints/QuoInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.QuoInt where
 
 open import Cubical.HITs.Ints.QuoInt.Base public

--- a/Cubical/HITs/Ints/QuoInt/Base.agda
+++ b/Cubical/HITs/Ints/QuoInt/Base.agda
@@ -1,5 +1,5 @@
 -- Define the integers as a HIT by identifying +0 and -0
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.QuoInt.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/QuoInt/Properties.agda
+++ b/Cubical/HITs/Ints/QuoInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Ints.QuoInt.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Join.agda
+++ b/Cubical/HITs/Join.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Join where
 
 open import Cubical.HITs.Join.Base public

--- a/Cubical/HITs/Join/Base.agda
+++ b/Cubical/HITs/Join/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Join.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -10,7 +10,7 @@ This file contains:
 
 -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Join.Properties where
 

--- a/Cubical/HITs/KleinBottle.agda
+++ b/Cubical/HITs/KleinBottle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.KleinBottle where
 
 open import Cubical.HITs.KleinBottle.Base public

--- a/Cubical/HITs/KleinBottle/Base.agda
+++ b/Cubical/HITs/KleinBottle/Base.agda
@@ -3,12 +3,12 @@
 Definition of the Klein bottle as a HIT
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.KleinBottle.Base where
 
 open import Cubical.Core.Everything
 
-data KleinBottle : Set where
+data KleinBottle : Type where
   point : KleinBottle
   line1 : point ≡ point
   line2 : point ≡ point

--- a/Cubical/HITs/KleinBottle/Properties.agda
+++ b/Cubical/HITs/KleinBottle/Properties.agda
@@ -3,7 +3,7 @@
 Definition of the Klein bottle as a HIT
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.KleinBottle.Properties where
 
 open import Cubical.Core.Everything
@@ -27,7 +27,7 @@ loop1 : S¹ → KleinBottle
 loop1 base = point
 loop1 (loop i) = line1 i
 
-invS¹Loop : S¹ → Set
+invS¹Loop : S¹ → Type
 invS¹Loop base = S¹
 invS¹Loop (loop i) = invS¹Path i
 

--- a/Cubical/HITs/ListedFiniteSet.agda
+++ b/Cubical/HITs/ListedFiniteSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.ListedFiniteSet where
 
 open import Cubical.HITs.ListedFiniteSet.Base public

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.ListedFiniteSet.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/ListedFiniteSet/Properties.agda
+++ b/Cubical/HITs/ListedFiniteSet/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.ListedFiniteSet.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Localization.agda
+++ b/Cubical/HITs/Localization.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Localization where
 
 open import Cubical.HITs.Localization.Base public

--- a/Cubical/HITs/Localization/Base.agda
+++ b/Cubical/HITs/Localization/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Localization.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Localization/Properties.agda
+++ b/Cubical/HITs/Localization/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Localization.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/MappingCones.agda
+++ b/Cubical/HITs/MappingCones.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.MappingCones where
 

--- a/Cubical/HITs/MappingCones/Base.agda
+++ b/Cubical/HITs/MappingCones/Base.agda
@@ -3,7 +3,7 @@
 Mapping cones or the homotopy cofiber/cokernel
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.MappingCones.Base where
 

--- a/Cubical/HITs/MappingCones/Properties.agda
+++ b/Cubical/HITs/MappingCones/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.MappingCones.Properties where
 

--- a/Cubical/HITs/Modulo.agda
+++ b/Cubical/HITs/Modulo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Modulo where
 

--- a/Cubical/HITs/Modulo/Base.agda
+++ b/Cubical/HITs/Modulo/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Modulo.Base where
 

--- a/Cubical/HITs/Modulo/FinEquiv.agda
+++ b/Cubical/HITs/Modulo/FinEquiv.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Modulo.FinEquiv where
 

--- a/Cubical/HITs/Modulo/Properties.agda
+++ b/Cubical/HITs/Modulo/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Modulo.Properties where
 

--- a/Cubical/HITs/Nullification.agda
+++ b/Cubical/HITs/Nullification.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Nullification where
 
 open import Cubical.HITs.Nullification.Base public

--- a/Cubical/HITs/Nullification/Base.agda
+++ b/Cubical/HITs/Nullification/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Nullification.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Nullification/Properties.agda
+++ b/Cubical/HITs/Nullification/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Nullification.Properties where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/HITs/PropositionalTruncation.agda
+++ b/Cubical/HITs/PropositionalTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.PropositionalTruncation where
 
 open import Cubical.HITs.PropositionalTruncation.Base public

--- a/Cubical/HITs/PropositionalTruncation/Base.agda
+++ b/Cubical/HITs/PropositionalTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of propositional truncation
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.PropositionalTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
+++ b/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
@@ -11,7 +11,7 @@ Also see the follow-up post by Jason Gross:
   https://homotopytypetheory.org/2014/02/24/composition-is-not-what-you-think-it-is-why-nearly-invertible-isnt/
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.PropositionalTruncation.MagicTrick where
 

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Eliminator for propositional truncation
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.PropositionalTruncation.Properties where
 
 open import Cubical.Core.Everything
@@ -178,7 +178,7 @@ module SetElim (Bset : isSet B) where
 open SetElim public using (rec→Set; trunc→Set≃)
 
 elim→Set
-  : {P : ∥ A ∥ → Set ℓ}
+  : {P : ∥ A ∥ → Type ℓ}
   → (∀ t → isSet (P t))
   → (f : (x : A) → P ∣ x ∣)
   → (kf : ∀ x y → PathP (λ i → P (squash ∣ x ∣ ∣ y ∣ i)) (f x) (f y))

--- a/Cubical/HITs/Pushout.agda
+++ b/Cubical/HITs/Pushout.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Pushout where
 
 open import Cubical.HITs.Pushout.Base public

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Pushout.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -7,7 +7,7 @@
     entirely from definitional equalities involving glue/unglue.
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Pushout.Flattening where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Pushout/KrausVonRaumer.agda
+++ b/Cubical/HITs/Pushout/KrausVonRaumer.agda
@@ -6,7 +6,7 @@ https://arxiv.org/abs/1901.06022
 
 -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Pushout.KrausVonRaumer where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -10,7 +10,7 @@ This file contains:
 
 -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.HITs.Pushout.Properties where
 

--- a/Cubical/HITs/RPn.agda
+++ b/Cubical/HITs/RPn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.RPn where
 
 open import Cubical.HITs.RPn.Base public

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -6,7 +6,7 @@
            (2017) https://arxiv.org/abs/1704.05770
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.RPn.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Rational.agda
+++ b/Cubical/HITs/Rational.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Rational where
 
 open import Cubical.HITs.Rational.Base public

--- a/Cubical/HITs/Rational/Base.agda
+++ b/Cubical/HITs/Rational/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Rational.Base where
 
 open import Cubical.Relation.Nullary

--- a/Cubical/HITs/S1.agda
+++ b/Cubical/HITs/S1.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S1 where
 
 open import Cubical.HITs.S1.Base public

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -3,7 +3,7 @@
 Definition of the circle as a HIT with a proof that Ω(S¹) ≡ ℤ
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S1.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S1/Properties.agda
+++ b/Cubical/HITs/S1/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S1.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S2.agda
+++ b/Cubical/HITs/S2.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S2 where
 
 open import Cubical.HITs.S2.Base public

--- a/Cubical/HITs/S2/Base.agda
+++ b/Cubical/HITs/S2/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S2.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S3.agda
+++ b/Cubical/HITs/S3.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S3 where
 
 open import Cubical.HITs.S3.Base public

--- a/Cubical/HITs/S3/Base.agda
+++ b/Cubical/HITs/S3/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.S3.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/SetQuotients.agda
+++ b/Cubical/HITs/SetQuotients.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe  #-}
+{-# OPTIONS --cubical --no-import-sorts --safe  #-}
 module Cubical.HITs.SetQuotients where
 
 open import Cubical.HITs.SetQuotients.Base public

--- a/Cubical/HITs/SetQuotients/Base.agda
+++ b/Cubical/HITs/SetQuotients/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of set quotients
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SetQuotients.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -4,7 +4,7 @@ Set quotients:
 
 -}
 
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SetQuotients.Properties where
 
 open import Cubical.HITs.SetQuotients.Base

--- a/Cubical/HITs/SetTruncation.agda
+++ b/Cubical/HITs/SetTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SetTruncation where
 
 open import Cubical.HITs.SetTruncation.Base public

--- a/Cubical/HITs/SetTruncation/Base.agda
+++ b/Cubical/HITs/SetTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of set truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SetTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of set truncations
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SetTruncation.Properties where
 
 open import Cubical.HITs.SetTruncation.Base

--- a/Cubical/HITs/SmashProduct.agda
+++ b/Cubical/HITs/SmashProduct.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SmashProduct where
 
 open import Cubical.HITs.SmashProduct.Base public

--- a/Cubical/HITs/SmashProduct/Base.agda
+++ b/Cubical/HITs/SmashProduct/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.SmashProduct.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Sn.agda
+++ b/Cubical/HITs/Sn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Sn where
 
 open import Cubical.HITs.Sn.Base public

--- a/Cubical/HITs/Sn/Base.agda
+++ b/Cubical/HITs/Sn/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Sn.Base where
 
 open import Cubical.HITs.Susp

--- a/Cubical/HITs/Sn/Properties.agda
+++ b/Cubical/HITs/Sn/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Sn.Properties where
 
 open import Cubical.Data.Int hiding (_+_)

--- a/Cubical/HITs/Susp.agda
+++ b/Cubical/HITs/Susp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Susp where
 
 open import Cubical.HITs.Susp.Base public

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Susp.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Susp.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Torus.agda
+++ b/Cubical/HITs/Torus.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Torus where
 
 open import Cubical.HITs.Torus.Base public

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -4,7 +4,7 @@ Definition of the torus as a HIT together with a proof that it is
 equivalent to two circles
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Torus.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Truncation.agda
+++ b/Cubical/HITs/Truncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation where
 
 open import Cubical.HITs.Truncation.Base public

--- a/Cubical/HITs/Truncation/Base.agda
+++ b/Cubical/HITs/Truncation/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Truncation/FromNegOne.agda
+++ b/Cubical/HITs/Truncation/FromNegOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation.FromNegOne where
 
 open import Cubical.HITs.Truncation.FromNegOne.Base public

--- a/Cubical/HITs/Truncation/FromNegOne/Base.agda
+++ b/Cubical/HITs/Truncation/FromNegOne/Base.agda
@@ -3,7 +3,7 @@
 An simpler definition of truncation ∥ A ∥ n from n ≥ -1
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation.FromNegOne.Base where
 
 open import Cubical.Data.NatMinusOne renaming (suc₋₁ to suc)

--- a/Cubical/HITs/Truncation/FromNegOne/Properties.agda
+++ b/Cubical/HITs/Truncation/FromNegOne/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation.FromNegOne.Properties where
 
 open import Cubical.HITs.Truncation.FromNegOne.Base

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Truncation.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Wedge.agda
+++ b/Cubical/HITs/Wedge.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Wedge where
 
 open import Cubical.HITs.Wedge.Base public

--- a/Cubical/HITs/Wedge/Base.agda
+++ b/Cubical/HITs/Wedge/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.HITs.Wedge.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Homotopy.Connected where
 
 open import Cubical.Core.Everything

--- a/Cubical/Homotopy/Freudenthal.agda
+++ b/Cubical/Homotopy/Freudenthal.agda
@@ -3,7 +3,7 @@
 Freudenthal suspension theorem
 
 -}
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Homotopy.Freudenthal where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Homotopy/Loopspace.agda
+++ b/Cubical/Homotopy/Loopspace.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Homotopy.Loopspace where
 

--- a/Cubical/Homotopy/WedgeConnectivity.agda
+++ b/Cubical/Homotopy/WedgeConnectivity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Homotopy.WedgeConnectivity where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Induction/WellFounded.agda
+++ b/Cubical/Induction/WellFounded.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Induction.WellFounded where
 

--- a/Cubical/Modalities/Lex.agda
+++ b/Cubical/Modalities/Lex.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --postfix-projections #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
 
 open import Cubical.Foundations.Everything renaming (uncurry to λ⟨,⟩_)
 open import Cubical.Data.Sigma.Properties

--- a/Cubical/Modalities/Modality.agda
+++ b/Cubical/Modalities/Modality.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Modalities.Modality where
 
 {-

--- a/Cubical/README.agda
+++ b/Cubical/README.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical #-}
+{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.README where
 
 ------------------------------------------------------------------------

--- a/Cubical/Relation/Binary.agda
+++ b/Cubical/Relation/Binary.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.Binary where
 
 open import Cubical.Relation.Binary.Base public

--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.Binary.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Relation/Binary/Properties.agda
+++ b/Cubical/Relation/Binary/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.Binary.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.Nullary where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Nullary/DecidableEq.agda
+++ b/Cubical/Relation/Nullary/DecidableEq.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.Nullary.DecidableEq where
 
 open import Cubical.Core.Everything

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -1,6 +1,6 @@
 -- We apply the theory of zigzag complete relations to finite multisets and association lists.
 -- See discussion at the end of the file.
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.ZigZag.Applications.MultiSet where
 
 open import Cubical.Core.Everything

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -1,6 +1,6 @@
 -- We define ZigZag-complete relations and prove that bisimulations
 -- give rise to equivalences on the set quotients.
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Relation.ZigZag.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Structures/AbGroup.agda
+++ b/Cubical/Structures/AbGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.AbGroup where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/CommRing.agda
+++ b/Cubical/Structures/CommRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.CommRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Group.agda
+++ b/Cubical/Structures/Group.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.Group where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Monoid.agda
+++ b/Cubical/Structures/Monoid.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.Monoid where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/MultiSet.agda
+++ b/Cubical/Structures/MultiSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Structures.MultiSet where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/NAryOp.agda
+++ b/Cubical/Structures/NAryOp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.NAryOp where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.Pointed where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Poset.agda
+++ b/Cubical/Structures/Poset.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Structures.Poset where
 

--- a/Cubical/Structures/Queue.agda
+++ b/Cubical/Structures/Queue.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Structures.Queue where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Ring.agda
+++ b/Cubical/Structures/Ring.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Structures.Ring where
 

--- a/Cubical/Structures/Rng.agda
+++ b/Cubical/Structures/Rng.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Structures.Rng where
 

--- a/Cubical/Structures/Semigroup.agda
+++ b/Cubical/Structures/Semigroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.Semigroup where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/TypeEqvTo.agda
+++ b/Cubical/Structures/TypeEqvTo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.Structures.TypeEqvTo where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/WithK.agda
+++ b/Cubical/WithK.agda
@@ -9,7 +9,7 @@ incompatible flags.
 
 -}
 
-{-# OPTIONS --cubical --with-K #-}
+{-# OPTIONS --cubical --no-import-sorts --with-K #-}
 
 module Cubical.WithK where
 
@@ -21,7 +21,7 @@ open import Cubical.Data.Empty
 private
  variable
   ℓ : Level
-  A : Set ℓ
+  A : Type ℓ
   x y : A
 
 uip : (prf : x ≡p x) → prf ≡c reflp
@@ -37,10 +37,10 @@ transport-not = cong (λ a → transport a true) (ptoc-ctop notEq)
 false-true : false ≡c true
 false-true = sym transport-not ∙ transport-uip (ctop notEq)
 
-absurd : (X : Set) → X
+absurd : (X : Type) → X
 absurd X = transport (cong sel false-true) true
   where
-    sel : Bool → Set
+    sel : Bool → Type
     sel false = Bool
     sel true = X
 

--- a/Cubical/ZCohomology/Base.agda
+++ b/Cubical/ZCohomology/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.ZCohomology.Base where
 
 open import Cubical.Data.Int.Base

--- a/Cubical/ZCohomology/KcompPrelims.agda
+++ b/Cubical/ZCohomology/KcompPrelims.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.ZCohomology.KcompPrelims where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.ZCohomology.Properties where
 
 open import Cubical.ZCohomology.Base
@@ -47,8 +47,8 @@ private
 
 {- Equivalence between cohomology of A and reduced cohomology of (A + 1) -}
 coHomRed+1Equiv : (n : ℕ) →
-                 (A : Set ℓ) →
-                 (coHom n A) ≡ (coHomRed n ((A ⊎ Unit , inr (tt))))
+                  (A : Type ℓ) →
+                  (coHom n A) ≡ (coHomRed n ((A ⊎ Unit , inr (tt))))
 coHomRed+1Equiv zero A i = ∥ helpLemma {C = (Int , pos 0)} i ∥₀
   module coHomRed+1 where
   helpLemma : {C : Pointed ℓ} → ( (A → (typ C)) ≡  ((((A ⊎ Unit) , inr (tt)) →∙ C)))

--- a/Cubical/ZCohomology/S1/S1.agda
+++ b/Cubical/ZCohomology/S1/S1.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
 module Cubical.ZCohomology.S1.S1 where
 
 open import Cubical.ZCohomology.Base

--- a/Everythings.hs
+++ b/Everythings.hs
@@ -85,7 +85,7 @@ genEverythings =
   mapM_ (\dir -> do
     let fp = addToFP ["Cubical"] dir
     files <- getMissingFiles fp Nothing
-    let ls = ["{-# OPTIONS --cubical --safe #-}",
+    let ls = ["{-# OPTIONS --cubical --no-import-sorts --safe #-}",
               "module " ++ showFP '.' (addToFP fp "Everything") ++ " where",[]]
              ++ sort (fmap (\file -> "import " ++ showFP '.' file)
                            (delete (addToFP fp "Everything") files))


### PR DESCRIPTION
This fixes https://github.com/agda/cubical/issues/327 by 

- Renaming Set to Type when importing Set in Cubical.Core.Primitives
- Adding the flag `--no-import-sorts` to all files, including the autogenerated Everything files
- Fix the uses of Set in the library