### PR TITLE
retractableIntoSet→isEmbedding, isPropIsHAEquiv and more universe polymorphic definitions in Equiv/Properties

### DIFF
--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -95,10 +95,10 @@ private
   expand×Inj : ∀ k → {t1 t2 : Fin (suc k) × ℕ} → expand× t1 ≡ expand× t2 → t1 ≡ t2
   expand×Inj k {f1 , zero} {f2 , zero} p i
     = toℕ-injective {fj = f1} {f2} p i , zero
-  expand×Inj k {f1 , suc o1} {(r , r<sk) , zero} p
-    = Empty.rec (<-asym r<sk (lemma₀ refl p))
-  expand×Inj k {(r , r<sk) , zero} {f2 , suc o2} p
-    = Empty.rec (<-asym r<sk (lemma₀ refl (sym p)))
+  expand×Inj k {f1 , suc o1} {f2 , zero} p
+    = Empty.rec (<-asym (snd f2) (lemma₀ refl p))
+  expand×Inj k {f1 , zero} {f2 , suc o2} p
+    = Empty.rec (<-asym (snd f1) (lemma₀ refl (sym p)))
   expand×Inj k {f1 , suc o1} {f2 , suc o2}
     = cong (λ { (f , o) → (f , suc o) })
     ∘ expand×Inj k {f1 , o1} {f2 , o2}

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -95,10 +95,10 @@ private
   expand×Inj : ∀ k → {t1 t2 : Fin (suc k) × ℕ} → expand× t1 ≡ expand× t2 → t1 ≡ t2
   expand×Inj k {f1 , zero} {f2 , zero} p i
     = toℕ-injective {fj = f1} {f2} p i , zero
-  expand×Inj k {f1 , suc o1} {f2 , zero} p
-    = Empty.rec (<-asym (snd f2) (lemma₀ refl p))
-  expand×Inj k {f1 , zero} {f2 , suc o2} p
-    = Empty.rec (<-asym (snd f1) (lemma₀ refl (sym p)))
+  expand×Inj k {f1 , suc o1} {(r , r<sk) , zero} p
+    = Empty.rec (<-asym r<sk (lemma₀ refl p))
+  expand×Inj k {(r , r<sk) , zero} {f2 , suc o2} p
+    = Empty.rec (<-asym r<sk (lemma₀ refl (sym p)))
   expand×Inj k {f1 , suc o1} {f2 , suc o2}
     = cong (λ { (f , o) → (f , suc o) })
     ∘ expand×Inj k {f1 , o1} {f2 , o2}

--- a/Cubical/Data/Group/Base.agda
+++ b/Cubical/Data/Group/Base.agda
@@ -6,7 +6,7 @@ open import Cubical.Foundations.Prelude hiding ( comp )
 
 import Cubical.Foundations.Isomorphism as I
 import Cubical.Foundations.Equiv as E
-import Cubical.Foundations.Equiv.HalfAdjoint as HAE
+import Cubical.Foundations.Equiv.Properties as EP
 
 record isGroup {ℓ} (A : Type ℓ) : Type ℓ where
   constructor group-struct
@@ -190,7 +190,7 @@ Iso'→Iso {G = group G Gset Ggroup} {H = group H Hset Hgroup} i = iso (fun , fu
     _⊙_ = isGroup.comp Ggroup
 
     invMorph : isMorph H_ G_ inv
