### PR TITLE
Groupoid quotients and the first Eilenberg–Mac Lane space (group delooping)

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -420,3 +420,24 @@ isOfHLevel→isOfHLevelDep (suc (suc n)) {A = A} {B} h {a0} {a1} b0 b1 =
   helper a1 p b1 = J
                      (λ a1 p → ∀ b1 → isOfHLevel (suc n) (PathP (λ i → B (p i)) b0 b1))
                      (λ _ → h _ _ _) p b1
+
+isSetDep : {A : Type ℓ} (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
+isSetDep {A = A} B = {a₀₀ a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁)
+  {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)
+  (a₋₀ : a₀₀ ≡ a₁₀) (a₋₁ : a₀₁ ≡ a₁₁) (s : Square a₀₋ a₁₋ a₋₀ a₋₁)
+  {b₀₀ : B a₀₀} {b₀₁ : B a₀₁} (b₀₋ : PathP (λ j → B (a₀₋ j)) b₀₀ b₀₁)
+  {b₁₀ : B a₁₀} {b₁₁ : B a₁₁} (b₁₋ : PathP (λ j → B (a₁₋ j)) b₁₀ b₁₁)
+  (b₋₀ : PathP (λ i → B (a₋₀ i)) b₀₀ b₁₀)
+  (b₋₁ : PathP (λ i → B (a₋₁ i)) b₀₁ b₁₁)
+  → SquareP (λ i j → B (s i j)) b₀₋ b₁₋ b₋₀ b₋₁
+
+isSet→isSetDep : {A : Type ℓ} {B : A → Type ℓ'}
+                 (h : (a : A) → isSet (B a))
+                 → isSetDep {A = A} B
+isSet→isSetDep {A = A} {B = B} h {a₀₀} a₀₋ a₁₋ a₋₀ a₋₁ s b₀₋ b₁₋ b₋₀ b₋₁ =
+  J-square (λ a₀₋ a₁₋ a₋₀ a₋₁ s
+    → ∀ {b₀₀} {b₀₁} (b₀₋ : PathP (λ j → B (a₀₋ j)) b₀₀ b₀₁)
+    → ∀ {b₁₀} {b₁₁} (b₁₋ : PathP (λ j → B (a₁₋ j)) b₁₀ b₁₁)
+      (b₋₀ : PathP (λ i → B (a₋₀ i)) b₀₀ b₁₀)
+      (b₋₁ : PathP (λ i → B (a₋₁ i)) b₀₁ b₁₁) → SquareP (λ i j → B (s i j)) b₀₋ b₁₋ b₋₀ b₋₁)
+    (isSet→isSet' (h a₀₀)) a₀₋ a₁₋ a₋₀ a₋₁ s b₀₋ b₁₋ b₋₀ b₋₁

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -337,6 +337,26 @@ Square :
   → Type _
 Square a₀₋ a₁₋ a₋₀ a₋₁ = PathP (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋
 
+-- J for squares
+module _ {A : Type ℓ} {a₀₀ : A}
+         (P : {a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁) {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)
+              (a₋₀ : a₀₀ ≡ a₁₀) (a₋₁ : a₀₁ ≡ a₁₁)
+              → Square a₀₋ a₁₋ a₋₀ a₋₁ → Type ℓ')
+         (d : P (λ _ → a₀₀) (λ _ → a₀₀) (λ _ → a₀₀) (λ _ → a₀₀)
+                (λ _ _ → a₀₀)) where
+
+  J-square : {a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁) {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)
+             (a₋₀ : a₀₀ ≡ a₁₀) (a₋₁ : a₀₁ ≡ a₁₁) (s : Square a₀₋ a₁₋ a₋₀ a₋₁)
+             → P a₀₋ a₁₋ a₋₀ a₋₁ s
+  J-square a₀₋ a₁₋ a₋₀ a₋₁ s =
+    transport (λ k → P (λ j → s i0 (k ∧ j)) (λ j → s k (k ∧ j))
+      (λ i → s (k ∧ i) i0) (λ i → s (k ∧ i) k)
+      (λ i j → s (k ∧ i) (k ∧ j))) d
+
+  J-square-refl : J-square (λ _ → a₀₀) (λ _ → a₀₀) (λ _ → a₀₀) (λ _ → a₀₀)
+                  (λ _ _ → a₀₀) ≡ d
+  J-square-refl = transportRefl d
+
 isSet' : Type ℓ → Type ℓ
 isSet' A =
   {a₀₀ a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁)

--- a/Cubical/HITs/EilenbergMacLane1.agda
+++ b/Cubical/HITs/EilenbergMacLane1.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --cubical --no-import-sorts --safe  #-}
+module Cubical.HITs.EilenbergMacLane1 where
+
+open import Cubical.HITs.EilenbergMacLane1.Base public
+open import Cubical.HITs.EilenbergMacLane1.Properties public

--- a/Cubical/HITs/EilenbergMacLane1/Base.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Base.agda
@@ -1,0 +1,43 @@
+{-
+
+This file contains:
+
+- The first Eilenberg–Mac Lane type as a HIT
+
+-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+module Cubical.HITs.EilenbergMacLane1.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Structures.Group.Base
+
+private
+  variable ℓ : Level
+
+module _ (G : Group {ℓ}) where
+  open Group G
+
+  data EM₁ : Type ℓ where
+    embase : EM₁
+    emloop : Carrier → embase ≡ embase
+    emcomp : (g h : Carrier)
+           → PathP (λ j → embase ≡ emloop h j) (emloop g) (emloop (g + h))
+    emsquash : ∀ (x y : EM₁) (p q : x ≡ y) (r s : p ≡ q) → r ≡ s
+
+  {- The comp// constructor fills the square:
+
+    emloop (g + h)
+    [a]— — — >[c]
+     ‖         ^
+     ‖         | emloop h     ^
+     ‖         |            j |
+    [a]— — — >[b]          ∙ — >
+       emloop g                i
+
+    We use this to give another constructor-like construction:
+  -}
+
+  emloop-comp : (g h : Carrier) → emloop (g + h) ≡ emloop g ∙ emloop h
+  emloop-comp g h i = compPath-unique refl (emloop g) (emloop h)
+    (emloop (g + h) , emcomp g h)
+    (emloop g ∙ emloop h , compPath-filler (emloop g) (emloop h)) i .fst

--- a/Cubical/HITs/EilenbergMacLane1/Properties.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Properties.agda
@@ -1,0 +1,116 @@
+{-
+
+Eilenberg–Mac Lane type K(G, 1)
+
+-}
+
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+module Cubical.HITs.EilenbergMacLane1.Properties where
+
+open import Cubical.HITs.EilenbergMacLane1.Base
+
+open import Cubical.Core.Everything
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.Univalence
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Structures.Group.Base
+
+open import Cubical.HITs.PropositionalTruncation as PropTrunc using (∥_∥; ∣_∣; squash)
+open import Cubical.HITs.SetTruncation as SetTrunc using (∥_∥₂; ∣_∣₂; squash₂)
+
+-- Type quotients
+
+private
+  variable
+    ℓG ℓ : Level
+
+module _ (G : Group {ℓG}) where
+
+  open Group G
+
+  elimEq : {B : EM₁ G → Type ℓ}
+           (Bprop : (x : EM₁ G) → isProp (B x))
+           {x y : EM₁ G}
+           (eq : x ≡ y)
+           (bx : B x)
+           (by : B y) →
+           PathP (λ i → B (eq i)) bx by
+  elimEq {B = B} Bprop {x = x} =
+    J (λ y eq → ∀ bx by → PathP (λ i → B (eq i)) bx by) (λ bx by → Bprop x bx by)
+
+  elimProp : {B : EM₁ G → Type ℓ}
+             → ((x : EM₁ G) → isProp (B x))
+             → B embase
+             → (x : EM₁ G)
+             → B x
+  elimProp Bprop b embase = b
+  elimProp Bprop b (emloop g i) = elimEq Bprop (emloop g) b b i
+  elimProp Bprop b (emcomp g h i j) =
+    isSet→isSetDep (λ x → isProp→isSet (Bprop x))
+    (emloop g) (emloop (g + h)) (λ j → embase) (emloop h) (emcomp g h)
+    (λ i → elimEq Bprop (emloop g) b b i)
+    (λ i → elimEq Bprop (emloop (g + h)) b b i)
+    (λ j → b) (λ j → elimEq Bprop (emloop h) b b j) i j
+  elimProp Bprop b (emsquash x y p q r s i j k) =
+    isOfHLevel→isOfHLevelDep 3 (λ x → isSet→isGroupoid (isProp→isSet (Bprop x)))
+    _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (emsquash x y p q r s) i j k
+    where
+      g = elimProp Bprop b
+
+  elimProp2 : {C : EM₁ G → EM₁ G → Type ℓ}
+            → ((x y : EM₁ G) → isProp (C x y))
+            → C embase embase
+            → (x y : EM₁ G)
+            → C x y
+  elimProp2 Cprop c = elimProp (λ x → isPropΠ (λ y → Cprop x y))
+                               (elimProp (λ y → Cprop embase y) c)
+
+  elimSet : {B : EM₁ G → Type ℓ}
+          → ((x : EM₁ G) → isSet (B x))
+          → (b : B embase)
+          → ((g : Carrier) → PathP (λ i → B (emloop g i)) b b)
+          → (x : EM₁ G)
+          → B x
+  elimSet Bset b bloop embase = b
+  elimSet Bset b bloop (emloop g i) = bloop g i
+  elimSet Bset b bloop (emcomp g h i j) =
+    isSet→isSetDep Bset (emloop g) (emloop (g + h)) (λ j → embase) (emloop h) (emcomp g h)
+      (bloop g) (bloop (g + h)) refl (bloop h) i j
+  elimSet Bset b bloop (emsquash x y p q r s i j k) =
+    isOfHLevel→isOfHLevelDep 3 (λ x → isSet→isGroupoid (Bset x))
+      _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (emsquash x y p q r s) i j k
+    where
+      g = elimSet Bset b bloop
+
+  elim : {B : EM₁ G → Type ℓ}
+       → ((x : EM₁ G) → isGroupoid (B x))
+       → (b : B embase)
+       → (bloop : (g : Carrier) → PathP (λ i → B (emloop g i)) b b)
+       → ((g h : Carrier) → SquareP (λ i j → B (emcomp g h i j))
+            (bloop g) (bloop (g + h)) (λ j → b) (bloop h))
+       → (x : EM₁ G)
+       → B x
+  elim Bgpd b bloop bcomp embase = b
+  elim Bgpd b bloop bcomp (emloop g i) = bloop g i
+  elim Bgpd b bloop bcomp (emcomp g h i j) = bcomp g h i j
+  elim Bgpd b bloop bcomp (emsquash x y p q r s i j k) =
+    isOfHLevel→isOfHLevelDep 3 Bgpd
+      _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (emsquash x y p q r s) i j k
+    where
+      g = elim Bgpd b bloop bcomp
+
+  rec : {B : Type ℓ}
+      → isGroupoid B
+      → (b : B)
+      → (bloop : Carrier → b ≡ b)
+      → ((g h : Carrier) → Square (bloop g) (bloop (g + h)) refl (bloop h))
+      → (x : EM₁ G)
+      → B
+  rec Bgpd = elim (λ _ → Bgpd)

--- a/Cubical/HITs/GroupoidQuotients.agda
+++ b/Cubical/HITs/GroupoidQuotients.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --cubical --no-import-sorts --safe  #-}
+module Cubical.HITs.GroupoidQuotients where
+
+open import Cubical.HITs.GroupoidQuotients.Base public
+open import Cubical.HITs.GroupoidQuotients.Properties public

--- a/Cubical/HITs/GroupoidQuotients/Base.agda
+++ b/Cubical/HITs/GroupoidQuotients/Base.agda
@@ -1,0 +1,43 @@
+{-
+
+This file contains:
+
+- Definition of groupoid quotients
+
+-}
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+module Cubical.HITs.GroupoidQuotients.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Relation.Binary.Base
+
+-- Groupoid quotients as a higher inductive type:
+-- For the definition, only transitivity is needed
+data _//_ {ℓ ℓ'} (A : Type ℓ) {R : A → A → Type ℓ'}
+          (Rt : BinaryRelation.isTrans R) : Type (ℓ-max ℓ ℓ') where
+  [_] : (a : A) → A // Rt
+  eq// : {a b : A} → (r : R a b) → [ a ] ≡ [ b ]
+  comp// : {a b c : A} → (r : R a b) → (s : R b c)
+          → PathP (λ j → [ a ] ≡ eq// s j) (eq// r) (eq// (Rt a b c r s))
+  squash// : ∀ (x y : A // Rt) (p q : x ≡ y) (r s : p ≡ q) → r ≡ s
+
+{- The comp// constructor fills the square:
+
+  eq// (Rt a b c r s)
+    [a]— — — >[c]
+     ‖         ^
+     ‖         | eq// s   ^
+     ‖         |        j |
+    [a]— — — >[b]         ∙ — >
+       eq// r               i
+
+  We use this to give another constructor-like construction:
+-}
+
+comp'// : {ℓ ℓ' : Level} (A : Type ℓ) {R : A → A → Type ℓ'}
+          (Rt : BinaryRelation.isTrans R)
+          {a b c : A} → (r : R a b) → (s : R b c)
+          → eq// {Rt = Rt} (Rt a b c r s) ≡ eq// r ∙ eq// s
+comp'// A Rt r s i = compPath-unique refl (eq// r) (eq// s)
+  (eq// {Rt = Rt} (Rt _ _ _ r s) , comp// r s)
+  (eq// r ∙ eq// s , compPath-filler (eq// r) (eq// s)) i .fst

--- a/Cubical/HITs/GroupoidQuotients/Properties.agda
+++ b/Cubical/HITs/GroupoidQuotients/Properties.agda
@@ -1,0 +1,136 @@
+{-
+
+Groupoid quotients:
+
+-}
+
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+module Cubical.HITs.GroupoidQuotients.Properties where
+
+open import Cubical.HITs.GroupoidQuotients.Base
+
+open import Cubical.Core.Everything
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.Univalence
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Binary.Base
+
+open import Cubical.HITs.PropositionalTruncation as PropTrunc using (∥_∥; ∣_∣; squash)
+open import Cubical.HITs.SetTruncation as SetTrunc using (∥_∥₂; ∣_∣₂; squash₂)
+
+-- Type quotients
+
+private
+  variable
+    ℓA ℓR ℓ : Level
+    A : Type ℓA
+    R : A → A → Type ℓR
+--    B : A // Rt → Type ℓ
+--    C : A // Rt → A // Rt → Type ℓ
+
+elimEq// : (Rt : BinaryRelation.isTrans R)
+          {B : A // Rt → Type ℓ}
+          (Bprop : (x : A // Rt) → isProp (B x))
+          {x y : A // Rt}
+          (eq : x ≡ y)
+          (bx : B x)
+          (by : B y) →
+          PathP (λ i → B (eq i)) bx by
+elimEq// Rt {B} Bprop {x = x} =
+  J (λ y eq → ∀ bx by → PathP (λ i → B (eq i)) bx by) (λ bx by → Bprop x bx by)
+
+elimProp : (Rt : BinaryRelation.isTrans R)
+         → {B : A // Rt → Type ℓ}
+         → ((x : A // Rt) → isProp (B x))
+         → ((a : A) → B [ a ])
+         → (x : A // Rt)
+         → B x
+elimProp Rt Bprop f [ x ] = f x
+elimProp Rt Bprop f (eq// {a} {b} r i) = elimEq// Rt Bprop (eq// r) (f a) (f b) i
+elimProp Rt Bprop f (comp// {a} {b} {c} r s i j) =
+  isSet→isSetDep (λ x → isProp→isSet (Bprop x))
+  (eq// r) (eq// (Rt a b c r s)) (λ j → [ a ]) (eq// s) (comp// r s)
+  (λ i → elimEq// Rt Bprop (eq// r) (f a) (f b) i)
+  (λ i → elimEq// Rt Bprop (eq// (Rt a b c r s)) (f a) (f c) i)
+  (λ j → f a ) (λ j → elimEq// Rt Bprop (eq// s) (f b) (f c) j) i j
+elimProp Rt Bprop f (squash// x y p q r s i j k) =
+  isOfHLevel→isOfHLevelDep 3 (λ x → isSet→isGroupoid (isProp→isSet (Bprop x)))
+  _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (squash// x y p q r s) i j k
+  where
+    g = elimProp Rt Bprop f
+
+elimProp2 : (Rt : BinaryRelation.isTrans R)
+          → {C : A // Rt → A // Rt → Type ℓ}
+         → ((x y : A // Rt) → isProp (C x y))
+         → ((a b : A) → C [ a ] [ b ])
+         → (x y : A // Rt)
+         → C x y
+elimProp2 Rt Cprop f = elimProp Rt (λ x → isPropΠ (λ y → Cprop x y))
+                                   (λ x → elimProp Rt (λ y → Cprop [ x ] y) (f x))
+
+[]surjective : (Rt : BinaryRelation.isTrans R)
+               → (x : A // Rt ) → ∃[ a ∈ A ] [ a ] ≡ x
+[]surjective Rt = elimProp Rt (λ x → squash) (λ a → ∣ a , refl ∣)
+
+elimSet : (Rt : BinaryRelation.isTrans R)
+     → {B : A // Rt → Type ℓ}
+     → ((x : A // Rt) → isSet (B x))
+     → (f : (a : A) → B [ a ])
+     → ({a b : A} (r : R a b) → PathP (λ i → B (eq// r i)) (f a) (f b))
+     → (x : A // Rt)
+     → B x
+elimSet Rt Bset f feq [ a ] = f a
+elimSet Rt Bset f feq (eq// r i) = feq r i
+elimSet Rt Bset f feq (comp// {a} {b} {c} r s i j) =
+  isSet→isSetDep Bset (eq// r) (eq// (Rt a b c r s)) (λ j → [ a ]) (eq// s) (comp// r s)
+  (feq r) (feq (Rt a b c r s)) refl (feq s) i j
+elimSet Rt Bset f feq (squash// x y p q r s i j k) =
+  isOfHLevel→isOfHLevelDep 3 (λ x → isSet→isGroupoid (Bset x))
+    _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (squash// x y p q r s) i j k
+  where
+    g = elimSet Rt Bset f feq
+
+elim : (Rt : BinaryRelation.isTrans R)
+     → {B : A // Rt → Type ℓ}
+     → ((x : A // Rt) → isGroupoid (B x))
+     → (f : (a : A) → B [ a ])
+     → (feq : {a b : A} (r : R a b) → PathP (λ i → B (eq// r i)) (f a) (f b))
+     → ({a b c : A} (r : R a b) (s : R b c)
+           → SquareP (λ i j → B (comp// r s i j))
+           (feq r) (feq (Rt a b c r s)) (λ j → f a) (feq s))
+     → (x : A // Rt)
+     → B x
+elim Rt Bgpd f feq fcomp [ a ] = f a
+elim Rt Bgpd f feq fcomp (eq// r i) = feq r i
+elim Rt Bgpd f feq fcomp (comp// r s i j) = fcomp r s i j
+elim Rt Bgpd f feq fcomp (squash// x y p q r s i j k) =
+  isOfHLevel→isOfHLevelDep 3 Bgpd
+    _ _ _ _ (λ j k → g (r j k)) (λ j k → g (s j k)) (squash// x y p q r s) i j k
+  where
+    g = elim Rt Bgpd f feq fcomp
+
+rec : (Rt : BinaryRelation.isTrans R)
+    → {B : Type ℓ}
+    → isGroupoid B
+    → (f : A → B)
+    → (feq : {a b : A} (r : R a b) → f a ≡ f b)
+    → ({a b c : A} (r : R a b) (s : R b c)
+          → Square (feq r) (feq (Rt a b c r s)) refl (feq s))
+    → (x : A // Rt)
+    → B
+rec Rt Bgpd = elim Rt (λ _ → Bgpd)
+
+module BinarySetRelation {ℓA ℓR : Level} {A : Type ℓA} (R : Rel A A ℓR) where
+  open BinaryRelation R
+
+  isSetValued : Type (ℓ-max ℓA ℓR)
+  isSetValued = (a b : A) → isSet (R a b)
+

--- a/Cubical/Structures/Group/EilenbergMacLane1.agda
+++ b/Cubical/Structures/Group/EilenbergMacLane1.agda
@@ -1,0 +1,130 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+
+module Cubical.Structures.Group.EilenbergMacLane1 where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.GroupoidLaws renaming (assoc to ∙assoc)
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Transport
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.SIP
+open import Cubical.Data.Unit
+open import Cubical.Data.Sigma
+open import Cubical.Relation.Binary.Base
+open import Cubical.Structures.Axioms
+open import Cubical.Structures.Auto
+open import Cubical.Structures.Group.Base
+open import Cubical.Structures.Group.Properties
+open import Cubical.Homotopy.Connected
+open import Cubical.HITs.Nullification as Null hiding (rec; elim)
+open import Cubical.HITs.Truncation as Trunc renaming (rec to trRec; elim to trElim)
+open import Cubical.HITs.GroupoidQuotients
+
+private
+  variable ℓ : Level
+module _ (G : Group {ℓ}) where
+
+  open Group G
+
+  EM₁R : Unit → Unit → Type ℓ
+  EM₁R x y = Carrier
+
+  EM₁Rt : BinaryRelation.isTrans EM₁R
+  EM₁Rt a b c g h = g + h
+
+  EM₁ : Type ℓ
+  EM₁ = Unit // EM₁Rt
+
+  embase : EM₁
+  embase = [ tt ]
+
+  emloop : ⟨ G ⟩ → embase ≡ embase
+  emloop g = eq// g
+
+  emloop-comp : (g h : Carrier) → emloop (g + h) ≡ emloop g ∙ emloop h
+  emloop-comp g h = comp'// Unit EM₁Rt g h
+
+  emloop-id : emloop 0g ≡ refl
+  emloop-id =
+    emloop 0g ≡⟨ rUnit (emloop 0g) ⟩
+    emloop 0g ∙ refl ≡⟨ cong (emloop 0g ∙_) (rCancel (emloop 0g) ⁻¹) ⟩
+    emloop 0g ∙ (emloop 0g ∙ (emloop 0g) ⁻¹) ≡⟨ ∙assoc _ _ _ ⟩
+    (emloop 0g ∙ emloop 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (_∙ emloop 0g ⁻¹) ((emloop-comp 0g 0g) ⁻¹) ⟩
+    emloop (0g + 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (λ g → emloop g ∙ (emloop 0g) ⁻¹) (lid 0g) ⟩
+    emloop 0g ∙ (emloop 0g) ⁻¹ ≡⟨ rCancel (emloop 0g) ⟩
+    refl ∎
+
+  emloop-inv : (g : Carrier) → emloop (- g) ≡ (emloop g) ⁻¹
+  emloop-inv g =
+    emloop (- g) ≡⟨ rUnit (emloop (- g)) ⟩
+    emloop (- g) ∙ refl ≡⟨ cong (emloop (- g) ∙_) (rCancel (emloop g) ⁻¹) ⟩
+    emloop (- g) ∙ (emloop g ∙ (emloop g) ⁻¹) ≡⟨ ∙assoc _ _ _ ⟩
+    (emloop (- g) ∙ emloop g) ∙ (emloop g) ⁻¹ ≡⟨ cong (_∙ emloop g ⁻¹) ((emloop-comp (- g) g) ⁻¹) ⟩
+    emloop (- g + g) ∙ (emloop g) ⁻¹ ≡⟨ cong (λ h → emloop h ∙ (emloop g) ⁻¹) (invl g) ⟩
+    emloop 0g ∙ (emloop g) ⁻¹ ≡⟨ cong (_∙ (emloop g) ⁻¹) emloop-id ⟩
+    refl ∙ (emloop g) ⁻¹ ≡⟨ (lUnit ((emloop g) ⁻¹)) ⁻¹ ⟩
+    (emloop g) ⁻¹ ∎
+
+  EM₁Groupoid : isGroupoid EM₁
+  EM₁Groupoid = squash//
+
+  EM₁Connected : isConnected 2 EM₁
+  EM₁Connected = ∣ embase ∣ , h
+    where
+      h : (y : hLevelTrunc 2 EM₁) → ∣ embase ∣ ≡ y
+      h = trElim (λ y → isOfHLevelSuc 1 (isOfHLevelTrunc 2 ∣ embase ∣ y))
+            (elimProp EM₁Rt (λ x → isOfHLevelTrunc 2 ∣ embase ∣ ∣ x ∣)
+              (λ { tt → refl }))
+
+  {- since we write composition in diagrammatic order,
+     and function composition in the other order,
+     we need right multiplication here -}
+  rightEquiv : (g : Carrier) → Carrier ≃ Carrier
+  rightEquiv g = isoToEquiv (iso (_+ g) (_+ - g)
+    (λ h → (h + - g) + g ≡⟨ (assoc h (- g) g) ⁻¹ ⟩
+             h + - g + g ≡⟨ cong (h +_) (invl g) ⟩
+                  h + 0g ≡⟨ rid h ⟩ h ∎)
+    λ h → (h + g) + - g ≡⟨ (assoc h g (- g)) ⁻¹ ⟩
+            h + g + - g ≡⟨ cong (h +_) (invr g) ⟩
+                 h + 0g ≡⟨ rid h ⟩ h ∎)
+
+  compRightEquiv : (g h : Carrier)
+    → compEquiv (rightEquiv g) (rightEquiv h) ≡ rightEquiv (g + h)
+  compRightEquiv g h = equivEq _ _ (funExt (λ x → (assoc x g h) ⁻¹))
+
+  Codes : EM₁ → hSet ℓ
+  Codes = rec EM₁Rt (isOfHLevelTypeOfHLevel 2)
+    (λ _ → Carrier , is-set) RE REComp
+    where
+      RE : (g : Carrier) → Path (hSet ℓ) (Carrier , is-set) (Carrier , is-set)
+      RE g = Σ≡Prop (λ X → isPropIsOfHLevel {A = X} 2) (ua (rightEquiv g))
+
+      lemma₁ : (g h : Carrier) → Square
+        (ua (rightEquiv g)) (ua (rightEquiv (g + h)))
+        refl (ua (rightEquiv h))
+      lemma₁ g h = invEq
+                   (Square≃doubleComp (ua (rightEquiv g)) (ua (rightEquiv (g + h)))
+                     refl (ua (rightEquiv h)))
+                   (ua (rightEquiv g) ∙ ua (rightEquiv h)
+                       ≡⟨ (uaCompEquiv (rightEquiv g) (rightEquiv h)) ⁻¹ ⟩
+                    ua (compEquiv (rightEquiv g) (rightEquiv h))
+                       ≡⟨ cong ua (compRightEquiv g h) ⟩
+                    ua (rightEquiv (g + h)) ∎)
+
+      lemma₂ : {A₀₀ A₀₁ : hSet ℓ} (p₀₋ : A₀₀ ≡ A₀₁)
+               {A₁₀ A₁₁ : hSet ℓ} (p₁₋ : A₁₀ ≡ A₁₁)
+               (p₋₀ : A₀₀ ≡ A₁₀) (p₋₁ : A₀₁ ≡ A₁₁)
+                 (s : Square (cong fst p₀₋) (cong fst p₁₋) (cong fst p₋₀) (cong fst p₋₁))
+               → Square p₀₋ p₁₋ p₋₀ p₋₁
+      fst (lemma₂ p₀₋ p₁₋ p₋₀ p₋₁ s i j) = s i j
+      snd (lemma₂ p₀₋ p₁₋ p₋₀ p₋₁ s i j) =
+        isSet→isSetDep (λ X → isProp→isSet (isPropIsOfHLevel {A = X} 2))
+          (cong fst p₀₋) (cong fst p₁₋) (cong fst p₋₀) (cong fst p₋₁) s
+          (cong snd p₀₋) (cong snd p₁₋) (cong snd p₋₀) (cong snd p₋₁) i j
+
+      REComp : (g h : Carrier) → Square (RE g) (RE (g + h)) refl (RE h)
+      REComp g h = lemma₂ (RE g) (RE (g + h)) refl (RE h) (lemma₁ g h)

--- a/Cubical/Structures/Group/EilenbergMacLane1.agda
+++ b/Cubical/Structures/Group/EilenbergMacLane1.agda
@@ -22,39 +22,22 @@ open import Cubical.Structures.Group.Properties
 open import Cubical.Homotopy.Connected
 open import Cubical.HITs.Nullification as Null hiding (rec; elim)
 open import Cubical.HITs.Truncation as Trunc renaming (rec to trRec; elim to trElim)
-open import Cubical.HITs.GroupoidQuotients
+open import Cubical.HITs.EilenbergMacLane1
 
 private
   variable ℓ : Level
+
 module _ (G : Group {ℓ}) where
 
   open Group G
-
-  EM₁R : Unit → Unit → Type ℓ
-  EM₁R x y = Carrier
-
-  EM₁Rt : BinaryRelation.isTrans EM₁R
-  EM₁Rt a b c g h = g + h
-
-  EM₁ : Type ℓ
-  EM₁ = Unit // EM₁Rt
-
-  embase : EM₁
-  embase = [ tt ]
-
-  emloop : ⟨ G ⟩ → embase ≡ embase
-  emloop g = eq// g
-
-  emloop-comp : (g h : Carrier) → emloop (g + h) ≡ emloop g ∙ emloop h
-  emloop-comp g h = comp'// Unit EM₁Rt g h
 
   emloop-id : emloop 0g ≡ refl
   emloop-id =
     emloop 0g ≡⟨ rUnit (emloop 0g) ⟩
     emloop 0g ∙ refl ≡⟨ cong (emloop 0g ∙_) (rCancel (emloop 0g) ⁻¹) ⟩
     emloop 0g ∙ (emloop 0g ∙ (emloop 0g) ⁻¹) ≡⟨ ∙assoc _ _ _ ⟩
-    (emloop 0g ∙ emloop 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (_∙ emloop 0g ⁻¹) ((emloop-comp 0g 0g) ⁻¹) ⟩
-    emloop (0g + 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (λ g → emloop g ∙ (emloop 0g) ⁻¹) (lid 0g) ⟩
+    (emloop 0g ∙ emloop 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (_∙ emloop 0g ⁻¹) ((emloop-comp G 0g 0g) ⁻¹) ⟩
+    emloop (0g + 0g) ∙ (emloop 0g) ⁻¹ ≡⟨ cong (λ g → emloop {G = G} g ∙ (emloop 0g) ⁻¹)  (rid 0g) ⟩
     emloop 0g ∙ (emloop 0g) ⁻¹ ≡⟨ rCancel (emloop 0g) ⟩
     refl ∎
 
@@ -63,22 +46,21 @@ module _ (G : Group {ℓ}) where
     emloop (- g) ≡⟨ rUnit (emloop (- g)) ⟩
     emloop (- g) ∙ refl ≡⟨ cong (emloop (- g) ∙_) (rCancel (emloop g) ⁻¹) ⟩
     emloop (- g) ∙ (emloop g ∙ (emloop g) ⁻¹) ≡⟨ ∙assoc _ _ _ ⟩
-    (emloop (- g) ∙ emloop g) ∙ (emloop g) ⁻¹ ≡⟨ cong (_∙ emloop g ⁻¹) ((emloop-comp (- g) g) ⁻¹) ⟩
-    emloop (- g + g) ∙ (emloop g) ⁻¹ ≡⟨ cong (λ h → emloop h ∙ (emloop g) ⁻¹) (invl g) ⟩
+    (emloop (- g) ∙ emloop g) ∙ (emloop g) ⁻¹ ≡⟨ cong (_∙ emloop g ⁻¹) ((emloop-comp G (- g) g) ⁻¹) ⟩
+    emloop (- g + g) ∙ (emloop g) ⁻¹ ≡⟨ cong (λ h → emloop {G = G} h ∙ (emloop g) ⁻¹) (invl g) ⟩
     emloop 0g ∙ (emloop g) ⁻¹ ≡⟨ cong (_∙ (emloop g) ⁻¹) emloop-id ⟩
     refl ∙ (emloop g) ⁻¹ ≡⟨ (lUnit ((emloop g) ⁻¹)) ⁻¹ ⟩
     (emloop g) ⁻¹ ∎
 
-  EM₁Groupoid : isGroupoid EM₁
-  EM₁Groupoid = squash//
+  EM₁Groupoid : isGroupoid (EM₁ G)
+  EM₁Groupoid = emsquash
 
-  EM₁Connected : isConnected 2 EM₁
+  EM₁Connected : isConnected 2 (EM₁ G)
   EM₁Connected = ∣ embase ∣ , h
     where
-      h : (y : hLevelTrunc 2 EM₁) → ∣ embase ∣ ≡ y
+      h : (y : hLevelTrunc 2 (EM₁ G)) → ∣ embase ∣ ≡ y
       h = trElim (λ y → isOfHLevelSuc 1 (isOfHLevelTrunc 2 ∣ embase ∣ y))
-            (elimProp EM₁Rt (λ x → isOfHLevelTrunc 2 ∣ embase ∣ ∣ x ∣)
-              (λ { tt → refl }))
+            (elimProp G (λ x → isOfHLevelTrunc 2 ∣ embase ∣ ∣ x ∣) refl)
 
   {- since we write composition in diagrammatic order,
      and function composition in the other order,
@@ -96,9 +78,8 @@ module _ (G : Group {ℓ}) where
     → compEquiv (rightEquiv g) (rightEquiv h) ≡ rightEquiv (g + h)
   compRightEquiv g h = equivEq _ _ (funExt (λ x → (assoc x g h) ⁻¹))
 
-  Codes : EM₁ → hSet ℓ
-  Codes = rec EM₁Rt (isOfHLevelTypeOfHLevel 2)
-    (λ _ → Carrier , is-set) RE REComp
+  CodesSet : EM₁ G → hSet ℓ
+  CodesSet = rec G (isOfHLevelTypeOfHLevel 2) (Carrier , is-set) RE REComp
     where
       RE : (g : Carrier) → Path (hSet ℓ) (Carrier , is-set) (Carrier , is-set)
       RE g = Σ≡Prop (λ X → isPropIsOfHLevel {A = X} 2) (ua (rightEquiv g))
@@ -128,3 +109,36 @@ module _ (G : Group {ℓ}) where
 
       REComp : (g h : Carrier) → Square (RE g) (RE (g + h)) refl (RE h)
       REComp g h = lemma₂ (RE g) (RE (g + h)) refl (RE h) (lemma₁ g h)
+
+
+  Codes : EM₁ G → Type ℓ
+  Codes x = CodesSet x .fst
+
+  encode : (x : EM₁ G) → embase ≡ x → Codes x
+  encode x p = subst Codes p 0g
+
+  decode : (x : EM₁ G) → Codes x → embase ≡ x
+  decode = elimSet G (λ x → isOfHLevelΠ 2 (λ c → EM₁Groupoid (embase) x))
+    emloop λ g → ua→ λ h → emcomp h g
+
+  decode-encode : (x : EM₁ G) (p : embase ≡ x) → decode x (encode x p) ≡ p
+  decode-encode x p = J (λ y q → decode y (encode y q) ≡ q)
+    (emloop (transport refl 0g) ≡⟨ cong emloop (transportRefl 0g) ⟩
+     emloop 0g ≡⟨ emloop-id ⟩ refl ∎) p
+
+  encode-decode : (x : EM₁ G) (c : Codes x) → encode x (decode x c) ≡ c
+  encode-decode = elimProp G (λ x → isOfHLevelΠ 1 (λ c → CodesSet x .snd _ _))
+    λ g → encode embase (decode embase g) ≡⟨ refl ⟩
+          encode embase (emloop g) ≡⟨ refl ⟩
+          transport (ua (rightEquiv g)) 0g ≡⟨ uaβ (rightEquiv g) 0g ⟩
+          0g + g ≡⟨ lid g ⟩
+          g ∎
+
+  ΩEM₁Iso : Iso (Path (EM₁ G) embase embase) Carrier
+  Iso.fun ΩEM₁Iso = encode embase
+  Iso.inv ΩEM₁Iso = emloop
+  Iso.rightInv ΩEM₁Iso = encode-decode embase
+  Iso.leftInv ΩEM₁Iso = decode-encode embase
+
+  ΩEM₁≡ : (Path (EM₁ G) embase embase) ≡ Carrier
+  ΩEM₁≡ = isoToPath ΩEM₁Iso


### PR DESCRIPTION
This PR introduces groupoid quotients, but most of the results are about the special case of group deloopings. (I looked at the category theory and it's not quite ready for Rezk/groupoid completions yet.)

However, on the way to proving that the loops in the first Eilenberg–Mac Lane space recovers the group, type-checking gets very slow. Any ideas how I can speed things up?