### PR TITLE
Simple application of Fin: Lehmer codes

### DIFF
--- a/Cubical/Data/Fin/LehmerCode.agda
+++ b/Cubical/Data/Fin/LehmerCode.agda
@@ -1,0 +1,222 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-
+This module develops Lehmer codes, i.e. an encoding of permutations as finite integers.
+
+
+-}
+module Cubical.Data.Fin.LehmerCode where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Transport
+
+open import Cubical.Functions.Embedding
+open import Cubical.Functions.Surjection
+
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Nullary.DecidableEq
+
+open import Cubical.Data.Unit as ⊤
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order
+open import Cubical.Data.Fin.Base as F
+open import Cubical.Data.Fin.Properties
+  renaming (punchOut to punchOutPrim)
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum using (_⊎_; inl; inr)
+
+private
+  variable
+    n : ℕ
+
+FinExcept : (i : Fin n) → Type₀
+FinExcept i = Σ[ j ∈ Fin _ ] ¬ (i ≡ j)
+
+isSetFinExcept : {i : Fin n} → isSet (FinExcept i)
+isSetFinExcept = isOfHLevelΣ 2 isSetFin (λ _ → isProp→isSet (isPropΠ (λ _ → ⊥.isProp⊥)))
+
+fsucExc : {i : Fin n} → FinExcept i → FinExcept (fsuc i)
+fsucExc {i = i} j = fsuc (fst j) , snd j ∘ fsuc-inj
+
+toFinExc : {i : Fin n} → FinExcept i → Fin n
+toFinExc = fst
+
+toFinExc-injective : {i : Fin n} → {j k : FinExcept i} → toFinExc j ≡ toFinExc k → j ≡ k
+toFinExc-injective = Σ≡Prop (λ _ → isPropΠ λ _ → ⊥.isProp⊥)
+
+toℕExc : {i : Fin n} → FinExcept i → ℕ
+toℕExc = toℕ ∘ toFinExc
+
+toℕExc-injective : {i : Fin n} → {j k : FinExcept i} → toℕExc j ≡ toℕExc k → j ≡ k
+toℕExc-injective = toFinExc-injective ∘ toℕ-injective
+
+projectionEquiv : {i : Fin n} → (Unit ⊎ FinExcept i) ≃ Fin n
+projectionEquiv {n = n} {i = i} = isoToEquiv goal where
+  goal : Iso (Unit ⊎ FinExcept i) (Fin n)
+  goal .Iso.fun (inl _) = i
+  goal .Iso.fun (inr m) = fst m
+  goal .Iso.inv m = case discreteFin i m of λ { (yes _) → inl tt ; (no n) → inr (m , n) }
+  goal .Iso.rightInv m with discreteFin i m
+  ... | (yes p) = p
+  ... | (no _) = toℕ-injective refl
+  goal .Iso.leftInv (inl tt) with discreteFin i i
+  ... | (yes _) = refl
+  ... | (no ¬ii) = ⊥.rec (¬ii refl)
+  goal .Iso.leftInv (inr m) with discreteFin i (fst m)
+  ... | (yes p) = ⊥.rec (snd m p)
+  ... | (no _) = cong inr (toℕExc-injective refl)
+
+punchOut : (i : Fin (suc n)) → FinExcept i → Fin n
+punchOut i ¬i = punchOutPrim (snd ¬i)
+
+punchOut-injective : (i : Fin (suc n)) → ∀ j k → punchOut i j ≡ punchOut i k → j ≡ k
+punchOut-injective i j k = toFinExc-injective ∘ punchOut-inj (snd j) (snd k)
+
+punchIn : (i : Fin (suc n)) → Fin n → FinExcept i
+punchIn {_} i j with fsplit i
+...             | inl iz = fsuc j , fznotfs ∘ (iz ∙_)
+punchIn {n} i j | inr (i′ , is) with n
+...                 | zero = ⊥.rec (¬Fin0 j)
+...                 | suc n′ with fsplit j
+...                     | inl jz = fzero , fznotfs ∘ sym ∘ (is ∙_)
+...                     | inr (j′ , _) =
+                            let (k , ¬k≡i′) = punchIn i′ j′
+                            in fsuc k , ¬k≡i′ ∘ fsuc-inj ∘ (is ∙_)
+
+punchOut∘In :(i : Fin (suc n)) → ∀ j → punchOut i (punchIn i j) ≡ j
+punchOut∘In {_} i j with fsplit i
+...                 | inl iz = toℕ-injective refl
+punchOut∘In {n} i j | inr (i′ , _) with n
+...                     | zero = ⊥.rec (¬Fin0 j)
+...                     | suc n′ with fsplit j
+...                         | inl jz = toℕ-injective (cong toℕ jz)
+...                         | inr (j′ , prfj) =
+                              -- the following uses a definitional equality of punchIn but I don't see
+                              -- how to sidestep this while using with-abstractions
+                              fsuc (punchOut i′ _)               ≡⟨ cong (λ j → fsuc (punchOut i′ j)) (toℕExc-injective refl) ⟩
+                              fsuc (punchOut i′ (punchIn i′ j′)) ≡⟨ cong fsuc (punchOut∘In i′ j′) ⟩
+                              fsuc j′                            ≡⟨ toℕ-injective (cong toℕ prfj) ⟩
+                              j                                  ∎
+
+isEquivPunchOut : {i : Fin (suc n)} → isEquiv (punchOut i)
+isEquivPunchOut {i = i} = isEmbedding×isSurjection→isEquiv (isEmbPunchOut , isSurPunchOut) where
+  isEmbPunchOut : isEmbedding (punchOut i)
+  isEmbPunchOut = injEmbedding isSetFinExcept isSetFin λ {_} {_} → punchOut-injective i _ _
+  isSurPunchOut : isSurjection (punchOut i)
+  isSurPunchOut b = ∣ _ , punchOut∘In i b ∣
+
+punchOutEquiv : {i : Fin (suc n)} → FinExcept i ≃ Fin n
+punchOutEquiv = _ , isEquivPunchOut
+
+infixr 4 _∷_
+data LehmerCode : (n : ℕ) → Type₀ where
+  [] : LehmerCode zero
+  _∷_ : ∀ {n} → Fin (suc n) → LehmerCode n → LehmerCode (suc n)
+
+isContrLehmerZero : isContr (LehmerCode 0)
+isContrLehmerZero = [] , λ { [] → refl }
+
+lehmerSucEquiv : Fin (suc n) × LehmerCode n ≃ LehmerCode (suc n)
+lehmerSucEquiv = isoToEquiv (iso (λ (e , c) → e ∷ c)
+                                 (λ { (e ∷ c) → (e , c) })
+                                 (λ { (e ∷ c) → refl })
+                                 (λ (e , c) → refl))
+
+lehmerEquiv : (Fin n ≃ Fin n) ≃ LehmerCode n
+lehmerEquiv {zero} = isContr→Equiv contrFF isContrLehmerZero where
+  contrFF : isContr (Fin zero ≃ Fin zero)
+  contrFF = idEquiv _ , λ y → equivEq _ _ (funExt λ f → ⊥.rec (¬Fin0 f))
+
+lehmerEquiv {suc n} =
+  (Fin (suc n) ≃ Fin (suc n))                            ≃⟨ isoToEquiv i ⟩
+  (Σ[ k ∈ Fin (suc n) ] (FinExcept fzero ≃ FinExcept k)) ≃⟨ Σ-cong-equiv-snd ii ⟩
+  (Fin (suc n) × (Fin n ≃ Fin n))                        ≃⟨ Σ-cong-equiv-snd (λ _ → lehmerEquiv) ⟩
+  (Fin (suc n) × LehmerCode n)                           ≃⟨ lehmerSucEquiv ⟩
+  LehmerCode (suc n) ■ where
+    equivIn : (f : Fin (suc n) ≃ Fin (suc n))
+            → FinExcept fzero ≃ FinExcept (equivFun f fzero)
+    equivIn f =
+      FinExcept fzero
+        ≃⟨ Σ-cong-equiv-snd (λ _ → preCompEquiv (invEquiv (congEquiv f))) ⟩
+      (Σ[ x ∈ Fin (suc n) ] ¬ ffun fzero ≡ ffun x)
+        ≃⟨ Σ-cong-equiv-fst f ⟩
+      FinExcept (ffun fzero)
+        ■ where ffun = equivFun f
+
+--    equivInChar : ∀ {f} x → fst (equivFun (equivIn f) x) ≡ equivFun f (fst x)
+--    equivInChar x = refl
+
+    equivOut : ∀ {k} → FinExcept (fzero {k = n}) ≃ FinExcept k
+             → Fin (suc n) ≃ Fin (suc n)
+    equivOut {k = k} f =
+      Fin (suc n)
+        ≃⟨ invEquiv projectionEquiv ⟩
+      Unit ⊎ FinExcept fzero
+        ≃⟨ isoToEquiv (Sum.sumIso idIso (equivToIso f)) ⟩
+      Unit ⊎ FinExcept k
+        ≃⟨ projectionEquiv ⟩
+      Fin (suc n)
+        ■
+
+    equivOutChar : ∀ {k} {f} (x : FinExcept fzero) → equivFun (equivOut {k = k} f) (fst x) ≡ fst (equivFun f x)
+    equivOutChar {f = f} x with discreteFin fzero (fst x)
+    ... | (yes y) = ⊥.rec (x .snd y)
+    ... | (no n) = cong (λ x′ → fst (equivFun f x′)) (toℕExc-injective refl)
+
+    i : Iso (Fin (suc n) ≃ Fin (suc n))
+            (Σ[ k ∈ Fin (suc n) ] (FinExcept (fzero {k = n}) ≃ FinExcept k))
+    Iso.fun i f = equivFun f fzero , equivIn f
+    Iso.inv i (k , f) = equivOut f
+    Iso.rightInv i (k , f) = ΣPathP (refl , equivEq _ _ (funExt λ x →
+       toℕExc-injective (cong toℕ (equivOutChar {f = f} x))))
+    Iso.leftInv i f = equivEq _ _ (funExt goal) where
+      goal : ∀ x → equivFun (equivOut (equivIn f)) x ≡ equivFun f x
+      goal x = case fsplit x return (λ _ → equivFun (equivOut (equivIn f)) x ≡ equivFun f x) of λ
+        { (inl xz) → subst (λ x → equivFun (equivOut (equivIn f)) x ≡ equivFun f x) xz refl
+        ; (inr (_ , xn)) → equivOutChar {f = equivIn f} (x , fznotfs ∘ (_∙ sym xn))
+        }
+
+    ii : ∀ k → (FinExcept fzero ≃ FinExcept k) ≃ (Fin n ≃ Fin n)
+    ii k = (FinExcept fzero ≃ FinExcept k) ≃⟨ cong≃ (λ R → FinExcept fzero ≃ R) punchOutEquiv ⟩
+           (FinExcept fzero ≃ Fin n)       ≃⟨ cong≃ (λ L → L ≃ Fin n) punchOutEquiv  ⟩
+           (Fin n ≃ Fin n)                 ■
+
+encode : (Fin n ≃ Fin n) → LehmerCode n
+encode = equivFun lehmerEquiv
+
+decode : LehmerCode n → Fin n ≃ Fin n
+decode = invEq lehmerEquiv
+
+factorial : ℕ → ℕ
+factorial zero = 1
+factorial (suc n) = suc n * factorial n
+
+lehmerFinEquiv : LehmerCode n ≃ Fin (factorial n)
+lehmerFinEquiv {zero} = isContr→Equiv isContrLehmerZero isContrFin1
+lehmerFinEquiv {suc n} = _ ≃⟨ invEquiv lehmerSucEquiv ⟩
+                         _ ≃⟨ ≃-× (idEquiv _) lehmerFinEquiv ⟩
+                         _ ≃⟨ factorEquiv ⟩
+                         _ ■
+
+private
+  -- this example is copied from wikipedia, using the permutation of the letters A-G
+  -- B,F,A,G,D,E,C
+  -- given by the corresponding Lehmer code of
+  -- 1 4 0 3 1 1 0
+  exampleCode : LehmerCode 7
+  exampleCode = (1 , (5 , refl)) ∷ (4 , (1 , refl)) ∷ (0 , (4 , refl)) ∷ (3 , (0 , refl)) ∷ (1 , (1 , refl)) ∷ (1 , (0 , refl)) ∷ (0 , (0 , refl)) ∷ []
+
+  example : Fin 7 ≃ Fin 7
+  example = decode exampleCode
+
+  -- C should decode to G
+  computation : fst (equivFun example (3 , (3 , refl))) ≡ 6
+  computation = refl
+
+  _ : toℕ (equivFun lehmerFinEquiv exampleCode) ≡ 4019
+  _ = refl

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -5,6 +5,8 @@ module Cubical.Data.Fin.Properties where
 open import Cubical.Core.Everything
 
 open import Cubical.Functions.Embedding