-    invMorph h0 h1 = E.invEq (HAE.congEquiv e')
+    invMorph h0 h1 = E.invEq (EP.congEquiv e')
           (fun (inv (h0 ∘ h1)) ≡⟨ rightInv (h0 ∘ h1) ⟩
            h0 ∘ h1 ≡⟨ cong (λ x → x ∘ h1) (sym (rightInv h0)) ⟩
            (fun (inv h0)) ∘ h1 ≡⟨ cong (λ x → fun (inv h0) ∘ x) (sym (rightInv h1)) ⟩

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -29,9 +29,6 @@ private
     ℓ ℓ' ℓ''  : Level
     A B C D : Type ℓ
 
-fiber : ∀ {A : Type ℓ} {B : Type ℓ'} (f : A → B) (y : B) → Type (ℓ-max ℓ ℓ')
-fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
-
 equivIsEquiv : (e : A ≃ B) → isEquiv (equivFun e)
 equivIsEquiv e = snd e
 

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -64,15 +64,28 @@ equiv-proof (isPropIsEquiv f p q i) y =
 equivEq : (e f : A ≃ B) → (h : e .fst ≡ f .fst) → e ≡ f
 equivEq e f h = λ i → (h i) , isProp→PathP (λ i → isPropIsEquiv (h i)) (e .snd) (f .snd) i
 
+module _ {f : A → B} (equivF : isEquiv f) where
+  invIsEq : B → A
+  invIsEq y = equivF .equiv-proof y .fst .fst
+
+  secIsEq : section f invIsEq
+  secIsEq y = equivF .equiv-proof y .fst .snd
+
+  retIsEq : retract f invIsEq
+  retIsEq a i = equivF .equiv-proof (f a) .snd (a , refl) i .fst
+
+  commSqIsEq : ∀ a → Square (secIsEq (f a)) refl (cong f (retIsEq a)) refl
+  commSqIsEq a i = equivF .equiv-proof (f a) .snd (a , refl) i .snd
+
 module _ (w : A ≃ B) where
   invEq : B → A
-  invEq y = fst (fst (snd w .equiv-proof y))
+  invEq = invIsEq (snd w)
 
   secEq : section invEq (w .fst)
-  secEq x i = fst (snd (snd w .equiv-proof (fst w x)) (x , (λ j → fst w x)) i)
+  secEq = retIsEq (snd w)
 
   retEq : retract invEq (w .fst)
-  retEq y = snd (fst (snd w .equiv-proof y))
+  retEq = secIsEq (snd w)
 
 open Iso
 

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -145,9 +145,6 @@ isContr→Equiv Actr Bctr = isoToEquiv (isContr→Iso Actr Bctr)
 isPropEquiv→Equiv : (Aprop : isProp A) (Bprop : isProp B) (f : A → B) (g : B → A) → A ≃ B
 isPropEquiv→Equiv Aprop Bprop f g = isoToEquiv (isProp→Iso Aprop Bprop f g)
 
-invEq≡→equivFun≡ : ∀ (e : A ≃ B) {x y} → invEq e x ≡ y → equivFun e y ≡ x
-invEq≡→equivFun≡ e {x} p = cong (equivFun e) (sym p) ∙ retEq e x
-
 equivPi : ∀ {F : A → Type ℓ} {G : A → Type ℓ'}
         → ((x : A) → F x ≃ G x) → ((x : A) → F x) ≃ ((x : A) → G x)
 equivPi k .fst f x = k x .fst (f x)

--- a/Cubical/Foundations/Equiv/Base.agda
+++ b/Cubical/Foundations/Equiv/Base.agda
@@ -7,6 +7,9 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Core.Glue public
   using ( isEquiv ; equiv-proof ; _≃_ ; equivFun ; equivProof )
 
+fiber : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) (y : B) → Type (ℓ-max ℓ ℓ')
+fiber {A = A} f y = Σ[ x ∈ A ] f x ≡ y
+
 -- The identity equivalence
 idIsEquiv : ∀ {ℓ} (A : Type ℓ) → isEquiv (idfun A)
 equiv-proof (idIsEquiv A) y =

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -65,6 +65,30 @@ record isHAEquiv {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) : Type 
                                     ; (i = i1) → filler j k })
                            (g (cap0 j i))
 
+  isHAEquiv→Iso : Iso A B
+  Iso.fun isHAEquiv→Iso = f
+  Iso.inv isHAEquiv→Iso = g
+  Iso.rightInv isHAEquiv→Iso = ret
+  Iso.leftInv isHAEquiv→Iso = sec
+
+  isHAEquiv→isEquiv : isEquiv f
+  isHAEquiv→isEquiv .equiv-proof y = (g y , ret y) , isCenter where
+    isCenter : ∀ xp → (g y , ret y) ≡ xp
+    isCenter (x , p) i = gy≡x i , ry≡p i where
+      gy≡x : g y ≡ x
+      gy≡x = sym (cong g p) ∙∙ refl ∙∙ sec x
+
+      lem0 : Square (cong f (sec x)) p (cong f (sec x)) p
+      lem0 i j = invSides-filler p (sym (cong f (sec x))) (~ i) j
+
+      ry≡p : Square (ret y) p (cong f gy≡x) refl
+      ry≡p i j = hcomp (λ k → λ { (i = i0) → cong ret p k j
+                                ; (i = i1) → lem0 k j
+                                ; (j = i0) → f (doubleCompPath-filler (sym (cong g p)) refl (sec x) k i)
+                                ; (j = i1) → p k })
+                       (com x (~ i) j)
+
+open isHAEquiv using (isHAEquiv→Iso; isHAEquiv→isEquiv) public
 
 HAEquiv : (A : Type ℓ) (B : Type ℓ') → Type (ℓ-max ℓ ℓ')
 HAEquiv A B = Σ[ f ∈ (A → B) ] isHAEquiv f

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -92,7 +92,15 @@ iso→HAEquiv (iso f g ε η) = f , isHAEquivf
             (f (Hfa≡fHa (λ x → g (f x)) η a (~ i) j))
 
 equiv→HAEquiv : A ≃ B → HAEquiv A B
-equiv→HAEquiv e = iso→HAEquiv (equivToIso e)
+equiv→HAEquiv e = e .fst , λ where
+  .isHAEquiv.g → invIsEq (snd e)
+  .isHAEquiv.sec → retIsEq (snd e)
+  .isHAEquiv.ret → secIsEq (snd e)
+  .isHAEquiv.com a i j → hcomp (λ k → λ { (i = i0) → cong (fst e) (retIsEq (snd e) a) j
+                                        ; (i = i1) → secIsEq (snd e) (fst e a) (~ k ∨ j)
+                                        ; (j = i0) → secIsEq (snd e) (fst e a) (~ k ∧ i)
+                                        ; (j = i1) → fst e a })
+                               (commSqIsEq (snd e) a j i)
 
 congIso : {x y : A} (e : Iso A B) → Iso (x ≡ y) (Iso.fun e x ≡ Iso.fun e y)
 congIso {x = x} {y} e = goal

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -123,12 +123,3 @@ congIso {x = x} {y} e = goal
                    ; (j = i0) → Iso.leftInv e x (i ∨ k)
                    ; (j = i1) → Iso.leftInv e y (i ∨ k) })
           (Iso.leftInv e (p j) i)
