### PR TITLE
truncate choice functions for QER

### DIFF
--- a/Cubical/Foundations/RelationalStructure.agda
+++ b/Cubical/Foundations/RelationalStructure.agda
@@ -224,29 +224,13 @@ structuredQER→structuredEquiv : {S : Type ℓ → Type ℓ'} {ρ : StrRel S �
   → QERDescends S ρ A B R
 structuredQER→structuredEquiv {ρ = ρ} θ (X , s) (Y , t) R r .quoᴸ =
   θ .quo (X , s) (QER→EquivRel R)
-    (subst (λ R' → ρ R' s s) correction
-      (θ .transitive (R .fst) (invPropRel (R .fst)) r (θ .symmetric (R .fst) r)))
+    (θ .transitive (R .fst) (invPropRel (R .fst)) r (θ .symmetric (R .fst) r))
     .fst
-  where
-  correction : compPropRel (R .fst) (invPropRel (R .fst)) .fst ≡ QER→EquivRel R .fst .fst
-  correction =
-    funExt₂ λ x₀ x₁ →
-      (hPropExt squash (R .fst .snd _ _)
-        (Trunc.rec (R .fst .snd _ _) (λ {(y , r , r') → R .snd .zigzag r r' (R .snd .fwdRel _)}))
-        (λ r → ∣ _ , r , R .snd .fwdRel _ ∣))
 
 structuredQER→structuredEquiv {ρ = ρ} θ (X , s) (Y , t) R r .quoᴿ =
   θ .quo (Y , t) (QER→EquivRel (invQER R))
-    (subst (λ R' → ρ R' t t) correction
-      (θ .transitive (invPropRel (R .fst)) (R .fst) (θ .symmetric (R .fst) r) r))
+    (θ .transitive (invPropRel (R .fst)) (R .fst) (θ .symmetric (R .fst) r) r)
     .fst
-  where
-  correction : compPropRel (invPropRel (R .fst)) (R .fst) .fst ≡ QER→EquivRel (invQER R) .fst .fst
-  correction =
-    funExt₂ λ y₀ y₁ →
-      (hPropExt squash (R .fst .snd _ _)
-        (Trunc.rec (R .fst .snd _ _) (λ {(x , r , r') → R .snd .zigzag (R .snd .bwdRel _) r' r}))
-        (λ r → ∣ _ , r , R .snd .bwdRel _ ∣))
 
 structuredQER→structuredEquiv {ρ = ρ} θ (X , s) (Y , t) R r .rel =
   subst (λ R' → ρ R' (quol .fst) (quor .fst)) correction
@@ -270,14 +254,16 @@ structuredQER→structuredEquiv {ρ = ρ} θ (X , s) (Y , t) R r .rel =
             Trunc.rec
               (squash/ _ _)
               (λ {(x , px , r) →
-                cong (E.Thm .fst) (sym px)
-                ∙ eq/ (R .snd .fwd x) y (R .snd .zigzag (R .snd .bwdRel y) r (R .snd .fwdRel x))
+                (cong (E.Thm .fst) (sym px)
+                ∙ E.relToFwd≡ r)
                 ∙ py})
               qr}))
-        (elimProp
-          {B = λ qx →
-            E.Thm .fst qx ≡ qy → [R] .fst qx qy}
+        (elimProp {B = λ qx → E.Thm .fst qx ≡ qy → [R] .fst qx qy}
           (λ _ → isPropΠ λ _ → squash)
-          (λ x p → ∣ _ , ∣ _ , refl , R .snd .fwdRel x ∣ , p ∣)
+          (λ x →
+            elimProp {B = λ qy → E.Thm .fst [ x ] ≡ qy → [R] .fst [ x ] qy}
+              (λ _ → isPropΠ λ _ → squash)
+              (λ y p → ∣ _ , ∣ _ , refl , E.fwd≡ToRel p ∣ , refl ∣)
+              qy)
           qx))
 

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -19,6 +19,7 @@ open import Cubical.Data.Sigma
 open import Cubical.HITs.SetQuotients
 open import Cubical.HITs.FiniteMultiset as FMS hiding ([_])
 open import Cubical.HITs.FiniteMultiset.CountExtensionality
+open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.ZigZag.Base
 
