### PR TITLE
Redefine isoToEquiv

### DIFF
--- a/Cubical/Algebra/AbGroup/Base.agda
+++ b/Cubical/Algebra/AbGroup/Base.agda
@@ -152,10 +152,13 @@ module AbGroupΣTheory {ℓ} where
 
   AbGroupPath : (G H : AbGroup) → (AbGroupEquiv G H) ≃ (G ≡ H)
   AbGroupPath G H =
-    AbGroupEquiv G H                        ≃⟨ isoToEquiv GroupIsoΣPath ⟩
+    AbGroupEquiv G H                        ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     AbGroupEquivΣ G H                       ≃⟨ AbGroupΣPath _ _ ⟩
-    AbGroup→AbGroupΣ G ≡ AbGroup→AbGroupΣ H ≃⟨ isoToEquiv (invIso (congIso AbGroupIsoAbGroupΣ)) ⟩
+    AbGroup→AbGroupΣ G ≡ AbGroup→AbGroupΣ H ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     G ≡ H ■
+    where
+    iso₁ = GroupIsoΣPath {G = AbGroup→Group G} {H = AbGroup→Group H}
+    iso₂ = invIso (congIso AbGroupIsoAbGroupΣ)
 
   AbGroup→RawGroupΣ : AbGroup {ℓ} → RawGroupΣ
   AbGroup→RawGroupΣ (abgroup G _ _+_ _ _) = G , _+_

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -317,14 +317,13 @@ module AlgebraΣTheory (R : Ring {ℓ}) where
 
   AlgebraPath : (M N : Algebra R) → (AlgebraEquiv M N) ≃ (M ≡ N)
   AlgebraPath M N =
-    AlgebraEquiv M N                                    ≃⟨ isoToEquiv AlgebraEquivΣPath ⟩
+    AlgebraEquiv M N                                    ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     AlgebraEquivΣ M N                                   ≃⟨ AlgebraΣPath _ _ ⟩
-    Algebra→AlgebraΣ M ≡ Algebra→AlgebraΣ N             ≃⟨ isoToEquiv
-                                                             (invIso
-                                                             (congIso
-                                                             AlgebraIsoAlgebraΣ))
-                                                           ⟩
+    Algebra→AlgebraΣ M ≡ Algebra→AlgebraΣ N             ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     M ≡ N ■
+    where
+    iso₁ = AlgebraEquivΣPath {M} {N}
+    iso₂ = invIso (congIso AlgebraIsoAlgebraΣ)
 
 AlgebraPath : {R : Ring {ℓ}} (M N : Algebra R) → (AlgebraEquiv M N) ≃ (M ≡ N)
 AlgebraPath {ℓ} {R} = AlgebraΣTheory.AlgebraPath R

--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -179,11 +179,14 @@ module CommAlgebraΣTheory (R : CommRing {ℓ}) where
 
   CommAlgebraPath : (A B : CommAlgebra R) → (CommAlgebraEquiv A B) ≃ (A ≡ B)
   CommAlgebraPath A B =
-    CommAlgebraEquiv A B   ≃⟨ isoToEquiv AlgebraEquivΣPath ⟩
+    CommAlgebraEquiv A B   ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     CommAlgebraEquivΣ A B  ≃⟨ CommAlgebraΣPath _ _ ⟩
     CommAlgebra→CommAlgebraΣ A ≡ CommAlgebra→CommAlgebraΣ B
-      ≃⟨ isoToEquiv (invIso (congIso CommAlgebraIsoCommAlgebraΣ)) ⟩
+      ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     A ≡ B ■
+    where
+    iso₁ = AlgebraEquivΣPath {CommAlgebra→Algebra A} {CommAlgebra→Algebra B}
+    iso₂ = invIso (congIso CommAlgebraIsoCommAlgebraΣ)
 
 CommAlgebraPath : (R : CommRing {ℓ}) → (A B : CommAlgebra R) → (CommAlgebraEquiv A B) ≃ (A ≡ B)
 CommAlgebraPath = CommAlgebraΣTheory.CommAlgebraPath

--- a/Cubical/Algebra/CommRing/Base.agda
+++ b/Cubical/Algebra/CommRing/Base.agda
@@ -160,11 +160,14 @@ module CommRingΣTheory {ℓ} where
 
   CommRingPath : (R S : CommRing) → (CommRingEquiv R S) ≃ (R ≡ S)
   CommRingPath R S =
-    CommRingEquiv R S   ≃⟨ isoToEquiv RingIsoΣPath ⟩
+    CommRingEquiv R S   ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     CommRingEquivΣ R S  ≃⟨ CommRingΣPath _ _ ⟩
     CommRing→CommRingΣ R ≡ CommRing→CommRingΣ S
-      ≃⟨ isoToEquiv (invIso (congIso CommRingIsoCommRingΣ)) ⟩
+      ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     R ≡ S ■
+    where
+    iso₁ = RingIsoΣPath {R = CommRing→Ring R} {S = CommRing→Ring S}
+    iso₂ = invIso (congIso CommRingIsoCommRingΣ)
 
 CommRingPath : (R S : CommRing {ℓ}) → (CommRingEquiv R S) ≃ (R ≡ S)
 CommRingPath = CommRingΣTheory.CommRingPath