-
--- This is proved more directly in Foundations.Equiv.Properties, but
--- that proof is not as universe polymorphic as this one and this one
--- seems to have a lot better computational properties
-isEquivCong : {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → cong (e .fst) p)
-isEquivCong e = isoToIsEquiv (congIso (equivToIso e))
-
-congEquiv : {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
-congEquiv e = isoToEquiv (congIso (equivToIso e))

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -16,6 +16,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Path
 
 private
   variable
@@ -120,11 +121,7 @@ equiv→HAEquiv e = e .fst , λ where
   .isHAEquiv.g → invIsEq (snd e)
   .isHAEquiv.sec → retIsEq (snd e)
   .isHAEquiv.ret → secIsEq (snd e)
-  .isHAEquiv.com a i j → hcomp (λ k → λ { (i = i0) → cong (fst e) (retIsEq (snd e) a) j
-                                        ; (i = i1) → secIsEq (snd e) (fst e a) (~ k ∨ j)
-                                        ; (j = i0) → secIsEq (snd e) (fst e a) (~ k ∧ i)
-                                        ; (j = i1) → fst e a })
-                               (commSqIsEq (snd e) a j i)
+  .isHAEquiv.com a → flipSquare (slideSquare (commSqIsEq (snd e) a))
 
 congIso : {x y : A} (e : Iso A B) → Iso (x ≡ y) (Iso.fun e x ≡ Iso.fun e y)
 congIso {x = x} {y} e = goal

--- a/Cubical/Foundations/Equiv/PathSplit.agda
+++ b/Cubical/Foundations/Equiv/PathSplit.agda
@@ -24,7 +24,6 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Isomorphism
 
-open import Cubical.Foundations.Equiv.HalfAdjoint
 open import Cubical.Foundations.Equiv.Properties
 
 open import Cubical.Data.Sigma

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -184,7 +184,7 @@ isPropIsHAEquiv {f = f} ishaef = goal ishaef where
       -- secondly, convert the path into a dependent path for later convenience
       ≃⟨  Σ-cong-equiv-snd (λ s → Σ-cong-equiv-snd
                              λ η → depPostCompEquiv
-                               λ x → compEquiv (flipSquareEquiv {a₀₀ = f x}) (invEquiv (slideSquareEquiv _ _ _))) ⟩
+                               λ x → compEquiv (flipSquareEquiv {a₀₀ = f x}) (invEquiv slideSquareEquiv)) ⟩
     Σ _ rCoh2
       ≃⟨ Σ-cong-equiv-snd (λ s → invEquiv Σ-Π-≃) ⟩
     Σ _ rCoh3

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -62,19 +62,19 @@ postCompEquiv : ∀ {ℓ ℓ′} {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B
 postCompEquiv e = (λ φ x → fst e (φ x)) , isEquivPostComp e
 
 
-hasSection : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → Type _
-hasSection {A = A} {B} f = Σ[ g ∈ (B → A) ] section f g
+hasSection : (A → B) → Type _
+hasSection {A = A} {B = B} f = Σ[ g ∈ (B → A) ] section f g
 
-hasRetract : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → Type _
-hasRetract {A = A} {B} f = Σ[ g ∈ (B → A) ] retract f g
+hasRetract : (A → B) → Type _
+hasRetract {A = A} {B = B} f = Σ[ g ∈ (B → A) ] retract f g
 
-isEquiv-hasSection : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B)
+isEquiv-hasSection : (f : A → B)
                     → isEquiv f
                     → hasSection f
 isEquiv-hasSection f isEq = (λ b → equiv-proof isEq b .fst .fst) ,
                             λ b → equiv-proof isEq b .fst .snd
 
-isContr-hasSection : ∀ {ℓ} {A B : Type ℓ} (e : A ≃ B) → isContr (hasSection (fst e))
+isContr-hasSection : (e : A ≃ B) → isContr (hasSection (fst e))
 fst (isContr-hasSection e) = invEq e , retEq e
 snd (isContr-hasSection e) (f , ε) i = (λ b → fst (p b i)) , (λ b → snd (p b i))
   where p : ∀ b → (invEq e b , retEq e b) ≡ (f b , ε b)

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -30,7 +30,7 @@ open import Cubical.Functions.FunExtEquiv
 private
   variable
     ℓ ℓ′ : Level
-    A B : Type ℓ
+    A B C : Type ℓ
 
 isEquivCong : {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → cong (e .fst) p)
 isEquivCong e = isoToIsEquiv (congIso (equivToIso e))
