### PR TITLE
Add "timings" target to makefile.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ AGDA=$(AGDA_EXEC) $(RTS_OPTIONS)
 EVERYTHINGS=runhaskell ./Everythings.hs
 
 .PHONY : all
-all : gen-everythings check
+all : check
 
 .PHONY : test
 test: check-whitespace gen-and-check-everythings check-README check
@@ -41,12 +41,12 @@ check-README:
 # typechecking and generating listings for all files imported in README
 
 .PHONY : check
-check:
+check: gen-everythings
 	$(AGDA) Cubical/README.agda
 	$(AGDA) Cubical/WithK.agda
 
 .PHONY : timings
-timings: clean
+timings: clean gen-everythings
 	$(AGDA) -v profile.modules:10 Cubical/README.agda
 
 .PHONY : listings

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,17 +38,21 @@ gen-and-check-everythings:
 check-README:
 	$(EVERYTHINGS) check-README
 
-# typechecking and generating listings for all files imported in in README
+# typechecking and generating listings for all files imported in README
 
 .PHONY : check
-check: $(wildcard Cubical/**/*.agda)
-	$(foreach f, $(shell $(EVERYTHINGS) get-imports-README), $(AGDA) "$(f)" && ) true
+check:
+	$(AGDA) Cubical/README.agda
 	$(AGDA) Cubical/WithK.agda
 
-.PHONY: listings
+.PHONY : timings
+timings: clean
+	$(AGDA) -v profile.modules:10 Cubical/README.agda
+
+.PHONY : listings
 listings: $(wildcard Cubical/**/*.agda)
 	$(AGDA) -i. -isrc --html Cubical/README.agda -v0
 
 .PHONY : clean
-clean :
+clean:
 	find . -type f -name '*.agdai' -delete


### PR DESCRIPTION
Closes #375. Running `make timings` will check all the files then output a sorted list of timings, e.g.:

```
Total                                           275,643ms 
Miscellaneous                                     3,518ms 
Cubical.ZCohomology.Groups.Sn                    26,112ms 
Cubical.ZCohomology.KcompPrelims                 19,645ms 
Cubical.ZCohomology.Groups.Wedge                  7,493ms 
Cubical.ZCohomology.Properties                    6,763ms 
Cubical.Data.DescendingList.Examples              6,420ms 
Cubical.ZCohomology.MayerVietorisUnreduced        5,956ms 
  [ ... ]
```

I also took the opportunity to clean up a couple things nearby in the makefile. In particular, I'm confused why `make check` was invoking agda separately on each dependency of `README.agda` instead of just checking that file directly. If there is a good reason I'm happy to revert that part of the PR. /cc @m-yac