### PR TITLE
Expand in-code explanation of Glue

### DIFF
--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -91,7 +91,7 @@ private
     trans-e :
       ∀ (t : PartialP φ T)
       → Partial φ A
-    trans-e t ϕ1 = e ϕ1 .fst (t ϕ1)
+    trans-e t ϕ1 = equivFun (e ϕ1) (t ϕ1)
 
     -- glue gives a partial element of Glue given an element of A. Note that it "undoes"
     -- the application of the equivalences!
@@ -126,8 +126,14 @@ private
     e0 = e i0 1=1
     e1 : T1 ≃ A1
     e1 = e i1 1=1
+    transportA : A0 → A1
+    transportA = transp (λ i → A i) i0
 
-    -- equivFun and invEq are not in scope, otherwise we could write
-    -- transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ →  invEq e1 (transp (λ i → A i) i0 (equivFun e0 t0))) ]
-    transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ →  e1 .snd .equiv-proof (transp (λ i → A i) i0 (e0 .fst t0)) .fst .fst) ]
+    -- copied over from Foundations/Equiv for readability
+    invEq : ∀ {X : Type ℓ'} {ℓ''} {Y : Type ℓ''} (w : X ≃ Y) → Y → X
+    invEq w y = w .snd .equiv-proof y .fst .fst
+
+    -- transport in Glue reduces to transport in A + the application of the equivalences in forward and backward
+    -- direction.
+    transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ → invEq e1 (transportA (equivFun e0 t0))) ]
     transp-S t0 = inS (transp (λ i → Glue (A i) (Te i)) i0 t0)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -126,14 +126,16 @@ private
     e0 = e i0 1=1
     e1 : T1 ≃ A1
     e1 = e i1 1=1
-    transportA : A0 → A1
-    transportA = transp (λ i → A i) i0
 
-    -- copied over from Foundations/Equiv for readability
+    open import Cubical.Foundations.Prelude using (transport)
+    transportA : A0 → A1
+    transportA = transport (λ i → A i)
+
+    -- copied over from Foundations/Equiv for readability, can't directly import due to cyclic dependency
     invEq : ∀ {X : Type ℓ'} {ℓ''} {Y : Type ℓ''} (w : X ≃ Y) → Y → X
     invEq w y = w .snd .equiv-proof y .fst .fst
 
     -- transport in Glue reduces to transport in A + the application of the equivalences in forward and backward
     -- direction.
     transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ → invEq e1 (transportA (equivFun e0 t0))) ]
-    transp-S t0 = inS (transp (λ i → Glue (A i) (Te i)) i0 t0)
+    transp-S t0 = inS (transport (λ i → Glue (A i) (Te i)) t0)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -64,22 +64,63 @@ unglue φ = prim^unglue {φ = φ}
 -- Cyril Cohen, Thierry Coquand, Simon Huber, Anders Mörtberg
 private
 