@@ -54,7 +54,7 @@ preCompEquiv : {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
              → (B → C) ≃ (A → C)
 preCompEquiv e = (λ φ → φ ∘ fst e) , isEquivPreComp e
 
-depPostCompEquiv : {C : Type ℓ′} {A B : C → Type ℓ} (e : ∀ c → A c ≃ B c)
+depPostCompEquiv : {A : C → Type ℓ} {B : C → Type ℓ′} (e : ∀ c → A c ≃ B c)
                  → (∀ c → A c) ≃ (∀ c → B c)
 depPostCompEquiv {A = A} {B} e = isoToEquiv pcIso where
   eIso : ∀ c → Iso (A c) (B c)
@@ -66,13 +66,11 @@ depPostCompEquiv {A = A} {B} e = isoToEquiv pcIso where
   Iso.rightInv pcIso f i c = Iso.rightInv (eIso c) (f c) i
   Iso.leftInv pcIso g i c = Iso.leftInv (eIso c) (g c) i
 
-isEquivPostComp : {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
-                → isEquiv (λ (φ : C → A) → e .fst ∘ φ)
+isEquivPostComp :(e : A ≃ B) → isEquiv (λ (φ : C → A) → e .fst ∘ φ)
 isEquivPostComp {A = A} {B} {C} e = snd (depPostCompEquiv (λ _ → e))
 
-postCompEquiv : {A B : Type ℓ} {C : Type ℓ′} (e : A ≃ B)
-              → (C → A) ≃ (C → B)
-postCompEquiv e = (λ φ → fst e ∘ φ) , isEquivPostComp e
+postCompEquiv : (e : A ≃ B) → (C → A) ≃ (C → B)
+postCompEquiv e = _ , isEquivPostComp e
 
 hasSection : (A → B) → Type _
 hasSection {A = A} {B = B} f = Σ[ g ∈ (B → A) ] section f g

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -18,8 +18,7 @@ open import Cubical.Data.Sigma
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Equiv.HalfAdjoint
-  using (isEquivCong; congEquiv)
+open import Cubical.Foundations.Equiv.HalfAdjoint using (congIso)
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Path
@@ -30,6 +29,12 @@ private
   variable
     ℓ ℓ′ : Level
     A B : Type ℓ
+
+isEquivCong : {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → cong (e .fst) p)
+isEquivCong e = isoToIsEquiv (congIso (equivToIso e))
+
+congEquiv : {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
+congEquiv e = isoToEquiv (congIso (equivToIso e))
 
 equivAdjointEquiv : (e : A ≃ B) → ∀ {a b} → (a ≡ invEq e b) ≃ (equivFun e a ≡ b)
 equivAdjointEquiv e = compEquiv (congEquiv e) (compPathrEquiv (retEq e _))

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -284,8 +284,8 @@ symDistr p q i j = symDistr-filler p q j i i1
 hcomp-equivFillerSub : {ϕ : I} → (p : I → Partial ϕ A) → (a : A [ ϕ ↦ p i0 ])
                      → (i : I)
                      → A [ ϕ ∨ i ∨ ~ i ↦ (λ { (i = i0) → outS a
-                                              ; (i = i1) → hcomp (λ i → p (~ i)) (hcomp p (outS a))
-                                              ; (ϕ = i1) → p i0 1=1 }) ]
+                                            ; (i = i1) → hcomp (λ i → p (~ i)) (hcomp p (outS a))
+                                            ; (ϕ = i1) → p i0 1=1 }) ]
 hcomp-equivFillerSub {ϕ = ϕ} p a i =
   inS (hcomp (λ k → λ { (i = i1) → hfill (λ j → p (~ j)) (inS (hcomp p (outS a))) k
                       ; (i = i0) → outS a

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -151,20 +151,20 @@ assocP {A = A} {B = B} {C = C} p q r k i =
 
 -- some exchange law for doubleCompPath and refl
 
-rhombus-filler : {ℓ : Level} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → I → I → A
-rhombus-filler p q i j =
-  hcomp (λ t → λ { (i = i0) → p (~ t ∨ j)
-                 ; (i = i1) → q (t ∧ j)
-                 ; (j = i0) → p (~ t ∨ i)
-                 ; (j = i1) → q (t ∧ i) })
-        (p i1)
+invSides-filler : {x y z : A} (p : x ≡ y) (q : x ≡ z) → Square p (sym q) q (sym p)
+invSides-filler {x = x} p q i j =
+  hcomp (λ k → λ { (i = i0) → p (k ∧ j)
+                 ; (i = i1) → q (~ j ∧ k)
+                 ; (j = i0) → q (i ∧ k)
+                 ; (j = i1) → p (~ i ∧ k)})
+        x
 
 leftright : {ℓ : Level} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) →
             (refl ∙∙ p ∙∙ q) ≡ (p ∙∙ q ∙∙ refl)
 leftright p q i j =
   hcomp (λ t → λ { (j = i0) → p (i ∧ (~ t))
                  ; (j = i1) → q (t ∨ i) })
-        (rhombus-filler p q i j)
+        (invSides-filler q (sym p) (~ i) j)
 
 -- equating doubleCompPath and a succession of two compPath
 
@@ -240,15 +240,6 @@ hcomp-cong : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 
              → (hcomp u (outS u0) ≡ hcomp u' (outS u0')) [ φ ↦ (\ { (φ = i1) → ueq i1 1=1 }) ]
 hcomp-cong u u0 u' u0' ueq 0eq = inS (\ j → hcomp (\ i o → ueq i o j) (outS 0eq j))
 
-
-invSides-filler : {x y z : A} (p : x ≡ y) (q : x ≡ z) → PathP (λ j → q j ≡ p (~ j)) p (sym q)
-invSides-filler {A = A} {x = x} p q i j =
-  hcomp (λ k → λ { (i = i0) → p (k ∧ j)
-                  ; (i = i1) → q (~ j ∧ k)
-                  ; (j = i0) → q (i ∧ k)
-                  ; (j = i1) → p (~ i ∧ k)})
-        x
-
 congFunct-filler : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {x y z : A} (f : A → B) (p : x ≡ y) (q : y ≡ z)
                 → I → I → I → B
 congFunct-filler {x = x} f p q i j z =
@@ -277,7 +268,6 @@ cong₂Funct {x = x} {y = y} f p {u = u} {v = v} q j i =
                   ; (j = i0) → f (p i) (q (i ∧ k))})
        (f (p i) u)
 
