### PR TITLE
Add definition of subfinite sets and finitely indexed types

### DIFF
--- a/Cubical/Data/FinInd.agda
+++ b/Cubical/Data/FinInd.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+
+module Cubical.Data.FinInd where
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Fin
+open import Cubical.Data.Sigma
+open import Cubical.Data.FinSet
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Functions.Surjection
+open import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.HITs.S1
+
+private
+  variable
+    ℓ : Level
+    A : Type ℓ
+
+isFinInd : Type ℓ → Type ℓ
+isFinInd A = ∃[ n ∈ ℕ ] Fin n ↠ A
+
+isFinSet→isFinInd : isFinSet A → isFinInd A
+isFinSet→isFinInd = PT.rec
+  squash
+  λ (n , equiv) →
+    ∣ n , invEq equiv , section→isSurjection (secEq equiv) ∣
+
+isFinInd-S¹ : isFinInd S¹
+isFinInd-S¹ = ∣ 1 , f , isSurjection-f ∣
+  where
+    f : Fin 1 → S¹
+    f _ = base
+    isSurjection-f : isSurjection f
+    isSurjection-f b = PT.map (λ base≡b → fzero , base≡b) (isConnectedS¹ b)

--- a/Cubical/Data/FinInd.agda
+++ b/Cubical/Data/FinInd.agda
@@ -1,3 +1,16 @@
+{-
+
+Definition of finitely indexed types
+
+A type is finitely indexed if, for some `n`, there merely exists a
+surjective function from `Fin n` to it. Note that a type doesn't need
+to be a set in order for it to be finitely indexed. For example, the
+circle is finitely indexed.
+
+This definition is weaker than `isFinSet`.
+
+-}
+
 {-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.FinInd where

--- a/Cubical/Data/SubFinSet.agda
+++ b/Cubical/Data/SubFinSet.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+
+module Cubical.Data.SubFinSet where
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Fin
+open import Cubical.Data.Sigma
+open import Cubical.Data.FinSet
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Functions.Embedding
+open import Cubical.HITs.PropositionalTruncation as PT
+open import Cubical.Relation.Nullary
+
+private
+  variable
+    ℓ : Level
+    A B : Type ℓ
+
+isSubFinSet : Type ℓ → Type ℓ
+isSubFinSet A = ∃[ n ∈ ℕ ] A ↪ Fin n
+
+isFinSet→isSubFinSet : isFinSet A → isSubFinSet A
+isFinSet→isSubFinSet = PT.map
+  λ (n , f , isEquiv-f) →
+    n , f , isEmbedding→hasPropFibers (isEquiv→isEmbedding isEquiv-f)
+
+isSubFinSet→isSet : isSubFinSet A → isSet A
+isSubFinSet→isSet = PT.rec
+  isPropIsSet
+  λ (n , emb) → Embedding-into-isSet→isSet emb isSetFin
+
+isSubFinSet→Discrete : isSubFinSet A → Discrete A
+isSubFinSet→Discrete isSubFinSet-A x y = PT.rec
+  (isPropDec (isSubFinSet→isSet isSubFinSet-A x y))
+  (λ (n , emb) → Embedding-into-Discrete→Discrete emb discreteFin x y)
+  isSubFinSet-A

--- a/Cubical/Data/SubFinSet.agda
+++ b/Cubical/Data/SubFinSet.agda
@@ -1,3 +1,15 @@
+{-
+
+Definition of subfinite sets
+
+A set is subfinite if it is merely a subset of `Fin n` for some `n`. This
+definition is weaker than `isFinSet` if we don't assume LEM, but they
+are equivalent if we do.
+
+Every subfinite set is guaranteed to be a set and discrete.
+
+-}
+
 {-# OPTIONS --cubical --no-import-sorts --safe #-}
 
 module Cubical.Data.SubFinSet where

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -12,10 +12,11 @@ open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Path
 open import Cubical.Foundations.Univalence using (ua)
+open import Cubical.Relation.Nullary using (Discrete; yes; no)
 
 private
   variable
-    ℓ : Level
+    ℓ ℓ₁ ℓ₂ : Level
     A B : Type ℓ
     f : A → B
     w x : A
@@ -80,7 +81,7 @@ hasPropFibers : (A → B) → Type _
 hasPropFibers f = ∀ y → isProp (fiber f y)
 
 -- some notation
-_↪_ : Type ℓ → Type ℓ → Type ℓ
+_↪_ : Type ℓ₁ → Type ℓ₂ → Type (ℓ-max ℓ₁ ℓ₂)
 A ↪ B = Σ[ f ∈ (A → B) ] hasPropFibers f
 
 
@@ -169,3 +170,19 @@ module _ {f : A → B} (retf : hasRetract f) where
   retractableIntoSet→isEmbedding : isSet B → isEmbedding f
   retractableIntoSet→isEmbedding setB w x =
     isoToIsEquiv (iso (cong f) congRetract (λ _ → setB _ _ _ _) (hasRetract→hasRetractCong .snd))
+
+Embedding-into-Discrete→Discrete : A ↪ B → Discrete B → Discrete A
+Embedding-into-Discrete→Discrete (f , propFibers) _≟_ x y with f x ≟ f y
+... | yes p = yes (cong fst (propFibers (f y) (x , p) (y , refl)))
+... | no ¬p = no (¬p ∘ cong f)
+
+Embedding-into-isSet→isSet : A ↪ B → isSet B → isSet A
+Embedding-into-isSet→isSet (f , hasPropFibers-f) isSet-B x y p q =
+  p ≡⟨ sym (retIsEq isEquiv-cong-f p) ⟩
+  cong-f⁻¹ (cong f p) ≡⟨ cong cong-f⁻¹ cong-f-p≡cong-f-q ⟩
+  cong-f⁻¹ (cong f q) ≡⟨ retIsEq isEquiv-cong-f q ⟩
+  q ∎
+  where
+    cong-f-p≡cong-f-q = isSet-B (f x) (f y) (cong f p) (cong f q)
+    isEquiv-cong-f = hasPropFibers→isEmbedding hasPropFibers-f x y
+    cong-f⁻¹ = invIsEq isEquiv-cong-f

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -20,6 +20,9 @@ private
 isSurjection : (A → B) → Type _
 isSurjection f = ∀ b → ∥ fiber f b ∥
 
+_↠_ : Type ℓ → Type ℓ' → Type (ℓ-max ℓ ℓ')
+A ↠ B = Σ[ f ∈ (A → B) ] isSurjection f
+
 section→isSurjection : {g : B → A} → section f g → isSurjection f
 section→isSurjection {g = g} s b = ∣ g b , s b ∣
 


### PR DESCRIPTION
As discussed in #392 and following [nLab](https://ncatlab.org/nlab/show/finite+set#Constructivist), I have defined subfinite sets and finitely indexed types. The latter are usually called finitely indexed sets, but they don't have to be sets in HoTT (for example, the circle is finitely indexed). They are usually called Kuratowski finite, but maybe we can leave that name to the more usual (equivalent) definition with `LFSet`.