-  Glue-S : (A : Type ℓ) {φ : I}
-         → (Te : Partial φ (Σ[ T ∈ Type ℓ' ] T ≃ A))
-         → Sub (Type ℓ') φ (λ { (φ = i1) → Te 1=1 .fst })
-  Glue-S A Te = inS (Glue A Te)
+  module GluePrims (A : Type ℓ) {φ : I} (Te : Partial φ (Σ[ T ∈ Type ℓ' ] T ≃ A)) where
+    T : Partial φ (Type ℓ')
+    T φ = Te φ .fst
+    e : PartialP φ (λ φ → T φ ≃ A)
+    e φ = Te φ .snd
 
-  glue-S :
-   ∀ {A : Type ℓ} {φ : I}
-   → {T : Partial φ (Type ℓ')} {e : PartialP φ (λ o → T o ≃ A)}
-   → (t : PartialP φ T)
-   → Sub A φ (λ { (φ = i1) → e 1=1 .fst (t 1=1) })
-   → Sub (primGlue A T e) φ (λ { (φ = i1) → t 1=1 })
-  glue-S t s = inS (glue t (outS s))
+    -- Glue is a partial element of Type that is definitionally equal to the left type
+    -- of the given equivalences where it is defined.
+    Glue-S : Type ℓ' [ φ ↦ T ]
+    Glue-S = inS (Glue A Te)
 
-  unglue-S :
-    ∀ {A : Type ℓ} (φ : I)
-    {T : Partial φ (Type ℓ')} {e : PartialP φ (λ o → T o ≃ A)}
-    → (x : primGlue A T e)
-    → Sub A φ (λ { (φ = i1) → e 1=1 .fst x })
-  unglue-S φ x = inS (prim^unglue {φ = φ} x)
+    -- Which means partial elements of T are partial elements of Glue
+    coeT→G : PartialP φ T
+           → Partial φ (Glue A Te)
+    coeT→G t (φ = i1) = t 1=1
+
+    -- What about elements that are applied to the equivalences?
+    trans-1 : PartialP φ T
+            → Partial φ A
+    trans-1 t ϕ1 = e ϕ1 .fst (t ϕ1)
+
+    -- glue gives a partial element of Glue given an element of A. Note that it "undoes"
+    -- the application of the equivalences!
+    glue-S :
+      ∀ (t : PartialP φ T)
+      → A [ φ ↦ trans-1 t ]
+      → Glue A Te [ φ ↦ coeT→G t ]
+    glue-S t s = inS (glue t (outS s))
+
+    -- typechecking glue enforces that this is possible. E.g. you can not write
+    -- glue-bad : (t : PartialP φ T) → A → Glue A Te
+    -- glue-bad t s = glue t s
+
+    -- unglue does the inverse:
+    unglue-S :
+      ∀ (t : PartialP φ T)
+      → Glue A Te [ φ ↦ coeT→G t ]
+      → A [ φ ↦ trans-1 t ]
+    unglue-S t x = inS (prim^unglue {φ = φ} (outS x))
+
+  module GlueTransp (A : I → Type ℓ) (Te : (i : I) → Partial (i ∨ ~ i) (Σ[ T ∈ Type ℓ' ] T ≃ A i)) where
+    A0 A1 : Type ℓ
+    A0 = A i0
+    A1 = A i1
+    T : (i : I) → Partial (i ∨ ~ i) (Type ℓ')
+    T i φ = Te i φ .fst
+    e : (i : I) → PartialP (i ∨ ~ i) (λ φ → T i φ ≃ A i)
+    e i φ = Te i φ .snd
+    T0 T1 : Type ℓ'
+    T0 = T i0 1=1
+    T1 = T i1 1=1
+    e0 : T0 ≃ A0
+    e0 = e i0 1=1
+    e1 : T1 ≃ A1
+    e1 = e i1 1=1
+
+    -- equivFun and invEq are not in scope, otherwise we could write
+    -- transp-S : (a : T0) → T1 [ i1 ↦ (λ _ →  invEq e1 (transp (λ i → A i) i0 (equivFun e0 a))) ]
+    transp-S : (a : T0) → T1 [ i1 ↦ (λ _ →  e1 .snd .equiv-proof (transp (λ i → A i) i0 (e0 .fst a)) .fst .fst) ]
+    transp-S a = inS (transp (λ i → Glue (A i) (Te i)) i0 a)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -66,43 +66,50 @@ private
 
   module GluePrims (A : Type ℓ) {φ : I} (Te : Partial φ (Σ[ T ∈ Type ℓ' ] T ≃ A)) where
     T : Partial φ (Type ℓ')
-    T φ = Te φ .fst
+    T φ1 = Te φ1 .fst
     e : PartialP φ (λ φ → T φ ≃ A)
-    e φ = Te φ .snd
+    e φ1 = Te φ1 .snd
 
-    -- Glue is a partial element of Type that is definitionally equal to the left type
-    -- of the given equivalences where it is defined.
+    -- Glue can be seen as a subtype of Type that, at φ, is definitionally equal to the left type
+    -- of the given equivalences.
     Glue-S : Type ℓ' [ φ ↦ T ]
     Glue-S = inS (Glue A Te)
 
     -- Which means partial elements of T are partial elements of Glue
-    coeT→G : PartialP φ T
-           → Partial φ (Glue A Te)
+    coeT→G :
+      ∀ (t : PartialP φ T)
+      → Partial φ (Glue A Te)
     coeT→G t (φ = i1) = t 1=1
 
+    -- ... and elements of Glue can be seen as partial elements of T
+    coeG→T :
+      ∀ (g : Glue A Te)
+      → PartialP φ T
+    coeG→T g (φ = i1) = g
+
     -- What about elements that are applied to the equivalences?
-    trans-1 : PartialP φ T
-            → Partial φ A
-    trans-1 t ϕ1 = e ϕ1 .fst (t ϕ1)
+    trans-e :
+      ∀ (t : PartialP φ T)
+      → Partial φ A
+    trans-e t ϕ1 = e ϕ1 .fst (t ϕ1)
 
     -- glue gives a partial element of Glue given an element of A. Note that it "undoes"
     -- the application of the equivalences!
     glue-S :
       ∀ (t : PartialP φ T)
-      → A [ φ ↦ trans-1 t ]
+      → A [ φ ↦ trans-e t ]
       → Glue A Te [ φ ↦ coeT→G t ]
     glue-S t s = inS (glue t (outS s))
 
-    -- typechecking glue enforces that this is possible. E.g. you can not write
+    -- typechecking glue enforces this, e.g. you can not simply write
     -- glue-bad : (t : PartialP φ T) → A → Glue A Te
     -- glue-bad t s = glue t s
 
     -- unglue does the inverse:
     unglue-S :
-      ∀ (t : PartialP φ T)
-      → Glue A Te [ φ ↦ coeT→G t ]
-      → A [ φ ↦ trans-1 t ]
-    unglue-S t x = inS (prim^unglue {φ = φ} (outS x))
+      ∀ (b : Glue A Te)
+      → A [ φ ↦ trans-e (coeG→T b) ]
+    unglue-S b = inS (unglue φ b)
 
   module GlueTransp (A : I → Type ℓ) (Te : (i : I) → Partial (i ∨ ~ i) (Σ[ T ∈ Type ℓ' ] T ≃ A i)) where
     A0 A1 : Type ℓ
@@ -121,6 +128,6 @@ private
     e1 = e i1 1=1
 
     -- equivFun and invEq are not in scope, otherwise we could write
-    -- transp-S : (a : T0) → T1 [ i1 ↦ (λ _ →  invEq e1 (transp (λ i → A i) i0 (equivFun e0 a))) ]
-    transp-S : (a : T0) → T1 [ i1 ↦ (λ _ →  e1 .snd .equiv-proof (transp (λ i → A i) i0 (e0 .fst a)) .fst .fst) ]
-    transp-S a = inS (transp (λ i → Glue (A i) (Te i)) i0 a)
+    -- transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ →  invEq e1 (transp (λ i → A i) i0 (equivFun e0 t0))) ]
+    transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ →  e1 .snd .equiv-proof (transp (λ i → A i) i0 (e0 .fst t0)) .fst .fst) ]
+    transp-S t0 = inS (transp (λ i → Glue (A i) (Te i)) i0 t0)


### PR DESCRIPTION
Adds a little bit more prose to the in-code documentation with the goal to increase readability for newcomers. Uses sub-typing to show definitional equality rules. The typing rules aren't numbered in the referenced paper, otherwise I'd add those to the corresponding definitions.