-
 symDistr-filler : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → I → I → I → A
 symDistr-filler {A = A} {z = z} p q i j k =
   hfill (λ k → λ { (i = i0) → q (k ∨ j)
@@ -289,6 +279,22 @@ symDistr : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → 
 symDistr p q i j = symDistr-filler p q j i i1
 
 
+-- we can not write hcomp-isEquiv : {ϕ : I} → (p : I → Partial ϕ A) → isEquiv (λ (a : A [ ϕ ↦ p i0 ]) → hcomp p a)
+-- due to size issues. But what we can write (compare to hfill) is:
+hcomp-equivFillerSub : {ϕ : I} → (p : I → Partial ϕ A) → (a : A [ ϕ ↦ p i0 ])
+                     → (i : I)
+                     → A [ ϕ ∨ i ∨ ~ i ↦ (λ { (i = i0) → outS a
+                                              ; (i = i1) → hcomp (λ i → p (~ i)) (hcomp p (outS a))
+                                              ; (ϕ = i1) → p i0 1=1 }) ]
+hcomp-equivFillerSub {ϕ = ϕ} p a i =
+  inS (hcomp (λ k → λ { (i = i1) → hfill (λ j → p (~ j)) (inS (hcomp p (outS a))) k
+                      ; (i = i0) → outS a
+                      ; (ϕ = i1) → p (~ k ∧ i) 1=1 })
+             (hfill p a i))
+
+hcomp-equivFiller : {ϕ : I} → (p : I → Partial ϕ A) → (a : A [ ϕ ↦ p i0 ])
+                  → (i : I) → A
+hcomp-equivFiller p a i = outS (hcomp-equivFillerSub p a i)
 
 
 pentagonIdentity : (p : x ≡ y) → (q : y ≡ z) → (r : z ≡ w) → (s : w ≡ v)

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -143,8 +143,8 @@ flipSquarePath :
   → Square a₀₋ a₁₋ a₋₀ a₋₁ ≡ Square a₋₀ a₋₁ a₀₋ a₁₋
 flipSquarePath = isoToPath (iso flipSquare flipSquare (λ _ → refl) (λ _ → refl))
 
-module _ {a₀₀ a₁₁ : A} (a₋ : a₀₀ ≡ a₁₁)
-  {a₁₀ : A} (a₁₋ : a₁₀ ≡ a₁₁) (a₋₀ : a₀₀ ≡ a₁₀) where
+module _ {a₀₀ a₁₁ : A} {a₋ : a₀₀ ≡ a₁₁}
+  {a₁₀ : A} {a₁₋ : a₁₀ ≡ a₁₁} {a₋₀ : a₀₀ ≡ a₁₀} where
 
   slideSquareFaces : (i j k : I) → Partial (i ∨ ~ i ∨ j ∨ ~ j) A
   slideSquareFaces i j k (i = i0) = a₋ (j ∧ ~ k)

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -150,7 +150,7 @@ module _ {a₀₀ a₁₁ : A} {a₋ : a₀₀ ≡ a₁₁}
   slideSquareFaces i j k (i = i0) = a₋ (j ∧ ~ k)
   slideSquareFaces i j k (i = i1) = a₁₋ j
   slideSquareFaces i j k (j = i0) = a₋₀ i
-  slideSquareFaces i j k (j = i1) = a₋ (i ∨ ~ k)  
+  slideSquareFaces i j k (j = i1) = a₋ (i ∨ ~ k)
 
   slideSquare : Square a₋ a₁₋ a₋₀ refl → Square refl a₁₋ a₋₀ a₋
   slideSquare sq i j = hcomp (slideSquareFaces i j) (sq i j)

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -102,11 +102,17 @@ compPathr-cancel p q = (q ∙ sym p) ∙ p ≡⟨ sym (assoc q (sym p) p) ⟩
                               q ∙ refl ≡⟨ sym (rUnit q) ⟩
                                      q ∎
 
-compPathl-isEquiv : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) → isEquiv (λ (q : y ≡ z) → p ∙ q)
+compPathl-isEquiv : {x y z : A} (p : x ≡ y) → isEquiv (λ (q : y ≡ z) → p ∙ q)
 compPathl-isEquiv p = isoToIsEquiv (iso (p ∙_) (sym p ∙_) (compPathl-cancel p) (compPathl-cancel (sym p)))
 
-compPathr-isEquiv : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : y ≡ z) → isEquiv (λ (q : x ≡ y) → q ∙ p)
+compPathlEquiv : {x y z : A} (p : x ≡ y) → (y ≡ z) ≃ (x ≡ z)
+compPathlEquiv p = (p ∙_) , compPathl-isEquiv p
+
+compPathr-isEquiv : {x y z : A} (p : y ≡ z) → isEquiv (λ (q : x ≡ y) → q ∙ p)
 compPathr-isEquiv p = isoToIsEquiv (iso (_∙ p) (_∙ sym p) (compPathr-cancel p) (compPathr-cancel (sym p)))
+
+compPathrEquiv : {x y z : A} (p : y ≡ z) → (x ≡ y) ≃ (x ≡ z)
+compPathrEquiv p = (_∙ p) , compPathr-isEquiv p
 
 -- Variation of isProp→isSet for PathP
 isProp→isSet-PathP : ∀ {ℓ} {B : I → Type ℓ} → ((i : I) → isProp (B i))

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -97,10 +97,8 @@ compPathl-cancel p q = p ∙ (sym p ∙ q) ≡⟨ assoc p (sym p) q ⟩
                                      q ∎
 
 compPathr-cancel : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : z ≡ y) (q : x ≡ y) → (q ∙ sym p) ∙ p ≡ q
-compPathr-cancel p q = (q ∙ sym p) ∙ p ≡⟨ sym (assoc q (sym p) p) ⟩
-                       q ∙ (sym p ∙ p) ≡⟨ cong (q ∙_) (lCancel p) ⟩
-                              q ∙ refl ≡⟨ sym (rUnit q) ⟩
-                                     q ∎
+compPathr-cancel {x = x} p q i j =
+  hcomp-equivFiller (doubleComp-faces (λ _ → x) (sym p) j) (inS (q j)) (~ i)
 
 compPathl-isEquiv : {x y z : A} (p : x ≡ y) → isEquiv (λ (q : y ≡ z) → p ∙ q)
 compPathl-isEquiv p = isoToIsEquiv (iso (p ∙_) (sym p ∙_) (compPathl-cancel p) (compPathl-cancel (sym p)))
@@ -123,7 +121,7 @@ isProp→isSet-PathP {B = B} hB b0 b1 =
 
 -- Flipping a square along its diagonal
 
-flipSquare : ∀ {ℓ} {A : Type ℓ}
+flipSquare :
   {a₀₀ a₀₁ : A} {a₀₋ : a₀₀ ≡ a₀₁}
   {a₁₀ a₁₁ : A} {a₁₋ : a₁₀ ≡ a₁₁}
   {a₋₀ : a₀₀ ≡ a₁₀} {a₋₁ : a₀₁ ≡ a₁₁}
@@ -131,9 +129,37 @@ flipSquare : ∀ {ℓ} {A : Type ℓ}
   → Square a₋₀ a₋₁ a₀₋ a₁₋
 flipSquare sq i j = sq j i
 