--- a/Cubical/Algebra/Group/Algebra.agda
+++ b/Cubical/Algebra/Group/Algebra.agda
@@ -153,7 +153,7 @@ rightInv (dirProdGroupIso iso1 iso2) a = ΣPathP (rightInv iso1 (fst a) , (right
 leftInv (dirProdGroupIso iso1 iso2) a = ΣPathP (leftInv iso1 (fst a) , (leftInv iso2 (snd a)))
 
 GrIsoToGrEquiv : {G : Group {ℓ}} {H : Group {ℓ₂}} → GroupIso G H → GroupEquiv G H
-GroupEquiv.eq (GrIsoToGrEquiv i) = isoToEquiv (iso (fun (map i)) (inv i) (rightInv i) (leftInv i))
+GroupEquiv.eq (GrIsoToGrEquiv i) = isoToEquiv (fun (map i)) (inv i) (rightInv i) (leftInv i)
 GroupEquiv.isHom (GrIsoToGrEquiv i) = isHom (map i)
 
 --- Proofs that BijectionIso and vSES both induce isomorphisms ---

--- a/Cubical/Algebra/Matrix.agda
+++ b/Cubical/Algebra/Matrix.agda
@@ -69,7 +69,8 @@ rightInv (FinMatrixIsoVecMatrix A m n) = VecMatrix→FinMatrix→VecMatrix
 leftInv (FinMatrixIsoVecMatrix A m n)  = FinMatrix→VecMatrix→FinMatrix
 
 FinMatrix≃VecMatrix : {m n : ℕ} → FinMatrix A m n ≃ VecMatrix A m n
-FinMatrix≃VecMatrix {_} {A} {m} {n} = isoToEquiv (FinMatrixIsoVecMatrix A m n)
+FinMatrix≃VecMatrix {_} {A} {m} {n} = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+ where isom = FinMatrixIsoVecMatrix A m n
 
 FinMatrix≡VecMatrix : (A : Type ℓ) (m n : ℕ) → FinMatrix A m n ≡ VecMatrix A m n
 FinMatrix≡VecMatrix _ _ _ = ua FinMatrix≃VecMatrix

--- a/Cubical/Algebra/Module/Base.agda
+++ b/Cubical/Algebra/Module/Base.agda
@@ -214,15 +214,13 @@ module LeftModuleΣTheory (R : Ring {ℓ}) where
 
   LeftModulePath : (M N : LeftModule R) → (LeftModuleEquiv M N) ≃ (M ≡ N)
   LeftModulePath M N =
-    LeftModuleEquiv M N                                    ≃⟨ isoToEquiv LeftModuleEquivStrΣPath ⟩
+    LeftModuleEquiv M N                                    ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     LeftModuleEquivStrΣ M N                                   ≃⟨ LeftModuleΣPath _ _ ⟩
-    LeftModule→LeftModuleΣ M ≡ LeftModule→LeftModuleΣ N  ≃⟨ isoToEquiv
-                                                             (invIso
-                                                             (congIso
-                                                             LeftModuleIsoLeftModuleΣ))
-                                                           ⟩
+    LeftModule→LeftModuleΣ M ≡ LeftModule→LeftModuleΣ N  ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     M ≡ N ■
+    where
+    iso₁ = LeftModuleEquivStrΣPath {M} {N}
+    iso₂ = invIso (congIso LeftModuleIsoLeftModuleΣ)
 
 LeftModulePath : {R : Ring {ℓ}} (M N : LeftModule R) → (LeftModuleEquiv M N) ≃ (M ≡ N)
 LeftModulePath {ℓ} {R} = LeftModuleΣTheory.LeftModulePath R
-

--- a/Cubical/Algebra/Monoid/Base.agda
+++ b/Cubical/Algebra/Monoid/Base.agda
@@ -176,10 +176,13 @@ module MonoidΣTheory {ℓ} where
 
   MonoidPath : (M N : Monoid) → (MonoidEquiv M N) ≃ (M ≡ N)
   MonoidPath M N =
-    MonoidEquiv M N                       ≃⟨ isoToEquiv MonoidIsoΣPath ⟩
-    MonoidEquivΣ M N                      ≃⟨ MonoidΣPath _ _ ⟩
-    Monoid→MonoidΣ M ≡ Monoid→MonoidΣ N ≃⟨ isoToEquiv (invIso (congIso MonoidIsoMonoidΣ)) ⟩
+    MonoidEquiv M N                     ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
+    MonoidEquivΣ M N                    ≃⟨ MonoidΣPath _ _ ⟩
+    Monoid→MonoidΣ M ≡ Monoid→MonoidΣ N ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     M ≡ N ■
+    where
+    iso₁ = MonoidIsoΣPath {M = M} {N = N}
+    iso₂ = invIso (congIso MonoidIsoMonoidΣ)
 
   RawMonoidΣ : Type (ℓ-suc ℓ)
   RawMonoidΣ = TypeWithStr ℓ RawMonoidStructure

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -248,10 +248,13 @@ module RingΣTheory {ℓ} where
 
   RingPath : (R S : Ring) → (RingEquiv R S) ≃ (R ≡ S)
   RingPath R S =
-    RingEquiv R S               ≃⟨ isoToEquiv RingIsoΣPath ⟩
+    RingEquiv R S               ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
     RingEquivΣ R S              ≃⟨ RingΣPath _ _ ⟩
-    Ring→RingΣ R ≡ Ring→RingΣ S ≃⟨ isoToEquiv (invIso (congIso RingIsoRingΣ)) ⟩
+    Ring→RingΣ R ≡ Ring→RingΣ S ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     R ≡ S ■
+    where
+    iso₁ = RingIsoΣPath {R} {S}
+    iso₂ = invIso (congIso RingIsoRingΣ)
 
 
 RingPath : (R S : Ring {ℓ}) → (RingEquiv R S) ≃ (R ≡ S)

--- a/Cubical/Algebra/Semigroup/Base.agda
+++ b/Cubical/Algebra/Semigroup/Base.agda
@@ -159,10 +159,13 @@ module SemigroupΣTheory {ℓ} where
 
   SemigroupPath : (M N : Semigroup) → (SemigroupEquiv M N) ≃ (M ≡ N)
   SemigroupPath M N =
-    SemigroupEquiv M N                                ≃⟨ isoToEquiv SemigroupIsoΣPath ⟩
-    SemigroupEquivΣ M N                               ≃⟨ SemigroupΣPath _ _ ⟩
-    Semigroup→SemigroupΣ M ≡ Semigroup→SemigroupΣ N ≃⟨ isoToEquiv (invIso (congIso SemigroupIsoSemigroupΣ)) ⟩
+    SemigroupEquiv M N                              ≃⟨ isoToEquiv (Iso.fun iso₁) (Iso.inv iso₁) (Iso.rightInv iso₁) (Iso.leftInv iso₁) ⟩
+    SemigroupEquivΣ M N                             ≃⟨ SemigroupΣPath _ _ ⟩
+    Semigroup→SemigroupΣ M ≡ Semigroup→SemigroupΣ N ≃⟨ isoToEquiv (Iso.fun iso₂) (Iso.inv iso₂) (Iso.rightInv iso₂) (Iso.leftInv iso₂) ⟩
     M ≡ N ■
+    where
+    iso₁ = SemigroupIsoΣPath {M = M} {N = N}
+    iso₂ = invIso (congIso SemigroupIsoSemigroupΣ)
 
 -- We now extract the important results from the above module
 

--- a/Cubical/Categories/Presheaves.agda
+++ b/Cubical/Categories/Presheaves.agda
@@ -63,7 +63,8 @@ module Yoneda (𝒞 : Precategory ℓ ℓ) ⦃ 𝒞-cat : isCategory 𝒞 ⦄ wh
             ∎
 
     yo-equiv : NatTrans (yo x) F ≃ F .F-ob x .fst
-    yo-equiv = isoToEquiv yo-iso
+    yo-equiv = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+      where isom = yo-iso
 
 
   YO-full : is-full YO

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -179,7 +179,7 @@ module Bisimulation where
   osi p = isSetConat _ _ _ p
 
   path≃bisim : ∀ {x y} → (x ≡ y) ≃ (x ≈ y)
-  path≃bisim = isoToEquiv (iso misib bisim iso″ osi)
+  path≃bisim = isoToEquiv misib bisim iso″ osi
 
   path≡bisim : ∀ {x y} → (x ≡ y) ≡ (x ≈ y)
   path≡bisim = ua path≃bisim

--- a/Cubical/Codata/Stream/Properties.agda
+++ b/Cubical/Codata/Stream/Properties.agda
@@ -80,7 +80,7 @@ module Equality≅Bisimulation where
   ≈tail (iso2 p i) = iso2 (≈tail p) i
 
   path≃bisim : {A : Type₀} → {x y : Stream A} → (x ≡ y) ≃ (x ≈ y)
-  path≃bisim = isoToEquiv (iso misib bisim iso2 iso1)
+  path≃bisim = isoToEquiv misib bisim iso2 iso1
 
   path≡bisim : {A : Type₀} → {x y : Stream A} → (x ≡ y) ≡ (x ≈ y)
   path≡bisim = ua path≃bisim

--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -171,7 +171,7 @@ Binℕ→ℕ→Binℕ binℕ0 = refl
 Binℕ→ℕ→Binℕ (binℕpos p) = cong binℕpos (Pos⇒ℕ⇒Pos p)
 
 Binℕ≃ℕ : Binℕ ≃ ℕ
-Binℕ≃ℕ = isoToEquiv (iso Binℕ→ℕ ℕ→Binℕ ℕ→Binℕ→ℕ Binℕ→ℕ→Binℕ)
+Binℕ≃ℕ = isoToEquiv Binℕ→ℕ ℕ→Binℕ ℕ→Binℕ→ℕ Binℕ→ℕ→Binℕ
 
 -- Use univalence (in fact only "ua") to get an equality from the
 -- above equivalence
@@ -442,7 +442,7 @@ binnat→ℕ→binnat (consEven n) =
            (λ i → suc-binnat (suc-ℕ→binnat-double (binnat→ℕ n) i)) ∙ (cong consEven (binnat→ℕ→binnat n))
 
 ℕ≃binnat : ℕ ≃ binnat
-ℕ≃binnat = isoToEquiv (iso ℕ→binnat binnat→ℕ binnat→ℕ→binnat ℕ→binnat→ℕ)
+ℕ≃binnat = isoToEquiv ℕ→binnat binnat→ℕ binnat→ℕ→binnat ℕ→binnat→ℕ
 
 ℕ≡binnat : ℕ ≡ binnat
 ℕ≡binnat = ua ℕ≃binnat

--- a/Cubical/Data/DescendingList/Strict/Properties.agda
+++ b/Cubical/Data/DescendingList/Strict/Properties.agda
@@ -219,4 +219,4 @@ module IsoToLFSet
   SDL-LFSet-iso = (iso unsort sort unsort∘sort sort∘unsort)
 
   SDL≡LFSet : SDL ≡ LFSet A
-  SDL≡LFSet = ua (isoToEquiv SDL-LFSet-iso)
+  SDL≡LFSet = ua (isoToEquiv unsort sort unsort∘sort sort∘unsort)

--- a/Cubical/Data/Empty/Properties.agda
+++ b/Cubical/Data/Empty/Properties.agda
@@ -17,11 +17,8 @@ snd isContr⊥→A f i ()
 
 uninhabEquiv : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
   → (A → ⊥) → (B → ⊥) → A ≃ B
-uninhabEquiv ¬a ¬b = isoToEquiv isom
-  where
-  open Iso
-  isom : Iso _ _
-  isom .fun a = rec (¬a a)
-  isom .inv b = rec (¬b b)
-  isom .rightInv b = rec (¬b b)
-  isom .leftInv a = rec (¬a a)
+uninhabEquiv ¬a ¬b = isoToEquiv
+  (λ a → rec (¬a a))
+  (λ b → rec (¬b b))
+  (λ b → rec (¬b b))
+  (λ a → rec (¬a a))

--- a/Cubical/Data/Fin/LehmerCode.agda
+++ b/Cubical/Data/Fin/LehmerCode.agda
@@ -56,20 +56,25 @@ toℕExc-injective : {i : Fin n} → {j k : FinExcept i} → toℕExc j ≡ to�
 toℕExc-injective = toFinExc-injective ∘ toℕ-injective
 
 projectionEquiv : {i : Fin n} → (Unit ⊎ FinExcept i) ≃ Fin n
-projectionEquiv {n = n} {i = i} = isoToEquiv goal where
-  goal : Iso (Unit ⊎ FinExcept i) (Fin n)
-  goal .Iso.fun (inl _) = i
-  goal .Iso.fun (inr m) = fst m
-  goal .Iso.inv m = case discreteFin i m of λ { (yes _) → inl tt ; (no n) → inr (m , n) }
-  goal .Iso.rightInv m with discreteFin i m
-  ... | (yes p) = p
-  ... | (no _) = toℕ-injective refl
-  goal .Iso.leftInv (inl tt) with discreteFin i i
-  ... | (yes _) = refl
-  ... | (no ¬ii) = ⊥.rec (¬ii refl)
-  goal .Iso.leftInv (inr m) with discreteFin i (fst m)
-  ... | (yes p) = ⊥.rec (snd m p)
-  ... | (no _) = cong inr (toℕExc-injective refl)
+projectionEquiv {n = n} {i = i} =
+  isoToEquiv f g fg gf
+  where
+    f  : Unit ⊎ FinExcept i → _
+    f (inl _) = i
+    f (inr m) = fst m
+    g  : Fin n → _
+    g m = case discreteFin i m of λ { (yes _) → inl tt ; (no n) → inr (m , n) }
+    fg : (b : Fin n) → _
+    fg m with discreteFin i m
+    ... | (yes p) = p
+    ... | (no _) = toℕ-injective refl
+    gf : (a : Unit ⊎ FinExcept i) → _
+    gf (inl tt) with discreteFin i i
+    ... | (yes _) = refl
+    ... | (no ¬ii) = ⊥.rec (¬ii refl)
+    gf (inr m) with discreteFin i (fst m)
+    ... | (yes p) = ⊥.rec (snd m p)
+    ... | (no _) = cong inr (toℕExc-injective refl)
 
 punchOut : (i : Fin (suc n)) → FinExcept i → Fin n
 punchOut i ¬i = punchOutPrim (snd ¬i)
@@ -122,10 +127,10 @@ isContrLehmerZero : isContr (LehmerCode 0)
 isContrLehmerZero = [] , λ { [] → refl }
 
 lehmerSucEquiv : Fin (suc n) × LehmerCode n ≃ LehmerCode (suc n)
-lehmerSucEquiv = isoToEquiv (iso (λ (e , c) → e ∷ c)
-                                 (λ { (e ∷ c) → (e , c) })
-                                 (λ { (e ∷ c) → refl })
-                                 (λ (e , c) → refl))
+lehmerSucEquiv = isoToEquiv (λ (e , c) → e ∷ c)
+                            (λ { (e ∷ c) → (e , c) })
+                            (λ { (e ∷ c) → refl })
+                            (λ (e , c) → refl)
 
 lehmerEquiv : (Fin n ≃ Fin n) ≃ LehmerCode n
 lehmerEquiv {zero} = isContr→Equiv contrFF isContrLehmerZero where
@@ -133,7 +138,7 @@ lehmerEquiv {zero} = isContr→Equiv contrFF isContrLehmerZero where
   contrFF = idEquiv _ , λ y → equivEq (funExt λ f → ⊥.rec (¬Fin0 f))
 
 lehmerEquiv {suc n} =
-  (Fin (suc n) ≃ Fin (suc n))                            ≃⟨ isoToEquiv i ⟩
+  (Fin (suc n) ≃ Fin (suc n))                            ≃⟨ isoToEquiv (Iso.fun i) (Iso.inv i) (Iso.rightInv i) (Iso.leftInv i) ⟩
   (Σ[ k ∈ Fin (suc n) ] (FinExcept fzero ≃ FinExcept k)) ≃⟨ Σ-cong-equiv-snd ii ⟩
   (Fin (suc n) × (Fin n ≃ Fin n))                        ≃⟨ Σ-cong-equiv-snd (λ _ → lehmerEquiv) ⟩
   (Fin (suc n) × LehmerCode n)                           ≃⟨ lehmerSucEquiv ⟩
@@ -157,11 +162,13 @@ lehmerEquiv {suc n} =
       Fin (suc n)
         ≃⟨ invEquiv projectionEquiv ⟩
       Unit ⊎ FinExcept fzero
-        ≃⟨ isoToEquiv (Sum.sumIso idIso (equivToIso f)) ⟩
+        ≃⟨ isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom) ⟩
       Unit ⊎ FinExcept k
         ≃⟨ projectionEquiv ⟩
       Fin (suc n)
         ■
+      where isom = Sum.sumIso idIso (equivToIso f)
+
 
     equivOutChar : ∀ {k} {f} (x : FinExcept fzero) → equivFun (equivOut {k = k} f) (fst x) ≡ fst (equivFun f x)
     equivOutChar {f = f} x with discreteFin fzero (fst x)

--- a/Cubical/Data/Fin/LehmerCode.agda
+++ b/Cubical/Data/Fin/LehmerCode.agda
@@ -130,7 +130,7 @@ lehmerSucEquiv = isoToEquiv (iso (λ (e , c) → e ∷ c)
 lehmerEquiv : (Fin n ≃ Fin n) ≃ LehmerCode n
 lehmerEquiv {zero} = isContr→Equiv contrFF isContrLehmerZero where
   contrFF : isContr (Fin zero ≃ Fin zero)
-  contrFF = idEquiv _ , λ y → equivEq _ _ (funExt λ f → ⊥.rec (¬Fin0 f))
+  contrFF = idEquiv _ , λ y → equivEq (funExt λ f → ⊥.rec (¬Fin0 f))
 
 lehmerEquiv {suc n} =
   (Fin (suc n) ≃ Fin (suc n))                            ≃⟨ isoToEquiv i ⟩
@@ -172,9 +172,9 @@ lehmerEquiv {suc n} =
             (Σ[ k ∈ Fin (suc n) ] (FinExcept (fzero {k = n}) ≃ FinExcept k))
     Iso.fun i f = equivFun f fzero , equivIn f
     Iso.inv i (k , f) = equivOut f
-    Iso.rightInv i (k , f) = ΣPathP (refl , equivEq _ _ (funExt λ x →
+    Iso.rightInv i (k , f) = ΣPathP (refl , equivEq (funExt λ x →
        toℕExc-injective (cong toℕ (equivOutChar {f = f} x))))
-    Iso.leftInv i f = equivEq _ _ (funExt goal) where
+    Iso.leftInv i f = equivEq (funExt goal) where
       goal : ∀ x → equivFun (equivOut (equivIn f)) x ≡ equivFun f x
       goal x = case fsplit x return (λ _ → equivFun (equivOut (equivIn f)) x ≡ equivFun f x) of λ
         { (inl xz) → subst (λ x → equivFun (equivOut (equivIn f)) x ≡ equivFun f x) xz refl

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -50,12 +50,10 @@ isContrFin1
 Unit≃Fin1 : Unit ≃ Fin 1
 Unit≃Fin1 =
   isoToEquiv
-    (iso
-      (const fzero)
-      (const tt)
-      (isContrFin1 .snd)
-      (isContrUnit .snd)
-    )
+    (const fzero)
+    (const tt)
+    (isContrFin1 .snd)
+    (isContrUnit .snd)
 
 -- Regardless of k, Fin k is a set.
 isSetFin : ∀{k} → isSet (Fin k)

--- a/Cubical/Data/FinSet.agda
+++ b/Cubical/Data/FinSet.agda
@@ -87,7 +87,7 @@ isFinSet≡isFinSetΣ {A = A} = hPropExt isProp-isFinSet isProp-isFinSetΣ to fr
     from (n , squash p q i) = isProp-isFinSet (from (n , p)) (from (n , q)) i
 
 FinSet≡FinSetΣ : FinSet {ℓ} ≡ FinSetΣ
-FinSet≡FinSetΣ = ua (isoToEquiv (iso to from to-from from-to))
+FinSet≡FinSetΣ = ua (isoToEquiv to from to-from from-to)
   where
     to : FinSet → FinSetΣ
     to (A , isFinSetA) = A , transport isFinSet≡isFinSetΣ isFinSetA

--- a/Cubical/Data/Maybe/Properties.agda
+++ b/Cubical/Data/Maybe/Properties.agda
@@ -58,7 +58,7 @@ module MaybePath {ℓ} {A : Type ℓ} where
 
   Cover≃Path : ∀ c c' → Cover c c' ≃ (c ≡ c')
   Cover≃Path c c' = isoToEquiv
-    (iso (decode c c') (encode c c') (decodeEncode c c') (encodeDecode c c'))
+    (decode c c') (encode c c') (decodeEncode c c') (encodeDecode c c')
 
   Cover≡Path : ∀ c c' → Cover c c' ≡ (c ≡ c')
   Cover≡Path c c' = isoToPath
@@ -146,13 +146,10 @@ Maybe≡SumUnit = isoToPath (iso SumUnit.Maybe→SumUnit SumUnit.SumUnit→Maybe
 
 congMaybeEquiv : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
   → A ≃ B → Maybe A ≃ Maybe B
-congMaybeEquiv e = isoToEquiv isom
-  where
-  open Iso
-  isom : Iso _ _
-  isom .fun = map-Maybe (equivFun e)
-  isom .inv = map-Maybe (invEq e)
-  isom .rightInv nothing = refl
-  isom .rightInv (just b) = cong just (retEq e b)
-  isom .leftInv nothing = refl
-  isom .leftInv (just a) = cong just (secEq e a)
+congMaybeEquiv {A = A} {B = B} e = isoToEquiv (map-Maybe (equivFun e)) (map-Maybe (invEq e)) fg gf where
+  fg : (b : Maybe B) → _
+  fg nothing = refl
+  fg (just b) = cong just (retEq e b)
+  gf : (a : Maybe A) → _
+  gf nothing = refl
+  gf (just a) = cong just (secEq e a)

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -52,10 +52,10 @@ private
 
 -- equivalence between the sigma-based definition and the inductive one
 A×B≃A×ΣB : A × B ≃ A ×Σ B
-A×B≃A×ΣB = isoToEquiv (iso (λ { (a , b) → (a , b)})
-                          (λ { (a , b) → (a , b)})
-                          (λ _ → refl)
-                          (λ { (a , b) → refl }))
+A×B≃A×ΣB = isoToEquiv (λ { (a , b) → (a , b)})
+                      (λ { (a , b) → (a , b)})
+                      (λ _ → refl)
+                      (λ { (a , b) → refl })
 
 A×B≡A×ΣB : A × B ≡ A ×Σ B
 A×B≡A×ΣB = ua A×B≃A×ΣB
@@ -70,7 +70,7 @@ isOfHLevelProd {A = A} {B = B} n h1 h2 =
 
 ×-≃ : ∀ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} {A : Type ℓ₁} {B : Type ℓ₂} {C : Type ℓ₃} {D : Type ℓ₄}
     → A ≃ C → B ≃ D → A × B ≃ C × D
-×-≃ {A = A} {B = B} {C = C} {D = D} f g = isoToEquiv (iso φ ψ η ε)
+×-≃ {A = A} {B = B} {C = C} {D = D} f g = isoToEquiv φ ψ η ε
    where
     φ : A × B → C × D
     φ (a , b) = equivFun f a , equivFun g b

--- a/Cubical/Data/Queue/Truncated2List.agda
+++ b/Cubical/Data/Queue/Truncated2List.agda
@@ -107,7 +107,7 @@ module Truncated2List {ℓ} (A : Type ℓ) (Aset : isSet A) where
 
  -- We get our desired equivalence
  quotEquiv : Q₁ ≃ Q
- quotEquiv = isoToEquiv (iso quot eval quot∘eval eval∘quot)
+ quotEquiv = isoToEquiv quot eval quot∘eval eval∘quot
 
  -- Now it only remains to prove that this is an equivalence of queue structures
  quot∘emp : quot emp₁ ≡ emp

--- a/Cubical/Data/Queue/Untruncated2List.agda
+++ b/Cubical/Data/Queue/Untruncated2List.agda
@@ -120,7 +120,7 @@ module Untruncated2List {ℓ} (A : Type ℓ) (Aset : isSet A) where
 
  -- We get our desired equivalence
  quotEquiv : Q₁ ≃ Q
- quotEquiv = isoToEquiv (iso quot eval quot∘eval eval∘quot)
+ quotEquiv = isoToEquiv quot eval quot∘eval eval∘quot
 
  -- Now it only remains to prove that this is an equivalence of queue structures
  quot∘emp : quot emp₁ ≡ emp

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -65,14 +65,15 @@ module _ {A : I → Type ℓ} {B : (i : I) → A i → Type ℓ'}
 
   ΣPathIsoPathΣ : Iso (Σ[ p ∈ PathP A (fst x) (fst y) ] (PathP (λ i → B i (p i)) (snd x) (snd y)))
                       (PathP (λ i → Σ (A i) (B i)) x y)
-  fun ΣPathIsoPathΣ        = ΣPathP
-  inv ΣPathIsoPathΣ eq     = (λ i → fst (eq i)) , (λ i → snd (eq i))
-  rightInv ΣPathIsoPathΣ _ = refl
-  leftInv ΣPathIsoPathΣ _  = refl
+  ΣPathIsoPathΣ = iso
+    ΣPathP
+    (λ eq → (λ i → fst (eq i)) , (λ i → snd (eq i)))
+    (λ _  → refl)
+    (λ _  → refl)
 
   ΣPath≃PathΣ : (Σ[ p ∈ PathP A (fst x) (fst y) ] (PathP (λ i → B i (p i)) (snd x) (snd y)))
               ≃ (PathP (λ i → Σ (A i) (B i)) x y)
-  ΣPath≃PathΣ = isoToEquiv ΣPathIsoPathΣ
+  ΣPath≃PathΣ = let iso = ΣPathIsoPathΣ in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
   ΣPath≡PathΣ : (Σ[ p ∈ PathP A (fst x) (fst y) ] (PathP (λ i → B i (p i)) (snd x) (snd y)))
               ≡ (PathP (λ i → Σ (A i) (B i)) x y)
@@ -91,16 +92,12 @@ module _ {A : I → Type ℓ} {B : (i : I) → (a : A i) → Type ℓ'}
   {x : Σ (A i0) (B i0)} {y : Σ (A i1) (B i1)}
   where
 
-  ΣPathPIsoPathPΣ :
-    Iso (Σ[ p ∈ PathP A (x .fst) (y .fst) ] PathP (λ i → B i (p i)) (x .snd) (y .snd))
-        (PathP (λ i → Σ (A i) (B i)) x y)
-  ΣPathPIsoPathPΣ .fun (p , q) i = p i , q i
-  ΣPathPIsoPathPΣ .inv pq .fst i = pq i .fst
-  ΣPathPIsoPathPΣ .inv pq .snd i = pq i .snd
-  ΣPathPIsoPathPΣ .rightInv _ = refl
-  ΣPathPIsoPathPΣ .leftInv _ = refl
-
-  ΣPathP≃PathPΣ = isoToEquiv ΣPathPIsoPathPΣ
+  ΣPathP≃PathPΣ : (Σ[ p ∈ PathP A (x .fst) (y .fst) ] PathP (λ i → B i (p i)) (x .snd) (y .snd))
+                ≃ (PathP (λ i → Σ (A i) (B i)) x y)
+  ΣPathP≃PathPΣ = isoToEquiv (λ{ (p , q) i → p i , q i }) g (λ _ → refl) (λ _ → refl) where
+    g : PathP (λ i → Σ (A i) (B i)) x y → Σ[ p ∈ _ ] _
+    g pq .fst i = pq i .fst
+    g pq .snd i = pq i .snd
 
   ΣPathP≡PathPΣ = ua ΣPathP≃PathPΣ
 
@@ -118,32 +115,26 @@ discreteΣ {B = B} Adis Bdis (a0 , b0) (a1 , b1) = discreteΣ' (Adis a0 a1)
         ... | (no ¬q) = no (λ r → ¬q (subst (λ X → PathP (λ i → B (X i)) b0 b1) (Discrete→isSet Adis a0 a0 (cong fst r) refl) (cong snd r)))
     discreteΣ' (no ¬p) = no (λ r → ¬p (cong fst r))
 
-Σ-swap-Iso : Iso (A × A') (A' × A)
-fun Σ-swap-Iso (x , y) = (y , x)
-inv Σ-swap-Iso (x , y) = (y , x)
-rightInv Σ-swap-Iso _ = refl
-leftInv Σ-swap-Iso _  = refl
-
 Σ-swap-≃ : A × A' ≃ A' × A
-Σ-swap-≃ = isoToEquiv Σ-swap-Iso
-
-Σ-assoc-Iso : Iso (Σ[ (a , b) ∈ Σ A B ] C a b) (Σ[ a ∈ A ] Σ[ b ∈ B a ] C a b)
-fun Σ-assoc-Iso ((x , y) , z) = (x , (y , z))
-inv Σ-assoc-Iso (x , (y , z)) = ((x , y) , z)
-rightInv Σ-assoc-Iso _ = refl
-leftInv Σ-assoc-Iso _  = refl
+Σ-swap-≃ = isoToEquiv
+  (λ{ (x , y) → (y , x) })
+  (λ{ (x , y) → (y , x) })
+  (λ _ → refl)
+  (λ _ → refl)
 
 Σ-assoc-≃ : (Σ[ (a , b) ∈ Σ A B ] C a b) ≃ (Σ[ a ∈ A ] Σ[ b ∈ B a ] C a b)
-Σ-assoc-≃ = isoToEquiv Σ-assoc-Iso
-
-Σ-Π-Iso : Iso ((a : A) → Σ[ b ∈ B a ] C a b) (Σ[ f ∈ ((a : A) → B a) ] ∀ a → C a (f a))
-fun Σ-Π-Iso f         = (fst ∘ f , snd ∘ f)
-inv Σ-Π-Iso (f , g) x = (f x , g x)
-rightInv Σ-Π-Iso _    = refl
-leftInv Σ-Π-Iso _     = refl
+Σ-assoc-≃ {A = A} {B = B} {C = C} = isoToEquiv
+  (λ{ ((x , y) , z) → (x , (y , z)) })
+  (λ{ (x , (y , z)) → ((x , y) , z) })
+  (λ _ → refl)
+  (λ _ → refl)
 
 Σ-Π-≃ : ((a : A) → Σ[ b ∈ B a ] C a b) ≃ (Σ[ f ∈ ((a : A) → B a) ] ∀ a → C a (f a))
-Σ-Π-≃ = isoToEquiv Σ-Π-Iso
+Σ-Π-≃ {A = A} {B = B} {C = C} = isoToEquiv
+  (λ  f        → (fst ∘ f , snd ∘ f))
+  (λ{(f , g) x → (f x , g x)})
+  (λ _ → refl)
+  (λ _ → refl)
 
 Σ-cong-iso-fst : (isom : Iso A A') → Iso (Σ A (B ∘ fun isom)) (Σ A' B)
 fun (Σ-cong-iso-fst isom) x = fun isom (x .fst) , x .snd
@@ -171,19 +162,21 @@ leftInv (Σ-cong-iso-fst {A = A} {B = B} isom) (x , y) = ΣPathP (leftInv isom x
       ∙∙ substRefl {B = B} y
 
 Σ-cong-equiv-fst : (e : A ≃ A') → Σ A (B ∘ equivFun e) ≃ Σ A' B
-Σ-cong-equiv-fst e = isoToEquiv (Σ-cong-iso-fst (equivToIso e))
+Σ-cong-equiv-fst e = let iso = Σ-cong-iso-fst (equivToIso e)
+                     in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 Σ-cong-fst : (p : A ≡ A') → Σ A (B ∘ transport p) ≡ Σ A' B
 Σ-cong-fst {B = B} p i = Σ (p i) (B ∘ transp (λ j → p (i ∨ j)) i)
 
 Σ-cong-iso-snd : ((x : A) → Iso (B x) (B' x)) → Iso (Σ A B) (Σ A B')
-fun (Σ-cong-iso-snd isom) (x , y) = x , fun (isom x) y
-inv (Σ-cong-iso-snd isom) (x , y') = x , inv (isom x) y'
-rightInv (Σ-cong-iso-snd isom) (x , y) = ΣPathP (refl , rightInv (isom x) y)
-leftInv (Σ-cong-iso-snd isom) (x , y') = ΣPathP (refl , leftInv (isom x) y')
+Σ-cong-iso-snd isom .fun      (x , y ) = x , fun (isom x) y
+Σ-cong-iso-snd isom .inv      (x , y') = x , inv (isom x) y'
+Σ-cong-iso-snd isom .rightInv (x , y ) = ΣPathP (refl , rightInv (isom x) y)
+Σ-cong-iso-snd isom .leftInv  (x , y') = ΣPathP (refl , leftInv (isom x) y')
 
 Σ-cong-equiv-snd : (∀ a → B a ≃ B' a) → Σ A B ≃ Σ A B'
-Σ-cong-equiv-snd h = isoToEquiv (Σ-cong-iso-snd (equivToIso ∘ h))
+Σ-cong-equiv-snd h = let iso = (Σ-cong-iso-snd (equivToIso ∘ h))
+                     in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 Σ-cong-snd : ((x : A) → B x ≡ B' x) → Σ A B ≡ Σ A B'
 Σ-cong-snd {A = A} p i = Σ[ x ∈ A ] (p x i)
@@ -196,7 +189,8 @@ leftInv (Σ-cong-iso-snd isom) (x , y') = ΣPathP (refl , leftInv (isom x) y')
 Σ-cong-equiv : (e : A ≃ A')
              → ((x : A) → B x ≃ B' (equivFun e x))
              → Σ A B ≃ Σ A' B'
-Σ-cong-equiv e e' = isoToEquiv (Σ-cong-iso (equivToIso e) (equivToIso ∘ e'))
+Σ-cong-equiv e e' = let iso = (Σ-cong-iso (equivToIso e) (equivToIso ∘ e'))
+                    in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 Σ-cong' : (p : A ≡ A') → PathP (λ i → p i → Type ℓ') B B' → Σ A B ≡ Σ A' B'
 Σ-cong' p p' = cong₂ (λ (A : Type _) (B : A → Type _) → Σ A B) p p'
@@ -211,7 +205,8 @@ IsoΣPathTransportPathΣ {B = B} a b = compIso (Σ-cong-iso-snd (λ p → invIso
          ΣPathIsoPathΣ
 
 ΣPathTransport≃PathΣ : (a b : Σ A B) → ΣPathTransport a b ≃ (a ≡ b)
-ΣPathTransport≃PathΣ {B = B} a b = isoToEquiv (IsoΣPathTransportPathΣ a b)
+ΣPathTransport≃PathΣ {B = B} a b = let iso = (IsoΣPathTransportPathΣ a b)
+                                   in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 ΣPathTransport→PathΣ : (a b : Σ A B) → ΣPathTransport a b → (a ≡ b)
 ΣPathTransport→PathΣ a b = Iso.fun (IsoΣPathTransportPathΣ a b)
@@ -223,28 +218,22 @@ PathΣ→ΣPathTransport a b = Iso.inv (IsoΣPathTransportPathΣ a b)
 ΣPathTransport≡PathΣ a b = ua (ΣPathTransport≃PathΣ a b)
 
 Σ-contractFst : (c : isContr A) → Σ A B ≃ B (c .fst)
-Σ-contractFst {B = B} c = isoToEquiv isom
-  where
-  isom : Iso _ _
-  isom .fun (a , b) = subst B (sym (c .snd a)) b
-  isom .inv b = (c .fst , b)
-  isom .rightInv b =
-    cong (λ p → subst B p b) (isProp→isSet (isContr→isProp c) _ _ _ _) ∙ transportRefl _
-  isom .leftInv (a , b) =
-    ΣPathTransport≃PathΣ _ _ .fst (c .snd a , transportTransport⁻ (cong B (c .snd a)) _)
+Σ-contractFst {B = B} c = isoToEquiv
+  (λ{ (a , b) → subst B (sym (c .snd a)) b })
+  (λ b → (c .fst , b))
+  (λ b →  cong (λ p → subst B p b) (isProp→isSet (isContr→isProp c) _ _ _ _) ∙ transportRefl _)
+  (λ{ (a , b) → ΣPathTransport≃PathΣ _ _ .fst (c .snd a , transportTransport⁻ (cong B (c .snd a)) _)})
 
 -- a special case of the above
 ΣUnit : ∀ {ℓ} (A : Unit → Type ℓ) → Σ Unit A ≃ A tt
-ΣUnit A = isoToEquiv (iso snd (λ { x → (tt , x) }) (λ _ → refl) (λ _ → refl))
+ΣUnit A = isoToEquiv snd (λ { x → (tt , x) }) (λ _ → refl) (λ _ → refl)
 
 Σ-contractSnd : ((a : A) → isContr (B a)) → Σ A B ≃ A
-Σ-contractSnd c = isoToEquiv isom
-  where
-  isom : Iso _ _
-  isom .fun = fst
-  isom .inv a = a , c a .fst
-  isom .rightInv _ = refl
-  isom .leftInv (a , b) = cong (a ,_) (c a .snd b)
+Σ-contractSnd c = isoToEquiv
+  fst
+  (λ a → a , c a .fst)
+  (λ _ → refl)
+  (λ{ (a , b) → cong (a ,_) (c a .snd b) })
 
 
 ≃-× : ∀ {ℓ'' ℓ'''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {D : Type ℓ'''} → A ≃ C → B ≃ D → A × B ≃ C × D

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -54,7 +54,7 @@ module SumPath {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
 
   Cover≃Path : ∀ c c' → Cover c c' ≃ (c ≡ c')
   Cover≃Path c c' =
-    isoToEquiv (iso (decode c c') (encode c c') (decodeEncode c c') (encodeDecode c c'))
+    isoToEquiv (decode c c') (encode c c') (decodeEncode c c') (encodeDecode c c')
 
   isOfHLevelCover : (n : HLevel)
     → isOfHLevel (suc (suc n)) A

--- a/Cubical/Data/SumFin/Properties.agda
+++ b/Cubical/Data/SumFin/Properties.agda
@@ -42,7 +42,7 @@ Fin→SumFin→Fin = Fin.elim (λ fk → SumFin→Fin (Fin→SumFin fk) ≡ fk)
 
 SumFin≃Fin : ∀ k → Fin k ≃ Fin.Fin k
 SumFin≃Fin _ =
-  isoToEquiv (iso SumFin→Fin Fin→SumFin Fin→SumFin→Fin SumFin→Fin→SumFin)
+  isoToEquiv SumFin→Fin Fin→SumFin Fin→SumFin→Fin SumFin→Fin→SumFin
 
 SumFin≡Fin : ∀ k → Fin k ≡ Fin.Fin k
 SumFin≡Fin k = ua (SumFin≃Fin k)

--- a/Cubical/Data/Unit/Properties.agda
+++ b/Cubical/Data/Unit/Properties.agda
@@ -49,7 +49,7 @@ fibId A =
                  , isOfHLevelSuc 1 isPropUnit _ _ (snd a) refl i))
 
 isContr→≃Unit : ∀ {ℓ} {A : Type ℓ} → isContr A → A ≃ Unit
-isContr→≃Unit contr = isoToEquiv (iso (λ _ → tt) (λ _ → fst contr) (λ _ → refl) λ _ → snd contr _)
+isContr→≃Unit contr = isoToEquiv (λ _ → tt) (λ _ → fst contr) (λ _ → refl) (λ _ → snd contr _)
 
 isContr→≡Unit : {A : Type₀} → isContr A → A ≡ Unit
 isContr→≡Unit contr = ua (isContr→≃Unit contr)

--- a/Cubical/Data/Vec/NAry.agda
+++ b/Cubical/Data/Vec/NAry.agda
@@ -41,13 +41,7 @@ curryⁿ-$ⁿ {n = zero} f  = refl
 curryⁿ-$ⁿ {n = suc n} f = funExt λ x → curryⁿ-$ⁿ {n = n} (f x)
 
 nAryOp≃VecFun : ∀ {n} → nAryOp n A B ≃ (Vec A n → B)
-nAryOp≃VecFun {n = n} = isoToEquiv f
-  where
-  f : Iso (nAryOp n A B) (Vec A n → B)
-  Iso.fun f      = _$ⁿ_
-  Iso.inv f      = curryⁿ
-  Iso.rightInv f = $ⁿ-curryⁿ
-  Iso.leftInv f  = curryⁿ-$ⁿ {n = n}
+nAryOp≃VecFun {n = n} = isoToEquiv _$ⁿ_ curryⁿ $ⁿ-curryⁿ (curryⁿ-$ⁿ {n = n})
 
 -- In order to apply ua to nAryOp≃VecFun we probably need to change
 -- the base-case of nAryLevel to "ℓ-max ℓ₁ ℓ₂". This will make it

--- a/Cubical/Data/Vec/Properties.agda
+++ b/Cubical/Data/Vec/Properties.agda
@@ -51,11 +51,8 @@ Vec→FinVec→Vec : {n : ℕ} (xs : Vec A n) → FinVec→Vec (Vec→FinVec xs)
 Vec→FinVec→Vec {n = zero}  [] = refl
 Vec→FinVec→Vec {n = suc n} (x ∷ xs) i = x ∷ Vec→FinVec→Vec xs i
 
-FinVecIsoVec : (n : ℕ) → Iso (FinVec A n) (Vec A n)
-FinVecIsoVec n = iso FinVec→Vec Vec→FinVec Vec→FinVec→Vec FinVec→Vec→FinVec
-
 FinVec≃Vec : (n : ℕ) → FinVec A n ≃ Vec A n
-FinVec≃Vec n = isoToEquiv (FinVecIsoVec n)
+FinVec≃Vec n = isoToEquiv FinVec→Vec Vec→FinVec Vec→FinVec→Vec FinVec→Vec→FinVec
 
 FinVec≡Vec : (n : ℕ) → FinVec A n ≡ Vec A n
 FinVec≡Vec n = ua (FinVec≃Vec n)

--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -46,7 +46,7 @@ NatΣ τ (x , a) = (x , τ x a)
 
 Σ-cong-≃ :  {X : Type ℓ} {A : X → Type ℓ'} {B : X → Type ℓ''} →
          ((x : X) → (A x ≃ B x)) → (Σ X A ≃ Σ X B)
-Σ-cong-≃ {X = X} {A = A} {B = B} φ = isoToEquiv (iso (NatΣ f) (NatΣ g) NatΣ-ε NatΣ-η)
+Σ-cong-≃ {X = X} {A = A} {B = B} φ = isoToEquiv (NatΣ f) (NatΣ g) NatΣ-ε NatΣ-η
  where
   f : (x : X) → (A x) → (B x)
   f x = equivFun (φ x)
@@ -115,7 +115,8 @@ NatΣ τ (x , a) = (x , τ x a)
 Σ-change-of-variable-≃ : {X : Type ℓ} {Y : Type ℓ'} {A : Y → Type ℓ''} (f : X → Y)
                       → (isEquiv f) → ((Σ X (A ∘ f)) ≃ (Σ Y A))
 Σ-change-of-variable-≃ f isEquivf =
-                      isoToEquiv (Σ-change-of-variable-Iso f (equiv→HAEquiv (f , isEquivf) .snd))
+                      isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+                      where isom = Σ-change-of-variable-Iso f (equiv→HAEquiv (f , isEquivf) .snd)
 
 
 -- A structure is a type-family S : Type ℓ → Type ℓ', i.e. for X : Type ℓ and s : S X, the pair (X , s)

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -61,8 +61,8 @@ equiv-proof (isPropIsEquiv f p q i) y =
                             ; (j = i1) → w })
                    (p2 w (i ∨ j))
 
-equivEq : (e f : A ≃ B) → (h : e .fst ≡ f .fst) → e ≡ f
-equivEq e f h = λ i → (h i) , isProp→PathP (λ i → isPropIsEquiv (h i)) (e .snd) (f .snd) i
+equivEq : {e f : A ≃ B} → (h : e .fst ≡ f .fst) → e ≡ f
+equivEq {e = e} {f = f} h = λ i → (h i) , isProp→PathP (λ i → isPropIsEquiv (h i)) (e .snd) (f .snd) i
 
 module _ {f : A → B} (equivF : isEquiv f) where
   funIsEq : A → B
@@ -103,27 +103,27 @@ invEquiv : A ≃ B → B ≃ A
 invEquiv e = isoToEquiv (invIso (equivToIso e))
 
 invEquivIdEquiv : (A : Type ℓ) → invEquiv (idEquiv A) ≡ idEquiv A
-invEquivIdEquiv _ = equivEq _ _ refl
+invEquivIdEquiv _ = equivEq refl
 
 -- TODO: there should be a direct proof of this that doesn't use equivToIso
 compEquiv : A ≃ B → B ≃ C → A ≃ C
 compEquiv f g = isoToEquiv (compIso (equivToIso f) (equivToIso g))
 
 compEquivIdEquiv : (e : A ≃ B) → compEquiv (idEquiv A) e ≡ e
-compEquivIdEquiv e = equivEq _ _ refl
+compEquivIdEquiv e = equivEq refl
 
 compEquivEquivId : (e : A ≃ B) → compEquiv e (idEquiv B) ≡ e
-compEquivEquivId e = equivEq _ _ refl
+compEquivEquivId e = equivEq refl
 
 invEquiv-is-rinv : (e : A ≃ B) → compEquiv e (invEquiv e) ≡ idEquiv A
-invEquiv-is-rinv e = equivEq _ _ (funExt (secEq e))
+invEquiv-is-rinv e = equivEq (funExt (secEq e))
 
 invEquiv-is-linv : (e : A ≃ B) → compEquiv (invEquiv e) e ≡ idEquiv B
-invEquiv-is-linv e = equivEq _ _ (funExt (retEq e))
+invEquiv-is-linv e = equivEq (funExt (retEq e))
 
 compEquiv-assoc : (f : A ≃ B) (g : B ≃ C) (h : C ≃ D)
                 → compEquiv f (compEquiv g h) ≡ compEquiv (compEquiv f g) h
-compEquiv-assoc f g h = equivEq _ _ refl
+compEquiv-assoc f g h = equivEq refl
 
 LiftEquiv : A ≃ Lift {i = ℓ} {j = ℓ'} A
 LiftEquiv .fst a .lower = a

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -100,14 +100,14 @@ leftInv (equivToIso e)  = secEq e
 
 -- TODO: there should be a direct proof of this that doesn't use equivToIso
 invEquiv : A ≃ B → B ≃ A
-invEquiv e = isoToEquiv (invIso (equivToIso e))
+invEquiv e = let iso = invIso (equivToIso e) in isoToEquiv (fun iso) (inv iso) (rightInv iso) (leftInv iso)
 
 invEquivIdEquiv : (A : Type ℓ) → invEquiv (idEquiv A) ≡ idEquiv A
 invEquivIdEquiv _ = equivEq refl
 
 -- TODO: there should be a direct proof of this that doesn't use equivToIso
 compEquiv : A ≃ B → B ≃ C → A ≃ C
-compEquiv f g = isoToEquiv (compIso (equivToIso f) (equivToIso g))
+compEquiv f g = let iso = compIso (equivToIso f) (equivToIso g) in isoToEquiv (fun iso) (inv iso) (rightInv iso) (leftInv iso)
 
 compEquivIdEquiv : (e : A ≃ B) → compEquiv (idEquiv A) e ≡ e
 compEquivIdEquiv e = equivEq refl
@@ -143,7 +143,7 @@ Lift≃Lift e .snd .equiv-proof b .snd (a , p) i .snd j .lower =
   e .snd .equiv-proof (b .lower) .snd (a .lower , cong lower p) i .snd j
 
 isContr→Equiv : isContr A → isContr B → A ≃ B
-isContr→Equiv Actr Bctr = isoToEquiv (isContr→Iso Actr Bctr)
+isContr→Equiv Actr Bctr = let iso = isContr→Iso Actr Bctr in isoToEquiv (fun iso) (inv iso) (rightInv iso) (leftInv iso)
 
 isPropEquiv→Equiv : (Aprop : isProp A) (Bprop : isProp B) (f : A → B) (g : B → A) → A ≃ B
 isPropEquiv→Equiv Aprop Bprop f g = f , hf
@@ -175,14 +175,11 @@ equivImplicitΠCod k .snd .equiv-proof f .snd (g , p) i .snd j {x} =
   equivCtrPath (k {x}) (f {x}) (g {x} , λ k → p k {x}) i .snd j
 
 equiv→ : (A ≃ B) → (C ≃ D) → (A → C) ≃ (B → D)
-equiv→ h k = isoToEquiv isom
-  where
-  open Iso
-  isom : Iso _ _
-  isom .fun f b = equivFun k (f (invEq h b))
-  isom .inv g a = invEq k (g (equivFun h a))
-  isom .rightInv g = funExt λ b → retEq k _ ∙ cong g (retEq h b)
-  isom .leftInv f = funExt λ a → secEq k _ ∙ cong f (secEq h a)
+equiv→ h k = isoToEquiv
+  (λ f b → equivFun k (f (invEq h b)))
+  (λ g a → invEq k (g (equivFun h a)))
+  (λ g   → funExt λ b → retEq k _ ∙ cong g (retEq h b))
+  (λ f   → funExt λ a → secEq k _ ∙ cong f (secEq h a))
 
 -- Some helpful notation:
 _≃⟨_⟩_ : (X : Type ℓ) → (X ≃ B) → (B ≃ C) → (X ≃ C)

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -36,7 +36,7 @@ isEquivCong : {x y : A} (e : A ≃ B) → isEquiv (λ (p : x ≡ y) → cong (e 
 isEquivCong e = isoToIsEquiv (congIso (equivToIso e))
 
 congEquiv : {x y : A} (e : A ≃ B) → (x ≡ y) ≃ (e .fst x ≡ e .fst y)
-congEquiv e = isoToEquiv (congIso (equivToIso e))
+congEquiv e = let iso = congIso (equivToIso e) in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 equivAdjointEquiv : (e : A ≃ B) → ∀ {a b} → (a ≡ invEq e b) ≃ (equivFun e a ≡ b)
 equivAdjointEquiv e = compEquiv (congEquiv e) (compPathrEquiv (retEq e _))
@@ -56,15 +56,14 @@ preCompEquiv e = (λ φ → φ ∘ fst e) , isEquivPreComp e
 
 depPostCompEquiv : {A : C → Type ℓ} {B : C → Type ℓ′} (e : ∀ c → A c ≃ B c)
                  → (∀ c → A c) ≃ (∀ c → B c)
-depPostCompEquiv {A = A} {B} e = isoToEquiv pcIso where
+depPostCompEquiv {A = A} {B} e = isoToEquiv
+  (λ f c   → Iso.fun      (eIso c) (f c))
+  (λ g c   → Iso.inv      (eIso c) (g c))
+  (λ f i c → Iso.rightInv (eIso c) (f c) i)
+  (λ g i c → Iso.leftInv  (eIso c) (g c) i)
+  where
   eIso : ∀ c → Iso (A c) (B c)
   eIso c = equivToIso (e c)
-
-  pcIso : Iso (∀ c → A c) (∀ c → B c)
-  Iso.fun pcIso f c = Iso.fun (eIso c) (f c)
-  Iso.inv pcIso g c = Iso.inv (eIso c) (g c)
-  Iso.rightInv pcIso f i c = Iso.rightInv (eIso c) (f c) i
-  Iso.leftInv pcIso g i c = Iso.leftInv (eIso c) (g c) i
 
 isEquivPostComp :(e : A ≃ B) → isEquiv (λ (φ : C → A) → e .fst ∘ φ)
 isEquivPostComp {A = A} {B} {C} e = snd (depPostCompEquiv (λ _ → e))
@@ -174,10 +173,10 @@ isPropIsHAEquiv {f = f} ishaef = goal ishaef where
   characterization =
     isHAEquiv f
       -- first convert between Σ and record
-      ≃⟨ isoToEquiv (iso (λ e → (e .g , e .ret) , (e .sec , e .com))
-                         (λ e → record { g = e .fst .fst ; ret = e .fst .snd
-                                       ; sec = e .snd .fst ; com = e .snd .snd })
-                         (λ _ → refl) λ _ → refl) ⟩
+      ≃⟨ isoToEquiv (λ e → (e .g , e .ret) , (e .sec , e .com))
+                    (λ e → record { g = e .fst .fst ; ret = e .fst .snd
+                                  ; sec = e .snd .fst ; com = e .snd .snd })
+                    (λ _ → refl) (λ _ → refl) ⟩
     Σ _ rCoh1
       -- secondly, convert the path into a dependent path for later convenience
       ≃⟨  Σ-cong-equiv-snd (λ s → Σ-cong-equiv-snd

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -100,14 +100,18 @@ module _ (i : Iso A B) where
   isoToIsEquiv .equiv-proof y .fst .snd = s y
   isoToIsEquiv .equiv-proof y .snd z = lemIso y (g y) (fst z) (s y) (snd z)
 
-
-isoToEquiv : Iso A B → A ≃ B
-isoToEquiv i .fst = _
-isoToEquiv i .snd = isoToIsEquiv i
+isoToEquiv : (f : A → B) (g : B → A) → ((b : B) → f (g b) ≡ b) → ((a : A) → g (f a) ≡ a) → A ≃ B
+isoToEquiv {A = A} {B = B} f g fg gf = f , isoToIsEquiv i
+  where
+  i : Iso A B
+  Iso.fun i      = f
+  Iso.inv i      = g
+  Iso.rightInv i = fg
+  Iso.leftInv i  = gf
 
 isoToPath : Iso A B → A ≡ B
 isoToPath {A = A} {B = B} f i =
-  Glue B (λ { (i = i0) → (A , isoToEquiv f)
+  Glue B (λ { (i = i0) → (A , isoToEquiv (Iso.fun f) (Iso.inv f) (Iso.rightInv f) (Iso.leftInv f))
             ; (i = i1) → (B , idEquiv B) })
 
 open Iso

--- a/Cubical/Foundations/Logic.agda
+++ b/Cubical/Foundations/Logic.agda
@@ -320,10 +320,10 @@ powersets-are-sets {X = X} = isSetΠ (λ _ → isSetHProp)
 
 ⊆-extensionalityEquiv : {X : Type ℓ} (A B : ℙ X)
                       → (A ⊆ B) × (B ⊆ A) ≃ (A ≡ B)
-⊆-extensionalityEquiv A B = isoToEquiv (iso (⊆-extensionality A B)
-                                            (⊆-refl-consequence A B)
-                                            (λ _ → powersets-are-sets A B _ _)
-                                            (λ _ → isPropΣ (⊆-isProp A B) (λ _ → ⊆-isProp B A) _ _))
+⊆-extensionalityEquiv A B = isoToEquiv (⊆-extensionality A B)
+                                       (⊆-refl-consequence A B)
+                                       (λ _ → powersets-are-sets A B _ _)
+                                       (λ _ → isPropΣ (⊆-isProp A B) (λ _ → ⊆-isProp B A) _ _)
 
 
 -- We show that the powerset is the subtype classifier
@@ -370,7 +370,7 @@ Embedding→Subset→Embedding {ℓ = ℓ} {X = X} (A , f , ψ) = cong (Σ-assoc
 
 
 Subset≃Embedding : {X : Type ℓ} → ℙ X ≃ (Σ[ A ∈ Type ℓ ] (A ↪ X))
-Subset≃Embedding = isoToEquiv (iso Subset→Embedding Embedding→Subset Embedding→Subset→Embedding Subset→Embedding→Subset)
+Subset≃Embedding = isoToEquiv Subset→Embedding Embedding→Subset Embedding→Subset→Embedding Subset→Embedding→Subset
 
 Subset≡Embedding : {X : Type ℓ} → ℙ X ≡ (Σ[ A ∈ Type ℓ ] (A ↪ X))
 Subset≡Embedding = ua Subset≃Embedding

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -134,7 +134,7 @@ flipSquareEquiv :
   {a₁₀ a₁₁ : A} {a₁₋ : a₁₀ ≡ a₁₁}
   {a₋₀ : a₀₀ ≡ a₁₀} {a₋₁ : a₀₁ ≡ a₁₁}
   → Square a₀₋ a₁₋ a₋₀ a₋₁ ≃ Square a₋₀ a₋₁ a₀₋ a₁₋
-flipSquareEquiv = isoToEquiv (iso flipSquare flipSquare (λ _ → refl) (λ _ → refl))
+flipSquareEquiv = isoToEquiv flipSquare flipSquare (λ _ → refl) (λ _ → refl)
 
 flipSquarePath :
   {a₀₀ a₀₁ : A} {a₀₋ : a₀₀ ≡ a₀₁}
@@ -156,7 +156,7 @@ module _ {a₀₀ a₁₁ : A} {a₋ : a₀₀ ≡ a₁₁}
   slideSquare sq i j = hcomp (slideSquareFaces i j) (sq i j)
 
   slideSquareEquiv : (Square a₋ a₁₋ a₋₀ refl) ≃ (Square refl a₁₋ a₋₀ a₋)
-  slideSquareEquiv = isoToEquiv (iso slideSquare slideSquareInv fillerTo fillerFrom) where
+  slideSquareEquiv = isoToEquiv slideSquare slideSquareInv fillerTo fillerFrom where
     slideSquareInv : Square refl a₁₋ a₋₀ a₋ → Square a₋ a₁₋ a₋₀ refl
     slideSquareInv sq i j = hcomp (λ k → slideSquareFaces i j (~ k)) (sq i j)
     fillerTo : ∀ p → slideSquare (slideSquareInv p) ≡ p

--- a/Cubical/Foundations/Pointed/FunExt.agda
+++ b/Cubical/Foundations/Pointed/FunExt.agda
@@ -32,7 +32,8 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
 
   -- transformed to equivalence
   funExt∙P≃ : (f g : Π∙ A B ptB) → (f ∙∼P g) ≃ (f ≡ g)
-  funExt∙P≃ f g = isoToEquiv (funExt∙PIso f g)
+  funExt∙P≃ f g = let iso = (funExt∙PIso f g)
+                  in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
   -- funExt∙≃ using the other kind of pointed homotopy
   funExt∙≃ : (f g : Π∙ A B ptB) → (f ∙∼ g) ≃ (f ≡ g)

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -75,7 +75,7 @@ module HomogeneousDiscrete {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙))
   switch-idp x | no ¬p | no ¬q | no  _ | no  _ = refl
 
   switch-eqv : typ A∙ ≃ typ A∙
-  switch-eqv = isoToEquiv (iso switch switch switch-idp switch-idp)
+  switch-eqv = isoToEquiv switch switch switch-idp switch-idp
 
 isHomogeneousDiscrete : ∀ {ℓ} {A∙ : Pointed ℓ} (dA : Discrete (typ A∙)) → isHomogeneous A∙
 isHomogeneousDiscrete {ℓ} {A∙} dA y

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -196,7 +196,7 @@ pathToEquiv : {A B : Type ℓ} → A ≡ B → A ≃ B
 pathToEquiv p = lineToEquiv (λ i → p i)
 
 pathToEquivRefl : {A : Type ℓ} → pathToEquiv refl ≡ idEquiv A
-pathToEquivRefl {A = A} = equivEq _ _ (λ i x → transp (λ _ → A) i x)
+pathToEquivRefl {A = A} = equivEq (λ i x → transp (λ _ → A) i x)
 
 pathToEquiv-ua : {A B : Type ℓ} (e : A ≃ B) → pathToEquiv (ua e) ≡ e
 pathToEquiv-ua = Univalence.au-ua pathToEquiv pathToEquivRefl

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -68,7 +68,7 @@ ua-gluePath e {x} p i = ua-glue e i (λ { (i = i0) → x }) (inS (p i))
 -- ua-ungluePath and ua-gluePath are definitional inverses
 ua-ungluePath-Equiv : ∀ {A B : Type ℓ} (e : A ≃ B) {x : A} {y : B}
                       → (PathP (λ i → ua e i) x y) ≃ (e .fst x ≡ y)
-ua-ungluePath-Equiv e = isoToEquiv (iso (ua-ungluePath e) (ua-gluePath e) (λ _ → refl) (λ _ → refl))
+ua-ungluePath-Equiv e = isoToEquiv (ua-ungluePath e) (ua-gluePath e) (λ _ → refl) (λ _ → refl)
 
 -- ua-unglue and ua-glue are also definitional inverses, in a way
 -- strengthening the types of ua-unglue and ua-glue gives a nicer formulation of this, see below

--- a/Cubical/Foundations/Univalence/Universe.agda
+++ b/Cubical/Foundations/Univalence/Universe.agda
@@ -54,7 +54,7 @@ module UU-Lemmas where
 
   nu-un : ∀ x y (e : El x ≃ El y) → nu x y (un x y e) ≡ e
   nu-un x y e
-    = equivEq (nu x y (un x y e)) e λ i z
+    = equivEq {e = nu x y (un x y e)} {f = e} λ i z
         → (cong (λ p → transport p z) (comp e) ∙ uaβ e z) i
 
   El-un-equiv : ∀ x i → El (un x x (idEquiv _) i) ≃ El x
@@ -77,7 +77,7 @@ module UU-Lemmas where
         (un (un x x (idEquiv (El x)) (~ i)) x (El-un-equiv x (~ i)) j)
 
   nu-refl : ∀ x → nu x x refl ≡ idEquiv (El x)
-  nu-refl x = equivEq (nu x x refl) (idEquiv (El x)) reg
+  nu-refl x = equivEq {e = nu x x refl} {f = idEquiv (El x)} reg
 
   un-nu : ∀ x y (p : x ≡ y) → un x y (nu x y p) ≡ p
   un-nu x y p

--- a/Cubical/Foundations/Univalence/Universe.agda
+++ b/Cubical/Foundations/Univalence/Universe.agda
@@ -99,10 +99,12 @@ pathIso s t .rightInv = cong-un-te s t
 pathIso s t .leftInv = un-nu s t
 
 minivalence : ∀{s t} → (s ≡ t) ≃ (El s ≃ El t)
-minivalence {s} {t} = isoToEquiv (equivIso s t)
+minivalence {s} {t} = let iso = equivIso s t
+                      in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 path-reflection : ∀{s t} → (s ≡ t) ≃ (El s ≡ El t)
-path-reflection {s} {t} = isoToEquiv (pathIso s t)
+path-reflection {s} {t} = let iso = pathIso s t
+                          in isoToEquiv (Iso.fun iso) (Iso.inv iso) (Iso.rightInv iso) (Iso.leftInv iso)
 
 isEmbeddingEl : isEmbedding El
 isEmbeddingEl s t = snd path-reflection

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -142,7 +142,8 @@ iso→isEmbedding : ∀ {ℓ} {A B : Type ℓ}
   → (isom : Iso A B)
   -------------------------------
   → isEmbedding (Iso.fun isom)
-iso→isEmbedding {A = A} {B} isom = (isEquiv→isEmbedding (equivIsEquiv (isoToEquiv isom)))
+iso→isEmbedding {A = A} {B} isom = isEquiv→isEmbedding (equivIsEquiv (isoToEquiv
+  (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)))
 
 isEmbedding→Injection :
   ∀ {ℓ} {A B C : Type ℓ}

--- a/Cubical/Functions/Fibration.agda
+++ b/Cubical/Functions/Fibration.agda
@@ -37,7 +37,7 @@ module FiberIso {ℓb} {B : Type ℓb} {ℓ} (p⁻¹ : B → Type ℓ) (x : B) w
 
   -- HoTT Lemma 4.8.1
   fiberEquiv : fiber p x ≃ p⁻¹ x
-  fiberEquiv = isoToEquiv (iso fwd bwd fwd-bwd bwd-fwd)
+  fiberEquiv = isoToEquiv fwd bwd fwd-bwd bwd-fwd
 
 open FiberIso using (fiberEquiv) public
 
@@ -45,12 +45,11 @@ module _ {ℓb} {B : Type ℓb} {ℓ} {E : Type ℓ} (p : E → B) where
 
   -- HoTT Lemma 4.8.2
   totalEquiv : E ≃ Σ B (fiber p)
-  totalEquiv = isoToEquiv isom
-    where isom : Iso E (Σ B (fiber p))
-          Iso.fun isom x           = p x , x , refl
-          Iso.inv isom (b , x , q) = x
-          Iso.leftInv  isom x           i = x
-          Iso.rightInv isom (b , x , q) i = q i , x , λ j → q (i ∧ j)
+  totalEquiv = isoToEquiv
+    (λ       x        → p x , x , refl)
+    (λ{ (b , x , q)   → x })
+    (λ{ (b , x , q) i → q i , x , λ j → q (i ∧ j) })
+    (λ       x      i → x  )
 
 module _ {ℓb} (B : Type ℓb) (ℓ : Level) where
   private
@@ -58,13 +57,11 @@ module _ {ℓb} (B : Type ℓb) (ℓ : Level) where
 
   -- HoTT Theorem 4.8.3
   fibrationEquiv : (Σ[ E ∈ Type ℓ' ] (E → B)) ≃ (B → Type ℓ')
-  fibrationEquiv = isoToEquiv isom
-    where isom : Iso (Σ[ E ∈ Type ℓ' ] (E → B)) (B → Type ℓ')
-          Iso.fun isom (E , p) = fiber p
-          Iso.inv isom p⁻¹     = Σ B p⁻¹ , fst
-          Iso.rightInv isom p⁻¹ i x = ua (fiberEquiv p⁻¹ x) i
-          Iso.leftInv  isom (E , p) i = ua e (~ i) , fst ∘ ua-unglue e (~ i)
-            where e = totalEquiv p
+  fibrationEquiv = isoToEquiv
+    (λ{ (E , p)   → fiber {ℓ'} {ℓb} p })
+    (λ p⁻¹        → Σ B p⁻¹ , fst {ℓb})
+    (λ p⁻¹ i x    → ua (fiberEquiv p⁻¹ x) i)
+    (λ{ (E , p) i → let e = totalEquiv p in ua e (~ i) , fst ∘ ua-unglue e (~ i) })
 
 -- The path type in a fiber of f is equivalent to a fiber of (cong f)
 open import Cubical.Foundations.Function

--- a/Cubical/Functions/FunExtEquiv.agda
+++ b/Cubical/Functions/FunExtEquiv.agda
@@ -120,8 +120,8 @@ nAryFunExt⁻ (suc n) fX fY p (x ∷ xs) = nAryFunExt⁻ n (fX x) (fY x) (λ i �
 
 nAryFunExtEquiv : (n : ℕ) {X : Type ℓ} {Y : I → Type ℓ₁} (fX : nAryOp n X (Y i0)) (fY : nAryOp n X (Y i1))
   → ((xs : Vec X n) → PathP Y (fX $ⁿ xs) (fY $ⁿ map (λ x → x) xs)) ≃ PathP (λ i → nAryOp n X (Y i)) fX fY
-nAryFunExtEquiv n {X} {Y} fX fY = isoToEquiv (iso (nAryFunExt n fX fY) (nAryFunExt⁻ n fX fY)
-                                              (linv n fX fY) (rinv n fX fY))
+nAryFunExtEquiv n {X} {Y} fX fY = isoToEquiv (nAryFunExt n fX fY) (nAryFunExt⁻ n fX fY)
+                                              (linv n fX fY) (rinv n fX fY)
   where
   linv : (n : ℕ) (fX : nAryOp n X (Y i0)) (fY : nAryOp n X (Y i1))
     (p : PathP (λ i → nAryOp n X (Y i)) fX fY)
@@ -160,13 +160,10 @@ funExtDepEquiv : {A : I → Type ℓ} {B : (i : I) → A i → Type ℓ₁}
   {f : (x : A i0) → B i0 x} {g : (x : A i1) → B i1 x}
   → ({x₀ : A i0} {x₁ : A i1} (p : PathP A x₀ x₁) → PathP (λ i → B i (p i)) (f x₀) (g x₁))
   ≃ PathP (λ i → (x : A i) → B i x) f g
-funExtDepEquiv {A = A} {B} {f} {g} = isoToEquiv isom
+funExtDepEquiv {A = A} {B} {f} {g} = isoToEquiv funExtDep funExtDep⁻ fg gf
   where
-  open Iso
-  isom : Iso _ _
-  isom .fun = funExtDep
-  isom .inv = funExtDep⁻
-  isom .rightInv q m i x =
+  fg : (b : PathP (λ i → (x : A i) → B i x) (λ x → f x) (λ x → g x)) → funExtDep (funExtDep⁻ b) ≡ b
+  fg q m i x =
     comp
       (λ k → B i (coei→i A i x (k ∨ m)))
       (λ k → λ
@@ -175,7 +172,8 @@ funExtDepEquiv {A = A} {B} {f} {g} = isoToEquiv isom
         ; (m = i1) → q i x
         })
       (q i (coei→i A i x m))
-  isom .leftInv h m p i =
+  gf : (a : {x₀ : A i0} {x₁ : A i1} (p : PathP A x₀ x₁) → PathP (λ i → B i (p i)) (f x₀) (g x₁)) → _
+  gf h m p i =
     comp
       (λ k → B i (lemi→i m k))
       (λ k → λ
@@ -198,20 +196,21 @@ heteroHomotopy≃Homotopy : {A : I → Type ℓ} {B : (i : I) → Type ℓ₁}
   {f : A i0 → B i0} {g : A i1 → B i1}
   → ({x₀ : A i0} {x₁ : A i1} → PathP A x₀ x₁ → PathP B (f x₀) (g x₁))
   ≃ ((x₀ : A i0) → PathP B (f x₀) (g (transport (λ i → A i) x₀)))
-heteroHomotopy≃Homotopy {A = A} {B} {f} {g} = isoToEquiv isom
+heteroHomotopy≃Homotopy {A = A} {B} {f} {g} = isoToEquiv
+  (λ h x₀ → h (isContrSinglP A x₀ .fst .snd))
+  (λ k {x₀} {x₁} p →
+    subst (λ fib → PathP B (f x₀) (g (fib .fst))) (isContrSinglP A x₀ .snd (x₁ , p)) (k x₀))
+  fg
+  gf
   where
-  open Iso
-  isom : Iso _ _
-  isom .fun h x₀ = h (isContrSinglP A x₀ .fst .snd)
-  isom .inv k {x₀} {x₁} p =
-    subst (λ fib → PathP B (f x₀) (g (fib .fst))) (isContrSinglP A x₀ .snd (x₁ , p)) (k x₀)
-  isom .rightInv k = funExt λ x₀ →
+  fg = λ k → funExt λ x₀ →
     cong (λ α → subst (λ fib → PathP B (f x₀) (g (fib .fst))) α (k x₀))
       (isProp→isSet (isContr→isProp (isContrSinglP A x₀)) (isContrSinglP A x₀ .fst) _
         (isContrSinglP A x₀ .snd (isContrSinglP A x₀ .fst))
         refl)
     ∙ transportRefl (k x₀)
-  isom .leftInv h j {x₀} {x₁} p =
+  gf : (a : {x₀ : A i0} {x₁ : A i1} → PathP A x₀ x₁ → PathP B (f x₀) (g x₁)) → _
+  gf h j {x₀} {x₁} p =
     transp
       (λ i → PathP B (f x₀) (g (isContrSinglP A x₀ .snd (x₁ , p) (i ∨ j) .fst)))
       j

--- a/Cubical/Functions/Involution.agda
+++ b/Cubical/Functions/Involution.agda
@@ -30,7 +30,7 @@ module _ {ℓ} {A : Type ℓ} {f : A → A} (invol : isInvolution f) where
 
   involEquivComp : compEquiv involEquiv involEquiv ≡ idEquiv A
   involEquivComp
-    = equivEq _ _ (λ i x → invol x i)
+    = equivEq (λ i x → invol x i)
 
   involPathComp : involPath ∙ involPath ≡ refl
   involPathComp
@@ -40,4 +40,3 @@ module _ {ℓ} {A : Type ℓ} {f : A → A} (invol : isInvolution f) where
   involPath²
     = subst (λ s → Square involPath s refl involPath)
         involPathComp (compPath-filler involPath involPath)
-

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -49,11 +49,11 @@ equiv-proof (isEmbedding×isSurjection→isEquiv {f = f} (emb , sur)) b =
   fib' = hpf b
 
 isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjection f
-isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
+isEquiv≃isEmbedding×isSurjection = isoToEquiv
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
   (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isSurjectionIsProp) _ _)
-  (λ _ → isPropIsEquiv _ _ _))
+  (λ _ → isPropIsEquiv _ _ _)
 
 isPropIsSurjection : isProp (isSurjection f)
 isPropIsSurjection = isPropΠ λ _ → propTruncIsProp

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -56,13 +56,11 @@ elim3 gB g = elim2 (λ _ _ → is2GroupoidΠ (λ _ → gB _ _ _))
 2GroupoidTruncIs2Groupoid a b p q r s = squash₄ a b p q r s
 
 2GroupoidTruncIdempotent≃ : is2Groupoid A → ∥ A ∥₄ ≃ A
-2GroupoidTruncIdempotent≃ {A = A} hA = isoToEquiv f
-  where
-  f : Iso ∥ A ∥₄ A
-  Iso.fun f = rec hA (idfun A)
-  Iso.inv f x = ∣ x ∣₄
-  Iso.rightInv f _ = refl
-  Iso.leftInv f = elim (λ _ → isOfHLevelSuc 4 2GroupoidTruncIs2Groupoid _ _) (λ _ → refl)
+2GroupoidTruncIdempotent≃ {A = A} hA = isoToEquiv
+  (rec hA (idfun A))
+  (λ x → ∣ x ∣₄)
+  (λ _ → refl)
+  (elim (λ _ → isOfHLevelSuc 4 2GroupoidTruncIs2Groupoid _ _) (λ _ → refl))
 
 2GroupoidTruncIdempotent : is2Groupoid A → ∥ A ∥₄ ≡ A
 2GroupoidTruncIdempotent hA = ua (2GroupoidTruncIdempotent≃ hA)

--- a/Cubical/HITs/AssocList/Properties.agda
+++ b/Cubical/HITs/AssocList/Properties.agda
@@ -74,10 +74,10 @@ FMS→AL∘AL→FMS≡id = AL.ElimProp.f (AL.trunc _ _) refl (λ x n {xs} p → 
 
 
 AssocList≃FMSet : AssocList A ≃ FMSet A
-AssocList≃FMSet = isoToEquiv (iso AL→FMS FMS→AL AL→FMS∘FMS→AL≡id FMS→AL∘AL→FMS≡id)
+AssocList≃FMSet = isoToEquiv AL→FMS FMS→AL AL→FMS∘FMS→AL≡id FMS→AL∘AL→FMS≡id
 
 FMSet≃AssocList : FMSet A ≃ AssocList A
-FMSet≃AssocList = isoToEquiv (iso FMS→AL AL→FMS FMS→AL∘AL→FMS≡id AL→FMS∘FMS→AL≡id)
+FMSet≃AssocList = isoToEquiv FMS→AL AL→FMS FMS→AL∘AL→FMS≡id AL→FMS∘FMS→AL≡id
 
 
 AssocList≡FMSet : AssocList A ≡ FMSet A

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -92,13 +92,13 @@ module _ {ℓ ℓ' ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} {X : 
 
   uniqColimit : isColimit F X → isColimit F Y → X ≃ Y
   uniqColimit cl cl'
-    = isoToEquiv (iso (fst fwd) (fst bwd)
-                      (λ x i → fst (isContr→isProp (equiv-proof (univ cl' ℓ' Y) (cone cl'))
-                                                   (compCoconeMor fwd bwd)
-                                                   (idCoconeMor (Y , cone cl')) i) x)
-                      (λ x i → fst (isContr→isProp (equiv-proof (univ cl ℓ  X) (cone cl))
-                                                   (compCoconeMor bwd fwd)
-                                                   (idCoconeMor (X , cone cl)) i) x))
+    = isoToEquiv (fst fwd) (fst bwd)
+                 (λ x i → fst (isContr→isProp (equiv-proof (univ cl' ℓ' Y) (cone cl'))
+                                              (compCoconeMor fwd bwd)
+                                              (idCoconeMor (Y , cone cl')) i) x)
+                 (λ x i → fst (isContr→isProp (equiv-proof (univ cl ℓ  X) (cone cl))
+                                              (compCoconeMor bwd fwd)
+                                              (idCoconeMor (X , cone cl)) i) x)
     where fwd : CoconeMor (X , cone cl ) (Y , cone cl')
           bwd : CoconeMor (Y , cone cl') (X , cone cl )
           fwd = postcomp⁻¹-mor cl (cone cl')

--- a/Cubical/HITs/Cylinder/Base.agda
+++ b/Cubical/HITs/Cylinder/Base.agda
@@ -74,7 +74,7 @@ module _ {ℓ} {A : Type ℓ} where
 
   -- The second part of the factorization above.
   CylinderA≃A : Cylinder A ≃ A
-  CylinderA≃A = isoToEquiv (iso out inl out-inl inl-out)
+  CylinderA≃A = isoToEquiv out inl out-inl inl-out
 
   -- The cocylinder has a similar equivalence that is part
   -- of factorizing the diagonal mapping.
@@ -95,7 +95,7 @@ module _ {ℓ} {A : Type ℓ} where
 
   A≃CocylinderA : A ≃ Cocylinder A
   A≃CocylinderA =
-    isoToEquiv (iso inco outco CocylinderA→A→CocylinderA A→CocylinderA→A)
+    isoToEquiv inco outco CocylinderA→A→CocylinderA A→CocylinderA→A
 
   project : Cocylinder A → A × A
   project c = c zero , c one
@@ -185,7 +185,7 @@ module IntervalEquiv where
 
   CylinderUnit≃Interval : Cylinder Unit ≃ Interval
   CylinderUnit≃Interval =
-    isoToEquiv (iso CylinderUnit→Interval Interval→CylinderUnit Interval→CylinderUnit→Interval CylinderUnit→Interval→CylinderUnit)
+    isoToEquiv CylinderUnit→Interval Interval→CylinderUnit Interval→CylinderUnit→Interval CylinderUnit→Interval→CylinderUnit
 
 
   -- More generally, there is an equivalence between the cylinder
@@ -220,10 +220,10 @@ module IntervalEquiv where
     CylinderA≃A×Interval : Cylinder A ≃ Cyl
     CylinderA≃A×Interval =
       isoToEquiv
-        (iso CylinderA→A×Interval
-             A×Interval→CylinderA
-             A×Interval→CylinderA→A×Interval
-             CylinderA→A×Interval→CylinderA)
+        CylinderA→A×Interval
+        A×Interval→CylinderA
+        A×Interval→CylinderA→A×Interval
+        CylinderA→A×Interval→CylinderA
 
 -- The cylinder is also the pushout of the identity on A with itself.
 module Push {ℓ} {A : Type ℓ} where
@@ -259,7 +259,7 @@ module Push {ℓ} {A : Type ℓ} where
   Pushout≃Cylinder : Push ≃ Cyl
   Pushout≃Cylinder =
     isoToEquiv
-      (iso Pushout→Cylinder
-           Cylinder→Pushout
-           Cylinder→Pushout→Cylinder
-           Pushout→Cylinder→Pushout)
+      Pushout→Cylinder
+      Cylinder→Pushout
+      Cylinder→Pushout→Cylinder
+      Pushout→Cylinder→Pushout

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -55,13 +55,11 @@ groupoidTruncIsGroupoid : isGroupoid ∥ A ∥₃
 groupoidTruncIsGroupoid a b p q r s = squash₃ a b p q r s
 
 groupoidTruncIdempotent≃ : isGroupoid A → ∥ A ∥₃ ≃ A
-groupoidTruncIdempotent≃ {A = A} hA = isoToEquiv f
-  where
-  f : Iso ∥ A ∥₃ A
-  Iso.fun f = rec hA (idfun A)
-  Iso.inv f x = ∣ x ∣₃
-  Iso.rightInv f _ = refl
-  Iso.leftInv f = elim (λ _ → isGroupoid→is2Groupoid groupoidTruncIsGroupoid _ _) (λ _ → refl)
+groupoidTruncIdempotent≃ {A = A} hA = isoToEquiv
+  (rec hA (idfun A))
+  (λ x → ∣ x ∣₃)
+  (λ _ → refl)
+  (elim (λ _ → isGroupoid→is2Groupoid groupoidTruncIsGroupoid _ _) (λ _ → refl))
 
 groupoidTruncIdempotent : isGroupoid A → ∥ A ∥₃ ≡ A
 groupoidTruncIdempotent hA = ua (groupoidTruncIdempotent≃ hA)

--- a/Cubical/HITs/Ints/BiInvInt/Properties.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Properties.agda
@@ -70,7 +70,7 @@ Iso.rightInv sucIso = suc-predl
 Iso.leftInv sucIso = predl-suc
 
 sucEquiv : BiInvInt ≃ BiInvInt
-sucEquiv = isoToEquiv sucIso
+sucEquiv = isoToEquiv suc pred suc-predl predl-suc
 
 -- addition
 

--- a/Cubical/HITs/Ints/QuoInt/Base.agda
+++ b/Cubical/HITs/Ints/QuoInt/Base.agda
@@ -117,7 +117,7 @@ negate-invol (signed s n) i = signed (notnot s i) n
 negate-invol (posneg i)   _ = posneg i
 
 negateEquiv : ℤ ≃ ℤ
-negateEquiv = isoToEquiv (iso -_ -_ negate-invol negate-invol)
+negateEquiv = isoToEquiv -_ -_ negate-invol negate-invol
 
 negateEq : ℤ ≡ ℤ
 negateEq = ua negateEquiv

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -58,7 +58,8 @@ joinPushout-iso-join A B = iso joinPushout→join join→joinPushout join→join
 
 -- We will need both the equivalence and path version
 joinPushout≃join : (A : Type ℓ) → (B : Type ℓ') → joinPushout A B ≃ join A B
-joinPushout≃join A B = isoToEquiv (joinPushout-iso-join A B)
+joinPushout≃join A B = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = joinPushout-iso-join A B
 
 joinPushout≡join : (A : Type ℓ) → (B : Type ℓ') → joinPushout A B ≡ join A B
 joinPushout≡join A B = isoToPath (joinPushout-iso-join A B)
@@ -155,7 +156,7 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         A□2→A×join→A□2 (a , push b c i) = refl
 
         A□2≃A×join : 3x3-span.A□2 span ≃ A×join
-        A□2≃A×join = isoToEquiv (iso A□2→A×join A×join→A□2 A□2→A×join→A□2 A×join→A□2→A×join)
+        A□2≃A×join = isoToEquiv A□2→A×join A×join→A□2 A□2→A×join→A□2 A×join→A□2→A×join
 
         A→A□0 : A → 3x3-span.A□0 span
         A→A□0 b = inl b
@@ -174,7 +175,7 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         A□0→A→A□0 (push a i) j = push a (j ∧ i)
 
         A□0≃A :  3x3-span.A□0 span ≃ A
-        A□0≃A = isoToEquiv (iso A□0→A A→A□0 A→A□0→A A□0→A→A□0)
+        A□0≃A = isoToEquiv A□0→A A→A□0 A→A□0→A A□0→A→A□0
 
         H1 : (x : 3x3-span.A□2 span) → proj₁ (A□2→A×join x) ≡ A□0→A (3x3-span.f□1 span x)
         H1 (inl (a , b)) = refl
@@ -237,7 +238,7 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         A2□→join×C→A2□ (push a b i , c) = refl
 
         A2□≃join×C : 3x3-span.A2□ span ≃ join×C
-        A2□≃join×C = isoToEquiv (iso A2□→join×C join×C→A2□ A2□→join×C→A2□ join×C→A2□→join×C)
+        A2□≃join×C = isoToEquiv A2□→join×C join×C→A2□ A2□→join×C→A2□ join×C→A2□→join×C
 
         C→A4□ : C → 3x3-span.A4□ span
         C→A4□ b = inr b
@@ -256,7 +257,7 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
         A4□→C→A4□ (push x i) j = push x (~ j ∨ i)
 
         A4□≃C :  3x3-span.A4□ span ≃ C
-        A4□≃C = isoToEquiv (iso A4□→C C→A4□ C→A4□→C A4□→C→A4□)
+        A4□≃C = isoToEquiv A4□→C C→A4□ C→A4□→C A4□→C→A4□
 
         H3 : (x : 3x3-span.A2□ span) → proj₂ (A2□→join×C x) ≡ A4□→C (3x3-span.f3□ span x)
         H3 (inl (a , c)) = refl
@@ -274,7 +275,7 @@ join-assoc A B C = (joinPushout≡join (join A B) C) ⁻¹
 -}
 joinSwitch : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
   → join (join A B) C ≃ join (join C B) A
-joinSwitch = isoToEquiv (iso switch switch invol invol)
+joinSwitch = isoToEquiv switch switch invol invol
   where
   switch : ∀ {ℓ ℓ' ℓ''}  {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
     → join (join A B) C → join (join C B) A
@@ -328,7 +329,7 @@ joinSwitch = isoToEquiv (iso switch switch invol invol)
 joinAssocDirect : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
   → join (join A B) C ≃ join A (join B C)
 joinAssocDirect {A = A} {B} {C} =
-  isoToEquiv (iso forward back forwardBack backForward)
+  isoToEquiv forward back forwardBack backForward
   where
   forward : join (join A B) C → join A (join B C)
   forward (inl (inl a)) = inl a

--- a/Cubical/HITs/KleinBottle/Properties.agda
+++ b/Cubical/HITs/KleinBottle/Properties.agda
@@ -43,7 +43,7 @@ twistBaseLoop base = base
 twistBaseLoop (loop i) = twist base i
 
 kleinBottle≃Σ : KleinBottle ≃ Σ S¹ invS¹Loop
-kleinBottle≃Σ = isoToEquiv (iso fro to froTo toFro)
+kleinBottle≃Σ = isoToEquiv fro to froTo toFro
   where
   fro : KleinBottle → Σ S¹ invS¹Loop
   fro point = (base , base)

--- a/Cubical/HITs/Nullification/Properties.agda
+++ b/Cubical/HITs/Nullification/Properties.agda
@@ -137,4 +137,5 @@ module Null-iso-Localize {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') where
   isom = iso to from to-from from-to
 
 Null≃Localize : ∀ {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') → Null S A ≃ Localize (λ _ → const tt) A
-Null≃Localize S A = isoToEquiv (Null-iso-Localize.isom S A)
+Null≃Localize S A = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = Null-iso-Localize.isom S A

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -64,13 +64,11 @@ propTruncIsProp : isProp ∥ A ∥
 propTruncIsProp x y = squash x y
 
 propTruncIdempotent≃ : isProp A → ∥ A ∥ ≃ A
-propTruncIdempotent≃ {A = A} hA = isoToEquiv f
-  where
-  f : Iso ∥ A ∥ A
-  Iso.fun f        = rec hA (idfun A)
-  Iso.inv f x      = ∣ x ∣
-  Iso.rightInv f _ = refl
-  Iso.leftInv f    = elim (λ _ → isProp→isSet propTruncIsProp _ _) (λ _ → refl)
+propTruncIdempotent≃ {A = A} hA = isoToEquiv
+  (rec hA (idfun A))
+  (λ x → ∣ x ∣)
+  (λ _ → refl)
+  (elim (λ _ → isProp→isSet propTruncIsProp _ _) (λ _ → refl))
 
 propTruncIdempotent : isProp A → ∥ A ∥ ≡ A
 propTruncIdempotent hA = ua (propTruncIdempotent≃ hA)
@@ -160,7 +158,7 @@ module SetElim (Bset : isSet B) where
   preEquiv₁ t = e , rec (isPropIsEquiv e) e-isEquiv t
 
   preEquiv₂ : (∥ A ∥ → Σ (A → B) 2-Constant) ≃ Σ (A → B) 2-Constant
-  preEquiv₂ = isoToEquiv (iso to const (λ _ → refl) retr)
+  preEquiv₂ = isoToEquiv to const (λ _ → refl) retr
     where
     to : (∥ A ∥ → Σ (A → B) 2-Constant) → Σ (A → B) 2-Constant
     to f .fst x = f ∣ x ∣ .fst x
@@ -281,7 +279,7 @@ module GpdElim (Bgpd : isGroupoid B) where
           i
 
   preEquiv₁ : (∥ A ∥ → Σ (A → B) 3-Constant) ≃ Σ (A → B) 3-Constant
-  preEquiv₁ = isoToEquiv (iso fn const (λ _ → refl) retr)
+  preEquiv₁ = isoToEquiv fn const (λ _ → refl) retr
     where
     open 3-Constant
 

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -50,7 +50,7 @@ Iso.leftInv PushoutSuspIsoSusp = PushoutSusp→Susp→PushoutSusp
 
 
 PushoutSusp≃Susp : ∀ {ℓ} {A : Type ℓ} → PushoutSusp A ≃ Susp A
-PushoutSusp≃Susp = isoToEquiv PushoutSuspIsoSusp
+PushoutSusp≃Susp = isoToEquiv PushoutSusp→Susp Susp→PushoutSusp Susp→PushoutSusp→Susp PushoutSusp→Susp→PushoutSusp
 
 PushoutSusp≡Susp : ∀ {ℓ} {A : Type ℓ} → PushoutSusp A ≡ Susp A
 PushoutSusp≡Susp = isoToPath PushoutSuspIsoSusp

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -88,4 +88,4 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
     isom = iso bwd fwd bwd-fwd fwd-bwd
 
   flatten : Σ (Pushout f g) E ≃ Pushout Σf Σg
-  flatten = isoToEquiv FlattenIso.isom
+  flatten = let open FlattenIso in isoToEquiv bwd fwd bwd-fwd fwd-bwd

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -174,7 +174,7 @@ cov⁻¹ (ℕ→ℕ₋₁ n) (push (x , y) i) = ua ((λ z → y ⊕* z) , ⊕*.i
 -}
 
 TotalCov≃Sn : ∀ n → Total (cov⁻¹ n) ≃ S n
-TotalCov≃Sn neg1 = isoToEquiv (iso (λ { () }) (λ { () }) (λ { () }) (λ { () }))
+TotalCov≃Sn neg1 = isoToEquiv (λ { () }) (λ { () }) (λ { () }) (λ { () })
 TotalCov≃Sn (ℕ→ℕ₋₁ n) =
   Total (cov⁻¹ (ℕ→ℕ₋₁ n))           ≃⟨ i ⟩
   Pushout Σf Σg                      ≃⟨ ii ⟩
@@ -300,7 +300,7 @@ fibcov≡cov⁻¹ n x =
 -- Finally, we state the trivial equivalences for RP 0 and RP 1 (Example III.3 in [BR17])
 
 RP0≃Unit : RP 0 ≃ Unit
-RP0≃Unit = isoToEquiv (iso (λ _ → tt) (λ _ → inr tt) (λ _ → refl) (λ { (inr tt) → refl }))
+RP0≃Unit = isoToEquiv (λ _ → tt) (λ _ → inr tt) (λ _ → refl) (λ { (inr tt) → refl })
 
 RP1≡S1 : RP 1 ≡ S 1
 RP1≡S1 = Pushout {A = Total (cov⁻¹ 0)} {B = RP 0} (pr (cov⁻¹ 0)) (λ _ → tt) ≡⟨ i ⟩

--- a/Cubical/HITs/Rationals/QuoQ/Properties.agda
+++ b/Cubical/HITs/Rationals/QuoQ/Properties.agda
@@ -221,7 +221,7 @@ negate-invol : ∀ x → - - x ≡ x
 negate-invol x = *-assoc -1 -1 x ∙ *-identityˡ x
 
 negateEquiv : ℚ ≃ ℚ
-negateEquiv = isoToEquiv (iso -_ -_ negate-invol negate-invol)
+negateEquiv = isoToEquiv -_ -_ negate-invol negate-invol
 
 negateEq : ℚ ≡ ℚ
 negateEq = ua negateEquiv
@@ -242,4 +242,3 @@ x - y = x + (- y)
 
 +-injʳ : ∀ x y z → x + y ≡ z + y → x ≡ z
 +-injʳ x y z p = +-injˡ y x z (+-comm y x ∙ p ∙ +-comm z y)
-

--- a/Cubical/HITs/Rationals/SigmaQ/Properties.agda
+++ b/Cubical/HITs/Rationals/SigmaQ/Properties.agda
@@ -72,7 +72,8 @@ Iso.rightInv Quoℚ-iso-Sigmaℚ = reduce-[]
 Iso.leftInv  Quoℚ-iso-Sigmaℚ = []-reduce
 
 Quoℚ≃Sigmaℚ : Quo.ℚ ≃ Sigma.ℚ
-Quoℚ≃Sigmaℚ = isoToEquiv Quoℚ-iso-Sigmaℚ
+Quoℚ≃Sigmaℚ = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = Quoℚ-iso-Sigmaℚ
 
 Quoℚ≡Sigmaℚ : Quo.ℚ ≡ Sigma.ℚ
 Quoℚ≡Sigmaℚ = isoToPath Quoℚ-iso-Sigmaℚ

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -346,13 +346,11 @@ invInvolutive base = refl
 invInvolutive (loop i) = refl
 
 invS¹Equiv : S¹ ≃ S¹
-invS¹Equiv = isoToEquiv theIso
-  where
-  theIso : Iso S¹ S¹
-  Iso.fun theIso = invLooper
-  Iso.inv theIso = invLooper
-  Iso.rightInv theIso = invInvolutive
-  Iso.leftInv theIso = invInvolutive
+invS¹Equiv = isoToEquiv
+  invLooper
+  invLooper
+  invInvolutive
+  invInvolutive
 
 invS¹Path : S¹ ≡ S¹
 invS¹Path = ua invS¹Equiv
@@ -403,10 +401,10 @@ rotLoopInv a i j = homotopySymInv rotLoop a j i
 rotLoopEquiv : (i : I) → S¹ ≃ S¹
 rotLoopEquiv i =
   isoToEquiv
-    (iso (λ a → rotLoop a i)
-         (λ a → rotLoop a (~ i))
-         (λ a → rotLoopInv a i)
-         (λ a → rotLoopInv a (~ i)))
+    (λ a → rotLoop a i)
+    (λ a → rotLoop a (~ i))
+    (λ a → rotLoopInv a i)
+    (λ a → rotLoopInv a (~ i))
 
 -- some cancellation laws, used in the Hopf fibration
 private

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -112,7 +112,7 @@ rec2 Bset f feql feqr = rec (isSetΠ (λ _ → Bset))
 
 setQuotUniversal : {B : Type ℓ} (Bset : isSet B) →
                    (A / R → B) ≃ (Σ[ f ∈ (A → B) ] ((a b : A) → R a b → f a ≡ f b))
-setQuotUniversal Bset = isoToEquiv (iso intro out outRightInv outLeftInv)
+setQuotUniversal Bset = isoToEquiv intro out outRightInv outLeftInv
   where
   intro = λ g →  (λ a → g [ a ]) , λ a b r i → g (eq/ a b r i)
   out = λ h → elim (λ x → Bset) (fst h) (snd h)

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -74,7 +74,7 @@ elim3 Bset g = elim2 (λ _ _ → isSetΠ (λ _ → Bset _ _ _))
 
 setTruncUniversal : isSet B → (∥ A ∥₂ → B) ≃ (A → B)
 setTruncUniversal {B = B} Bset =
-  isoToEquiv (iso (λ h x → h ∣ x ∣₂) (rec Bset) (λ _ → refl) rinv)
+  isoToEquiv (λ h x → h ∣ x ∣₂) (rec Bset) (λ _ → refl) rinv
   where
   rinv : (f : ∥ A ∥₂ → B) → rec Bset (λ x → f ∣ x ∣₂) ≡ f
   rinv f i x =
@@ -85,13 +85,11 @@ setTruncIsSet : isSet ∥ A ∥₂
 setTruncIsSet a b p q = squash₂ a b p q
 
 setTruncIdempotent≃ : isSet A → ∥ A ∥₂ ≃ A
-setTruncIdempotent≃ {A = A} hA = isoToEquiv f
-  where
-  f : Iso ∥ A ∥₂ A
-  Iso.fun f = rec hA (idfun A)
-  Iso.inv f x = ∣ x ∣₂
-  Iso.rightInv f _ = refl
-  Iso.leftInv f = elim (λ _ → isSet→isGroupoid setTruncIsSet _ _) (λ _ → refl)
+setTruncIdempotent≃ {A = A} hA = isoToEquiv
+  (rec hA (idfun A))
+  (λ x → ∣ x ∣₂)
+  (λ _ → refl)
+  (elim (λ _ → isSet→isGroupoid setTruncIsSet _ _) (λ _ → refl))
 
 setTruncIdempotent : isSet A → ∥ A ∥₂ ≡ A
 setTruncIdempotent hA = ua (setTruncIdempotent≃ hA)

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -31,7 +31,7 @@ rightInv BoolIsoSusp⊥ = λ {north → refl;  south → refl}
 leftInv BoolIsoSusp⊥  = λ {true  → refl;  false → refl}
 
 Bool≃Susp⊥ : Bool ≃ Susp ⊥
-Bool≃Susp⊥ = isoToEquiv BoolIsoSusp⊥
+Bool≃Susp⊥ = isoToEquiv (Iso.fun BoolIsoSusp⊥) (Iso.inv BoolIsoSusp⊥) (Iso.rightInv BoolIsoSusp⊥) (Iso.leftInv BoolIsoSusp⊥)
 
 SuspBool : Type₀
 SuspBool = Susp Bool
@@ -61,14 +61,8 @@ S¹→SuspBool→S¹ (loop i) j = hfill (λ k → λ { (i = i0) → base
                                            ; (i = i1) → base })
                                   (inS (loop i)) (~ j)
 
-S¹IsoSuspBool : Iso S¹ SuspBool
-fun S¹IsoSuspBool      = S¹→SuspBool
-inv S¹IsoSuspBool      = SuspBool→S¹
-rightInv S¹IsoSuspBool = SuspBool→S¹→SuspBool
-leftInv S¹IsoSuspBool  = S¹→SuspBool→S¹
-
 S¹≃SuspBool : S¹ ≃ SuspBool
-S¹≃SuspBool = isoToEquiv S¹IsoSuspBool
+S¹≃SuspBool = isoToEquiv S¹→SuspBool SuspBool→S¹ SuspBool→S¹→SuspBool S¹→SuspBool→S¹
 
 S¹≡SuspBool : S¹ ≡ SuspBool
 S¹≡SuspBool = ua S¹≃SuspBool
@@ -106,13 +100,13 @@ SuspS¹→S²→SuspS¹ (merid base j) k = merid base (k ∧ j)
 SuspS¹→S²→SuspS¹ (merid (loop j) i) k = meridian-contraction i j (~ k)
 
 S²IsoSuspS¹ : Iso S² SuspS¹
-fun S²IsoSuspS¹      = S²→SuspS¹
-inv S²IsoSuspS¹      = SuspS¹→S²
-rightInv S²IsoSuspS¹ = SuspS¹→S²→SuspS¹
-leftInv S²IsoSuspS¹  = S²→SuspS¹→S²
+S²IsoSuspS¹ .fun      = S²→SuspS¹
+S²IsoSuspS¹ .inv      = SuspS¹→S²
+S²IsoSuspS¹ .rightInv = SuspS¹→S²→SuspS¹
+S²IsoSuspS¹ .leftInv  = S²→SuspS¹→S²
 
 S²≃SuspS¹ : S² ≃ SuspS¹
-S²≃SuspS¹ = isoToEquiv S²IsoSuspS¹
+S²≃SuspS¹ = isoToEquiv S²→SuspS¹ SuspS¹→S² SuspS¹→S²→SuspS¹ S²→SuspS¹→S²
 
 S²≡SuspS¹ : S² ≡ SuspS¹
 S²≡SuspS¹ = ua S²≃SuspS¹
@@ -152,13 +146,13 @@ SuspS²→S³→SuspS² (merid base j) l = merid base (l ∧ j)
 SuspS²→S³→SuspS² (merid (surf j k) i) l = meridian-contraction-2 i j k (~ l)
 
 S³IsoSuspS² : Iso S³ SuspS²
-fun S³IsoSuspS²      = S³→SuspS²
-inv S³IsoSuspS²      = SuspS²→S³
-rightInv S³IsoSuspS² = SuspS²→S³→SuspS²
-leftInv S³IsoSuspS²  = S³→SuspS²→S³
+S³IsoSuspS² .fun      = S³→SuspS²
+S³IsoSuspS² .inv      = SuspS²→S³
+S³IsoSuspS² .rightInv = SuspS²→S³→SuspS²
+S³IsoSuspS² .leftInv  = S³→SuspS²→S³
 
 S³≃SuspS² : S³ ≃ SuspS²
-S³≃SuspS² = isoToEquiv S³IsoSuspS²
+S³≃SuspS² = isoToEquiv S³→SuspS² SuspS²→S³ SuspS²→S³→SuspS² S³→SuspS²→S³
 
 S³≡SuspS² : S³ ≡ SuspS²
 S³≡SuspS² = ua S³≃SuspS²

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -61,6 +61,12 @@ S¹→SuspBool→S¹ (loop i) j = hfill (λ k → λ { (i = i0) → base
                                            ; (i = i1) → base })
                                   (inS (loop i)) (~ j)
 
+S¹IsoSuspBool : Iso S¹ SuspBool
+S¹IsoSuspBool .fun      = S¹→SuspBool
+S¹IsoSuspBool .inv      = SuspBool→S¹
+S¹IsoSuspBool .rightInv = SuspBool→S¹→SuspBool
+S¹IsoSuspBool .leftInv  = S¹→SuspBool→S¹
+
 S¹≃SuspBool : S¹ ≃ SuspBool
 S¹≃SuspBool = isoToEquiv S¹→SuspBool SuspBool→S¹ SuspBool→S¹→SuspBool S¹→SuspBool→S¹
 

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -39,26 +39,31 @@ leftInv (Susp-iso-joinBool {A = A}) (merid a i) j
           (transp (λ _ → Susp A) j north)
 
 Susp≃joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≃ join A Bool
-Susp≃joinBool = isoToEquiv Susp-iso-joinBool
+Susp≃joinBool = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = Susp-iso-joinBool
 
 Susp≡joinBool : ∀ {ℓ} {A : Type ℓ} → Susp A ≡ join A Bool
 Susp≡joinBool = isoToPath Susp-iso-joinBool
 
 congSuspEquiv : ∀ {ℓ} {A B : Type ℓ} → A ≃ B → Susp A ≃ Susp B
-congSuspEquiv {ℓ} {A} {B} h = isoToEquiv isom
-  where isom : Iso (Susp A) (Susp B)
-        Iso.fun isom north = north
-        Iso.fun isom south = south
-        Iso.fun isom (merid a i) = merid (fst h a) i
-        Iso.inv isom north = north
-        Iso.inv isom south = south
-        Iso.inv isom (merid a i) = merid (invEq h a) i
-        Iso.rightInv isom north = refl
-        Iso.rightInv isom south = refl
-        Iso.rightInv isom (merid a i) j = merid (retEq h a j) i
-        Iso.leftInv isom north = refl
-        Iso.leftInv isom south = refl
-        Iso.leftInv isom (merid a i) j = merid (secEq h a j) i
+congSuspEquiv {ℓ} {A} {B} h = isoToEquiv f g fg gf
+  where
+  f : Susp A → _
+  f north = north
+  f south = south
+  f (merid a i) = merid (fst h a) i
+  g : Susp B → _
+  g north = north
+  g south = south
+  g (merid a i) = merid (invEq h a) i
+  fg : (b : Susp B) → _
+  fg north = refl
+  fg south = refl
+  fg (merid a i) j = merid (retEq h a j) i
+  gf : (a : Susp A) → _
+  gf north = refl
+  gf south = refl
+  gf (merid a i) j = merid (secEq h a j) i
 
 suspToPropRec : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Susp A → Type ℓ'} (a : A)
                  → ((x : Susp A) → isProp (B x))

--- a/Cubical/HITs/Truncation/FromNegOne/Properties.agda
+++ b/Cubical/HITs/Truncation/FromNegOne/Properties.agda
@@ -189,7 +189,8 @@ Iso.rightInv (truncIdempotentIso (suc n) hA) _ = refl
 Iso.leftInv (truncIdempotentIso (suc n) hA) = elim (λ _ → isOfHLevelPath (suc n) (isOfHLevelTrunc (suc n)) _ _) λ _ → refl
 
 truncIdempotent≃ : (n : ℕ) → isOfHLevel n A → ∥ A ∥ n ≃ A
-truncIdempotent≃ n hA = isoToEquiv (truncIdempotentIso n hA)
+truncIdempotent≃ n hA = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = truncIdempotentIso n hA
 
 truncIdempotent : (n : ℕ) → isOfHLevel n A → ∥ A ∥ n ≡ A
 truncIdempotent n hA = ua (truncIdempotent≃ n hA)
@@ -246,7 +247,8 @@ Iso.rightInv propTruncTrunc1Iso = elim (λ _ → isOfHLevelPath 1 (isOfHLevelTru
 Iso.leftInv propTruncTrunc1Iso = PropTrunc.elim (λ _ → isOfHLevelPath 1 squash₁ _ _) (λ _ → refl)
 
 propTrunc≃Trunc1 : ∥ A ∥₁ ≃ ∥ A ∥ 1
-propTrunc≃Trunc1 = isoToEquiv propTruncTrunc1Iso
+propTrunc≃Trunc1 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = propTruncTrunc1Iso
 
 propTrunc≡Trunc1 : ∥ A ∥₁ ≡ ∥ A ∥ 1
 propTrunc≡Trunc1 = ua propTrunc≃Trunc1
@@ -259,7 +261,8 @@ Iso.rightInv setTruncTrunc2Iso = elim (λ _ → isOfHLevelPath 2 (isOfHLevelTrun
 Iso.leftInv setTruncTrunc2Iso = SetTrunc.elim (λ _ → isOfHLevelPath 2 squash₂ _ _) (λ _ → refl)
 
 setTrunc≃Trunc2 : ∥ A ∥₂ ≃ ∥ A ∥ 2
-setTrunc≃Trunc2 = isoToEquiv setTruncTrunc2Iso
+setTrunc≃Trunc2 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = setTruncTrunc2Iso
 
 propTrunc≡Trunc2 : ∥ A ∥₂ ≡ ∥ A ∥ 2
 propTrunc≡Trunc2 = ua setTrunc≃Trunc2
@@ -271,7 +274,8 @@ Iso.rightInv groupoidTruncTrunc3Iso = elim (λ _ → isOfHLevelPath 3 (isOfHLeve
 Iso.leftInv groupoidTruncTrunc3Iso = GpdTrunc.elim (λ _ → isOfHLevelPath 3 squash₃ _ _) (λ _ → refl)
 
 groupoidTrunc≃Trunc3 : ∥ A ∥₃ ≃ ∥ A ∥ 3
-groupoidTrunc≃Trunc3 = isoToEquiv groupoidTruncTrunc3Iso
+groupoidTrunc≃Trunc3 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = groupoidTruncTrunc3Iso
 
 groupoidTrunc≡Trunc3 : ∥ A ∥₃ ≡ ∥ A ∥ 3
 groupoidTrunc≡Trunc3 = ua groupoidTrunc≃Trunc3
@@ -283,7 +287,8 @@ Iso.rightInv 2GroupoidTruncTrunc4Iso = elim (λ _ → isOfHLevelPath 4 (isOfHLev
 Iso.leftInv 2GroupoidTruncTrunc4Iso = 2GpdTrunc.elim (λ _ → isOfHLevelPath 4 squash₄ _ _) (λ _ → refl)
 
 2GroupoidTrunc≃Trunc4 : ∥ A ∥₄ ≃ ∥ A ∥ 4
-2GroupoidTrunc≃Trunc4 = isoToEquiv 2GroupoidTruncTrunc4Iso
+2GroupoidTrunc≃Trunc4 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = 2GroupoidTruncTrunc4Iso
 
 2GroupoidTrunc≡Trunc4 : ∥ A ∥₄ ≡ ∥ A ∥ 4
 2GroupoidTrunc≡Trunc4 = ua 2GroupoidTrunc≃Trunc4
@@ -436,4 +441,5 @@ Iso.leftInv (truncOfTruncIso (suc n) zero) = elim (λ x → isOfHLevelPath (suc 
 Iso.leftInv (truncOfTruncIso (suc n) (suc m)) = elim (λ x → isOfHLevelPath (suc n) (isOfHLevelTrunc (suc n)) _ _) λ a → refl
 
 truncOfTruncEq : (n m : ℕ) → (hLevelTrunc n A) ≃ (hLevelTrunc n (hLevelTrunc (m + n) A))
-truncOfTruncEq n m = isoToEquiv (truncOfTruncIso n m)
+truncOfTruncEq n m = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = truncOfTruncIso n m

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -206,7 +206,8 @@ Iso.rightInv propTruncTrunc1Iso = elim (λ _ → isOfHLevelPath 1 (isOfHLevelTru
 Iso.leftInv propTruncTrunc1Iso = PropTrunc.elim (λ _ → isOfHLevelPath 1 squash₁ _ _) (λ _ → refl)
 
 propTrunc≃Trunc1 : ∥ A ∥₁ ≃ ∥ A ∥ 1
-propTrunc≃Trunc1 = isoToEquiv propTruncTrunc1Iso
+propTrunc≃Trunc1 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = propTruncTrunc1Iso
 
 propTrunc≡Trunc1 : ∥ A ∥₁ ≡ ∥ A ∥ 1
 propTrunc≡Trunc1 = ua propTrunc≃Trunc1
@@ -219,7 +220,8 @@ Iso.rightInv setTruncTrunc2Iso = elim (λ _ → isOfHLevelPath 2 (isOfHLevelTrun
 Iso.leftInv setTruncTrunc2Iso = SetTrunc.elim (λ _ → isOfHLevelPath 2 squash₂ _ _) (λ _ → refl)
 
 setTrunc≃Trunc2 : ∥ A ∥₂ ≃ ∥ A ∥ 2
-setTrunc≃Trunc2 = isoToEquiv setTruncTrunc2Iso
+setTrunc≃Trunc2 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = setTruncTrunc2Iso
 
 propTrunc≡Trunc2 : ∥ A ∥₂ ≡ ∥ A ∥ 2
 propTrunc≡Trunc2 = ua setTrunc≃Trunc2
@@ -231,7 +233,8 @@ Iso.rightInv groupoidTrunc≃Trunc3Iso = elim (λ _ → isOfHLevelPath 3 (isOfHL
 Iso.leftInv groupoidTrunc≃Trunc3Iso = GpdTrunc.elim (λ _ → isOfHLevelPath 3 squash₃ _ _) (λ _ → refl)
 
 groupoidTrunc≃Trunc3 : ∥ A ∥₃ ≃ ∥ A ∥ 3
-groupoidTrunc≃Trunc3 = isoToEquiv groupoidTrunc≃Trunc3Iso
+groupoidTrunc≃Trunc3 = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = groupoidTrunc≃Trunc3Iso
 
 groupoidTrunc≡Trunc3 : ∥ A ∥₃ ≡ ∥ A ∥ 3
 groupoidTrunc≡Trunc3 = ua groupoidTrunc≃Trunc3
@@ -246,11 +249,10 @@ Iso.leftInv 2GroupoidTrunc≃Trunc4Iso = 2GpdTrunc.elim (λ _ → isOfHLevelPath
 2GroupoidTrunc≃Trunc4 : ∥ A ∥₄ ≃ ∥ A ∥ 4
 2GroupoidTrunc≃Trunc4 =
   isoToEquiv
-    (iso
-      (2GpdTrunc.elim (λ _ → isOfHLevelTrunc 4) ∣_∣)
-      (elim (λ _ → squash₄) ∣_∣₄)
-      (elim (λ _ → isOfHLevelPath 4 (isOfHLevelTrunc 4) _ _) (λ _ → refl))
-      (2GpdTrunc.elim (λ _ → isOfHLevelPath 4 squash₄ _ _) (λ _ → refl)))
+    (2GpdTrunc.elim (λ _ → isOfHLevelTrunc 4) ∣_∣)
+    (elim (λ _ → squash₄) ∣_∣₄)
+    (elim (λ _ → isOfHLevelPath 4 (isOfHLevelTrunc 4) _ _) (λ _ → refl))
+    (2GpdTrunc.elim (λ _ → isOfHLevelPath 4 squash₄ _ _) (λ _ → refl))
 
 2GroupoidTrunc≡Trunc4 : ∥ A ∥₄ ≡ ∥ A ∥ 4
 2GroupoidTrunc≡Trunc4 = ua 2GroupoidTrunc≃Trunc4
@@ -393,4 +395,5 @@ Iso.rightInv (truncOfTruncIso {A = A} n m) =
 Iso.leftInv (truncOfTruncIso n m) = elim (λ x → isOfHLevelPath n (isOfHLevelTrunc n) _ _) λ a → refl
 
 truncOfTruncEq : (n m : ℕ) → (hLevelTrunc n A) ≃ (hLevelTrunc n (hLevelTrunc (m + n) A))
-truncOfTruncEq n m = isoToEquiv (truncOfTruncIso n m)
+truncOfTruncEq n m = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = (truncOfTruncIso n m)

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -270,7 +270,8 @@ connectedTruncIso2 {A = A} {B = B} n m f (x , pf) con =
 connectedTruncEquiv : ∀ {ℓ} {A B : Type ℓ} (n : HLevel) (f : A → B)
                    → isConnectedFun n f
                    → hLevelTrunc n A ≃ hLevelTrunc n B
-connectedTruncEquiv {A = A} {B = B} n f con = isoToEquiv (connectedTruncIso n f con)
+connectedTruncEquiv {A = A} {B = B} n f con = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = connectedTruncIso n f con
 
 
 -- TODO : Reorganise the following proofs.

--- a/Cubical/Relation/Binary/Poset.agda
+++ b/Cubical/Relation/Binary/Poset.agda
@@ -285,7 +285,7 @@ P ≅ₚ Q = Σ[ f ∈ P ─m→ Q ] isPosetIso P Q f
 -- ≅ₚ is equivalent to ≃ₚ.
 
 ≃ₚ≃≅ₚ : (P Q : Poset ℓ₀ ℓ₁) → (P ≅ₚ Q) ≃ (P ≃ₚ Q)
-≃ₚ≃≅ₚ P Q = isoToEquiv (iso from to ret sec)
+≃ₚ≃≅ₚ P Q = isoToEquiv from to ret sec
   where
     to : P ≃ₚ Q → P ≅ₚ Q
     to (e@(f , _) , (f-mono , g-mono)) =
@@ -302,10 +302,7 @@ P ≅ₚ Q = Σ[ f ∈ P ─m→ Q ] isPosetIso P Q f
 
     from : P ≅ₚ Q → P ≃ₚ Q
     from ((f , f-mono) , ((g , g-mono) , sec , ret)) =
-      isoToEquiv is , f-mono , g-mono
-      where
-        is : Iso ∣ P ∣ₚ ∣ Q ∣ₚ
-        is = iso f g sec ret
+      isoToEquiv f g sec ret , f-mono , g-mono
 
     sec : section to from
     sec (f , _) = Σ≡Prop (isPosetIso-prop P Q) refl

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -251,7 +251,7 @@ module Lists&ALists {A : Type ℓ} (discA : Discrete A) where
   List/Rᴸ→FMSet-insert x = elimProp (λ _ → FMS.trunc _ _) λ xs → refl
 
   List/Rᴸ≃FMSet : List/Rᴸ ≃ FMSet A
-  List/Rᴸ≃FMSet = isoToEquiv (iso List/Rᴸ→FMSet FMSet→List/Rᴸ τ σ)
+  List/Rᴸ≃FMSet = isoToEquiv List/Rᴸ→FMSet FMSet→List/Rᴸ τ σ
     where
     σ' : (xs : List A) → FMSet→List/Rᴸ (List/Rᴸ→FMSet [ xs ]) ≡ [ xs ]
     σ' [] = refl

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -158,4 +158,4 @@ module QER→Equiv {A B : Type ℓ} (R : QuasiEquivRel A B ℓ') where
   bwd≡ToRel {a} {b} p = fwd≡ToRel (cong φ (sym p) ∙ η [ b ])
 
   Thm : (A / Rᴸ) ≃ (B / Rᴿ)
-  Thm = isoToEquiv (iso φ ψ η ε)
+  Thm = isoToEquiv φ ψ η ε

--- a/Cubical/Structures/Maybe.agda
+++ b/Cubical/Structures/Maybe.agda
@@ -74,13 +74,11 @@ module MaybePathP where
       (transportRefl _)
 
   Code≃PathP : {A : I → Type ℓ} → ∀ ox oy → Code A ox oy ≃ PathP (λ i → Maybe (A i)) ox oy
-  Code≃PathP {A = A} ox oy = isoToEquiv isom
-    where
-    isom : Iso _ _
-    isom .Iso.fun = decode ox oy
-    isom .Iso.inv = encode _ ox oy
-    isom .Iso.rightInv = decodeEncode ox oy
-    isom .Iso.leftInv = encodeDecode A ox oy
+  Code≃PathP {A = A} ox oy = isoToEquiv
+    (decode         ox oy)
+    (encode _       ox oy)
+    (decodeEncode   ox oy)
+    (encodeDecode A ox oy)
 
 -- Structured isomorphisms
 

--- a/Cubical/Structures/Relational/Function.agda
+++ b/Cubical/Structures/Relational/Function.agda
@@ -173,19 +173,15 @@ functionRelMatchesEquiv+ : {S : Type ℓ → Type ℓ₁} {T : Type ℓ → Type
 functionRelMatchesEquiv+ ρ₁ α₁ ρ₂ ι₂ μ₁ μ₂ (X , f) (Y , g) e =
   compEquiv
     (functionRelMatchesEquiv ρ₁ ρ₂ μ₁ μ₂ (X , f) (Y , g) e)
-    (isoToEquiv isom)
+    (isoToEquiv a b ab ba)
   where
-  open Iso
-  isom : Iso
-    (FunctionEquivStr (EquivAction→StrEquiv α₁) ι₂ (X , f) (Y , g) e)
-    (FunctionEquivStr+ α₁ ι₂ (X , f) (Y , g) e)
-  isom .fun h s = h refl
-  isom .inv k {x} = J (λ y _ → ι₂ (X , f x) (Y , g y) e) (k x)
-  isom .rightInv k i x = JRefl (λ y _ → ι₂ (X , f x) (Y , g y) e) (k x) i
-  isom .leftInv h =
-    implicitFunExt λ {x} →
-    implicitFunExt λ {y} →
-    funExt λ p →
-    J (λ y p → isom .inv (isom .fun h) p ≡ h p)
-      (funExt⁻ (isom .rightInv (isom .fun h)) x)
-      p
+  a : FunctionEquivStr (λ A B z → EquivAction→StrEquiv α₁ A B z) (λ A B z → ι₂ A B z) (X , f) (Y , g) e → _
+  a h s = h refl
+  b : FunctionEquivStr+ α₁ ι₂ (X , f) (Y , g) e → _
+  b k {x} = J (λ y _ → ι₂ (X , f x) (Y , g y) e) (k x)
+  ab : ∀ k → _
+  ab = λ k i x → JRefl (λ y _ → ι₂ (X , f x) (Y , g y) e) (k x) i
+  ba : ∀ h → _
+  ba h = implicitFunExt λ {x} →
+         implicitFunExt λ {y} →
+         funExt λ p → J (λ y p → b (a (h {s = _})) p ≡ h p) (funExt⁻ (ab (a (h {s = _}))) x) p

--- a/Cubical/Structures/Relational/Maybe.agda
+++ b/Cubical/Structures/Relational/Maybe.agda
@@ -84,7 +84,7 @@ maybePositiveRel {S = S} {ρ = ρ} {θ = θ} σ .quo {X} R =
     (funExt
       (elimProp (λ _ → maybeSuitableRel θ .set squash/ _ _)
         (λ {nothing → refl; (just _) → refl})))
-    (compEquiv (isoToEquiv isom) (congMaybeEquiv (_ , σ .quo R)) .snd)
+    (compEquiv (isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)) (congMaybeEquiv (_ , σ .quo R)) .snd)
   where
   fwd : Maybe (S X) / MaybeRel (ρ (R .fst .fst)) → Maybe (S X / ρ (R .fst .fst))
   fwd [ nothing ] = nothing

--- a/Cubical/Structures/Relational/Product.agda
+++ b/Cubical/Structures/Relational/Product.agda
@@ -91,7 +91,7 @@ productPositiveRel {S₁ = S₁} {ρ₁} {θ₁} {S₂} {ρ₂} {θ₂} σ₁ σ
   subst isEquiv
     (funExt (elimProp (λ _ → productSuitableRel θ₁ θ₂ .set squash/ _ _) (λ _ → refl)))
     (compEquiv
-      (isoToEquiv isom)
+      (isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom))
       (Σ-cong-equiv (_ , σ₁ .quo R) (λ _ → _ , σ₂ .quo R)) .snd)
   where
   fwd :

--- a/Cubical/Talks/EPA2020.agda
+++ b/Cubical/Talks/EPA2020.agda
@@ -93,13 +93,15 @@ J' P d p = transport (λ i → P (p i) (λ j → p (i ∧ j))) d
 ua' : {A B : Type} → A ≃ B → A ≡ B
 ua' = ua
 
--- Any isomorphism of types gives rise to an equivalence
-isoToEquiv' : {A B : Type} → Iso A B → A ≃ B
-isoToEquiv' = isoToEquiv
-
--- And hence to a path
-isoToPath' : {A B : Type} → Iso A B → A ≡ B
-isoToPath' e = ua' (isoToEquiv' e)
+-- NOTE: the definition of `isoToEquiv` was changed such that the following is not that idiomatic any longer
+--
+-- -- Any isomorphism of types gives rise to an equivalence
+-- isoToEquiv' : {A B : Type} → Iso A B → A ≃ B
+-- isoToEquiv' = isoToEquiv
+--
+-- -- And hence to a path
+-- isoToPath' : {A B : Type} → Iso A B → A ≡ B
+-- isoToPath' e = ua' (isoToEquiv' e)
 
 -- ua satisfies the following computation rule
 -- This suffices to be able to prove the standard formulation of univalence.
@@ -120,7 +122,7 @@ not false = true
 not true  = false
 
 notPath : Bool ≡ Bool
-notPath = isoToPath' (iso not not rem rem)
+notPath = isoToPath (iso not not rem rem)
   where
   rem : (b : Bool) → not (not b) ≡ b
   rem false = refl
@@ -133,7 +135,7 @@ _ = refl
 -- Another example, integers:
 
 sucPath : Int ≡ Int
-sucPath = isoToPath' (iso sucInt predInt sucPred predSuc)
+sucPath = isoToPath (iso sucInt predInt sucPred predSuc)
 
 _ : transport sucPath (pos 0) ≡ pos 1
 _ = refl
@@ -250,7 +252,7 @@ t2c-c2t (loop _ , loop _) = refl
 
 -- Using univalence we get the following equality:
 Torus≡S¹×S¹ : Torus ≡ S¹ × S¹
-Torus≡S¹×S¹ = isoToPath' (iso t2c c2t t2c-c2t c2t-t2c)
+Torus≡S¹×S¹ = isoToPath (iso t2c c2t t2c-c2t c2t-t2c)
 
 
 windingTorus : point ≡ point → Int × Int

--- a/Cubical/ZCohomology/Groups/Sn.agda
+++ b/Cubical/ZCohomology/Groups/Sn.agda
@@ -392,4 +392,3 @@ Hⁿ-Sⁿ≅ℤ (suc n) =
   vSES.ϕ theIso = K.d (suc n)
   Ker-ϕ⊂Im-left theIso = K.Ker-d⊂Im-Δ  (suc n)
   Ker-right⊂Im-ϕ theIso = K.Ker-i⊂Im-d (suc n)
-

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -99,7 +99,8 @@ Kn→ΩKn+1 n = Iso.fun (Iso-Kn-ΩKn+1 n)
 ΩKn+1→Kn n = Iso.inv (Iso-Kn-ΩKn+1 n)
 
 Kn≃ΩKn+1 : {n : ℕ} → coHomK n ≃ typ (Ω (coHomK-ptd (suc n)))
-Kn≃ΩKn+1 {n = n} = isoToEquiv (Iso-Kn-ΩKn+1 n)
+Kn≃ΩKn+1 {n = n} = isoToEquiv (Iso.fun isom) (Iso.inv isom) (Iso.rightInv isom) (Iso.leftInv isom)
+  where isom = Iso-Kn-ΩKn+1 n
 
 ---------- Algebra/Group stuff --------
 


### PR DESCRIPTION
I tried to "inline" Iso definitions into `isoToEquiv` when it was obvious that the definition was solely created for that purpose of passing it into isoToEquiv. Where this was not obvious, I've used a let-binding with the Iso-projections.

In some cases, I found a re-use of certain Isomorphisms such that they are really used as a single argument to `isoToEquiv` which would make a definition similar to the old one necessary again for producing idiomatic code.