+open import Cubical.Functions.Surjection
+open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
@@ -25,9 +27,12 @@ open import Cubical.Relation.Nullary.DecidableEq
 
 open import Cubical.Induction.WellFounded
 
+open import Cubical.Relation.Nullary
+
 private
  variable
    a b ℓ : Level
+   n : ℕ
    A : Type a
 
 -- Fin 0 is empty, and thus a proposition.
@@ -140,9 +145,6 @@ private
 Residue : ℕ → ℕ → Type₀
 Residue k n = Σ[ tup ∈ Fin k × ℕ ] expand× tup ≡ n
 
-extract : ∀{k n} → Residue k n → Fin k
-extract = fst ∘ fst
-
 -- There is at most one canonical finite value congruent to each
 -- natural.
 isPropResidue : ∀ k n → isProp (Residue k n)
@@ -211,6 +213,9 @@ module Reduce (k₀ : ℕ) where
 
 open Reduce using (reduce; reduce≡) public
 
+extract : ∀{k n} → Residue k n → Fin k
+extract = fst ∘ fst
+
 private
   lemma₅
     : ∀ k n (R : Residue k n)
@@ -225,17 +230,22 @@ extract≡ k n
 isContrResidue : ∀{k n} → isContr (Residue (suc k) n)
 isContrResidue {k} {n} = inhProp→isContr (reduce k n) (isPropResidue (suc k) n)
 