@@ -150,10 +151,8 @@ module Lists&ALists {A : Type ℓ} (discA : Discrete A) where
   QuasiR .fst .fst = R
   QuasiR .fst .snd _ _ = isPropΠ λ _ → isSetℕ _ _
   QuasiR .snd .zigzag r r' r'' a = (r a) ∙∙ sym (r' a) ∙∙ (r'' a)
-  QuasiR .snd .fwd = φ
-  QuasiR .snd .fwdRel = η
-  QuasiR .snd .bwd = ψ
-  QuasiR .snd .bwdRel = ε
+  QuasiR .snd .fwd a = ∣ φ a , η a ∣
+  QuasiR .snd .bwd b = ∣ ψ b , ε b ∣
 
   isStructuredInsert : (x : A) {xs : List A} {ys : AList A}
     → R xs ys → R (L.insert x xs) (AL.insert x ys)
@@ -214,7 +213,8 @@ module Lists&ALists {A : Type ℓ} (discA : Discrete A) where
     δ c a b xs | no  _        | no  _ = refl
 
     γ : ∀ a b xs → Rᴸ (a ∷ b ∷ xs) (b ∷ a ∷ xs)
-    γ a b xs c = δ c a b xs ∙ η (b ∷ a ∷ xs) c
+    γ a b xs =
+      ∣ φ (a ∷ b ∷ xs) , η (a ∷ b ∷ xs) , (λ c → δ c b a xs ∙ η (a ∷ b ∷ xs) c) ∣
 
     β : ∀ a b [xs] → a ∷/ b ∷/ [xs] ≡ b ∷/ a ∷/ [xs]
     β a b = elimProp (λ _ → squash/ _ _) (λ xs → eq/ _ _ (γ a b xs))
@@ -237,7 +237,7 @@ module Lists&ALists {A : Type ℓ} (discA : Discrete A) where
   List/Rᴸ→FMSet (eq/ xs ys r i) = path i
     where
     countsAgree : ∀ a → L.count a xs ≡ L.count a ys
-    countsAgree a = r a ∙ sym (η ys a)
+    countsAgree a = cong (LQstructure .snd .snd a) (eq/ xs ys r)
 
     θ : ∀ a → FMScount discA a (List→FMSet xs) ≡ FMScount discA a (List→FMSet ys)
     θ a = sym (List→FMSet-count a xs) ∙∙ countsAgree a ∙∙ List→FMSet-count a ys

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -5,8 +5,10 @@ module Cubical.Relation.ZigZag.Base where
 
 open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.HLevels
+open import Cubical.Data.Sigma
 open import Cubical.HITs.SetQuotients
 open import Cubical.HITs.PropositionalTruncation as Trunc
 open import Cubical.Relation.Binary.Base
@@ -27,10 +29,8 @@ ZigZagRel A B ℓ' = Σ[ R ∈ (A → B → Type ℓ') ] (isZigZagComplete R)
 record isQuasiEquivRel {A B : Type ℓ} (R : A → B → Type ℓ') : Type (ℓ-max ℓ ℓ') where
   field
     zigzag : isZigZagComplete R
-    fwd : A → B
-    fwdRel : (a : A) → R a (fwd a)
-    bwd : B → A
-    bwdRel : (b : B) → R (bwd b) b
+    fwd : (a : A) → ∃[ b ∈ B ] R a b
+    bwd : (b : B) → ∃[ a ∈ A ] R a b
 
 open isQuasiEquivRel
 
