### PR TITLE
rename sec and ret in isHAEquiv to linv and rinv

### DIFF
--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -149,17 +149,17 @@ leftInv Σ-Π-Iso _     = refl
 fun (Σ-cong-iso-fst isom) x = fun isom (x .fst) , x .snd
 inv (Σ-cong-iso-fst {B = B} isom) x = inv isom (x .fst) , subst B (sym (ε (x .fst))) (x .snd)
   where
-  ε = isHAEquiv.ret (snd (iso→HAEquiv isom))
+  ε = isHAEquiv.rinv (snd (iso→HAEquiv isom))
 rightInv (Σ-cong-iso-fst {B = B} isom) (x , y) = ΣPathP (ε x , toPathP goal)
   where
-  ε = isHAEquiv.ret (snd (iso→HAEquiv isom))
+  ε = isHAEquiv.rinv (snd (iso→HAEquiv isom))
   goal : subst B (ε x) (subst B (sym (ε x)) y) ≡ y
   goal = sym (substComposite B (sym (ε x)) (ε x) y)
       ∙∙ cong (λ x → subst B x y) (lCancel (ε x))
       ∙∙ substRefl {B = B} y
 leftInv (Σ-cong-iso-fst {A = A} {B = B} isom) (x , y) = ΣPathP (leftInv isom x , toPathP goal)
   where
-  ε = isHAEquiv.ret (snd (iso→HAEquiv isom))
+  ε = isHAEquiv.rinv (snd (iso→HAEquiv isom))
   γ = isHAEquiv.com (snd (iso→HAEquiv isom))
 
   lem : (x : A) → sym (ε (fun isom x)) ∙ cong (fun isom) (leftInv isom x) ≡ refl

--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -78,9 +78,9 @@ NatΣ τ (x , a) = (x , τ x a)
    g : Y → X
    g = isHAEquiv.g isHAEquivf
    ε : (x : X) → (g (f x)) ≡ x
-   ε = isHAEquiv.sec isHAEquivf
+   ε = isHAEquiv.linv isHAEquivf
    η : (y : Y) → f (g y) ≡ y