-
 -- the modulo operator on ℕ
 
 _%_ : ℕ → ℕ → ℕ
 n % zero = n
 n % (suc k) = toℕ (extract (reduce k n))
 
+_/_ : ℕ → ℕ → ℕ
+n / zero = zero
+n / (suc k) = reduce k n .fst .snd
+
+moddiv : ∀ n k → (n / k) * k + n % k ≡ n
+moddiv n zero = refl
+moddiv n (suc k) = sym (expand≡ _ _ (n / suc k)) ∙ reduce k n .snd
+
 n%k≡n[modk] : ∀ n k → Σ[ o ∈ ℕ ] o * k + n % k ≡ n
-n%k≡n[modk] n zero = zero , refl
-n%k≡n[modk] n (suc k) = o , sym (expand≡ _ _ o) ∙ reduce k n .snd
-  where o = reduce k n .fst .snd
+n%k≡n[modk] n k = (n / k) , moddiv n k
 
 n%sk<sk : (n k : ℕ) → (n % suc k) < suc k
 n%sk<sk n k = extract (reduce k n) .snd
@@ -247,23 +257,8 @@ fznotfs {m} p = subst F p tt
     F (zero , _) = Unit
     F (suc _ , _) = ⊥
 
-fsuc-inj
-  : ∀ {m} {i j : Fin m}
-  → fsuc i ≡ fsuc j
-  → i ≡ j
-fsuc-inj {m} {i} p =
-  transport
-    (cong₂
-      (λ h₁ h₂ → h₁ ≡ h₂)
-      (Σ≡Prop (λ _ → m≤n-isProp) refl)
-      (Σ≡Prop (λ _ → m≤n-isProp) refl)
-    )
-    (cong pred′ p)
-  where
-    pred′ : Fin (suc m) → Fin m
-    pred′ n with fsplit n
-    ... | inl _ = i
-    ... | inr (n′ , prf) = n′
+fsuc-inj : {fj fk : Fin n} → fsuc fj ≡ fsuc fk → fj ≡ fk
+fsuc-inj = toℕ-injective ∘ injSuc ∘ cong toℕ
 
 punchOut : ∀ {m} {i j : Fin (suc m)} → (¬ i ≡ j) → Fin m
 punchOut {_} {i} {j} p with fsplit i | fsplit j