@@ -42,44 +42,120 @@ invQER : {A B : Type ℓ} {ℓ' : Level} → QuasiEquivRel A B ℓ' → QuasiEqu
 invQER (R , qer) .fst = invPropRel R
 invQER (R , qer) .snd .zigzag aRb aRb' a'Rb' = qer .zigzag a'Rb' aRb' aRb
 invQER (R , qer) .snd .fwd = qer .bwd
-invQER (R , qer) .snd .fwdRel = qer .bwdRel
 invQER (R , qer) .snd .bwd = qer .fwd
-invQER (R , qer) .snd .bwdRel = qer .fwdRel
 
 QER→EquivRel : {A B : Type ℓ}
-  → QuasiEquivRel A B ℓ' → EquivPropRel A ℓ'
-QER→EquivRel (R , sim) .fst .fst a₀ a₁ = R .fst a₀ (sim .fwd a₁)
-QER→EquivRel (R , sim) .fst .snd _ _ = R .snd _ _
-QER→EquivRel (R , sim) .snd .reflexive a = sim .fwdRel a
-QER→EquivRel (R , sim) .snd .symmetric a₀ a₁ r =
-  sim .zigzag (sim .fwdRel a₁) r (sim .fwdRel a₀)
-QER→EquivRel (R , sim) .snd .transitive a₀ a₁ a₂ r s =
-  sim .zigzag r (sim .fwdRel a₁) s
+  → QuasiEquivRel A B ℓ' → EquivPropRel A (ℓ-max ℓ ℓ')
+QER→EquivRel (R , sim) .fst = compPropRel R (invPropRel R)
+QER→EquivRel (R , sim) .snd .reflexive a = Trunc.map (λ {(b , r) → b , r , r}) (sim .fwd a)
+QER→EquivRel (R , sim) .snd .symmetric _ _ = Trunc.map (λ {(b , r₀ , r₁) → b , r₁ , r₀})
+QER→EquivRel (R , sim) .snd .transitive _ _ _ =
+  Trunc.map2 (λ {(b , r₀ , r₁) (b' , r₀' , r₁') → b , r₀ , sim .zigzag r₁' r₀' r₁})
 
 -- The following result is due to Carlo Angiuli
 module QER→Equiv {A B : Type ℓ} (R : QuasiEquivRel A B ℓ') where
 
-  private
-    sim = R .snd
-    f = sim .fwd
-    g = sim .bwd
-
   Rᴸ = QER→EquivRel R .fst .fst
   Rᴿ = QER→EquivRel (invQER R) .fst .fst
 
-  Thm : (A / Rᴸ) ≃ (B / Rᴿ)
-  Thm = isoToEquiv (iso φ ψ η ε)
-    where
-    φ : _
-    φ [ a ] = [ f a ]
-    φ (eq/ a₀ a₁ r i) = eq/ _ _ (sim .zigzag (sim .bwdRel (f a₁)) r (sim .fwdRel a₀)) i
+  private
+    sim = R .snd
+
+  private
+    f : (a : A) → ∃[ b ∈ B ] R .fst .fst a b → B / Rᴿ
+    f a =
+      Trunc.rec→Set squash/
+        ([_] ∘ fst)
+        (λ {(b , r) (b' , r') → eq/ b b' ∣ a , r , r' ∣})
+
+    fPath :
+      (a₀ : A) (s₀ : ∃[ b ∈ B ] R .fst .fst a₀ b)
+      (a₁ : A) (s₁ : ∃[ b ∈ B ] R .fst .fst a₁ b)
+      → Rᴸ a₀ a₁
+      → f a₀ s₀ ≡ f a₁ s₁
+    fPath a₀ =
+      Trunc.elim (λ _ → isPropΠ3 λ _ _ _ → squash/ _ _)
+        (λ {(b₀ , r₀) a₁ →
+          Trunc.elim (λ _ → isPropΠ λ _ → squash/ _ _)
+            (λ {(b₁ , r₁) →
+              Trunc.elim (λ _ → squash/ _ _)
+                (λ {(b' , r₀' , r₁') → eq/ b₀ b₁ ∣ a₀ , r₀ , sim .zigzag r₀' r₁' r₁ ∣})})})
+
+    φ : A / Rᴸ → B / Rᴿ
+    φ [ a ] = f a (sim .fwd a)
+    φ (eq/ a₀ a₁ r i) =  fPath a₀ (sim .fwd a₀) a₁ (sim .fwd a₁) r i
     φ (squash/ _ _ p q j i) = squash/ _ _ (cong φ p) (cong φ q) j i
 
-    ψ : _
-    ψ [ b ] = [ g b ]
-    ψ (eq/ b₀ b₁ s i) = eq/ _ _ (sim .zigzag (sim .bwdRel b₀) s (sim .fwdRel (g b₁))) i
+
+  relToFwd≡ : ∀ {a b} → R .fst .fst a b → φ [ a ] ≡ [ b ]
+  relToFwd≡ {a} {b} r =
+    Trunc.elim {P = λ s → f a s ≡ [ b ]} (λ _ → squash/ _ _)
+      (λ {(b' , r') → eq/ b' b ∣ a , r' , r ∣})
+      (sim .fwd a)
+
+  fwd≡ToRel : ∀ {a b} → φ [ a ] ≡ [ b ] → R .fst .fst a b
+  fwd≡ToRel {a} {b} =
+    Trunc.elim {P = λ s → f a s ≡ [ b ] → R .fst .fst a b}
+      (λ _ → isPropΠ λ _ → R .fst .snd _ _)
+      (λ {(b' , r') p →
+        Trunc.rec (R .fst .snd _ _)
+          (λ {(a' , s' , s) → R .snd .zigzag r' s' s})
+          (effective
+            (QER→EquivRel (invQER R) .fst .snd)
+            (QER→EquivRel (invQER R) .snd)
+            b' b p)})
+      (sim .fwd a)
+
+  private
+    g : (b : B) → ∃[ a ∈ A ] R .fst .fst a b → A / Rᴸ
+    g b =
+      Trunc.rec→Set squash/
+        ([_] ∘ fst)
+        (λ {(a , r) (a' , r') → eq/ a a' ∣ b , r , r' ∣})
+
+    gPath :
+      (b₀ : B) (s₀ : ∃[ a ∈ A ] R .fst .fst a b₀)
+      (b₁ : B) (s₁ : ∃[ a ∈ A ] R .fst .fst a b₁)
+      → Rᴿ b₀ b₁
+      → g b₀ s₀ ≡ g b₁ s₁
+    gPath b₀ =
+      Trunc.elim (λ _ → isPropΠ3 λ _ _ _ → squash/ _ _)
+        (λ {(a₀ , r₀) b₁ →
+          Trunc.elim (λ _ → isPropΠ λ _ → squash/ _ _)
+            (λ {(a₁ , r₁) →
+              Trunc.elim (λ _ → squash/ _ _)
+                (λ {(a' , r₀' , r₁') → eq/ a₀ a₁ ∣ b₀ , r₀ , sim .zigzag r₁ r₁' r₀' ∣})})})
+
+    ψ : B / Rᴿ → A / Rᴸ
+    ψ [ b ] = g b (sim .bwd b)
+    ψ (eq/ b₀ b₁ r i) = gPath b₀ (sim .bwd b₀) b₁ (sim .bwd b₁) r i
     ψ (squash/ _ _ p q j i) = squash/ _ _ (cong ψ p) (cong ψ q) j i
 
-    η = elimProp (λ _ → squash/ _ _) (λ b → eq/ _ _ (sim .fwdRel (g b)))
+  relToBwd≡ : ∀ {a b} → R .fst .fst a b → ψ [ b ] ≡ [ a ]
+  relToBwd≡ {a} {b} r =
+    Trunc.elim {P = λ s → g b s ≡ [ a ]} (λ _ → squash/ _ _)
+      (λ {(a' , r') → eq/ a' a ∣ b , r' , r ∣})
+      (sim .bwd b)
 
-    ε = elimProp (λ _ → squash/ _ _) (λ a → eq/ _ _ (sim .bwdRel (f a)))
+  private
+    η : ∀ qb → φ (ψ qb) ≡ qb
+    η =
+      elimProp (λ _ → squash/ _ _)
+        (λ b →
+          Trunc.elim {P = λ s → φ (g b s) ≡ [ b ]} (λ _ → squash/ _ _)
+            (λ {(a , r) → relToFwd≡ r})
+            (sim .bwd b))
+
+    ε : ∀ qa → ψ (φ qa) ≡ qa
+    ε =
+      elimProp (λ _ → squash/ _ _)
+        (λ a →
+          Trunc.elim {P = λ s → ψ (f a s) ≡ [ a ]} (λ _ → squash/ _ _)
+            (λ {(b , r) → relToBwd≡ r})
+            (sim .fwd a))
+
+  bwd≡ToRel : ∀ {a b} → ψ [ b ] ≡ [ a ] → R .fst .fst a b
+  bwd≡ToRel {a} {b} p = fwd≡ToRel (cong φ (sym p) ∙ η [ b ])
+
+  Thm : (A / Rᴸ) ≃ (B / Rᴿ)
+  Thm = isoToEquiv (iso φ ψ η ε)


### PR DESCRIPTION
Weaken the definition of QER to only require `(a : A) → ∃[ b ∈ B ] R a b` and vice versa, which is all that's needed for the applications. Then we get that R is a QER iff (R . R^-1) and (R^{-1} . R) are equivalence relations (though I didn't prove it explicitly in this PR), which matches the situation for QPERs.