-   η = isHAEquiv.ret isHAEquivf
+   η = isHAEquiv.rinv isHAEquivf
    τ :  (x : X) → cong f (ε x) ≡ η (f x)
    τ = isHAEquiv.com isHAEquivf
 

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -27,41 +27,41 @@ private
 record isHAEquiv {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) : Type (ℓ-max ℓ ℓ') where
   field
     g : B → A
-    sec : ∀ a → g (f a) ≡ a
-    ret : ∀ b → f (g b) ≡ b
-    com : ∀ a → cong f (sec a) ≡ ret (f a)
+    linv : ∀ a → g (f a) ≡ a
+    rinv : ∀ b → f (g b) ≡ b
+    com : ∀ a → cong f (linv a) ≡ rinv (f a)
 
   -- from redtt's ha-equiv/symm
-  com-op : ∀ b → cong g (ret b) ≡ sec (g b)
-  com-op b j i = hcomp (λ k → λ { (i = i0) → sec (g b) (j ∧ (~ k))
-                                ; (j = i0) → g (ret b i)
-                                ; (j = i1) → sec (g b) (i ∨ (~ k))
+  com-op : ∀ b → cong g (rinv b) ≡ linv (g b)
+  com-op b j i = hcomp (λ k → λ { (i = i0) → linv (g b) (j ∧ (~ k))
+                                ; (j = i0) → g (rinv b i)
+                                ; (j = i1) → linv (g b) (i ∨ (~ k))
                                 ; (i = i1) → g b })
                        (cap1 j i)
 
-    where cap0 : Square {- (j = i0) -} (λ i → f (g (ret b i)))
-                        {- (j = i1) -} (λ i → ret b i)
-                        {- (i = i0) -} (λ j → f (sec (g b) j))
-                        {- (i = i1) -} (λ j → ret b j)
+    where cap0 : Square {- (j = i0) -} (λ i → f (g (rinv b i)))
+                        {- (j = i1) -} (λ i → rinv b i)
+                        {- (i = i0) -} (λ j → f (linv (g b) j))
+                        {- (i = i1) -} (λ j → rinv b j)
 
           cap0 j i = hcomp (λ k → λ { (i = i0) → com (g b) (~ k) j
-                                    ; (j = i0) → f (g (ret b i))
-                                    ; (j = i1) → ret b i
-                                    ; (i = i1) → ret b j })
-                           (ret (ret b i) j)
+                                    ; (j = i0) → f (g (rinv b i))
+                                    ; (j = i1) → rinv b i
+                                    ; (i = i1) → rinv b j })
+                           (rinv (rinv b i) j)
 
           filler : I → I → A
-          filler j i = hfill (λ k → λ { (i = i0) → g (ret b k)
+          filler j i = hfill (λ k → λ { (i = i0) → g (rinv b k)
                                       ; (i = i1) → g b })
-                             (inS (sec (g b) i)) j
+                             (inS (linv (g b) i)) j
 
-          cap1 : Square {- (j = i0) -} (λ i → g (ret b i))
+          cap1 : Square {- (j = i0) -} (λ i → g (rinv b i))
                         {- (j = i1) -} (λ i → g b)
-                        {- (i = i0) -} (λ j → sec (g b) j)
+                        {- (i = i0) -} (λ j → linv (g b) j)
                         {- (i = i1) -} (λ j → g b)
 
-          cap1 j i = hcomp (λ k → λ { (i = i0) → sec (sec (g b) j) k
-                                    ; (j = i0) → sec (g (ret b i)) k
+          cap1 j i = hcomp (λ k → λ { (i = i0) → linv (linv (g b) j) k
+                                    ; (j = i0) → linv (g (rinv b i)) k
                                     ; (j = i1) → filler i k
                                     ; (i = i1) → filler j k })
                            (g (cap0 j i))
@@ -69,23 +69,23 @@ record isHAEquiv {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) : Type 
   isHAEquiv→Iso : Iso A B
   Iso.fun isHAEquiv→Iso = f
   Iso.inv isHAEquiv→Iso = g
-  Iso.rightInv isHAEquiv→Iso = ret
-  Iso.leftInv isHAEquiv→Iso = sec
+  Iso.rightInv isHAEquiv→Iso = rinv
+  Iso.leftInv isHAEquiv→Iso = linv
 
   isHAEquiv→isEquiv : isEquiv f
-  isHAEquiv→isEquiv .equiv-proof y = (g y , ret y) , isCenter where
-    isCenter : ∀ xp → (g y , ret y) ≡ xp
+  isHAEquiv→isEquiv .equiv-proof y = (g y , rinv y) , isCenter where
+    isCenter : ∀ xp → (g y , rinv y) ≡ xp
     isCenter (x , p) i = gy≡x i , ry≡p i where
       gy≡x : g y ≡ x
-      gy≡x = sym (cong g p) ∙∙ refl ∙∙ sec x
+      gy≡x = sym (cong g p) ∙∙ refl ∙∙ linv x
 
-      lem0 : Square (cong f (sec x)) p (cong f (sec x)) p
-      lem0 i j = invSides-filler p (sym (cong f (sec x))) (~ i) j
+      lem0 : Square (cong f (linv x)) p (cong f (linv x)) p
+      lem0 i j = invSides-filler p (sym (cong f (linv x))) (~ i) j
 
-      ry≡p : Square (ret y) p (cong f gy≡x) refl
-      ry≡p i j = hcomp (λ k → λ { (i = i0) → cong ret p k j
+      ry≡p : Square (rinv y) p (cong f gy≡x) refl
+      ry≡p i j = hcomp (λ k → λ { (i = i0) → cong rinv p k j
                                 ; (i = i1) → lem0 k j
-                                ; (j = i0) → f (doubleCompPath-filler (sym (cong g p)) refl (sec x) k i)
+                                ; (j = i0) → f (doubleCompPath-filler (sym (cong g p)) refl (linv x) k i)
                                 ; (j = i1) → p k })
                        (com x (~ i) j)
 
@@ -110,8 +110,8 @@ iso→HAEquiv e = f , isHAEquivf
 
     isHAEquivf : isHAEquiv f
     isHAEquiv.g isHAEquivf         = g
-    isHAEquiv.sec isHAEquivf       = η
-    isHAEquiv.ret isHAEquivf b i   =
+    isHAEquiv.linv isHAEquivf       = η
+    isHAEquiv.rinv isHAEquivf b i   =
       hcomp (λ j → λ { (i = i0) → ε (f (g b)) j
                      ; (i = i1) → ε b j })
             (f (η (g b) i))
@@ -124,8 +124,8 @@ iso→HAEquiv e = f , isHAEquivf
 equiv→HAEquiv : A ≃ B → HAEquiv A B
 equiv→HAEquiv e = e .fst , λ where
   .isHAEquiv.g → invIsEq (snd e)
-  .isHAEquiv.sec → retIsEq (snd e)
-  .isHAEquiv.ret → secIsEq (snd e)
+  .isHAEquiv.linv → retIsEq (snd e)
+  .isHAEquiv.rinv → secIsEq (snd e)
   .isHAEquiv.com a → flipSquare (slideSquare (commSqIsEq (snd e) a))
 
 congIso : {x y : A} (e : Iso A B) → Iso (x ≡ y) (Iso.fun e x ≡ Iso.fun e y)
@@ -136,11 +136,11 @@ congIso {x = x} {y} e = goal
 
   goal : Iso (x ≡ y) (Iso.fun e x ≡ Iso.fun e y)
   fun goal   = cong (iso→HAEquiv e .fst)
-  inv goal p = sym (sec x) ∙∙ cong g p ∙∙ sec y
+  inv goal p = sym (linv x) ∙∙ cong g p ∙∙ linv y
   rightInv goal p i j =
     hcomp (λ k → λ { (i = i0) → iso→HAEquiv e .fst
-                                  (doubleCompPath-filler (sym (sec x)) (cong g p) (sec y) k j)
-                   ; (i = i1) → ret (p j) k
+                                  (doubleCompPath-filler (sym (linv x)) (cong g p) (linv y) k j)
+                   ; (i = i1) → rinv (p j) k
                    ; (j = i0) → com x i k
                    ; (j = i1) → com y i k })
           (iso→HAEquiv e .fst (g (p j)))

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -174,9 +174,9 @@ isPropIsHAEquiv {f = f} ishaef = goal ishaef where
   characterization =
     isHAEquiv f
       -- first convert between Σ and record
-      ≃⟨ isoToEquiv (iso (λ e → (e .g , e .ret) , (e .sec , e .com))
-                         (λ e → record { g = e .fst .fst ; ret = e .fst .snd
-                                       ; sec = e .snd .fst ; com = e .snd .snd })
+      ≃⟨ isoToEquiv (iso (λ e → (e .g , e .rinv) , (e .linv , e .com))
+                         (λ e → record { g = e .fst .fst ; rinv = e .fst .snd
+                                       ; linv = e .snd .fst ; com = e .snd .snd })
                          (λ _ → refl) λ _ → refl) ⟩
     Σ _ rCoh1
       -- secondly, convert the path into a dependent path for later convenience

--- a/Cubical/HITs/Ints/BiInvInt/Base.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Base.agda
@@ -59,7 +59,7 @@ suc-haequiv : HAEquiv BiInvInt BiInvInt
 suc-haequiv = biInvEquiv→HAEquiv suc-biinvequiv
 
 suc-predl : ∀ z -> suc (predl z) ≡ z
-suc-predl = isHAEquiv.ret (snd suc-haequiv)
+suc-predl = isHAEquiv.rinv (snd suc-haequiv)
 
 -- predr and predl (as well as suc-predr and suc-predl - up to a path) are indistinguishable,
 --  so we can safely define 'pred' to just be predl

--- a/Cubical/HITs/Ints/HAEquivInt/Base.agda
+++ b/Cubical/HITs/Ints/HAEquivInt/Base.agda
@@ -17,7 +17,7 @@ data HAEquivInt : Type₀ where
 
 
 suc-haequiv : HAEquiv HAEquivInt HAEquivInt
-suc-haequiv = suc , record { g = pred ; sec = pred-suc ; ret = suc-pred ; com = coh }
+suc-haequiv = suc , record { g = pred ; linv = pred-suc ; rinv = suc-pred ; com = coh }
 
 
 -- OPEN: prove HAEquivInt ≃ Int! See Experiments/HInt.agda


### PR DESCRIPTION
As discussed in the AIM 33 conversation, this is for consistency with Isomorphism and the HoTT book; it is more clear terminology.

To check this I typechecked README.agda, but several "Everything" files were missing (I commented them out temporarily) so I missed checking some directories. I don't know if there's a better way to do this.