@@ -382,36 +377,36 @@ pigeonhole {m} {n} (zero , sm≡n) f =
     transport-prf φ =
       Σ[ i ∈ Fin (sm≡n φ) ] Σ[ j ∈ Fin (sm≡n φ) ]
         (¬ i ≡ j) × (f′≡f φ i ≡ f′≡f φ j)
-pigeonhole {m} {n′} (suc k , prf) f =
+pigeonhole {m} {n} (suc k , prf) f =
   let
-    g : Fin (suc n) → Fin n
-    g k = fst (f′ k) , <-trans (snd (f′ k)) m<n
+    g : Fin (suc n′) → Fin n′
+    g k = fst (f′ k) , <-trans (snd (f′ k)) m<n′
     i , j , ¬q , r = pigeonhole-special g
   in transport transport-prf (i , j , ¬q , Σ≡Prop (λ _ → m≤n-isProp) (cong fst r))
   where
-    n : ℕ
-    n = k + suc m
+    n′ : ℕ
+    n′ = k + suc m
 
-    n′≡sn : n′ ≡ suc n
-    n′≡sn =
-      n′ ≡⟨ sym prf ⟩
+    n≡sn′ : n ≡ suc n′
+    n≡sn′ =
+      n ≡⟨ sym prf ⟩
       suc (k + suc m) ≡⟨ refl ⟩
