### PR TITLE
Abelian Groups are now right-associative instead of left-associative

### DIFF
--- a/Cubical/Structures/AbGroup.agda
+++ b/Cubical/Structures/AbGroup.agda
@@ -48,7 +48,7 @@ record AbGroup : Type (ℓ-suc ℓ) where
     isAbGroup : IsAbGroup 0g _+_ -_
 
   infix  8 -_
-  infixl 7 _+_
+  infixr 7 _+_
 
   open IsAbGroup isAbGroup public
 


### PR DESCRIPTION
I noticed the current definition of Abelian Groups defines the law _+_ as light associative, while it is left-associative in the definition of Group. Perhaps there are other places in the library where such a change should be made ?