### PR TITLE
Some assorted lemmas

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -472,7 +472,8 @@ isOfHLevelΣ' 0 Actr Bctr .snd (x , y) i
 isOfHLevelΣ' 1 Alvl Blvl (w , y) (x , z) i .fst = Alvl w x i
 isOfHLevelΣ' 1 Alvl Blvl (w , y) (x , z) i .snd = Blvl y z (Alvl w x) i
 isOfHLevelΣ' {A = A} {B = B} (suc (suc n)) Alvl Blvl (w , y) (x , z)
-  = transport (λ i → isOfHLevel (suc n) (ΣP≡PΣ i))
+  = isOfHLevelRetract (suc n)
+      (λ p → (λ i → p i .fst) , λ i → p i .snd)
+      ΣPathP
+      (λ x → refl)
       (isOfHLevelΣ' (suc n) (Alvl w x) (Blvl y z))
-  where
-  ΣP≡PΣ = ΣPath≡PathΣ {A = λ _ → A} {B = λ _ → B} {x = (w , y)} {y = (x , z)}

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -35,7 +35,7 @@ private
     C : (x : A) → B x → Type ℓ
     D : (x : A) (y : B x) → C x y → Type ℓ
     E : (x : A) (y : B x) → (z : C x y) → D x y z → Type ℓ
-    x y : A
+    w x y z : A
     n : HLevel
 
 isOfHLevel : HLevel → Type ℓ → Type ℓ
@@ -423,3 +423,44 @@ isOfHLevel→isOfHLevelDep (suc (suc n)) {A = A} {B} h {a0} {a1} b0 b1 =
   helper a1 p b1 = J
                      (λ a1 p → ∀ b1 → isOfHLevel (suc n) (PathP (λ i → B (p i)) b0 b1))
                      (λ _ → h _ _ _) p b1
+
+isContrDep→isPropDep : isOfHLevelDep 0 B → isOfHLevelDep 1 B
+isContrDep→isPropDep {B = B} Bctr {a0 = a0} b0 b1 p i
+  = comp (λ k → B (p (i ∧ k))) (λ k → λ where
+        (i = i0) → Bctr .snd b0 refl k
+        (i = i1) → Bctr .snd b1 p k)
+      (c0 .fst)
+  where
+  c0 = Bctr {a0}
+
+isPropDep→isSetDep : isOfHLevelDep 1 B → isOfHLevelDep 2 B
+isPropDep→isSetDep {B = B} Bprp b0 b1 b2 b3 p i j
+  = comp (λ k → B (p (i ∧ k) (j ∧ k))) (λ k → λ where
+        (j = i0) → Bprp b0 b0 refl k
+        (i = i0) → Bprp b0 (b2 j) (λ k → p i0 (j ∧ k)) k
+        (i = i1) → Bprp b0 (b3 j) (λ k → p k (j ∧ k)) k
+        (j = i1) → Bprp b0 b1 (λ k → p (i ∧ k) (j ∧ k)) k)
+      b0
+
+isOfHLevelDepSuc : (n : HLevel) → isOfHLevelDep n B → isOfHLevelDep (suc n) B
+isOfHLevelDepSuc 0 = isContrDep→isPropDep
+isOfHLevelDepSuc 1 = isPropDep→isSetDep
+isOfHLevelDepSuc (suc (suc n)) Blvl b0 b1 = isOfHLevelDepSuc (suc n) (Blvl b0 b1)
+
+isPropDep→isSetDep'
+  : isOfHLevelDep 1 B
+  → {p : w ≡ x} {q : y ≡ z} {r : w ≡ y} {s : x ≡ z}
+  → {tw : B w} {tx : B x} {ty : B y} {tz : B z}
+  → (sq : Square p q r s)
+  → (tp : PathP (λ i → B (p i)) tw tx)
+  → (tq : PathP (λ i → B (q i)) ty tz)
+  → (tr : PathP (λ i → B (r i)) tw ty)
+  → (ts : PathP (λ i → B (s i)) tx tz)
+  → SquareP (λ i j → B (sq i j)) tp tq tr ts
+isPropDep→isSetDep' {B = B} Bprp {p} {q} {r} {s} {tw} sq tp tq tr ts i j
+  = comp (λ k → B (sq (i ∧ k) (j ∧ k))) (λ k → λ where
+        (i = i0) → Bprp tw (tp j) (λ k → p (k ∧ j)) k
+        (i = i1) → Bprp tw (tq j) (λ k → sq (i ∧ k) (j ∧ k)) k
+        (j = i0) → Bprp tw (tr i) (λ k → r (k ∧ i)) k
+        (j = i1) → Bprp tw (ts i) (λ k → sq (k ∧ i) (j ∧ k)) k)
+      tw

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -464,3 +464,15 @@ isPropDep→isSetDep' {B = B} Bprp {p} {q} {r} {s} {tw} sq tp tq tr ts i j
         (j = i0) → Bprp tw (tr i) (λ k → r (k ∧ i)) k
         (j = i1) → Bprp tw (ts i) (λ k → sq (k ∧ i) (j ∧ k)) k)
       tw