-      suc n ∎
+      suc n′ ∎
 
-    m<n : m < n
-    m<n = k , injSuc (suc (k + suc m) ≡⟨ prf ⟩ n′ ≡⟨ n′≡sn ⟩ suc n ∎)
+    m<n′ : m < n′
+    m<n′ = k , injSuc (suc (k + suc m) ≡⟨ prf ⟩ n ≡⟨ n≡sn′ ⟩ suc n′ ∎)
 
-    f′ : Fin (suc n) → Fin m
-    f′ = subst (λ h → Fin h → Fin m) n′≡sn f
+    f′ : Fin (suc n′) → Fin m
+    f′ = subst (λ h → Fin h → Fin m) n≡sn′ f
 
-    f′≡f : PathP (λ i → Fin (n′≡sn (~ i)) → Fin m) f′ f
-    f′≡f i = transport-fillerExt (cong (λ h → Fin h → Fin m) n′≡sn) (~ i) f
+    f′≡f : PathP (λ i → Fin (n≡sn′ (~ i)) → Fin m) f′ f
+    f′≡f i = transport-fillerExt (cong (λ h → Fin h → Fin m) n≡sn′) (~ i) f
 
     transport-prf
-      : (Σ[ i ∈ Fin (suc n) ] Σ[ j ∈ Fin (suc n) ] (¬ i ≡ j) × (f′ i ≡ f′ j))
-      ≡ (Σ[ i ∈ Fin n′ ] Σ[ j ∈ Fin n′ ] (¬ i ≡ j) × (f i ≡ f j))
+      : (Σ[ i ∈ Fin (suc n′) ] Σ[ j ∈ Fin (suc n′) ] (¬ i ≡ j) × (f′ i ≡ f′ j))
+      ≡ (Σ[ i ∈ Fin n ] Σ[ j ∈ Fin n ] (¬ i ≡ j) × (f i ≡ f j))
     transport-prf φ =
-      Σ[ i ∈ Fin (n′≡sn (~ φ)) ] Σ[ j ∈ Fin (n′≡sn (~ φ)) ]
+      Σ[ i ∈ Fin (n≡sn′ (~ φ)) ] Σ[ j ∈ Fin (n≡sn′ (~ φ)) ]
         (¬ i ≡ j) × (f′≡f φ i ≡ f′≡f φ j)
 
 Fin-inj′ : {n m : ℕ} → n < m → ¬ Fin m ≡ Fin n
@@ -440,3 +435,82 @@ Fin-inj n m p with n ≟ m
 ... | eq prf = prf
 ... | lt n<m = Empty.rec (Fin-inj′ n<m (sym p))
 ... | gt n>m = Empty.rec (Fin-inj′ n>m p)