-flipSquarePath : ∀ {ℓ} {A : Type ℓ}
+flipSquareEquiv :
+  {a₀₀ a₀₁ : A} {a₀₋ : a₀₀ ≡ a₀₁}
+  {a₁₀ a₁₁ : A} {a₁₋ : a₁₀ ≡ a₁₁}
+  {a₋₀ : a₀₀ ≡ a₁₀} {a₋₁ : a₀₁ ≡ a₁₁}
+  → Square a₀₋ a₁₋ a₋₀ a₋₁ ≃ Square a₋₀ a₋₁ a₀₋ a₁₋
+flipSquareEquiv = isoToEquiv (iso flipSquare flipSquare (λ _ → refl) (λ _ → refl))
+
+flipSquarePath :
   {a₀₀ a₀₁ : A} {a₀₋ : a₀₀ ≡ a₀₁}
   {a₁₀ a₁₁ : A} {a₁₋ : a₁₀ ≡ a₁₁}
   {a₋₀ : a₀₀ ≡ a₁₀} {a₋₁ : a₀₁ ≡ a₁₁}
   → Square a₀₋ a₁₋ a₋₀ a₋₁ ≡ Square a₋₀ a₋₁ a₀₋ a₁₋
 flipSquarePath = isoToPath (iso flipSquare flipSquare (λ _ → refl) (λ _ → refl))
+
+module _ {a₀₀ a₁₁ : A} (a₋ : a₀₀ ≡ a₁₁)
+  {a₁₀ : A} (a₁₋ : a₁₀ ≡ a₁₁) (a₋₀ : a₀₀ ≡ a₁₀) where
+
+  slideSquareFaces : (i j k : I) → Partial (i ∨ ~ i ∨ j ∨ ~ j) A
+  slideSquareFaces i j k (i = i0) = a₋ (j ∧ ~ k)
+  slideSquareFaces i j k (i = i1) = a₁₋ j
+  slideSquareFaces i j k (j = i0) = a₋₀ i
+  slideSquareFaces i j k (j = i1) = a₋ (i ∨ ~ k)  
+
+  slideSquare : Square a₋ a₁₋ a₋₀ refl → Square refl a₁₋ a₋₀ a₋
+  slideSquare sq i j = hcomp (slideSquareFaces i j) (sq i j)
+
+  slideSquareEquiv : (Square a₋ a₁₋ a₋₀ refl) ≃ (Square refl a₁₋ a₋₀ a₋)
+  slideSquareEquiv = isoToEquiv (iso slideSquare slideSquareInv fillerTo fillerFrom) where
+    slideSquareInv : Square refl a₁₋ a₋₀ a₋ → Square a₋ a₁₋ a₋₀ refl
+    slideSquareInv sq i j = hcomp (λ k → slideSquareFaces i j (~ k)) (sq i j)
+    fillerTo : ∀ p → slideSquare (slideSquareInv p) ≡ p
+    fillerTo p k i j = hcomp-equivFiller (λ k → slideSquareFaces i j (~ k)) (inS (p i j)) (~ k)
+    fillerFrom : ∀ p → slideSquareInv (slideSquare p) ≡ p
+    fillerFrom p k i j = hcomp-equivFiller (slideSquareFaces i j) (inS (p i j)) (~ k)

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -38,7 +38,7 @@ isHomogeneousPath : ∀ {ℓ} (A : Type ℓ) {x y : A} (p : x ≡ y) → isHomog
 isHomogeneousPath A {x} {y} p q
   = pointed-sip ((x ≡ y) , p) ((x ≡ y) , q) (eqv , compPathr-cancel p q)
   where eqv : (x ≡ y) ≃ (x ≡ y)
-        eqv = ((q ∙ sym p) ∙_) , compPathl-isEquiv (q ∙ sym p)
+        eqv = compPathlEquiv (q ∙ sym p)
 
 module HomogeneousDiscrete {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙)) (y : typ A∙) where
 

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -79,18 +79,19 @@ cong₂ f p q i = f (p i) (q i)
    `doubleCompPath-filler p q r` gives the whole square
 -}
 
+doubleComp-faces : {x y z w : A } (p : x ≡ y) (r : z ≡ w)
+                 → (i : I) (j : I) → Partial (i ∨ ~ i) A
+doubleComp-faces p r i j (i = i0) = p (~ j)
+doubleComp-faces p r i j (i = i1) = r j
+
 _∙∙_∙∙_ : w ≡ x → x ≡ y → y ≡ z → w ≡ z
 (p ∙∙ q ∙∙ r) i =
-  hcomp (λ j → λ { (i = i0) → p (~ j)
-                 ; (i = i1) → r j })
-        (q i)
+  hcomp (doubleComp-faces p r i) (q i)
 
 doubleCompPath-filler : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)
                       → PathP (λ j → p (~ j) ≡ r j) q (p ∙∙ q ∙∙ r)
 doubleCompPath-filler p q r j i =
-  hfill (λ j → λ { (i = i0) → p (~ j)
-                 ; (i = i1) → r j })
-        (inS (q i)) j
+  hfill (doubleComp-faces p r i) (inS (q i)) j
 
 -- any two definitions of double composition are equal
 compPath-unique : ∀ (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -25,24 +25,39 @@ transpFill φ A u0 i = transp (λ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
 transport⁻ : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → B → A
 transport⁻ p = transport (λ i → p (~ i))
 
+transport-fillerExt : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B)
+                    → PathP (λ i → A → p i) (λ x → x) (transport p)
+transport-fillerExt p i x = transport-filler p x i
+
+transport⁻-fillerExt : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B)
+                     → PathP (λ i → p i → A) (λ x → x) (transport⁻ p)
+transport⁻-fillerExt p i x = transp (λ j → p (i ∧ ~ j)) (~ i) x
+
+transport-fillerExt⁻ : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B)
+                    → PathP (λ i → p i → B) (transport p) (λ x → x)
+transport-fillerExt⁻ p = symP (transport⁻-fillerExt (sym p))
+
+transport⁻-fillerExt⁻ : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B)
+                     → PathP (λ i → B → p i) (transport⁻ p) (λ x → x)
+transport⁻-fillerExt⁻ p = symP (transport-fillerExt (sym p))
+
+
 transport⁻-filler : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B) (x : B)
                    → PathP (λ i → p (~ i)) x (transport⁻ p x)