+
+isOfHLevelΣ' : ∀ n → isOfHLevel n A → isOfHLevelDep n B → isOfHLevel n (Σ A B)
+isOfHLevelΣ' 0 Actr Bctr .fst = (Actr .fst , Bctr .fst)
+isOfHLevelΣ' 0 Actr Bctr .snd (x , y) i
+  = Actr .snd x i , Bctr .snd y (Actr .snd x) i
+isOfHLevelΣ' 1 Alvl Blvl (w , y) (x , z) i .fst = Alvl w x i
+isOfHLevelΣ' 1 Alvl Blvl (w , y) (x , z) i .snd = Blvl y z (Alvl w x) i
+isOfHLevelΣ' {A = A} {B = B} (suc (suc n)) Alvl Blvl (w , y) (x , z)
+  = transport (λ i → isOfHLevel (suc n) (ΣP≡PΣ i))
+      (isOfHLevelΣ' (suc n) (Alvl w x) (Blvl y z))
+  where
+  ΣP≡PΣ = ΣPath≡PathΣ {A = λ _ → A} {B = λ _ → B} {x = (w , y)} {y = (x , z)}

--- a/Cubical/Functions/Involution.agda
+++ b/Cubical/Functions/Involution.agda
@@ -1,0 +1,43 @@
+{-# OPTIONS --cubical --no-import-sorts --safe #-}
+
+module Cubical.Functions.Involution where
+
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Univalence
+
+isInvolution : ∀{ℓ} {A : Type ℓ} → (A → A) → Type _
+isInvolution f = ∀ x → f (f x) ≡ x
+
+module _ {ℓ} {A : Type ℓ} {f : A → A} (invol : isInvolution f) where
+  open Iso
+
+  involIso : Iso A A
+  involIso .fun = f
+  involIso .inv = f
+  involIso .rightInv = invol
+  involIso .leftInv = invol
+
+  involIsEquiv : isEquiv f
+  involIsEquiv = isoToIsEquiv involIso
+
+  involEquiv : A ≃ A
+  involEquiv = f , involIsEquiv
+
+  involPath : A ≡ A
+  involPath = ua involEquiv
+
+  involEquivComp : compEquiv involEquiv involEquiv ≡ idEquiv A
+  involEquivComp
+    = equivEq (compEquiv involEquiv involEquiv) (idEquiv A) (λ i x → invol x i)
+
+  involPathComp : involPath ∙ involPath ≡ refl
+  involPathComp
+    = sym (uaCompEquiv involEquiv involEquiv) ∙ cong ua involEquivComp ∙ uaIdEquiv
+
+  involPath² : Square involPath refl refl involPath
+  involPath²
+    = subst (λ s → Square involPath s refl involPath)
+        involPathComp (compPath-filler involPath involPath)
+

--- a/Cubical/Functions/Involution.agda
+++ b/Cubical/Functions/Involution.agda
@@ -30,11 +30,11 @@ module _ {ℓ} {A : Type ℓ} {f : A → A} (invol : isInvolution f) where
 
   involEquivComp : compEquiv involEquiv involEquiv ≡ idEquiv A
   involEquivComp
-    = equivEq (compEquiv involEquiv involEquiv) (idEquiv A) (λ i x → invol x i)
+    = equivEq _ _ (λ i x → invol x i)
 
   involPathComp : involPath ∙ involPath ≡ refl
   involPathComp
-    = sym (uaCompEquiv involEquiv involEquiv) ∙ cong ua involEquivComp ∙ uaIdEquiv
+    = sym (uaCompEquiv involEquiv involEquiv) ∙∙ cong ua involEquivComp ∙∙ uaIdEquiv
 
   involPath² : Square involPath refl refl involPath
   involPath²


### PR DESCRIPTION
These changes add a few simple lemmas.

- Level lifting for `isOfHLevelDep`
  - Also includes lifting from level 1 to a `SquareP`
- A proof of the h-level of Σ types using `isOfHLevelDep` for the second parameter
- Added a module about involutions with some proofs about the paths they induce