+
+≤-*sk-cancel : ∀ {m} {k} {n} → m * suc k ≤ n * suc k → m ≤ n
+≤-*sk-cancel {m} {k} {n} (d , p) = o , inj-*sm {m = k} goal where
+  r = d % suc k
+  o = d / suc k
+  resn*k : Residue (suc k) (n * suc k)
+  resn*k = ((r , n%sk<sk d k) , (o + m)) , reason where
+   reason = expand× ((r , n%sk<sk d k) , o + m) ≡⟨ expand≡ (suc k) r (o + m) ⟩
+            (o + m) * suc k + r                 ≡[ i ]⟨ +-comm (*-distribʳ o m (suc k) (~ i)) r i ⟩
+            r + (o * suc k + m * suc k)         ≡⟨ +-assoc r (o * suc k) (m * suc k) ⟩
+            (r + o * suc k) + m * suc k         ≡⟨ cong (_+ m * suc k) (+-comm r (o * suc k) ∙ moddiv d (suc k)) ⟩
+            d + m * suc k                       ≡⟨ p ⟩
+            n * suc k ∎
+
+  residuek*n : ∀ k n → (r : Residue (suc k) (n * suc k)) → ((fzero , n) , expand≡ (suc k) 0 n ∙ +-zero _) ≡ r
+  residuek*n _ _ = isContr→isProp isContrResidue _
+
+  r≡0 : r ≡ 0
+  r≡0 = cong (toℕ ∘ extract) (sym (residuek*n k n resn*k))
+  d≡o*sk : d ≡ o * suc k
+  d≡o*sk = sym (moddiv d (suc k)) ∙∙ cong (o * suc k +_) r≡0 ∙∙ +-zero _
+  goal : (o + m) * suc k ≡ n * suc k
+  goal = sym (*-distribʳ o m (suc k)) ∙∙ cong (_+ m * suc k) (sym d≡o*sk) ∙∙ p
+
+<-*sk-cancel : ∀ {m} {k} {n} → m * suc k < n * suc k → m < n
+<-*sk-cancel {m} {k} {n} p = goal where
+  ≤-helper : m ≤ n
+  ≤-helper = ≤-*sk-cancel (pred-≤-pred (<≤-trans p (≤-suc ≤-refl)))
+  goal : m < n
+  goal = case <-split (suc-≤-suc ≤-helper) of λ
+    { (inl g) → g
+    ; (inr e) → Empty.rec (¬m<m (subst (λ m → m * suc k < n * suc k) e p))
+    }
+
+factorEquiv : ∀ {n} {m} → Fin n × Fin m ≃ Fin (n * m)
+factorEquiv {zero} {m} = uninhabEquiv (¬Fin0 ∘ fst) ¬Fin0
+factorEquiv {suc n} {m} = intro , isEmbedding×isSurjection→isEquiv (isEmbeddingIntro , isSurjectionIntro) where
+  intro : Fin (suc n) × Fin m → Fin (suc n * m)
+  intro (nn , mm) = nm , subst (λ nm₁ → nm₁ < suc n * m) (sym (expand≡ _ (toℕ nn) (toℕ mm))) nm<n*m where
+    nm : ℕ
+    nm = expand× (nn , toℕ mm)
+    nm<n*m : toℕ mm * suc n + toℕ nn < suc n * m
+    nm<n*m =
+      toℕ mm * suc n + toℕ nn <≤⟨ <-k+ (snd nn) ⟩
+      toℕ mm * suc n + suc n  ≡≤⟨ +-comm _ (suc n) ⟩
+      suc (toℕ mm) * suc n    ≤≡⟨ ≤-*k (snd mm) ⟩
+      m * suc n               ≡⟨ *-comm _ (suc n) ⟩
+      suc n * m               ∎ where open <-Reasoning
+
+  intro-injective : ∀ {o} {p} → intro o ≡ intro p → o ≡ p
+  intro-injective {o} {p} io≡ip = λ i → io′≡ip′ i .fst , toℕ-injective {fj = snd o} {fk = snd p} (cong snd io′≡ip′) i where
+    io′≡ip′ : (fst o , toℕ (snd o)) ≡ (fst p , toℕ (snd p))
+    io′≡ip′ = expand×Inj _ (cong fst io≡ip)
+  isEmbeddingIntro : isEmbedding intro
+  isEmbeddingIntro = injEmbedding (isSet× isSetFin isSetFin) isSetFin intro-injective
+
+  elimF : ∀ nm → fiber intro nm
+  elimF nm = ((nn , nn<n) , (mm , mm<m)) , toℕ-injective (reduce n (toℕ nm) .snd) where
+    mm = toℕ nm / suc n
+    nn = toℕ nm % suc n
+
+    nmmoddiv : mm * suc n + nn ≡ toℕ nm
+    nmmoddiv = moddiv _ (suc n)
+    nn<n : nn < suc n
+    nn<n = n%sk<sk (toℕ nm) _
+
+    nmsnd : mm * suc n + nn < suc n * m
+    nmsnd = subst (λ l → l < suc n * m) (sym nmmoddiv) (snd nm)
+    mm*sn<m*sn : mm * suc n < m * suc n
+    mm*sn<m*sn =
+      mm * suc n      ≤<⟨ nn , +-comm nn (mm * suc n) ⟩
+      mm * suc n + nn <≡⟨ nmsnd ⟩
+      suc n * m       ≡⟨ *-comm (suc n) m ⟩
+      m * suc n       ∎ where open <-Reasoning
+    mm<m : mm < m
+    mm<m = <-*sk-cancel mm*sn<m*sn
+
+  isSurjectionIntro : isSurjection intro
+  isSurjectionIntro = ∣_∣ ∘ elimF

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -104,6 +104,13 @@ pred-≤-pred (k , p) = k , injSuc ((sym (+-suc k _)) ∙ p)
  cancelled : l + m ≡ n
  cancelled = inj-+m (sym (+-assoc l m k) ∙ p)
 