-transport⁻-filler p x i = transp (λ j → p (~ i ∨ ~ j)) (~ i) x
+transport⁻-filler p x = transport-filler (λ i → p (~ i)) x
 
 transport⁻Transport : ∀ {ℓ} {A B : Type ℓ} → (p : A ≡ B) → (a : A) →
                           transport⁻ p (transport p a) ≡ a
-transport⁻Transport p a j =
-  transp (λ i → p (~ i ∧ ~ j)) j (transp (λ i → p (i ∧ ~ j)) j a)
+transport⁻Transport p a j = transport⁻-fillerExt p (~ j) (transport-fillerExt p (~ j) a)
 
 transportTransport⁻ : ∀ {ℓ} {A B : Type ℓ} → (p : A ≡ B) → (b : B) →
                         transport p (transport⁻ p b) ≡ b
-transportTransport⁻ p b j =
-  transp (λ i → p (i ∨ j)) j (transp (λ i → p (~ i ∨ j)) j b)
+transportTransport⁻ p b j = transport-fillerExt⁻ p j (transport⁻-fillerExt⁻ p j b)
 
 -- Transport is an equivalence
 isEquivTransport : ∀ {ℓ} {A B : Type ℓ} (p : A ≡ B) → isEquiv (transport p)
 isEquivTransport {A = A} {B = B} p =
-  transport (λ i → isEquiv (λ x → transp (λ j → p (i ∧ j)) (~ i) x)) (idIsEquiv A)
+  transport (λ i → isEquiv (transport-fillerExt p i)) (idIsEquiv A)
 
 transportEquiv : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → A ≃ B
 transportEquiv p = (transport p , isEquivTransport p)
@@ -61,7 +76,7 @@ uaTransportη P i j
       (j = i1) → P i1 , idEquiv (P i1)
 
 pathToIso : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → Iso A B
-pathToIso x = iso (transport x) (transport⁻ x ) ( transportTransport⁻ x) (transport⁻Transport x)
+pathToIso x = iso (transport x) (transport⁻ x) (transportTransport⁻ x) (transport⁻Transport x)
 
 isInjectiveTransport : ∀ {ℓ : Level} {A B : Type ℓ} {p q : A ≡ B}
   → transport p ≡ transport q → p ≡ q
