### PR TITLE
Records only

### DIFF
--- a/Cubical/Data/Sigma/Record/Base.agda
+++ b/Cubical/Data/Sigma/Record/Base.agda
@@ -1,0 +1,436 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+module Cubical.Data.Sigma.Record.Base where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Nat
+
+open import Cubical.Foundations.Equiv.Fiberwise
+
+open import Cubical.Data.List renaming (_++_ to _++L_)
+open import Cubical.Data.Vec
+open import Cubical.Data.Bool
+open import Cubical.Data.Sigma
+
+open import Cubical.Foundations.Everything
+
+open import Cubical.Foundations.CartesianKanOps
+
+open import Cubical.HITs.Interval.Base renaming (elim to I-elim ; rec to I-rec)
+open import Cubical.HITs.Interval.NCube
+
+
+
+
+Sig : ∀ ℓ → ℕ →  Type (ℓ-suc ℓ)
+Sig ℓ zero = Lift Unit
+Sig ℓ (suc zero) = Type ℓ
+Sig ℓ (suc (suc n)) = Σ (Type ℓ) λ x → x → Sig ℓ (suc n)
+
+Rec : ∀ {ℓ} → ∀ n → Sig ℓ n → Type ℓ
+Rec zero _ = Lift Unit
+Rec (suc zero) Ty = Ty
+Rec (suc (suc n)) (Ty , →Sig) = Σ Ty (Rec (suc n)∘ →Sig)
+
+
+prependTy : ∀ {ℓ} → ∀ {n} → {A : Type ℓ} → (A → Sig ℓ n) → Sig ℓ (suc n)
+prependTy {n = zero} {A} _ = A
+prependTy {n = suc n} = _ ,_ 
+
+prependVal : ∀ {ℓ} → ∀ {n} → {A : Type ℓ}
+                → (s : A → Sig ℓ n)
+                → (x : A)
+                → Rec n (s x)
+                → Rec (suc n) (prependTy {n = n} s)
+prependVal {n = zero} s x _ = x
+prependVal {n = suc n} s = _,_
+
+
+Sig-section-from : ∀ {ℓ} → ∀ {n m}
+           → (sₙ : Sig ℓ n)
+           → (sₘ : Rec n sₙ →  Sig ℓ m)
+           → Sig ℓ (n + m)
+Sig-section-from {n = zero} sₙ sₘ = sₘ _
+Sig-section-from {n = suc zero} {m} sₙ sₘ = prependTy {n = m} {A = sₙ} sₘ
+Sig-section-from {n = suc (suc n)} {m} sₙ sₘ =
+   prependTy {n = (suc n) + m}
+     λ x → Sig-section-from {n = suc n} {m} (snd sₙ x) (sₘ ∘ (x ,_)) 
+
+Sig-section-to : ∀ {ℓ} → ∀ {n m}
+           → Sig ℓ (n + m)
+           → Σ[ sₙ ∈  Sig ℓ n ] (Rec n sₙ → Sig ℓ m)
+Sig-section-to {n = zero} x = _ , const x
+Sig-section-to {n = suc zero} {zero} = _, _
+Sig-section-to {n = suc zero} {suc m} = idfun _
+Sig-section-to {n = suc (suc n)} x =
+  let z = λ (y : fst x) → Sig-section-to {n = suc n} (snd x y)
+  in (fst x , fst ∘ z) ,  uncurry (snd ∘ z)
+
+Sig-section-to-from : ∀ {ℓ} → ∀ {n m}
+    → section (Sig-section-to {ℓ} {n} {m}) (uncurry (Sig-section-from {ℓ} {n} {m}))
+Sig-section-to-from {n = zero} b = refl
+Sig-section-to-from {n = suc zero} {zero} b = refl
+Sig-section-to-from {n = suc zero} {suc m} b = refl
+Sig-section-to-from {n = suc (suc n)} {m} b i =
+  let z = λ (y : fst (fst b)) →
+            Sig-section-to-from {n = (suc n)} {m = m} (snd (fst b) y , snd b ∘ (y ,_)) i
+  in ((fst (fst b)) ,  fst ∘ z) , uncurry (snd ∘ z)
+
+Sig-section-from-to : ∀ {ℓ} → ∀ {n m}
+    → retract (Sig-section-to {ℓ} {n} {m}) (uncurry (Sig-section-from {ℓ} {n} {m}))
+Sig-section-from-to {n = zero} a = refl
+Sig-section-from-to {n = suc zero} {zero} a = refl
+Sig-section-from-to {n = suc zero} {suc m} a = refl
+Sig-section-from-to {n = suc (suc n)} {m} a i =
+  prependTy {n = (suc n) + m} λ (y : fst a) → Sig-section-from-to {n = suc n} {m} (snd a y) i
+
+Sig-section-Iso : ∀ {ℓ} → ∀ {n m}
+                   → Iso (Sig ℓ (n + m))
+                         (Σ[ sₙ ∈  Sig ℓ n ] (Rec n sₙ → Sig ℓ m))
+Sig-section-Iso {ℓ} {n} {m} =
+  iso (Sig-section-to {n = n} {m}) (uncurry (Sig-section-from {n = n} {m}))
+      (Sig-section-to-from {ℓ} {n} {m}) (Sig-section-from-to {ℓ} {n} {m})
+
+
+Rec-section-to :  ∀ {ℓ} → ∀ {n m} 
+                       → (s : Sig ℓ (n + m))
+                       → Rec (n + m) s
+                       → Σ (Rec n (fst (Sig-section-to {n = n} s)))
+                           (Rec m ∘ (snd (Sig-section-to {n = n} {m = m} s))) 
+Rec-section-to {n = zero} s x = _ , x
+Rec-section-to {n = suc zero} {zero} s = _, _
+Rec-section-to {n = suc zero} {suc m} s x = x
+Rec-section-to {n = suc (suc n)} {m} s x =
+   _ , snd (Rec-section-to {n = suc n} ((snd s) (fst x)) (snd x))
+
+Rec-section-from :  ∀ {ℓ} → ∀ {n m} 
+                       → (sₙ : Sig ℓ n)
+                       → (sₘ : Rec n sₙ →  Sig ℓ m)
+                       → Σ (Rec n sₙ)
+                           (Rec m ∘ sₘ)
+                       → Rec (n + m) (Sig-section-from {n = n} {m = m}  sₙ sₘ)
+Rec-section-from {n = zero} sₙ sₘ = snd
+Rec-section-from {n = suc zero} {m} sₙ sₘ = prependVal {n = m} {A = sₙ} sₘ _ ∘ snd
+Rec-section-from {n = suc (suc n)} {m} sₙ sₘ x =
+     prependVal {n = suc n + m} (_) _
+      (Rec-section-from {n = suc n} _ _ (_ , snd x))
+
+-- Rec-section-iso : ∀ {ℓ} → ∀ {n m} 
+--                        → (s : Sig ℓ (n + m))
+--                        → Iso (Rec {n = n + m} s)
+--                          (Σ (Rec {n = n} (fst (Sig-section-to {n = n} s)))
+--                            (Rec {n = m} ∘ (snd (Sig-section-to {n = n} {m = m} s)))) 
+-- Rec-section-iso s = {!!}
+
+
+
+-- this split could be done with sections, but would introduce transp during conversion 
+-- betwen Sig (1 + n) and Sig (n + 1) 
+
+Sig-n+1-split : ∀ {ℓ} → ∀ n → Sig ℓ (suc n) → Σ (Sig ℓ n) (λ sₙ → Rec n sₙ → Sig ℓ 1)
+Sig-n+1-split zero s =  _ , const s
+Sig-n+1-split 1 s = s
+Sig-n+1-split (suc (suc n)) s =
+  let z : (fst s) → _
+      z x = Sig-n+1-split (suc n) (snd s x)
+
+  in (fst s , fst ∘ z ) , uncurry (snd ∘ z)
+
+Sig-n+1-unsplit : ∀ {ℓ} → ∀ n → Σ (Sig ℓ n) (λ sₙ → Rec n sₙ → Sig ℓ 1) → Sig ℓ (suc n) 
+Sig-n+1-unsplit zero x = snd x _
+Sig-n+1-unsplit (suc zero) x = x
+Sig-n+1-unsplit (suc (suc n)) (s , r→Ty) =
+  (fst s) , λ x → Sig-n+1-unsplit (suc n) ((snd s) x , r→Ty ∘ (x ,_))
+
+Sig-n+1-iso : ∀ {ℓ} → ∀ n → Iso (Σ (Sig ℓ n) (λ sₙ → Rec n sₙ → Sig ℓ 1)) (Sig ℓ (suc n)) 
+Iso.fun (Sig-n+1-iso n) = Sig-n+1-unsplit n
+Iso.inv (Sig-n+1-iso n) = Sig-n+1-split n
+Iso.rightInv (Sig-n+1-iso zero) b = refl
+Iso.rightInv (Sig-n+1-iso (suc zero)) b = refl
+Iso.rightInv (Sig-n+1-iso (suc (suc n))) (s , z) =
+  cong ( s ,_ ) (funExt λ x → Iso.rightInv (Sig-n+1-iso (suc n)) (z x))
+
+Iso.leftInv (Sig-n+1-iso zero) a = refl
+Iso.leftInv (Sig-n+1-iso (suc zero)) a = refl
+Iso.leftInv (Sig-n+1-iso (suc (suc n))) ((Ty , s) , r→Ty) i =
+  let z : Ty → _
+      z x = (Iso.leftInv (Sig-n+1-iso (suc n))) (s x , (r→Ty ∘ (x ,_))) i
+
+  in (Ty , fst ∘ z) , uncurry (snd ∘ z)
+
+Rec-n+1-split-iso : ∀ {ℓ} → ∀ n → (s : Sig ℓ (suc n)) →
+                        Iso (Rec (suc n) s) (Σ _ (snd (Sig-n+1-split n s)))
+Rec-n+1-split-iso zero s = iso (_ ,_) snd (λ b → refl) λ a → refl
+Rec-n+1-split-iso 1 s = idIso
+Rec-n+1-split-iso {ℓ} (suc (suc n)) s =
+ let prev = Rec-n+1-split-iso {ℓ} (suc n) in 
+ iso (λ r → let (fs , se) = Iso.fun (prev ((snd s) (fst r))) (snd r)
+            in (fst r , fs) , se )
+     (λ r → fst (fst r) , Iso.inv (prev ((snd s) (fst (fst r)))) (snd (fst r) , snd r))
+     (λ r i → let (fs , se) = Iso.rightInv (prev ((snd s) (fst (fst r)))) (snd (fst r) , snd r) i
+              in (fst (fst r) , fs) , se)
+     λ r i →   let (fs , se) =
+                     Iso.leftInv (prev ((snd s) (fst r))) (snd r) i
+               in (fst r) , fs , se
+
+Rec-n+1-unsplit-iso : ∀ {ℓ} → ∀ n →
+                         (s-r  : Σ (Sig ℓ n) λ z → Rec n z → Sig ℓ 1) →
+                          Iso (Rec (suc n) (Sig-n+1-unsplit {ℓ} n s-r)) (Σ _ (snd s-r))
+Rec-n+1-unsplit-iso zero s = iso (_ ,_) snd (λ b → refl) λ a → refl
+Rec-n+1-unsplit-iso 1 s = idIso
+Iso.fun (Rec-n+1-unsplit-iso (suc (suc n)) s-r) r =
+  let (fs , se) = Iso.fun (Rec-n+1-unsplit-iso (suc n)
+            ((snd (fst s-r) (fst r)) , (snd s-r) ∘ ( fst r ,_))) (snd r )
+
+  in ((fst r) , fs) , se
+Iso.inv (Rec-n+1-unsplit-iso (suc (suc n)) s) ((_ , _) , b) =
+  _ , Iso.inv (Rec-n+1-unsplit-iso (suc n) (_ , snd s ∘ (_ ,_))) (_ , b)
+Iso.rightInv (Rec-n+1-unsplit-iso (suc (suc n)) s) ((a , r) , b) i =
+  let z = Iso.rightInv (Rec-n+1-unsplit-iso (suc n) (snd (fst s) a , snd s ∘ (a ,_)))
+               (r , b) i
+  in (a , fst z) , snd z
+Iso.leftInv (Rec-n+1-unsplit-iso (suc (suc n)) s) (_ , r) =
+  cong (_ ,_) (Iso.leftInv (Rec-n+1-unsplit-iso (suc n) _ ) r)
+ 
+
+-- generating function and types
+
+iso-Π-Π' : ∀ {ℓ ℓ'} {A : Type ℓ}
+               → (B : A → Type ℓ')
+               → Iso (Π B) (Π' B)
+iso-Π-Π' B = iso (λ x {y} → x y) (λ x y → x {y}) (λ b → refl) (λ b → refl)
+
+
+λ' : ∀ {ℓ ℓ'} (A : Type ℓ)
+               → (B : A → Type ℓ')
+               → Π B → ∀ i → isoToPath (iso-Π-Π' B) i
+λ' A B x i = coe0→i (λ i → isoToPath (iso-Π-Π' B) i) i x
+
+app' : ∀ {ℓ ℓ'} (A : Type ℓ)
+               → (B : A → Type ℓ')
+               → ∀ i → isoToPath (iso-Π-Π' B) i → Π B
+app' A B i x = coei→0 (λ i → isoToPath (iso-Π-Π' B) i) i x
+
+
+-- generates a type of maximaly uncurried functions from record of given sginature
+
+fromSigType : ∀ {ℓ} → ∀ n → NCube n → Sig ℓ n → Type ℓ → Type ℓ 
+fromSigType zero _ _ Target = Target
+fromSigType (suc zero) v s Target =
+    I-rec (isoToPath (iso-Π-Π' {A = s} λ x₂ → Target)) (head v) 
+fromSigType (suc (suc n)) v s Target =
+   I-rec (isoToPath
+    (iso-Π-Π' {A = fst s} λ x → fromSigType (suc n) (tail v) (snd s x) Target))
+      (head v)
+
+-- version for higher level
+fromSigType-Ty : ∀ {ℓ} → ∀ n → NCube n → Sig ℓ n → Type (ℓ-suc ℓ) → Type (ℓ-suc ℓ) 
+fromSigType-Ty zero _ _ Target = Target
+fromSigType-Ty (suc zero) v s Target =
+    I-rec (isoToPath (iso-Π-Π' {A = s} λ x₂ → Target)) (head v) 
+fromSigType-Ty (suc (suc n)) v s Target =
+   I-rec (isoToPath
+    (iso-Π-Π' {A = fst s} λ x → fromSigType-Ty (suc n) (tail v) (snd s x) Target))
+      (head v)
+
+
+
+
+mkFun : ∀ {ℓ} → ∀ n → (v : Vec Interval n) → (s : Sig ℓ n) → (Target : Type ℓ)
+           → (Rec n s → Target)
+           → fromSigType n v s Target
+mkFun zero v s Target x = x _
+mkFun (suc zero) (i' ∷ _) s Target x =
+  I-elim (I-rec (isoToPath (iso-Π-Π' λ _ → Target))) (λ i → λ' s (λ z → Target) x i ) i'
+mkFun (suc (suc n)) v s Target x =
+  I-elim (I-rec (isoToPath (iso-Π-Π' _))) (λ i → λ' _ _
+    (λ x₁ → mkFun (suc n) (tail v) (snd s x₁) Target λ x₂ → x (x₁ , x₂))
+    i ) (head v)
+
+mkFun-Ty : ∀ {ℓ} → ∀ n → (v : Vec Interval n) → (s : Sig ℓ n) → (Target : Type (ℓ-suc ℓ))
+           → (Rec n s → Target)
+           → fromSigType-Ty n v s Target
+mkFun-Ty zero v s Target x = x _
+mkFun-Ty (suc zero) v s Target x =
+  I-elim (I-rec (isoToPath (iso-Π-Π' {A = s} λ _ → Target))) (λ i → λ' s (λ z → Target) x i )
+     (head v)
+mkFun-Ty (suc (suc n)) v s Target x =
+  I-elim (I-rec (isoToPath (iso-Π-Π' _))) (λ i → λ' _ _
+    (λ x₁ → mkFun-Ty (suc n) (tail v) (snd s x₁) Target λ x₂ → x (x₁ , x₂))
+    i ) (head v)
+
+from-mkFun-Ty : ∀ {ℓ} → ∀ n → (s : Sig ℓ n) → (Target : Type (ℓ-suc ℓ))          
+           → fromSigType-Ty n (corner0) s Target
+           → (Rec n s → Target)
+from-mkFun-Ty zero s Target x _ = x
+from-mkFun-Ty {ℓ} (suc zero) s Target x = x
+from-mkFun-Ty (suc (suc zero)) s Target = uncurry
+from-mkFun-Ty (suc (suc (suc n))) s Target x =
+  uncurry λ x₁ →  from-mkFun-Ty (suc (suc n)) (snd s x₁) Target (x x₁)
+
+constructorType : ∀ {ℓ} → ∀ n → Vec Interval n → Sig ℓ n → Type ℓ 
+constructorType n v s = fromSigType n v s (Rec n s)
+
+mkConstructor : ∀ {ℓ} → ∀ n → (v : Vec Interval n) → (s : Sig ℓ n)
+                  → constructorType n v s
+mkConstructor n v s = mkFun n v s (Rec n s) (idfun _) 
+
+-- dependnt functions
+
+fromSigType-dep : ∀ {ℓ} → ∀ n → (s : Sig ℓ n) → (Rec n s → Type ℓ) → Type ℓ 
+fromSigType-dep zero s x = x _
+fromSigType-dep (suc zero) s x = Π x
+fromSigType-dep (suc (suc n)) s x =
+  Π λ x₁ → fromSigType-dep (suc n) (snd s x₁) (x ∘ (x₁ ,_))
+
+mk-fromSigType-dep : ∀ {ℓ} → ∀ n → (s : Sig ℓ n)
+                     → (A : Rec n s → Type ℓ)
+                     → Π A → fromSigType-dep n s A
+mk-fromSigType-dep zero s A x = x _
+mk-fromSigType-dep (suc zero) s A = idfun _
+mk-fromSigType-dep (suc (suc n)) s A f x =
+  mk-fromSigType-dep (suc n) (snd s x) (A ∘ (x ,_)) (f ∘ (x ,_))
+
+
+fromSigType-dep-Lower : ∀ {ℓ} → ∀ n → (s : Sig (ℓ-suc ℓ) n) → (Rec n s → Type ℓ) → Type (ℓ-suc ℓ) 
+fromSigType-dep-Lower zero s x = Lift (x _)
+fromSigType-dep-Lower (suc zero) s x = Π x
+fromSigType-dep-Lower (suc (suc n)) s x =
+  Π λ x₁ → fromSigType-dep-Lower (suc n) (snd s x₁) (x ∘ (x₁ ,_))
+
+mk-fromSigType-dep-Lower : ∀ {ℓ} → ∀ n → (s : Sig (ℓ-suc ℓ) n)
+                     → (A : Rec n s → Type ℓ)
+                     → Π A → fromSigType-dep-Lower n s A
+mk-fromSigType-dep-Lower zero s A x = lift (x _)
+mk-fromSigType-dep-Lower (suc zero) s A = idfun _
+mk-fromSigType-dep-Lower (suc (suc n)) s A f x =
+  mk-fromSigType-dep-Lower (suc n) (snd s x) (A ∘ (x ,_)) (f ∘ (x ,_)) 
+
+-- records of shape described by List of Bools
+
+Recc : ∀ {ℓ} → ∀ n → (v : List Bool) → (s : Sig ℓ (suc (suc (suc n)))) → Type ℓ
+
+Recc-≃ : ∀ {ℓ} → ∀ n → (v : List Bool) → (s : Sig ℓ (suc (suc (suc n)))) →
+                        Recc n v s ≃ Rec (3 + n) s  
+
+
+Recc n [] =  Rec (3 + n)
+Recc zero (false ∷ v) s = Rec 3 s
+Recc (suc n) (false ∷ v) s = Σ (fst s) ( Recc n v ∘ snd s)
+Recc zero (true ∷ v) s = Σ (Σ (fst s) (fst ∘ snd s)) λ x → snd (snd s (fst x)) (snd x)
+Recc (suc n) (true ∷ v) s =
+  let (s- , r→s) = Sig-n+1-split (3 + n) s
+  in  Σ (Recc n v s-) (r→s ∘ fst (Recc-≃ n v s-))
+
+replic : ∀ {ℓ} → {A : Type ℓ} → ℕ → A → List A
+replic zero _ = []
+replic (suc x) a = a ∷ replic x a
+
+mapConst : ∀ {ℓ} → {A : Type ℓ} → List A → A → List A
+mapConst [] _ = []
+mapConst (x ∷ x₁) a = a ∷ mapConst x₁ a
+
+
+ReccF-≃ : ∀ {ℓ} → ∀ n → (v : List Bool) → (s : Sig ℓ (suc (suc (suc n)))) →
+                        Recc n (mapConst v false) s ≃ Rec (3 + n) s  
+ReccF-≃ n [] s = idEquiv _
+ReccF-≃ zero (x ∷ v) s = idEquiv _
+ReccF-≃ (suc n) (x ∷ v) s =
+ Σ-cong-equiv-snd λ a → ReccF-≃ n v (snd s a)
+
+Recc-v-≃ : ∀ {ℓ} → ∀ n → (v : List Bool) → (s : Sig ℓ (suc (suc (suc n)))) →
+                        Recc n v s ≃
+                          Recc n (mapConst v false) s
+Recc-v-≃ n [] s = idEquiv _
+Recc-v-≃ zero (false ∷ v) s = idEquiv _
+Recc-v-≃ (suc n) (false ∷ v) s =
+  Σ-cong-equiv-snd λ a → Recc-v-≃ n v (snd s a)
+Recc-v-≃ zero (true ∷ v) s = Σ-assoc-≃
+Recc-v-≃ {ℓ} (suc n) (true ∷ v) s =
+  let (s- , r→s) = Sig-n+1-split (3 + n) s
+  in  
+  compEquiv (Σ-cong-equiv-fst {ℓ} {B = r→s} (Recc-≃ n v s-))
+  (compEquiv (invEquiv (isoToEquiv (Rec-n+1-split-iso (3 + n) s)))
+   (invEquiv (ReccF-≃ (suc n) (true ∷ v) s )))
+
+Recc-≃ n v s = compEquiv (Recc-v-≃ n v s) (ReccF-≃ n v s)
+
+-- records of "rigth-most" shape
+
+Recᵣ : ∀ {ℓ} → ∀ n → (Sig ℓ n) → Type ℓ
+Recᵣ zero = const (Lift Unit)
+Recᵣ (suc zero) = idfun _
+Recᵣ (suc (suc zero)) = (uncurry Σ)
+Recᵣ (suc (suc (suc n))) = Recc n (replic (suc n) true)
+
+-- this is analogue to Σ-assoc, but is acting on all levels at once
+
+Recᵣ≃ : ∀ {ℓ} → ∀ n → (s : Sig ℓ n) → Recᵣ n s ≃ Rec n s 
+Recᵣ≃ zero s = idEquiv _
+Recᵣ≃ (suc zero) s = idEquiv _
+Recᵣ≃ (suc (suc zero)) s = idEquiv _
+Recᵣ≃ (suc (suc (suc n))) s = Recc-≃ n (replic (suc n) true) s
+
+
+SigR : ∀ ℓ → ℕ → Type (ℓ-suc ℓ)
+
+SigR≃S : ∀ {ℓ} → ∀ n → (SigR ℓ n) ≃ (Sig ℓ n)
+
+SigR ℓ 0 = Sig ℓ 0
+SigR ℓ 1 = Sig ℓ 1
+SigR ℓ 2 = Sig ℓ 2
+SigR ℓ (suc (suc (suc n))) =
+  Σ (SigR ℓ (suc (suc n))) (λ x →
+    (Recᵣ (suc (suc n)) ∘ equivFun (SigR≃S (suc (suc n)))) x → Type _ )
+
+
+SigR≃S 0 = idEquiv _
+SigR≃S 1 = idEquiv _
+SigR≃S 2 = idEquiv _
+
+SigR≃S {ℓ} (suc (suc (suc n))) =
+   compEquiv ((Σ-cong-equiv-fst {A = SigR ℓ (suc (suc n))}
+        {B = λ a → (Recᵣ (suc (suc n))) a → Type ℓ} ((SigR≃S (suc (suc n))))))
+   (compEquiv ( (Σ-cong-equiv-snd λ a → cong≃ (λ x → x → Type ℓ)  (Recᵣ≃ ( 2 + n) _)))
+                (isoToEquiv (Sig-n+1-iso (suc (suc n)))))
+
+
+-- we can construct "signature of signatures"
+-- encoding signatures into records of higher level
+
+SSig : ∀ ℓ → ∀ n → (Sig (ℓ-suc ℓ) n)
+
+SSig→ : ∀ {ℓ} → ∀ n → Rec n (SSig ℓ n) → Sig ℓ n
+
+SSig ℓ zero = _
+SSig ℓ (suc zero) = Type _
+SSig ℓ (suc (suc n)) =
+ Sig-n+1-unsplit (suc n) ((SSig ℓ (suc n)) ,
+  (λ x → fromSigType-Ty (suc n) corner0 x (Type ℓ) ) ∘ SSig→ (suc n))
+
+
+SSig→ zero x = x
+SSig→ (suc zero) x = x
+SSig→ (suc (suc zero)) x = x
+SSig→ (suc (suc (suc n))) x =
+  let (_ , y) = Iso.fun (Rec-n+1-unsplit-iso (suc (suc  n)) (SSig _ _ ,
+         (λ x₁ → fromSigType-Ty (suc (suc  n)) corner0 x₁ _ ) ∘ SSig→ _)) x  
+  in Sig-n+1-unsplit _
+            ((SSig→ _ _) ,
+                from-mkFun-Ty (suc (suc  n)) _ (Type _) y)
+
+-- SSig← : ∀ {ℓ} → ∀ n → Sig ℓ n → Rec n (SSig ℓ n)
+-- SSig← zero x = x
+-- SSig← (suc zero) x = x
+-- SSig← (suc (suc zero)) x = x
+-- SSig← (suc (suc (suc n))) x =
+--   let z = {!!}
+
+--   in {!!}
+
+mk-Σ-assoc-n : ∀ {ℓ} → ∀ n → _
+mk-Σ-assoc-n {ℓ} n =
+  mk-fromSigType-dep-Lower n (SSig ℓ n)
+   ((λ x →  Recᵣ n x ≃ Rec n x) ∘ SSig→ n)
+     (Recᵣ≃ n ∘ SSig→ n)
+

--- a/Cubical/Data/Sigma/Record/Examples.agda
+++ b/Cubical/Data/Sigma/Record/Examples.agda
@@ -1,0 +1,96 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.Data.Sigma.Record.Examples where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Fin
+
+open import Cubical.Data.List
+open import Cubical.Data.Vec
+open import Cubical.Data.Bool
+open import Cubical.Data.Sigma
+
+open import Cubical.Foundations.Everything
+
+open import Cubical.Foundations.CartesianKanOps
+
+open import Cubical.HITs.Interval.Base renaming (elim to I-elim ; rec to I-rec)
+open import Cubical.HITs.Interval.NCube
+
+open import Cubical.Data.Sigma.Record.Base
+
+
+
+someSig : Sig ℓ-zero 9
+someSig = ℕ , λ n₁
+          → ℕ , λ n₂
+          → ((Vec (Fin n₂) n₁) → ℕ) , λ P
+          → Vec (Fin n₂) n₁ , λ x
+          → Fin n₁ , λ k
+          → (P x ≡ toℕ k) , λ eq1
+          → ℕ , (λ n₃ → ℕ , (λ n₄ → n₁ + n₂ ≡ n₃ + n₄))
+
+
+
+someSigConstructor : _
+someSigConstructor = mkConstructor 9 corner0 someSig
+
+someSigConstructor-3-implicit-args : _
+someSigConstructor-3-implicit-args = mkConstructor 9 (one ∷ one ∷ zero ∷ one ∷ corner0) someSig
+   
+rec-from-constructor : Rec 9 someSig
+rec-from-constructor = someSigConstructor 1 2 (const 0) (fzero {1} ∷ []) (fzero {zero})
+                                 refl 1 2 refl
+
+rec-from-constructor-3-implicit-args : Rec 9 someSig
+rec-from-constructor-3-implicit-args = someSigConstructor-3-implicit-args
+                         {1} {2} (const 0) {fzero {1} ∷ []} (fzero {zero})
+                                   refl 1 2 refl 
+
+l-test : Rec 9 someSig
+l-test = 1 , 2 , const 0 , fzero {1} ∷ []  , fzero {zero} , refl , 1 , 2 , refl
+
+lr-test' : Recᵣ 9 someSig
+lr-test' = (((((((1 , 2) , (const 0)) , fzero {1} ∷ []) , fzero {zero})
+           , refl) , 1) , 2) , refl
+
+
+Σ-assoc-7 : (x : Type)
+              (x₁ : (x₂ : x) → Type)
+              (x₂ : (x₃ : x) (x₄ : x₁ x₃) → Type)
+              (x₃ : (x₄ : x) (x₅ : x₁ x₄) (x₆ : x₂ x₄ x₅) → Type)
+              (x₄ : (x₅ : x) (x₆ : x₁ x₅) (x₇ : x₂ x₅ x₆) (x₈ : x₃ x₅ x₆ x₇) → Type)
+              (x₅ : (x₆ : x) (x₇ : x₁ x₆) (x₈ : x₂ x₆ x₇)
+                         (x₉ : x₃ x₆ x₇ x₈) (x₁₀ : x₄ x₆ x₇ x₈ x₉) → Type)
+              (x₆ : (x₇ : x) (x₈ : x₁ x₇) (x₉ : x₂ x₇ x₈) (x₁₀ : x₃ x₇ x₈ x₉)
+                         (x₁₁ : x₄ x₇ x₈ x₉ x₁₀) (x₁₂ : x₅ x₇ x₈ x₉ x₁₀ x₁₁) → Type)
+           →
+          Σ
+           (Σ
+            (Σ
+             (Σ
+              (Σ
+               (Σ x
+                (λ x₇ → x₁ x₇))
+                (λ x₇ → x₂ (fst x₇) (snd x₇)))
+                (λ x₇ → x₃ (fst (fst x₇)) (snd (fst x₇)) (snd x₇)))
+                (λ x₇ → x₄ (fst (fst (x₇ .fst))) (snd (fst (x₇ .fst))) (snd (x₇ .fst)) (x₇ .snd)))
+                (λ x₇ → x₅ (fst (fst (x₇ .fst .fst))) (snd (fst (x₇ .fst .fst)))
+                          (snd (x₇ .fst .fst)) (x₇ .fst .snd) (x₇ .snd)))
+                (λ x₇ → x₆ (fst (fst (x₇ .fst .fst .fst))) (snd (fst (x₇ .fst .fst .fst)))
+                             (snd (x₇ .fst .fst .fst)) (x₇ .fst .fst .snd) (x₇ .fst .snd)
+                (x₇ .snd))
+       ≃
+          Σ x
+            (λ x₇ →
+               Σ (x₁ x₇)
+               (λ x₈ →
+                  Σ (x₂ x₇ x₈)
+                  (λ x₉ →
+                     Σ (x₃ x₇ x₈ x₉)
+                     (λ x₁₀ →
+                        Σ (x₄ x₇ x₈ x₉ x₁₀)
+                        (λ x₁₁ →
+                           Σ (x₅ x₇ x₈ x₉ x₁₀ x₁₁) (λ x₁₂ → x₆ x₇ x₈ x₉ x₁₀ x₁₁ x₁₂))))))
+Σ-assoc-7 = mk-Σ-assoc-n {ℓ-zero} 7

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -14,6 +14,15 @@ private
     C : (a : A) → B a → Type ℓ
     D : (a : A) (b : B a) → C a b → Type ℓ
 
+
+
+Π : {A : Type ℓ} → (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
+Π B = ∀ x → B x
+
+Π' : {A : Type ℓ} → (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
+Π' B = ∀ {x} → B x
+
+
 -- The identity function
 idfun : (A : Type ℓ) → A → A
 idfun _ x = x
@@ -22,7 +31,6 @@ infixr 9 _∘_
 
 _∘_ : (g : {a : A} → (b : B a) → C a b) → (f : (a : A) → B a) → (a : A) → C a (f a)
 g ∘ f = λ x → g (f x)
-{-# INLINE _∘_ #-}
 
 ∘-assoc : (h : {a : A} {b : B a} → (c : C a b) → D a b c)
           (g : {a : A} → (b : B a) → C a b)
@@ -39,18 +47,23 @@ g ∘ f = λ x → g (f x)
 
 const : {B : Type ℓ} → A → B → A
 const x = λ _ → x
-{-# INLINE const #-}
+
 
 case_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} → (x : A) → (∀ x → B x) → B x
 case x of f = f x
-{-# INLINE case_of_ #-}
 
 case_return_of_ : ∀ {ℓ ℓ'} {A : Type ℓ} (x : A) (B : A → Type ℓ') → (∀ x → B x) → B x
 case x return P of f = f x
-{-# INLINE case_return_of_ #-}
 
 uncurry : ((x : A) → (y : B x) → C x y) → (p : Σ A B) → C (fst p) (snd p)
 uncurry f (x , y) = f x y
+
+curry
+  : ∀{ℓ ℓ′ ℓ″} {A : Type ℓ} {B : A → Type ℓ′} {C : (a : A) → B a → Type ℓ″}
+  → ((p : Σ A B) → C (fst p) (snd p))
+  → ((x : A) → (y : B x) → C x y)
+curry f x y = f (x , y)
+
 
 module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
   -- Notions of 'coherently constant' functions for low dimensions.

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -42,11 +42,9 @@ private
 
 refl : x ≡ x
 refl {x = x} = λ _ → x
-{-# INLINE refl #-}
 
 sym : x ≡ y → y ≡ x
 sym p i = p (~ i)
-{-# INLINE sym #-}
 
 symP : {A : I → Type ℓ} → {x : A i0} → {y : A i1} →
        (p : PathP A x y) → PathP (λ i → A (~ i)) y x
@@ -55,7 +53,6 @@ symP p j = p (~ j)
 cong : ∀ (f : (a : A) → B a) (p : x ≡ y) →
        PathP (λ i → B (p i)) (f x) (f y)
 cong f p i = f (p i)
-{-# INLINE cong #-}
 
 cong₂ : ∀ {C : (a : A) → (b : B a) → Type ℓ} →
         (f : (a : A) → (b : B a) → C a b) →
@@ -63,7 +60,6 @@ cong₂ : ∀ {C : (a : A) → (b : B a) → Type ℓ} →
         {u : B x} {v : B y} (q : PathP (λ i → B (p i)) u v) →
         PathP (λ i → C (p i) (q i)) (f x u) (f y v)
 cong₂ f p q i = f (p i) (q i)
-{-# INLINE cong₂ #-}
 
 {- The most natural notion of homogenous path composition
     in a cubical setting is double composition:
@@ -212,6 +208,7 @@ funExt p i x = p x i
 -- between functions to homotopies; `funExt⁻` is called `happly` and
 -- defined by path induction in the HoTT book (see function 2.9.2 in
 -- section 2.9)
+
 funExt⁻ : {B : A → I → Type ℓ'}
   {f : (x : A) → B x i0} {g : (x : A) → B x i1}
   → PathP (λ i → (x : A) → B x i) f g

--- a/Cubical/HITs/Interval/Base.agda
+++ b/Cubical/HITs/Interval/Base.agda
@@ -3,6 +3,8 @@ module Cubical.HITs.Interval.Base where
 
 open import Cubical.Core.Everything
 
+open import Cubical.Data.Bool
+
 open import Cubical.Foundations.Prelude
 
 data Interval : Type₀ where
@@ -26,14 +28,68 @@ funExtInterval A B f g p = λ i x → hmtpy x (seg i)
   hmtpy x one     = g x
   hmtpy x (seg i) = p x i
 
-elim : (A : Interval → Type₀) (x : A zero) (y : A one)
+rec : ∀ {ℓ} → {A : Type ℓ} {a0 a1 : A}
+               (p : a0 ≡ a1) → (x : Interval) → A
+rec p zero = p i0
+rec p one = p i1
+rec p (seg i) = p i
+
+intervalEta-rec : ∀ {ℓ} → {A : Type ℓ} 
+                    → (f : Interval → A)
+                    → rec (cong f seg) ≡ f
+intervalEta-rec f i zero = f zero
+intervalEta-rec f i one = f one
+intervalEta-rec f i (seg i₁) = f (seg i₁)
+
+elim : ∀ {ℓ} → (A : Interval → Type ℓ) → {x : A (seg i0)} → {y : A (seg i1)}
                (p : PathP (λ i → A (seg i)) x y) → (x : Interval) → A x
-elim A x y p zero    = x
-elim A x y p one     = y
-elim A x y p (seg i) = p i
+elim A p zero    = p i0
+elim A p one     = p i1
+elim A p (seg i) = p i
 
 -- Note that this is not definitional (it is not proved by refl)
-intervalEta : ∀ {A : Type₀} (f : Interval → A) → elim _ (f zero) (f one) (λ i → f (seg i)) ≡ f
+intervalEta : ∀ {ℓ} → ∀ {A : Interval → Type ℓ}
+                (f : (x : Interval) → A x) → elim A (λ i → f (seg i)) ≡ f
 intervalEta f i zero    = f zero
 intervalEta f i one     = f one
 intervalEta f i (seg j) = f (seg j)
+
+endI : Bool → Interval
+endI true = one
+endI false = zero
+
+
+seg≡seg : ∀ i j → seg i ≡ seg j
+seg≡seg i j i' = seg ( (i ∧ (~ i'))  ∨ (j ∧ i') ) 
+
+-- using this instead of isContr→isProp, do not introduce and hcomp
+isProp-Interval' : isProp Interval
+isProp-Interval' zero zero = seg≡seg i0 i0
+isProp-Interval' zero one = seg≡seg i0 i1
+isProp-Interval' zero (seg i) = seg≡seg i0 i
+isProp-Interval' one zero = seg≡seg i1 i0
+isProp-Interval' one one = seg≡seg i1 i1
+isProp-Interval' one (seg i) = seg≡seg i1 i
+isProp-Interval' (seg i) zero = seg≡seg i i0
+isProp-Interval' (seg i) one  = seg≡seg i i1
+isProp-Interval' (seg i) (seg i₁) = seg≡seg i i₁
+
+one= : ∀ i' → one ≡ i'
+one= (zero) = sym seg
+one= (one) = refl
+one= (seg i) i₁ = seg (i ∨ ~ i₁)
+
+=zero : ∀ (i' : Interval) → i' ≡ zero 
+=zero zero = refl
+=zero one = sym seg
+=zero (seg i) i₁ = seg (i ∧ ~ i₁)
+
+=one : ∀ i' → i' ≡ one
+=one (zero) = seg
+=one (one) = refl
+=one (seg i) i₁ = seg (i ∨ i₁)
+
+zero= : ∀ (i' : Interval) → zero ≡ i' 
+zero= zero = refl
+zero= one = seg
+zero= (seg i) i₁ = seg (i ∧ i₁)

--- a/Cubical/HITs/Interval/NCube.agda
+++ b/Cubical/HITs/Interval/NCube.agda
@@ -1,0 +1,217 @@
+{-# OPTIONS --cubical --safe #-}
+module Cubical.HITs.Interval.NCube where
+
+open import Cubical.Core.Everything
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order
+
+open import Cubical.Data.Vec
+open import Cubical.Data.List
+open import Cubical.Data.Bool
+open import Cubical.Data.Sigma
+open import Cubical.Data.Empty renaming (elim to ⊥-elim ; rec to ⊥-rec )
+
+open import Cubical.Foundations.Everything
+
+open import Cubical.Foundations.CartesianKanOps
+
+open import Cubical.HITs.Interval.Base renaming (elim to I-elim ; rec to I-rec)
+
+NCube : ℕ → Type₀
+NCube = λ n → Vec Interval n
+
+corner0 : ∀ {n} →  NCube n
+corner0 {zero} = []
+corner0 {suc n} =  zero ∷ corner0
+
+corner1 : ∀ {n} →  NCube n
+corner1 {zero} = []
+corner1 {suc n} =  one ∷ corner1
+
+isPropCube : ∀ {n} → isProp (NCube n)
+isPropCube {zero} [] [] i = []
+isPropCube {suc n} (x ∷ x₁) (x₂ ∷ x₃) i = (isProp-Interval' x x₂ i) ∷ isPropCube x₁ x₃ i
+
+
+
+
+
+
+-- Typeⁿ' : ℕ → Level → Typeω
+-- Typeⁿ' zero ℓ = I → Type ℓ
+-- Typeⁿ' (suc n) ℓ = I → Typeⁿ' n ℓ
+
+-- NCube : ℕ → Type₀
+-- NCube = Vec Interval
+
+-- Typeⁿ : ℕ → ∀ ℓ → Type (ℓ-suc ℓ)
+-- Typeⁿ n ℓ = NCube n → Type ℓ
+
+
+-- _∘∷_ : ∀ {ℓ ℓ'} → {A : Type ℓ} → {B : Type ℓ'}
+--        → ∀ {n}
+--        → (Vec A (suc n) → B) → A → (Vec A n → B)
+-- A ∘∷ a = A ∘ (a ∷_ )
+
+-- ∷∘ : ∀ {ℓ ℓ'} → {A : Type ℓ} → {B : Type ℓ'}
+--        → ∀ {n}
+--        → (A → (Vec A n → B)) → (Vec A (suc n) → B) 
+-- ∷∘ x x₁ = x (head x₁) (tail x₁)
+
+-- _∘∷-dep_ : ∀ {ℓ ℓ'} → {A : Type ℓ} → ∀ {n}
+--            → {B : Vec A (suc n) → Type ℓ'}
+--            → Π B → Π (Π ∘ (B ∘∷_))
+-- A ∘∷-dep a = A ∘ (a ∷_ )
+
+
+-- ∷∘-dep : ∀ {ℓ ℓ'} → {A : Type ℓ} → ∀ {n}
+--            → {B : Vec A (suc n) → Type ℓ'}
+--            → Π (Π ∘ B ∘∷_) → Π B 
+-- ∷∘-dep x (h ∷ t) = x h t
+
+-- ∘∷-Iso :  ∀ {ℓ ℓ'} → {A : Type ℓ} → ∀ {n}
+--            → {B : Vec A (suc n) → Type ℓ'}
+--            → Iso (Π B) (Π (Π ∘ (B ∘∷_)))
+-- Iso.fun ∘∷-Iso = _∘∷-dep_
+-- Iso.inv ∘∷-Iso = ∷∘-dep
+-- Iso.rightInv ∘∷-Iso b = refl
+-- Iso.leftInv ∘∷-Iso a i (x ∷ x₁) = a (x ∷ x₁)
+
+
+-- _∷ₗ_ : ∀ {ℓ} → {A : Type ℓ} → ∀ {n} → Vec A n → A → Vec A (suc n)
+-- _∷ₗ_ {n = zero} x x₁ = x₁ ∷ []
+-- _∷ₗ_ {n = suc n} x x₁ = head x ∷ ((tail x) ∷ₗ x₁)
+
+-- _∘∷ₗ_ : ∀ {ℓ ℓ'} → {A : Type ℓ} → {B : Type ℓ'}
+--        → ∀ {n}
+--        → (Vec A (suc n) → B) → A → (Vec A n → B)
+-- A ∘∷ₗ a = A ∘ (_∷ₗ a )
+
+
+
+-- Typeⁿ'→Typeⁿ : ∀ {ℓ} → ∀ n →  Typeⁿ' n ℓ → Typeⁿ (suc n) ℓ
+-- Typeⁿ'→Typeⁿ zero x x₁ = I-rec (λ i → x i) (head x₁)
+-- Typeⁿ'→Typeⁿ (suc n) x x₁ = I-rec (λ i →  Typeⁿ'→Typeⁿ n (x i) (tail x₁)) (head x₁)
+
+-- Typeⁿ→Typeⁿ' : ∀ {ℓ} → ∀ n → Typeⁿ (suc n) ℓ → Typeⁿ' n ℓ
+-- Typeⁿ→Typeⁿ' zero x i = x (seg i ∷ [])
+-- Typeⁿ→Typeⁿ' (suc n) x i = Typeⁿ→Typeⁿ' n (x ∘∷ (seg i))
+
+
+
+-- 3^ : ℕ → ℕ
+-- 3^ zero = suc zero
+-- 3^ (suc x) = (3^ x) * 3
+
+-- -- this signature is describing record of all the cells of the n-cube
+
+-- NCubeSig : ∀ {ℓ} → ∀ {n} → Typeⁿ n ℓ → Sigₗ ℓ (3^ n)
+-- NCubeSig {n = zero} x = x []
+-- NCubeSig {n = suc n} x = sigₗ-Ends-with-PathP' (λ i → NCubeSig (x ∘∷ (seg i)))
+
+-- -- this isomorphism is betwen
+-- -- dependent function from n dimensional cube
+-- -- and record of 3^ n cells 
+
+-- cubeSig-Iso : ∀ {ℓ} → ∀ {n} → (A : Typeⁿ n ℓ)
+--            → Iso (Π A) (Recₗ (NCubeSig A))
+-- Iso.fun (cubeSig-Iso {n = zero} _) x = x []
+-- Iso.inv (cubeSig-Iso {n = zero} _) x [] = x 
+-- Iso.rightInv (cubeSig-Iso {n = zero} _) _ = refl
+-- Iso.leftInv (cubeSig-Iso {n = zero} A) a i [] = a []
+-- cubeSig-Iso {n = suc n} A =
+--   compIso
+--   (compIso ∘∷-Iso (pathToIso (cong Π (funExt (isoToPath ∘ cubeSig-Iso ∘ A ∘∷_)))))
+--   (sigₗ-Ends-with-PathP'-Iso-Interval (NCubeSig ∘ A ∘∷_ ))
+
+-- PathPⁿ-explicit : ∀ {ℓ} → ∀ {n}
+--                  → (A : Typeⁿ n ℓ)
+--                   → Type-in-sig false [] (trim-sig (NCubeSig A) )
+-- PathPⁿ-explicit x = pop-Type _ _ (NCubeSig x)
+
+-- argsToPick : ℕ → List ℕ
+-- argsToPick zero = []
+-- argsToPick (suc x) = predℕ (3^ x) ∷ predℕ (3^ x) ∷ argsToPick x 
+
+-- PathPⁿ : ∀ {ℓ} → ∀ {n}
+--                  → (A : Typeⁿ n ℓ)
+--                   → Type-in-sig true (argsToPick n) (trim-sig (NCubeSig A) )
+-- PathPⁿ x = pop-Type _ _ (NCubeSig x)
+
+-- Pathⁿ : ∀ {ℓ} → ∀ n
+--                  → {A : Type ℓ}
+--                   → Type-in-sig true (argsToPick n) (trim-sig (NCubeSig {n = n} (const A)) )
+-- Pathⁿ n {x} = PathPⁿ (const x)
+
+-- -- generated cube is definationaly equall to one from Prelude
+-- Cube-test : ∀ {ℓ} → ∀ (A : Type ℓ) → 
+--   {a₀₀₀ a₀₀₁ : A} {a₀₀₋ : a₀₀₀ ≡ a₀₀₁}
+--   {a₀₁₀ a₀₁₁ : A} {a₀₁₋ : a₀₁₀ ≡ a₀₁₁}
+--   {a₀₋₀ : a₀₀₀ ≡ a₀₁₀} {a₀₋₁ : a₀₀₁ ≡ a₀₁₁}
+--   (a₀₋₋ : Square a₀₀₋ a₀₁₋ a₀₋₀ a₀₋₁)
+--   {a₁₀₀ a₁₀₁ : A} {a₁₀₋ : a₁₀₀ ≡ a₁₀₁}
+--   {a₁₁₀ a₁₁₁ : A} {a₁₁₋ : a₁₁₀ ≡ a₁₁₁}
+--   {a₁₋₀ : a₁₀₀ ≡ a₁₁₀} {a₁₋₁ : a₁₀₁ ≡ a₁₁₁}
+--   (a₁₋₋ : Square a₁₀₋ a₁₁₋ a₁₋₀ a₁₋₁)
+--   {a₋₀₀ : a₀₀₀ ≡ a₁₀₀} {a₋₀₁ : a₀₀₁ ≡ a₁₀₁}
+--   (a₋₀₋ : Square a₀₀₋ a₁₀₋ a₋₀₀ a₋₀₁)
+--   {a₋₁₀ : a₀₁₀ ≡ a₁₁₀} {a₋₁₁ : a₀₁₁ ≡ a₁₁₁}
+--   (a₋₁₋ : Square a₀₁₋ a₁₁₋ a₋₁₀ a₋₁₁)
+--   (a₋₋₀ : Square a₀₋₀ a₁₋₀ a₋₀₀ a₋₁₀)
+--   (a₋₋₁ : Square a₀₋₁ a₁₋₁ a₋₀₁ a₋₁₁)
+--   → Cube a₀₋₋ a₁₋₋ a₋₀₋ a₋₁₋ a₋₋₀ a₋₋₁
+--     ≡
+--     Pathⁿ 3 _ _ _ _ _ _
+-- Cube-test _ _ _ _ _ _ _ = refl
+
+
+-- -- by discarding last field (the interior cell) we can create signature of boundary record
+
+-- BoundaryPⁿ : ∀ {ℓ} → ∀ {n}
+--                  → (A : Typeⁿ n ℓ)
+--                  → Type ℓ
+-- BoundaryPⁿ A = Recₗ (trim-sig (NCubeSig A) )
+
+-- Boundaryⁿ : ∀ {ℓ} → ∀ n → (A : Type ℓ) → Type ℓ
+-- Boundaryⁿ n A = BoundaryPⁿ {n = n} (const A)
+
+-- InteriorP :  ∀ {ℓ} → ∀ {n}
+--                  → (A : Typeⁿ n ℓ)
+--                  → BoundaryPⁿ A → Type ℓ
+-- InteriorP A = pop-Type-overRecₗ (NCubeSig A)
+
+
+-- Σ-Bd-Ins : ∀ {ℓ} → ∀ {n} → (A : Typeⁿ n ℓ) → Type ℓ
+-- Σ-Bd-Ins A = Σ (BoundaryPⁿ A) (InteriorP A)
+
+
+-- -- this isomorphism splits cube into boundary and interior
+
+-- IsoCub : ∀ {ℓ} → ∀ {n} → (A : Typeⁿ n ℓ)
+--            → Iso (Π A) (Σ (BoundaryPⁿ A) (InteriorP A))
+-- IsoCub A = compIso (cubeSig-Iso A) (invIso (push-popVal-Iso (NCubeSig A)))
+
+
+-- from-ends-Path :  ∀ {ℓ} → ∀ {n} → (A : Typeⁿ (suc n) ℓ)
+--                   → Iso (Π (Σ-Bd-Ins ∘ A ∘∷_))
+--                         (Σ-Bd-Ins A)
+-- from-ends-Path  A = compIso (pathToIso p1) (compIso p2 p3)
+
+--   where
+--     p1 : ((i' : Interval) → Σ-Bd-Ins (A ∘∷ i'))
+--            ≡ ((i' : Interval) → Recₗ (NCubeSig (A ∘∷ i')))
+--     p1 i = (i' : Interval) → isoToPath (push-popVal-Iso (NCubeSig (A ∘∷ i'))) i
+
+--     p2 : Iso ((i' : Interval) → Recₗ (NCubeSig (A ∘∷ i'))) (Recₗ (NCubeSig A))
+--     p2 = sigₗ-Ends-with-PathP'-Iso-Interval λ x → (NCubeSig (A ∘∷ x))
+
+--     p3 : Iso (Recₗ (NCubeSig A)) (Σ-Bd-Ins A)
+--     p3 = invIso (push-popVal-Iso (NCubeSig A))
+
+
+
+
+-- PathPⁿ-test-3' : ∀ {ℓ} → ∀ (A : Type ℓ) → {!!}
+              
+-- PathPⁿ-test-3'  A = {! PathPⁿ {n = 5}!}


### PR DESCRIPTION
This is ongoing work on records, part of the larger code to generate various coherence conditions, 
temporarily i put some examples in Cubical/Data/Sigma/Record/Examples.agda file,
i was able to generate complicate records (200 fields, with lots of dependence between fields).

there are functions to generate constructors for record where explicitly of the fields can be configurated, those functions have "baked in" paths between constructors
sadly the length of the records often must be provided explicitly. 
I would apriciete advice on some way to fix it. 