+≤-*k : m ≤ n → m * k ≤ n * k
+≤-*k {m} {n} {k} (d , r) = d * k , reason where
+  reason : d * k + m * k ≡ n * k
+  reason = d * k + m * k ≡⟨ *-distribʳ d m k ⟩
+           (d + m) * k   ≡⟨ cong (_* k) r ⟩
+           n * k         ∎
+
 <-k+-cancel : k + m < k + n → m < n
 <-k+-cancel {k} {m} {n} = ≤-k+-cancel ∘ subst (_≤ k + n) (sym (+-suc k m))
 
@@ -130,29 +137,31 @@ predℕ-≤-predℕ {suc m} {suc n} ineq = pred-≤-pred ineq
 <-weaken (k , p) = suc k , sym (+-suc k _) ∙ p
 
 ≤<-trans : l ≤ m → m < n → l < n
-≤<-trans {l} {m} {n} (i , p) (j , q) = (j + i) , reason
-  where
-  reason : j + i + suc l ≡ n
-  reason = j + i + suc l ≡⟨ sym (+-assoc j i (suc l)) ⟩
-           j + (i + suc l) ≡⟨ cong (j +_) (+-suc i l) ⟩
-           j + (suc (i + l)) ≡⟨ cong (_+_ j ∘ suc) p ⟩
-           j + suc m ≡⟨ q ⟩
-           n ∎
+≤<-trans p = ≤-trans (suc-≤-suc p)
 
 <≤-trans : l < m → m ≤ n → l < n
-<≤-trans {l} {m} {n} (i , p) (j , q) = j + i , reason
-  where
-  reason : j + i + suc l ≡ n
-  reason = j + i + suc l ≡⟨ sym (+-assoc j i (suc l)) ⟩
-           j + (i + suc l) ≡⟨ cong (j +_) p ⟩
-           j + m ≡⟨ q ⟩
-           n ∎
+<≤-trans = ≤-trans
 
 <-trans : l < m → m < n → l < n
 <-trans p = ≤<-trans (<-weaken p)
 
 <-asym : m < n → ¬ n ≤ m
 <-asym m<n = ¬m<m ∘ <≤-trans m<n
+
+<-+k : m < n → m + k < n + k
+<-+k p = ≤-+k p
+
+<-k+ : m < n → k + m < k + n
+<-k+ {m} {n} {k} p = subst (λ km → km ≤ k + n) (+-suc k m) (≤-k+ p)
+
+<-*sk : m < n → m * suc k < n * suc k
+<-*sk {m} {n} {k} (d , r) = (d * suc k + k) , reason where
+  reason : (d * suc k + k) + suc (m * suc k) ≡ n * suc k
+  reason = (d * suc k + k) + suc (m * suc k) ≡⟨ sym (+-assoc (d * suc k) k _) ⟩
+           d * suc k + (k + suc (m * suc k)) ≡[ i ]⟨ d * suc k + +-suc k (m * suc k) i ⟩
+           d * suc k + suc m * suc k         ≡⟨ *-distribʳ d (suc m) (suc k) ⟩
+           (d + suc m) * suc k               ≡⟨ cong (_* suc k) r ⟩
+           n * suc k                         ∎
 
 Trichotomy-suc : Trichotomy m n → Trichotomy (suc m) (suc n)
 Trichotomy-suc (lt m<n) = lt (suc-≤-suc m<n)
@@ -247,3 +256,30 @@ module _
 
   +inductionStep : ∀ n → +induction (b + n) ≡ step n (+induction n)
   +inductionStep n = induction-compute wfStep (b + n) ∙ wfStepLemma₁ n _