@@ -84,25 +99,16 @@ isSet-subst {B = B} isSet-A p x = subst (λ p′ → subst B p′ x ≡ x) (isSe
 
 -- substituting along a composite path is equivalent to substituting twice
 substComposite : ∀ {ℓ ℓ′} {A : Type ℓ} → (B : A → Type ℓ′)
-                   → {x y z : A} (p : x ≡ y) (q : y ≡ z) (u : B x)
-                   → subst B (p ∙ q) u ≡ subst B q (subst B p u)
-substComposite B p q Bx = sym (substRefl {B = B} _) ∙ helper where
-  compSq : I → I → _
-  compSq j i = compPath-filler' p q j i
-  helper : subst B refl (subst B (p ∙ q) Bx) ≡ subst B q (subst B p Bx)
-  helper i = subst B (λ k → compSq (~ i ∧ ~ k) (~ i ∨ k)) (subst B (λ k → compSq (~ i ∨ ~ k) (~ i ∧ k)) Bx)
+                 → {x y z : A} (p : x ≡ y) (q : y ≡ z) (u : B x)
+                 → subst B (p ∙ q) u ≡ subst B q (subst B p u)
+substComposite B p q Bx i =
+  transport (cong B (compPath-filler' p q (~ i))) (transport-fillerExt (cong B p) i Bx)
 
 -- substitution commutes with morphisms in slices
 substCommSlice : ∀ {ℓ ℓ′} {A : Type ℓ}
-                   → (B C : A → Type ℓ′)
-                   → (F : ∀ i → B i → C i)
-                   → {x y : A} (p : x ≡ y) (u : B x)
-                   → subst C p (F x u) ≡ F y (subst B p u)
-substCommSlice B C F p Bx i = comp pathC (λ k → λ where
-      (i = i0) → toPathP {A = pathC} (λ _ → subst C p (F _ Bx)) k
-      (i = i1) → F (p k) (toPathP {A = pathB} (λ _ → subst B p Bx) k)
-    ) (F _ Bx) where
-  pathC : I → Type _
-  pathC i = cong C p i
-  pathB : I → Type _
-  pathB i = cong B p i
+                 → (B C : A → Type ℓ′)
+                 → (F : ∀ i → B i → C i)
+                 → {x y : A} (p : x ≡ y) (u : B x)
+                 → subst C p (F x u) ≡ F y (subst B p u)
+substCommSlice B C F p Bx i =
+  transport-fillerExt⁻ (cong C p) i (F _ (transport-fillerExt (cong B p) i Bx))

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -6,6 +6,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.Equiv.HalfAdjoint
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
@@ -134,7 +135,7 @@ isEquiv→hasPropFibers : isEquiv f → hasPropFibers f
 isEquiv→hasPropFibers e b = isContr→isProp (equiv-proof e b)
 
 isEquiv→isEmbedding : isEquiv f → isEmbedding f
-isEquiv→isEmbedding e = hasPropFibers→isEmbedding (isEquiv→hasPropFibers e)
+isEquiv→isEmbedding e = λ _ _ → congEquiv (_ , e) .snd
 
 iso→isEmbedding : ∀ {ℓ} {A B : Type ℓ}
   → (isom : Iso A B)

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -154,20 +154,18 @@ isEmbedding→Injection a e {f = f} {g} x = sym (ua (cong a , e (f x) (g x)))
 -- if `f` has a retract, then `cong f` has, as well. If `B` is a set, then `cong f`
 -- further has a section, making it an embedding. If `B` is not a set, the situation
 -- is more complicated.
-module _ (retf : hasRetract f) where
+module _ {f : A → B} (retf : hasRetract f) where
   open Σ retf renaming (fst to g ; snd to ϕ)
-  private
-    imgTypeOf : (f : A → B) → Type _
-    imgTypeOf {B = B} _ = B
 
   congRetract : f w ≡ f x → w ≡ x
   congRetract {w = w} {x = x} p = sym (ϕ w) ∙∙ cong g p ∙∙ ϕ x
-  isRetractRetractCong : retract (cong {x = w} {y = x} f) congRetract
-  isRetractRetractCong p = transport (PathP≡doubleCompPathˡ _ _ _ _) (λ i j → ϕ (p j) i)
+
+  isRetractCongRetract : retract (cong {x = w} {y = x} f) congRetract
+  isRetractCongRetract p = transport (PathP≡doubleCompPathˡ _ _ _ _) (λ i j → ϕ (p j) i)
 
   hasRetract→hasRetractCong : hasRetract (cong {x = w} {y = x} f)
-  hasRetract→hasRetractCong = congRetract , isRetractRetractCong
+  hasRetract→hasRetractCong = congRetract , isRetractCongRetract
 
-  setRetraction→isEmbedding : isSet (imgTypeOf f) → isEmbedding f
-  setRetraction→isEmbedding setB w x =
+  isSetRetract→isEmbedding : isSet B → isEmbedding f
+  isSetRetract→isEmbedding setB w x =
     isoToIsEquiv (iso (cong f) congRetract (λ _ → setB _ _ _ _) (hasRetract→hasRetractCong .snd))

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -153,8 +153,7 @@ isEmbedding→Injection :
 isEmbedding→Injection a e {f = f} {g} x = sym (ua (cong a , e (f x) (g x)))
 
 -- if `f` has a retract, then `cong f` has, as well. If `B` is a set, then `cong f`
--- further has a section, making it an embedding. If `B` is not a set, the situation
--- is more complicated.
+-- further has a section, making `f` an embedding.
 module _ {f : A → B} (retf : hasRetract f) where
   open Σ retf renaming (fst to g ; snd to ϕ)
 
@@ -167,6 +166,6 @@ module _ {f : A → B} (retf : hasRetract f) where
   hasRetract→hasRetractCong : hasRetract (cong {x = w} {y = x} f)
   hasRetract→hasRetractCong = congRetract , isRetractCongRetract
 
-  isSetRetract→isEmbedding : isSet B → isEmbedding f
-  isSetRetract→isEmbedding setB w x =
+  retractableIntoSet→isEmbedding : isSet B → isEmbedding f
+  retractableIntoSet→isEmbedding setB w x =
     isoToIsEquiv (iso (cong f) congRetract (λ _ → setB _ _ _ _) (hasRetract→hasRetractCong .snd))

--- a/Cubical/HITs/Nullification/Properties.agda
+++ b/Cubical/HITs/Nullification/Properties.agda
@@ -6,7 +6,6 @@ open import Cubical.Foundations.Function
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Equiv.HalfAdjoint
 open import Cubical.Foundations.Equiv.PathSplit
 open import Cubical.Foundations.Equiv.Properties
 open import Cubical.Foundations.Univalence

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -151,8 +151,8 @@ indMapEquiv→conType : ∀ {ℓ} {A : Type ℓ} (n : HLevel)
 indMapEquiv→conType {A = A} n BEq =
   transport (λ i → isContr (hLevelTrunc n (typeToFiber A (~ i))))
             (elim.isConnectedPrecompose (λ _ → tt) n
-                                        (λ P → isEquiv-hasSection _ ((compEquiv ((λ Q → Q tt) , isoToIsEquiv (helper P))
-                                                                                 (_ , BEq (P tt)) .snd )))
+                                        (λ P → isEquiv→hasSection ((compEquiv ((λ Q → Q tt) , isoToIsEquiv (helper P))
+                                                                              (_ , BEq (P tt)) .snd )))
                                         tt)
   where
   helper : ∀ {ℓ'} (P : Unit → TypeOfHLevel ℓ' n)


### PR DESCRIPTION
A bit messier than I'd hoped, since the PR contains more unrelated things than I initially expected.

I originally wanted to prove that any retract of a function into a set makes that function an embedding. Then I stumbled upon other stuff to do, mostly with HAEquivs:

- `isHAEquiv→Iso` and `isHAEquiv→isEquiv`
- a more direct proof of `equiv→HAEquiv`
- added `depPostCompEquiv`
- `postCompEquiv` and few other things are more universe polymorphic
- direct proof of `isEquiv→isContrHasRetract` (for universe polymorphism and term size), a bit more complicated than the one for HasSection, but manageable.
- **`isPropIsHAEquiv`** didn't find it elsewhere and thought I'd want to use it. Ended up not using it.
- `hcomp-equivFiller`: this basically proves that `hcomp` has an inverse, but I don't know to straight-forwardly state that. See `slideSquareEquiv` for a usage.
- shortened proof of `substComposite` and `substCommSlice`
- last but not least `retractableIntoSet→isEmbedding : hasRetract f → isSet B → isEmbedding f`

If I should split the PR into more self-contained pieces, just tell me. Other comments are of course welcome too, as always.