+
+module <-Reasoning where
+  -- TODO: would it be better to mirror the way it is done in the agda-stdlib?
+  infixr 2 _<⟨_⟩_ _≤<⟨_⟩_ _≤⟨_⟩_ _<≤⟨_⟩_ _≡<⟨_⟩_ _≡≤⟨_⟩_ _<≡⟨_⟩_ _≤≡⟨_⟩_
+  _<⟨_⟩_ : ∀ k → k < n → n < m → k < m
+  _ <⟨ p ⟩ q = <-trans p q
+
+  _≤<⟨_⟩_ : ∀ k → k ≤ n → n < m → k < m
+  _ ≤<⟨ p ⟩ q = ≤<-trans p q
+
+  _≤⟨_⟩_ : ∀ k → k ≤ n → n ≤ m → k ≤ m
+  _ ≤⟨ p ⟩ q = ≤-trans p q
+
+  _<≤⟨_⟩_ : ∀ k → k < n → n ≤ m → k < m
+  _ <≤⟨ p ⟩ q = <≤-trans p q
+
+  _≡≤⟨_⟩_ : ∀ k → k ≡ l → l ≤ m → k ≤ m
+  _ ≡≤⟨ p ⟩ q = subst (λ k → k ≤ _) (sym p) q
+
+  _≡<⟨_⟩_ : ∀ k → k ≡ l → l < m → k < m
+  _ ≡<⟨ p ⟩ q = _ ≡≤⟨ cong suc p ⟩ q
+
+  _≤≡⟨_⟩_ : ∀ k → k ≤ l → l ≡ m → k ≤ m
+  _ ≤≡⟨ p ⟩ q = subst (λ l → _ ≤ l) q p
+
+  _<≡⟨_⟩_ : ∀ k → k < l → l ≡ m → k < m
+  _ <≡⟨ p ⟩ q = _ ≤≡⟨ p ⟩ q

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -92,3 +92,15 @@ isGroupoidSum = isOfHLevelSum 1
 
 is2GroupoidSum : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → is2Groupoid A → is2Groupoid B → is2Groupoid (A ⊎ B)
 is2GroupoidSum = isOfHLevelSum 2
+
+sumIso : ∀ {ℓa ℓb ℓc ℓd} {A : Type ℓa} {B : Type ℓb} {C : Type ℓc} {D : Type ℓd}
+       → Iso A C → Iso B D
+       → Iso (A ⊎ B) (C ⊎ D)
+Iso.fun (sumIso iac ibd) (inl x) = inl (iac .Iso.fun x)
+Iso.fun (sumIso iac ibd) (inr x) = inr (ibd .Iso.fun x)
+Iso.inv (sumIso iac ibd) (inl x) = inl (iac .Iso.inv x)
+Iso.inv (sumIso iac ibd) (inr x) = inr (ibd .Iso.inv x)
+Iso.rightInv (sumIso iac ibd) (inl x) = cong inl (iac .Iso.rightInv x)
+Iso.rightInv (sumIso iac ibd) (inr x) = cong inr (ibd .Iso.rightInv x)
+Iso.leftInv (sumIso iac ibd) (inl x) = cong inl (iac .Iso.leftInv x)
+Iso.leftInv (sumIso iac ibd) (inr x) = cong inr (ibd .Iso.leftInv x)

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -217,6 +217,9 @@ isContrΣ {A = A} {B = B} (a , p) q =
      , ( λ x i → p (x .fst) i
        , h (p (x .fst) i) (transp (λ j → B (p (x .fst) (i ∨ ~ j))) i (x .snd)) i))
 
+isContrΣ′ : (ca : isContr A) → isContr (B (fst ca)) → isContr (Σ A B)
+isContrΣ′ ca cb = isContrΣ ca (λ x → subst _ (snd ca x) cb)
+
 Σ≡Prop-equiv
   : (pB : (x : A) → isProp (B x)) {u v : Σ[ a ∈ A ] B a}
   → isEquiv (Σ≡Prop pB {u} {v})


### PR DESCRIPTION
As a small addition to what has been developed for `Data.Fin` in #393 this implements Lehmer codes, i.e. most notably

- `factorEquiv : ∀ {n} {m} → Fin n × Fin m ≃ Fin (n * m)`
- `lehmerEquiv : (Fin n ≃ Fin n) ≃ LehmerCode n`
- `lehmerFinEquiv : LehmerCode n ≃ Fin (factorial n)`