### PR TITLE
CommRing structure on Integers from CommRing structure of BiInvInt (Part 1)

### DIFF
--- a/Cubical/Algebra/CommRing/Integers.agda
+++ b/Cubical/Algebra/CommRing/Integers.agda
@@ -2,22 +2,145 @@
 module Cubical.Algebra.CommRing.Integers where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.SIP
 
+import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing
-open import Cubical.HITs.Ints.BiInvInt
-  renaming (
-    _+_ to _+ℤ_;
-    -_ to _-ℤ_;
-    +-assoc to +ℤ-assoc;
-    +-comm to +ℤ-comm
-  )
 
-BiInvIntAsCommRing : CommRing {ℓ-zero}
-BiInvIntAsCommRing =
-  makeCommRing
-    zero (suc zero) _+ℤ_ _·_ _-ℤ_
-    isSetBiInvInt
-    +ℤ-assoc +-zero +-invʳ +ℤ-comm
-    ·-assoc ·-identityʳ
-    (λ x y z → sym (·-distribˡ x y z))
-    ·-comm
+module _ where
+  open import Cubical.HITs.Ints.BiInvInt
+    renaming (
+      _+_ to _+ℤ_;
+      -_ to _-ℤ_;
+      +-assoc to +ℤ-assoc;
+      +-comm to +ℤ-comm
+    )
+
+  BiInvIntAsCommRing : CommRing {ℓ-zero}
+  BiInvIntAsCommRing =
+    makeCommRing
+      zero (suc zero) _+ℤ_ _·_ _-ℤ_
+      isSetBiInvInt
+      +ℤ-assoc +-zero +-invʳ +ℤ-comm
+      ·-assoc ·-identityʳ
+      (λ x y z → sym (·-distribˡ x y z))
+      ·-comm
+
+  open Cubical.Algebra.Ring.RingΣTheory
+
+  BiInvInt-RawRingStructure : RawRingStructure BiInvInt
+  BiInvInt-RawRingStructure = _+ℤ_ , 1 , _·_
+
+  BiInvIntΣraw : TypeWithStr ℓ-zero RawRingStructure
+  BiInvIntΣraw = BiInvInt , _+ℤ_ , 1 , _·_
+
+open import Cubical.Algebra.Ring using (ringequiv; RingEquiv)
+open import Cubical.Algebra.CommRing
+open import Cubical.Foundations.Equiv
+open import Cubical.Reflection.Base using (_$_) -- TODO: add this to Foundation.Function
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+open import Cubical.Data.Nat using (suc; zero)
+
+module _ where
+  open import Cubical.Data.Int as Int using (sucInt; predInt; Int) renaming
+    ( _+_ to _+'_
+    ; _·_ to _·'_
+    ; -_ to -'_
+    ; pos to pos'
+    ; negsuc to negsuc'
+    )
+  open import Cubical.HITs.Ints.BiInvInt renaming
+    ( fwd to ⟦_⟧
+    ; suc to sucᵇ
+    )
+
+  suc-⟦⟧ : ∀ x → sucᵇ ⟦ x ⟧ ≡ ⟦ sucInt x ⟧
+  suc-⟦⟧ (pos' n) = refl
+  suc-⟦⟧ (negsuc' zero) = suc-pred _
+  suc-⟦⟧ (negsuc' (suc n)) = suc-pred _
+
+  pred-⟦⟧ : ∀ x → predl ⟦ x ⟧ ≡ ⟦ predInt x ⟧
+  pred-⟦⟧ (pos' zero) = refl
+  pred-⟦⟧ (pos' (suc n)) = pred-suc _
+  pred-⟦⟧ (negsuc' zero) = refl
+  pred-⟦⟧ (negsuc' (suc n)) = refl
+
+  neg-⟦⟧ : ∀ x → - ⟦ x ⟧ ≡ ⟦ -' x ⟧
+  neg-⟦⟧ (pos' zero) = refl
+  neg-⟦⟧ (pos' (suc n)) = (λ i → predl (neg-⟦⟧ (pos' n) i)) ∙ pred-⟦⟧ (-' pos' n) ∙ cong ⟦_⟧ (Int.predInt-neg (pos' n))
+  neg-⟦⟧ (negsuc' zero) = refl
+  neg-⟦⟧ (negsuc' (suc n)) = (λ i → sucᵇ (neg-⟦⟧ (negsuc' n) i))
+
+  pres1 : 1 ≡ ⟦ 1 ⟧
+  pres1 = refl
+
+  isHom+ : ∀ x y → ⟦ x +' y ⟧ ≡ ⟦ x ⟧ + ⟦ y ⟧
+  isHom+ (pos' zero) y i = ⟦ Int.+-comm 0 y i ⟧
+  isHom+ (pos' (suc n)) y =
+    ⟦ pos' (suc n) +' y ⟧     ≡[ i ]⟨ ⟦ Int.sucInt+ (pos' n) y (~ i) ⟧ ⟩
+    ⟦ sucInt (pos' n +' y) ⟧  ≡⟨ sym $ suc-⟦⟧ _ ⟩
+    sucᵇ  ⟦ pos' n +' y ⟧     ≡[ i ]⟨ sucᵇ $ isHom+ (pos' n) y i ⟩
+    sucᵇ (⟦ pos' n ⟧ + ⟦ y ⟧) ≡⟨ refl ⟩
+    sucᵇ  ⟦ pos' n ⟧ + ⟦ y ⟧  ∎
+  isHom+ (negsuc' zero) y = pred-suc-inj _ _ (λ i → predl (γ i)) where
+    γ : sucᵇ (⟦ negsuc' zero +' y ⟧) ≡ sucᵇ (pred zero + ⟦ y ⟧)
+    γ = suc-⟦⟧ (negsuc' zero +' y) ∙ (λ i → ⟦ (Int.sucInt+ (negsuc' zero) y ∙ Int.+-comm 0 y) i ⟧) ∙ sym (suc-pred ⟦ y ⟧)
+  isHom+ (negsuc' (suc n)) y = (λ i → ⟦ Int.predInt+ (negsuc' n) y (~ i) ⟧) ∙ sym (pred-⟦⟧ (negsuc' n +' y)) ∙ (λ i → pred $ isHom+ (negsuc' n) y i)
+
+  isHom· : ∀ x y → ⟦ x ·' y ⟧ ≡ ⟦ x ⟧ · ⟦ y ⟧
+  isHom· (pos' zero) y i = ⟦ Int.signed-zero (Int.sgn y) i ⟧
+  isHom· (pos' (suc n)) y =
+    ⟦ pos' (suc n) ·' y ⟧      ≡⟨ cong ⟦_⟧ $ Int.·-pos-suc n y ⟩
+    ⟦ y +' pos' n ·' y ⟧       ≡⟨ isHom+ y _ ⟩
+    ⟦ y ⟧ + ⟦ pos' n ·' y ⟧    ≡[ i ]⟨ ⟦ y ⟧ + isHom· (pos' n) y i ⟩
+    ⟦ y ⟧ + ⟦ pos' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → ⟦ y ⟧ + ·-comm ⟦ pos' n ⟧ ⟦ y ⟧ i) ∙ sym (·-suc ⟦ y ⟧ ⟦ pos' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
+    sucᵇ ⟦ pos' n ⟧ · ⟦ y ⟧ ∎
+  isHom· (negsuc' zero) y =
+    ⟦ -1 ·'  y ⟧ ≡⟨ cong ⟦_⟧ (Int.·-neg1 y) ⟩
+    ⟦ -'     y ⟧ ≡⟨ sym (neg-⟦⟧ y) ⟩
+      -    ⟦ y ⟧ ≡⟨ sym (·-neg1 ⟦ y ⟧) ⟩
+      -1 · ⟦ y ⟧ ∎
+  isHom· (negsuc' (suc n)) y =
+    ⟦ negsuc' (suc n) ·' y ⟧         ≡⟨ cong ⟦_⟧ $ Int.·-negsuc-suc n y ⟩
+    ⟦ -' y   +'  negsuc' n   ·'  y ⟧ ≡⟨ isHom+ (-' y) _ ⟩
+    ⟦ -' y ⟧ + ⟦ negsuc' n   ·'  y ⟧ ≡[ i ]⟨ ⟦ -' y ⟧ + isHom· (negsuc' n) y i ⟩
+    ⟦ -' y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ cong₂ _+_ (sym (neg-⟦⟧ y)) refl ⟩
+    -  ⟦ y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → - ⟦ y ⟧ + ·-comm ⟦ negsuc' n ⟧ ⟦ y ⟧ i) ∙ sym (·-pred ⟦ y ⟧ ⟦ negsuc' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
+    pred ⟦ negsuc' n ⟧ · ⟦ y ⟧       ∎
+
+  ⟦⟧-isEquiv : isEquiv ⟦_⟧
+  ⟦⟧-isEquiv = isoToIsEquiv (iso ⟦_⟧ bwd fwd-bwd bwd-fwd)
+
+module _ where
+  open import Cubical.Foundations.Structure
+  open import Cubical.Structures.Axioms
+  open import Cubical.Data.Int
+
+  open Cubical.Algebra.CommRing.CommRingΣTheory hiding (CommRingPath)
+  open Cubical.Algebra.Ring.RingΣTheory
+
+  Int-RawRingStructure : RawRingStructure Int
+  Int-RawRingStructure = _+_ , 1 , _·_
+
+  IntΣraw : TypeWithStr ℓ-zero RawRingStructure
+  IntΣraw = Int , _+_ , 1 , _·_
+
+  Int-Σraw≃BiInvInt : IntΣraw ≃[ (λ A B z → RawRingEquivStr (fst A , snd A) (fst B , snd B) z) ] BiInvIntΣraw
+  Int-Σraw≃BiInvInt = (_ , ⟦⟧-isEquiv) , isHom+ , pres1 , isHom·
+
+  BiInvInt≃Int-Σraw : BiInvIntΣraw ≃[ (λ A B z → RawRingEquivStr (fst A , snd A) (fst B , snd B) z) ] IntΣraw
+  BiInvInt≃Int-Σraw = sip⁻ rawRingUnivalentStr BiInvIntΣraw IntΣraw (sym (sip rawRingUnivalentStr IntΣraw BiInvIntΣraw Int-Σraw≃BiInvInt))
+
+  Int-CommRingAxioms : CommRingAxioms Int Int-RawRingStructure
+  Int-CommRingAxioms = transferAxioms {S = RawRingStructure} rawRingUnivalentStr {axioms = CommRingAxioms} (CommRing→CommRingΣ BiInvIntAsCommRing) IntΣraw BiInvInt≃Int-Σraw
+
+  IntΣ : TypeWithStr ℓ-zero CommRingStructure
+  IntΣ = Int , (_+_ , 1 , _·_) , Int-CommRingAxioms
+
+  IntAsCommRing : CommRing
+  IntAsCommRing = CommRingΣ→CommRing IntΣ
+
+  Int≃BiInvInt-CommRingEquivΣ : Σ[ e ∈ ⟨ IntAsCommRing ⟩ ≃ ⟨ BiInvIntAsCommRing ⟩ ] CommRingEquiv IntAsCommRing BiInvIntAsCommRing e
+  Int≃BiInvInt-CommRingEquivΣ .fst = _ , ⟦⟧-isEquiv
+  Int≃BiInvInt-CommRingEquivΣ .snd = ringequiv pres1 isHom+ isHom·

--- a/Cubical/Algebra/CommRing/Integers.agda
+++ b/Cubical/Algebra/CommRing/Integers.agda
@@ -3,9 +3,19 @@ module Cubical.Algebra.CommRing.Integers where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.SIP
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
 
-import Cubical.Algebra.Ring
+open import Cubical.Reflection.Base using (_$_) -- TODO: add this to Foundation.Function
+
+open import Cubical.Data.Nat using (suc; zero)
+
+open import Cubical.Structures.Axioms using (transferAxioms)
+open import Cubical.Algebra.Ring as RRing using (ringequiv; RingEquiv)
 open import Cubical.Algebra.CommRing
+
+open RRing.RingΣTheory using (RawRingStructure; RawRingEquivStr; rawRingUnivalentStr)
+open Cubical.Algebra.CommRing.CommRingΣTheory using (CommRingAxioms; CommRingStructure; CommRing→CommRingΣ; CommRingΣ→CommRing)
 
 module _ where
   open import Cubical.HITs.Ints.BiInvInt
@@ -26,28 +36,15 @@ module _ where
       (λ x y z → sym (·-distribˡ x y z))
       ·-comm
 
-  open Cubical.Algebra.Ring.RingΣTheory
-
-  BiInvInt-RawRingStructure : RawRingStructure BiInvInt
-  BiInvInt-RawRingStructure = _+ℤ_ , 1 , _·_
-
   BiInvIntΣraw : TypeWithStr ℓ-zero RawRingStructure
   BiInvIntΣraw = BiInvInt , _+ℤ_ , 1 , _·_
 
-open import Cubical.Algebra.Ring using (ringequiv; RingEquiv)
-open import Cubical.Algebra.CommRing
-open import Cubical.Foundations.Equiv
-open import Cubical.Reflection.Base using (_$_) -- TODO: add this to Foundation.Function
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Univalence
-open import Cubical.Data.Nat using (suc; zero)
-
 module _ where
   open import Cubical.Data.Int as Int using (sucInt; predInt; Int) renaming
-    ( _+_ to _+'_
-    ; _·_ to _·'_
-    ; -_ to -'_
-    ; pos to pos'
+    ( _+_    to _+'_
+    ; _·_    to _·'_
+    ; -_     to -'_
+    ; pos    to pos'
     ; negsuc to negsuc'
     )
   open import Cubical.HITs.Ints.BiInvInt renaming
@@ -55,92 +52,82 @@ module _ where
     ; suc to sucᵇ
     )
 
-  suc-⟦⟧ : ∀ x → sucᵇ ⟦ x ⟧ ≡ ⟦ sucInt x ⟧
-  suc-⟦⟧ (pos' n) = refl
-  suc-⟦⟧ (negsuc' zero) = suc-pred _
-  suc-⟦⟧ (negsuc' (suc n)) = suc-pred _
+  private
+    suc-⟦⟧ : ∀ x → sucᵇ ⟦ x ⟧ ≡ ⟦ sucInt x ⟧
+    suc-⟦⟧ (pos' n) = refl
+    suc-⟦⟧ (negsuc' zero) = suc-pred _
+    suc-⟦⟧ (negsuc' (suc n)) = suc-pred _
 
-  pred-⟦⟧ : ∀ x → predl ⟦ x ⟧ ≡ ⟦ predInt x ⟧
-  pred-⟦⟧ (pos' zero) = refl
-  pred-⟦⟧ (pos' (suc n)) = pred-suc _
-  pred-⟦⟧ (negsuc' zero) = refl
-  pred-⟦⟧ (negsuc' (suc n)) = refl
+    pred-⟦⟧ : ∀ x → predl ⟦ x ⟧ ≡ ⟦ predInt x ⟧
+    pred-⟦⟧ (pos' zero) = refl
+    pred-⟦⟧ (pos' (suc n)) = pred-suc _
+    pred-⟦⟧ (negsuc' zero) = refl
+    pred-⟦⟧ (negsuc' (suc n)) = refl
 
-  neg-⟦⟧ : ∀ x → - ⟦ x ⟧ ≡ ⟦ -' x ⟧
-  neg-⟦⟧ (pos' zero) = refl
-  neg-⟦⟧ (pos' (suc n)) = (λ i → predl (neg-⟦⟧ (pos' n) i)) ∙ pred-⟦⟧ (-' pos' n) ∙ cong ⟦_⟧ (Int.predInt-neg (pos' n))
-  neg-⟦⟧ (negsuc' zero) = refl
-  neg-⟦⟧ (negsuc' (suc n)) = (λ i → sucᵇ (neg-⟦⟧ (negsuc' n) i))
+    neg-⟦⟧ : ∀ x → - ⟦ x ⟧ ≡ ⟦ -' x ⟧
+    neg-⟦⟧ (pos' zero) = refl
+    neg-⟦⟧ (pos' (suc n)) = (λ i → predl (neg-⟦⟧ (pos' n) i)) ∙ pred-⟦⟧ (-' pos' n) ∙ cong ⟦_⟧ (Int.predInt-neg (pos' n))
+    neg-⟦⟧ (negsuc' zero) = refl
+    neg-⟦⟧ (negsuc' (suc n)) = (λ i → sucᵇ (neg-⟦⟧ (negsuc' n) i))
 
-  pres1 : 1 ≡ ⟦ 1 ⟧
-  pres1 = refl
+    pres1 : 1 ≡ ⟦ 1 ⟧
+    pres1 = refl
 
-  isHom+ : ∀ x y → ⟦ x +' y ⟧ ≡ ⟦ x ⟧ + ⟦ y ⟧
-  isHom+ (pos' zero) y i = ⟦ Int.+-comm 0 y i ⟧
-  isHom+ (pos' (suc n)) y =
-    ⟦ pos' (suc n) +' y ⟧     ≡[ i ]⟨ ⟦ Int.sucInt+ (pos' n) y (~ i) ⟧ ⟩
-    ⟦ sucInt (pos' n +' y) ⟧  ≡⟨ sym $ suc-⟦⟧ _ ⟩
-    sucᵇ  ⟦ pos' n +' y ⟧     ≡[ i ]⟨ sucᵇ $ isHom+ (pos' n) y i ⟩
-    sucᵇ (⟦ pos' n ⟧ + ⟦ y ⟧) ≡⟨ refl ⟩
-    sucᵇ  ⟦ pos' n ⟧ + ⟦ y ⟧  ∎
-  isHom+ (negsuc' zero) y = pred-suc-inj _ _ (λ i → predl (γ i)) where
-    γ : sucᵇ (⟦ negsuc' zero +' y ⟧) ≡ sucᵇ (pred zero + ⟦ y ⟧)
-    γ = suc-⟦⟧ (negsuc' zero +' y) ∙ (λ i → ⟦ (Int.sucInt+ (negsuc' zero) y ∙ Int.+-comm 0 y) i ⟧) ∙ sym (suc-pred ⟦ y ⟧)
-  isHom+ (negsuc' (suc n)) y = (λ i → ⟦ Int.predInt+ (negsuc' n) y (~ i) ⟧) ∙ sym (pred-⟦⟧ (negsuc' n +' y)) ∙ (λ i → pred $ isHom+ (negsuc' n) y i)
+    isHom+ : ∀ x y → ⟦ x +' y ⟧ ≡ ⟦ x ⟧ + ⟦ y ⟧
+    isHom+ (pos' zero) y i = ⟦ Int.+-comm 0 y i ⟧
+    isHom+ (pos' (suc n)) y =
+      ⟦ pos' (suc n) +' y ⟧     ≡[ i ]⟨ ⟦ Int.sucInt+ (pos' n) y (~ i) ⟧ ⟩
+      ⟦ sucInt (pos' n +' y) ⟧  ≡⟨ sym $ suc-⟦⟧ _ ⟩
+      sucᵇ  ⟦ pos' n +' y ⟧     ≡[ i ]⟨ sucᵇ $ isHom+ (pos' n) y i ⟩
+      sucᵇ (⟦ pos' n ⟧ + ⟦ y ⟧) ≡⟨ refl ⟩
+      sucᵇ  ⟦ pos' n ⟧ + ⟦ y ⟧  ∎
+    isHom+ (negsuc' zero) y = pred-suc-inj _ _ (λ i → predl (γ i)) where
+      γ : sucᵇ (⟦ negsuc' zero +' y ⟧) ≡ sucᵇ (pred zero + ⟦ y ⟧)
+      γ = suc-⟦⟧ (negsuc' zero +' y) ∙ (λ i → ⟦ (Int.sucInt+ (negsuc' zero) y ∙ Int.+-comm 0 y) i ⟧) ∙ sym (suc-pred ⟦ y ⟧)
+    isHom+ (negsuc' (suc n)) y = (λ i → ⟦ Int.predInt+ (negsuc' n) y (~ i) ⟧) ∙ sym (pred-⟦⟧ (negsuc' n +' y)) ∙ (λ i → pred $ isHom+ (negsuc' n) y i)
 
-  isHom· : ∀ x y → ⟦ x ·' y ⟧ ≡ ⟦ x ⟧ · ⟦ y ⟧
-  isHom· (pos' zero) y i = ⟦ Int.signed-zero (Int.sgn y) i ⟧
-  isHom· (pos' (suc n)) y =
-    ⟦ pos' (suc n) ·' y ⟧      ≡⟨ cong ⟦_⟧ $ Int.·-pos-suc n y ⟩
-    ⟦ y +' pos' n ·' y ⟧       ≡⟨ isHom+ y _ ⟩
-    ⟦ y ⟧ + ⟦ pos' n ·' y ⟧    ≡[ i ]⟨ ⟦ y ⟧ + isHom· (pos' n) y i ⟩
-    ⟦ y ⟧ + ⟦ pos' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → ⟦ y ⟧ + ·-comm ⟦ pos' n ⟧ ⟦ y ⟧ i) ∙ sym (·-suc ⟦ y ⟧ ⟦ pos' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
-    sucᵇ ⟦ pos' n ⟧ · ⟦ y ⟧ ∎
-  isHom· (negsuc' zero) y =
-    ⟦ -1 ·'  y ⟧ ≡⟨ cong ⟦_⟧ (Int.·-neg1 y) ⟩
-    ⟦ -'     y ⟧ ≡⟨ sym (neg-⟦⟧ y) ⟩
-      -    ⟦ y ⟧ ≡⟨ sym (·-neg1 ⟦ y ⟧) ⟩
-      -1 · ⟦ y ⟧ ∎
-  isHom· (negsuc' (suc n)) y =
-    ⟦ negsuc' (suc n) ·' y ⟧         ≡⟨ cong ⟦_⟧ $ Int.·-negsuc-suc n y ⟩
-    ⟦ -' y   +'  negsuc' n   ·'  y ⟧ ≡⟨ isHom+ (-' y) _ ⟩
-    ⟦ -' y ⟧ + ⟦ negsuc' n   ·'  y ⟧ ≡[ i ]⟨ ⟦ -' y ⟧ + isHom· (negsuc' n) y i ⟩
-    ⟦ -' y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ cong₂ _+_ (sym (neg-⟦⟧ y)) refl ⟩
-    -  ⟦ y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → - ⟦ y ⟧ + ·-comm ⟦ negsuc' n ⟧ ⟦ y ⟧ i) ∙ sym (·-pred ⟦ y ⟧ ⟦ negsuc' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
-    pred ⟦ negsuc' n ⟧ · ⟦ y ⟧       ∎
+    isHom· : ∀ x y → ⟦ x ·' y ⟧ ≡ ⟦ x ⟧ · ⟦ y ⟧
+    isHom· (pos' zero) y i = ⟦ Int.signed-zero (Int.sgn y) i ⟧
+    isHom· (pos' (suc n)) y =
+      ⟦ pos' (suc n) ·' y ⟧      ≡⟨ cong ⟦_⟧ $ Int.·-pos-suc n y ⟩
+      ⟦ y +' pos' n ·' y ⟧       ≡⟨ isHom+ y _ ⟩
+      ⟦ y ⟧ + ⟦ pos' n ·' y ⟧    ≡[ i ]⟨ ⟦ y ⟧ + isHom· (pos' n) y i ⟩
+      ⟦ y ⟧ + ⟦ pos' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → ⟦ y ⟧ + ·-comm ⟦ pos' n ⟧ ⟦ y ⟧ i) ∙ sym (·-suc ⟦ y ⟧ ⟦ pos' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
+      sucᵇ ⟦ pos' n ⟧ · ⟦ y ⟧ ∎
+    isHom· (negsuc' zero) y =
+      ⟦ -1 ·'  y ⟧ ≡⟨ cong ⟦_⟧ (Int.·-neg1 y) ⟩
+      ⟦ -'     y ⟧ ≡⟨ sym (neg-⟦⟧ y) ⟩
+        -    ⟦ y ⟧ ≡⟨ sym (·-neg1 ⟦ y ⟧) ⟩
+        -1 · ⟦ y ⟧ ∎
+    isHom· (negsuc' (suc n)) y =
+      ⟦ negsuc' (suc n) ·' y ⟧         ≡⟨ cong ⟦_⟧ $ Int.·-negsuc-suc n y ⟩
+      ⟦ -' y   +'  negsuc' n   ·'  y ⟧ ≡⟨ isHom+ (-' y) _ ⟩
+      ⟦ -' y ⟧ + ⟦ negsuc' n   ·'  y ⟧ ≡[ i ]⟨ ⟦ -' y ⟧ + isHom· (negsuc' n) y i ⟩
+      ⟦ -' y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ cong₂ _+_ (sym (neg-⟦⟧ y)) refl ⟩
+      -  ⟦ y ⟧ + ⟦ negsuc' n ⟧ · ⟦ y ⟧ ≡⟨ (λ i → - ⟦ y ⟧ + ·-comm ⟦ negsuc' n ⟧ ⟦ y ⟧ i) ∙ sym (·-pred ⟦ y ⟧ ⟦ negsuc' n ⟧) ∙ ·-comm ⟦ y ⟧ _ ⟩
+      pred ⟦ negsuc' n ⟧ · ⟦ y ⟧       ∎
 
-  ⟦⟧-isEquiv : isEquiv ⟦_⟧
-  ⟦⟧-isEquiv = isoToIsEquiv (iso ⟦_⟧ bwd fwd-bwd bwd-fwd)
-
-module _ where
-  open import Cubical.Foundations.Structure
-  open import Cubical.Structures.Axioms
-  open import Cubical.Data.Int
-
-  open Cubical.Algebra.CommRing.CommRingΣTheory hiding (CommRingPath)
-  open Cubical.Algebra.Ring.RingΣTheory
-
-  Int-RawRingStructure : RawRingStructure Int
-  Int-RawRingStructure = _+_ , 1 , _·_
+    ⟦⟧-isEquiv : isEquiv ⟦_⟧
+    ⟦⟧-isEquiv = isoToIsEquiv (iso ⟦_⟧ bwd fwd-bwd bwd-fwd)
 
   IntΣraw : TypeWithStr ℓ-zero RawRingStructure
-  IntΣraw = Int , _+_ , 1 , _·_
+  IntΣraw = Int , _+'_ , 1 , _·'_
 
-  Int-Σraw≃BiInvInt : IntΣraw ≃[ (λ A B z → RawRingEquivStr (fst A , snd A) (fst B , snd B) z) ] BiInvIntΣraw
-  Int-Σraw≃BiInvInt = (_ , ⟦⟧-isEquiv) , isHom+ , pres1 , isHom·
+  BiInvInt≃Int-Σraw : BiInvIntΣraw ≃[ RawRingEquivStr ] IntΣraw
+  BiInvInt≃Int-Σraw = ≃[]-swap rawRingUnivalentStr IntΣraw BiInvIntΣraw ((_ , ⟦⟧-isEquiv) , (isHom+ , pres1 , isHom·))
 
-  BiInvInt≃Int-Σraw : BiInvIntΣraw ≃[ (λ A B z → RawRingEquivStr (fst A , snd A) (fst B , snd B) z) ] IntΣraw
-  BiInvInt≃Int-Σraw = sip⁻ rawRingUnivalentStr BiInvIntΣraw IntΣraw (sym (sip rawRingUnivalentStr IntΣraw BiInvIntΣraw Int-Σraw≃BiInvInt))
-
-  Int-CommRingAxioms : CommRingAxioms Int Int-RawRingStructure
+  Int-CommRingAxioms : CommRingAxioms Int (str IntΣraw)
   Int-CommRingAxioms = transferAxioms {S = RawRingStructure} rawRingUnivalentStr {axioms = CommRingAxioms} (CommRing→CommRingΣ BiInvIntAsCommRing) IntΣraw BiInvInt≃Int-Σraw
 
-  IntΣ : TypeWithStr ℓ-zero CommRingStructure
-  IntΣ = Int , (_+_ , 1 , _·_) , Int-CommRingAxioms
+  IntΣ : TypeWithStr _ CommRingStructure
+  IntΣ = (typ IntΣraw) , (str IntΣraw) , Int-CommRingAxioms
 
   IntAsCommRing : CommRing
   IntAsCommRing = CommRingΣ→CommRing IntΣ
 
-  Int≃BiInvInt-CommRingEquivΣ : Σ[ e ∈ ⟨ IntAsCommRing ⟩ ≃ ⟨ BiInvIntAsCommRing ⟩ ] CommRingEquiv IntAsCommRing BiInvIntAsCommRing e
-  Int≃BiInvInt-CommRingEquivΣ .fst = _ , ⟦⟧-isEquiv
-  Int≃BiInvInt-CommRingEquivΣ .snd = ringequiv pres1 isHom+ isHom·
+  Int≃BiInvInt-CommRingEquiv : Σ[ e ∈ ⟨ IntAsCommRing ⟩ ≃ ⟨ BiInvIntAsCommRing ⟩ ] CommRingEquiv IntAsCommRing BiInvIntAsCommRing e
+  Int≃BiInvInt-CommRingEquiv .fst = _ , ⟦⟧-isEquiv
+  Int≃BiInvInt-CommRingEquiv .snd = ringequiv pres1 isHom+ isHom·
+
+  Int≡BiInvInt-AsCommRing : IntAsCommRing ≡ BiInvIntAsCommRing
+  Int≡BiInvInt-AsCommRing = CommRingPath _ _ .fst Int≃BiInvInt-CommRingEquiv

--- a/Cubical/Algebra/Group/Base.agda
+++ b/Cubical/Algebra/Group/Base.agda
@@ -4,7 +4,7 @@ module Cubical.Algebra.Group.Base where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.SIP
 open import Cubical.Data.Sigma
-open import Cubical.Data.Int renaming (_+_ to _+Int_ ; _-_ to _-Int_)
+open import Cubical.Data.Int hiding (-_) renaming (_+_ to _+Int_ ; _-_ to _-Int_)
 open import Cubical.Data.Unit
 
 open import Cubical.Algebra.Monoid

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -122,3 +122,8 @@ module _ {S : Type ℓ₁ → Type ℓ₂} {ι : StrEquiv S ℓ₃}
 
   sip⁻ : A ≡ B → A ≃[ ι ] B
   sip⁻ = invEq SIP
+
+≃[]-swap : {S : Type ℓ₁ → Type ℓ₂} {ι : StrEquiv S ℓ₂}
+         → (θ : UnivalentStr S ι) → (A B : TypeWithStr ℓ₁ S)
+         → A ≃[ ι ] B → B ≃[ ι ] A
+≃[]-swap θ A B A≃[ι]B = sip⁻ θ B A (sym (sip θ A B A≃[ι]B))

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 
-open import Cubical.Data.Int
+open import Cubical.Data.Int hiding (_·_)
 open import Cubical.Data.Sigma
 open import Cubical.Foundations.Function
 

--- a/Cubical/HITs/Ints/BiInvInt/Base.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Base.agda
@@ -307,4 +307,3 @@ private
 
   predl'-suc : ∀ z → predl' (suc z) ≡ z
   predl'-suc z = refl
-

--- a/Cubical/HITs/Ints/BiInvInt/Properties.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Properties.agda
@@ -153,6 +153,18 @@ neg : ℕ → BiInvInt
 neg ℕ.zero = zero
 neg (ℕ.suc n) = pred (neg n)
 
+-- Natural number and negative integer literals for BiInvInt
+
+open import Cubical.Data.Nat.Literals public
+
+instance
+  fromNatBiInvInt : HasFromNat BiInvInt
+  fromNatBiInvInt = record { Constraint = λ _ → Unit ; fromNat = λ n → pos n }
+
+instance
+  fromNegBiInvInt : HasFromNeg BiInvInt
+  fromNegBiInvInt = record { Constraint = λ _ → Unit ; fromNeg = λ n → neg n }
+
 -- absolute value and sign
 -- (Note that there doesn't appear to be any way around using
 --  bwd here! Any direct proof ends up doing the same work...)
@@ -246,3 +258,9 @@ inv-· m n = ·-comm (- m) n ∙ ·-inv n m ∙ cong (-_) (·-comm n m)
   (λ m p n o →
     cong (- (n · o) +_) (p n o) ∙ cong (_+ m · n · o) (sym (inv-· n o)) ∙
     ·-distribʳ (- n) (m · n) o)
+
+·-neg1 : ∀ x → -1 · x ≡ - x
+·-neg1 x = inv-· 1 x ∙ cong -_ (·-identityˡ x)
+
+pred-suc-inj : ∀ a b → pred (suc a) ≡ pred (suc b) → a ≡ b
+pred-suc-inj a b p = sym (pred-suc a) ∙∙ p ∙∙ pred-suc b

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -18,7 +18,7 @@ open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Nat
   hiding (_+_ ; _·_ ; +-assoc ; +-comm)
-open import Cubical.Data.Int
+open import Cubical.Data.Int hiding (_·_)
 
 data S¹ : Type₀ where
   base : S¹

--- a/Cubical/Papers/RepresentationIndependence.agda
+++ b/Cubical/Papers/RepresentationIndependence.agda
@@ -187,7 +187,7 @@ open Matrices using (VecMatrix ; FinMatrix ; FinMatrix≡VecMatrix
 open Matrices.FinMatrixAbGroup using (addFinMatrix ; addFinMatrixComm) public
 
 -- example (not in the library)
-open import Cubical.Data.Int renaming (Int to ℤ ; isSetInt to isSetℤ)
+open import Cubical.Data.Int hiding (-_) renaming (Int to ℤ ; isSetInt to isSetℤ)
 
 ℤ-AbGroup : AbGroup
 ℤ-AbGroup = makeAbGroup {G = ℤ} 0 _+_ -_ isSetℤ +-assoc (λ x _ → x) rem +-comm

--- a/Cubical/ZCohomology/KcompPrelims.agda
+++ b/Cubical/ZCohomology/KcompPrelims.agda
@@ -19,7 +19,7 @@ open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Equiv.HalfAdjoint
 
-open import Cubical.Data.Int renaming (_+_ to +Int)
+open import Cubical.Data.Int hiding (_·_; -_) renaming (_+_ to +Int)
 open import Cubical.Data.Nat hiding (_·_)
 open import Cubical.Data.Unit
 

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -18,7 +18,7 @@ open import Cubical.Data.Sigma hiding (_×_)
 open import Cubical.HITs.Susp
 open import Cubical.HITs.Wedge
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2 ; setTruncIsSet to §)
-open import Cubical.Data.Int renaming (_+_ to _ℤ+_)
+open import Cubical.Data.Int hiding (-_) renaming (_+_ to _ℤ+_)
 open import Cubical.Data.Nat
 open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; rec to trRec ; elim3 to trElim3)
 open import Cubical.Homotopy.Loopspace


### PR DESCRIPTION
This PR uses `transferAxioms` from `Cubical.Structures.Axioms` to obtain a `CommRing` structure on

- **`Cubical.HITs.Ints.BiInvInt`** (this CommRing structure is given directly)
- **`Cubical.Data.Int`**
- **`Cubical.Data.DiffInt`**
- **`Cubical.HITs.Ints.QuoInt`**

Not in this PR (and remaining for #404) are `CommRing` structures for

- _(`Cubical.HITs.Ints.DeltaInt`)_
- _(`Cubical.HITs.Ints.HAEquivInt`)_
- _(`Cubical.HITs.S1`)_

I'll need some more time to learn more about the actual "cubical" Agda, especially about hcomp, to adress the remaining ones. To mitigate [upcoming bitrod](https://agda.zulipchat.com/#narrow/stream/260790-cubical/topic/SIP/near/214292567) I've bundled the progress so far.

For getting an overview of the definitions that we would currently have and that might become superfluous, I've made a list for `Int.Properties`, `BiInvInt.Properties`, `QuoInt.Properties` and `DiffInt.Properties`. A `✓` denotes that this definition is directly used by `Cubical.Algebra.CommRing.Integers` and a `(✓)` means that this definition is a dependency of a directly used definition (which I just checked a bit manually).

The changes mostly affect `QuoInt` where a lot of properties like `·-assoc` would not be necessary anymore when importing the `CommRing` structure from `Cubical.Algebra.CommRing.Integers`.

## Int.Properties

||name|signature|
|---|---|---|
|(✓)|`abs`|`Int → ℕ`|
|(✓)|`Sign`|`Type₀`|
|(✓)|`spos`|`= Bool.false`|
|(✓)|`sneg`|`= Bool.true`|
||`_·ˢ_`|`Sign → Sign → Sign`|
|(✓)|`sgn`|`Int → Bool`|
|(✓)|`signed`|`Sign → ℕ → Int`|
|✓|`signed-zero`|`∀ s → signed s 0 ≡ 0`|
|(✓)|`signed-inv`|`∀ a → signed (sgn a) (abs a) ≡ a`|
|(✓)|`sucPred`|`∀ i → sucInt (predInt i) ≡ i`|
|(✓)|`predSuc`|`∀ i → predInt (sucInt i) ≡ i`|
|(✓)|`injPos`|`∀ {a b : ℕ} → pos a ≡ pos b → a ≡ b`|
|(✓)|`injNegsuc`|`∀ {a b : ℕ} → negsuc a ≡ negsuc b → a ≡ b`|
|(✓)|`posNotnegsuc`|`∀ (a b : ℕ) → ¬ (pos a ≡ negsuc b)`|
|(✓)|`negsucNotpos`|`∀ (a b : ℕ) → ¬ (negsuc a ≡ pos b)`|
|(✓)|`discreteInt`|`Discrete Int`|
|✓|`isSetInt`|`isSet Int`|
|[0]|`_ℕ-_`|`ℕ → ℕ → Int`|
|(✓)|`_+pos_`|`Int → ℕ  → Int`|
|(✓)|`_+negsuc_`|`Int → ℕ → Int`|
|✓|`_+_`|`Int → Int → Int`|
|✓|`-_`|`Int → Int`|
||`_-_`|`Int → Int → Int`|
|✓|`_·_`|`Int → Int → Int`|
|(✓)|`neg-signed-not`|`∀ s n → - signed s n ≡ signed (not s) n`|
|(✓)|`sucInt+pos`|`∀ n m → sucInt (m +pos n) ≡ (sucInt m) +pos n`|
|(✓)|`predInt+negsuc`|`∀ n m → predInt (m +negsuc n) ≡ (predInt m) +negsuc n`|
|(✓)|`sucInt+negsuc`|`∀ n m → sucInt (m +negsuc n) ≡ (sucInt m) +negsuc n`|
|(✓)|`predInt+pos`|`∀ n m → predInt (m +pos n) ≡ (predInt m) +pos n`|
|✓|`predInt+`|`∀ m n → predInt (m + n) ≡ (predInt m) + n`|
||`+predInt`|`∀ m n → predInt (m + n) ≡ m + (predInt n)`|
|✓|`sucInt+`|`∀ m n → sucInt (m + n) ≡ (sucInt m) + n`|
||`+sucInt`|`∀ m n → sucInt (m + n) ≡  m + (sucInt n)`|
|(✓)|`pos0+`|`∀ z → z ≡ pos 0 + z`|
||`negsuc0+`|`∀ z → predInt z ≡ negsuc 0 + z`|
||`ind-comm`|`...`|
||`ind-assoc`|`...`|
||`+-comm`|`∀ m n → m + n ≡ n + m`|
||`+-assoc`|`∀ m n o → m + (n + o) ≡ (m + n) + o`|
||`+-identityʳ`|`∀ x → x + 0 ≡ x`|
|✓|`+-identityˡ`|`∀ x → 0 + x ≡ x`|
|(✓)|`negsuc+negsuc`|`∀ a x → (negsuc a +negsuc x) ≡ negsuc (suc (a +ⁿ x))`|
|(✓)|`signed-distrib`|`∀ s m n → signed s (m +ⁿ n) ≡ signed s m + signed s n`|
|✓|`·-pos-suc`|`∀ m n → pos (suc m) · n ≡ n + pos m · n`|
|✓|`·-negsuc-suc`|`∀ m n → negsuc (suc m) · n ≡ - n + negsuc m · n`|
|✓|`predInt-neg`|`∀ a → predInt (- a) ≡ - (sucInt a)`|
||`sucInt-neg`|`∀ a → sucInt (- a) ≡ - (predInt a)`|
|✓|`·-neg1`|`∀ x → -1 · x ≡ - x`|
|[2]|`sucPathInt`|`Int ≡ Int`|
|[3]|`addEq`|`ℕ → Int ≡ Int`|
||`predPathInt`|`Int ≡ Int`|
||`subEq`|`ℕ → Int ≡ Int`|
||`_+'_`|`Int → Int → Int`|
||`+'≡+`|`_+'_ ≡ _+_`|
||`isEquivAddInt'`|`(m : Int) → isEquiv (λ n → n +' m)`|
||`isEquivAddInt`|`(m : Int) → isEquiv (λ n → n + m)`|
|[1]|`minusPlus`|`∀ m n → (n - m) + m ≡ n`|
||`plusMinus`|`∀ m n → (n + m) - m ≡ n`|

- [0] used in `Cubical.HITs.Ints.DeltaInt`
- [1] used in `Cubical.Algebra.Group.Base` (IntGroup) and `Cubical.Papers.RepresentationIndependence`
  - IntGroup is used in various places in `Cubical.ZCohomology.Groups.*`
- [2] used in `Cubical.HITs.S1`, `Cubical.Talks...Papers...Experiments`
- [3] used in `Cubical.Experiments.Generic`

## BiInvInt.Properties

||name|signature|
|---|---|---|
|(✓)|`BiInvInt-ind-prop`|`...`|
|(✓)|`BiInvInt-rec`|`∀ {ℓ} {A : Type ℓ} → A → A ≃ A → BiInvInt → A`|
|(✓)|`sucIso`|`Iso BiInvInt BiInvInt`|
|(✓)|`sucEquiv`|`BiInvInt ≃ BiInvInt`|
|✓|`_+_`|`BiInvInt → BiInvInt → BiInvInt`|
|✓|`+-zero`|`∀ n → n + zero ≡ n`|
|(✓)|`+-suc`|`∀ m n → m + suc n ≡ suc (m + n)`|
|(✓)|`+-pred`|`∀ m n → m + pred n ≡ pred (m + n)`|
|✓|`+-comm`|`∀ m n → m + n ≡ n + m`|
|✓|`+-assoc`|`∀ m n o → m + (n + o) ≡ (m + n) + o`|
|✓|`-_`|`BiInvInt → BiInvInt`|
||`_-_`|`BiInvInt → BiInvInt → BiInvInt`|
|(✓)|`+-invˡ`|`∀ n → (- n) + n ≡ zero`|
|✓|`+-invʳ`|`∀ n → n + (- n) ≡ zero`|
|(✓)|`inv-hom`|`∀ m n → - (m + n) ≡ (- m) + (- n)`|
|✓|`pos`|`ℕ → BiInvInt`|
|✓|`neg`|`ℕ → BiInvInt`|
|✓|`fromNatBiInvInt`|`HasFromNat BiInvInt`|
|✓|`fromNegBiInvInt`|`HasFromNeg BiInvInt`|
||`abs`|`BiInvInt → ℕ`|
||`sgn`|`BiInvInt → Bool`|
|(✓)|`Iso-n+`|`(n : BiInvInt) → Iso BiInvInt BiInvInt`|
|(✓)|`isEquiv-n+`|`∀ n → isEquiv (n +_)`|
|✓|`_·_`|`BiInvInt → BiInvInt → BiInvInt`|
|(✓)|`·-zero`|`∀ n → n · zero ≡ zero`|
|✓|`·-suc`|`∀ m n → m · suc n ≡ m + m · n`|
|✓|`·-pred`|`∀ m n → m · pred n ≡ (- m) + m · n`|
|✓|`·-comm`|`∀ m n → m · n ≡ n · m`|
|(✓)|`·-identityˡ`|`∀ m → suc zero · m ≡ m`|
|✓|`·-identityʳ`|`∀ m → m · suc zero ≡ m`|
|(✓)|`·-distribʳ`|`∀ m n o → (m · o) + (n · o) ≡ (m + n) · o`|
|✓|`·-distribˡ`|`∀ o m n → (o · m) + (o · n) ≡ o · (m + n)`|
|(✓)|`·-inv`|`∀ m n → m · (- n) ≡ - (m · n)`|
|(✓)|`inv-·`|`∀ m n → (- m) · n ≡ - (m · n)`|
|✓|`·-assoc`|`∀ m n o → m · (n · o) ≡ (m · n) · o`|
|✓|`·-neg1`|`∀ x → -1 · x ≡ - x`|
|✓|`pred-suc-inj`|`∀ a b → pred (suc a) ≡ pred (suc b) → a ≡ b`|

## QuoInt.Properties

`QuoInt` is used in `Cubical.HITs.Rationals.*` for which I have not checked the necessary definitions

||name|signature|
|---|---|---|
||`·S-comm`|`∀ x y → x ·S y ≡ y ·S x`|
||`·S-assoc`|`∀ x y z → x ·S (y ·S z) ≡ (x ·S y) ·S z`|
||`not-·Sˡ`|`∀ x y → not (x ·S y) ≡ not x ·S y`|
||`snotz`|`∀ s n s' → ¬ (signed s (suc n) ≡ signed s' zero)`|
||`+-zeroʳ`|`∀ s m → m + signed s zero ≡ m`|
||`+-identityʳ`|`∀ m → m + pos zero ≡ m`|
||`sucℤ-+ʳ`|`∀ m n → sucℤ (m + n) ≡ m + sucℤ n`|
||`predℤ-+ʳ`|`∀ m n → predℤ (m + n) ≡ m + predℤ n`|
||`+-comm`|`∀ m n → m + n ≡ n + m`|
||`sucℤ-+ˡ`|`∀ m n → sucℤ (m + n) ≡ sucℤ m + n`|
||`predℤ-+ˡ`|`∀ m n → predℤ (m + n) ≡ predℤ m + n`|
||`+-assoc`|`∀ m n o → m + (n + o) ≡ m + n + o`|
|✓|`sucℤ-inj`|`∀ m n → sucℤ m ≡ sucℤ n → m ≡ n`|
||`predℤ-inj`|`∀ m n → predℤ m ≡ predℤ n → m ≡ n`|
||`+-injˡ`|`∀ o m n → o + m ≡ o + n → m ≡ n`|
||`+-injʳ`|`∀ m n o → m + o ≡ n + o → m ≡ n`|
||`·-comm`|`∀ m n → m · n ≡ n · m`|
||`·-identityˡ`|`∀ n → pos 1 · n ≡ n`|
||`·-identityʳ`|`∀ n → n · pos 1 ≡ n`|
||`·-zeroˡ`|`∀ {s} n → signed s zero · n ≡ signed s zero`|
||`·-zeroʳ`|`∀ {s} n → n · signed s zero ≡ signed s zero`|
||`·-signed-pos`|`∀ {s} m n → signed s m · pos n ≡ signed s (m ℕ.· n)`|
||`·-assoc`|`∀ m n o → m · (n · o) ≡ m · n · o`|
||`negateSuc`|`∀ n → - sucℤ n ≡ predℤ (- n)`|
||`negatePred`|`∀ n → - predℤ n ≡ sucℤ (- n)`|
||`negate-+`|`∀ m n → - (m + n) ≡  (- m) + (- n)`|
||`negate-·ˡ`|`∀ m n → - (m · n) ≡ (- m) · n`|
|(✓)|`signed-distrib`|`∀ s m n → signed s (m ℕ.+ n) ≡ signed s m + signed s n`|
|✓|`·-pos-suc`|`∀ m n → pos (suc m) · n ≡ n + pos m · n`|
|✓|`·-neg-suc`|`∀ m n → neg (suc m) · n ≡ - n + neg m · n`|
|✓|`·-neg1`|`∀ m → -1 · m ≡ - m`|
||`·-distribˡ-pos`|`∀ o m n → (pos o · m) + (pos o · n) ≡ pos o · (m + n)`|
||`·-distribˡ-neg`|`∀ o m n → (neg o · m) + (neg o · n) ≡ neg o · (m + n)`|
||`·-distribˡ`|`∀ o m n → (o · m) + (o · n) ≡ o · (m + n)`|
||`·-distribʳ`|`∀ m n o → (m · o) + (n · o) ≡ (m + n) · o`|
||`sign-pos-suc-·`|`∀ m n → sign (pos (suc m) · n) ≡ sign n`|
||`·-injˡ`|`∀ o m n → pos (suc o) · m ≡ pos (suc o) · n → m ≡ n`|
||`·-injʳ`|`∀ m n o → m · pos (suc o) ≡ n · pos (suc o) → m ≡ n`|

## Cubical.Data.DiffInt.Properties

||name|signature|
|---|---|---|
|(✓)|`relIsEquiv`|`isEquivRel rel`|
|(✓)|`relIsProp`|`BinaryRelation.isPropValued rel`|
|(✓)|`discreteℤ`|`Discrete ℤ`|
|✓|`isSetℤ`|`isSet ℤ`|
|✓|`suc-identity`|`∀ a⁺ a⁻ → [ suc a⁺ , suc a⁻ ] ≡ [ a⁺ , a⁻ ]`|
|(✓)|`sucℤ'`|`ℕ × ℕ -> ℤ`|
|(✓)|`sucℤ'-respects-rel`|`(a b : ℕ × ℕ) → rel a b → sucℤ' a ≡ sucℤ' b`|
|(✓)|`sucℤ''`|`ℤ -> ℤ`|
|✓|`sucℤ`|`ℤ -> ℤ`|
|(✓)|`predℤ'`|`ℕ × ℕ -> ℤ`|
|(✓)|`predℤ'-respects-rel`|`(a b : ℕ × ℕ) → rel a b → predℤ' a ≡ predℤ' b`|
|(✓)|`predℤ''`|`ℤ -> ℤ`|
|✓|`predℤ`|`ℤ -> ℤ`|
|✓|`⟦_⟧`|`Int -> ℤ`|
|✓|`suc-⟦⟧`|`∀ x → sucℤ ⟦ x ⟧ ≡ ⟦ sucInt x ⟧`|
|✓|`pred-⟦⟧`|`∀ x → predℤ ⟦ x ⟧ ≡ ⟦ predInt x ⟧`|
||`fwd`|`= ⟦_⟧`|
|(✓)|`bwd'`|`ℕ × ℕ -> Int`|
|(✓)|`rel-suc`|`∀ a⁺ a⁻ → rel (a⁺ , a⁻) (suc a⁺ , suc a⁻)`|
|(✓)|`bwd'-suc`|`∀ a⁺ a⁻ → bwd' (a⁺ , a⁻) ≡ bwd' (suc a⁺ , suc a⁻)`|
|(✓)|`bwd'+`|`∀ m n → bwd' (m , m +ⁿ n) ≡ bwd' (0 , n)`|
|(✓)|`bwd'-respects-rel`|`(a b : ℕ × ℕ) → rel a b → bwd' a ≡ bwd' b`|
|✓|`bwd`|`ℤ -> Int`|
|✓|`bwd-fwd`|`∀ (x : Int) -> bwd (fwd x) ≡ x`|
||`fwd-bwd'`|`(a : ℕ × ℕ) → fwd (bwd [ a ]) ≡ [ a ]`|
|✓|`fwd-bwd`|`∀ (z : ℤ) -> fwd (bwd z) ≡ z`|
||`Int≡ℤ`|`Int ≡ ℤ`|
|(✓)|`_+'_`|`(a b : ℕ × ℕ) → ℤ`|
|(✓)|`+ⁿ-creates-rel-≡`|`∀ a⁺ a⁻ x → _≡_ {A = ℤ} [ a⁺ , a⁻ ] [ a⁺ +ⁿ x , a⁻ +ⁿ x ]`|
|(✓)|`+-respects-relʳ`|`(a b c : ℕ × ℕ) → rel a b → (a +' c) ≡ (b +' c)`|
|(✓)|`+-respects-relˡ`|`(a b c : ℕ × ℕ) → rel b c → (a +' b) ≡ (a +' c)`|
|(✓)|`_+''_`|`ℤ → ℤ → ℤ`|
|✓|`_+_`|`ℤ → ℤ → ℤ`|
|(✓)|`-'_`|`ℕ × ℕ → ℤ`|
|(✓)|`neg-respects-rel'-≡`|`(a b : ℕ × ℕ) → rel a b → (-' a) ≡ (-' b)`|
|(✓)|`-''_`|`ℤ → ℤ`|
|✓|`-_`|`ℤ -> ℤ`|
|(✓)|`neg-⟦⟧`|`∀ x → - ⟦ x ⟧ ≡ ⟦ Int.- x ⟧`|
|(✓)|`_·'_`|`(a b : ℕ × ℕ) → ℤ`|
|(✓)|`·-respects-relʳ`|`(a b c : ℕ × ℕ) → rel a b → (a ·' c) ≡ (b ·' c)`|
|(✓)|`·-respects-relˡ`|`(a b c : ℕ × ℕ) → rel b c → (a ·' b) ≡ (a ·' c)`|
|(✓)|`_·''_`|`ℤ → ℤ → ℤ`|
|✓|`_·_`|`ℤ → ℤ → ℤ`|
|✓|`+-identityˡ`|`(x : ℤ) → 0 + x ≡ x`|
|(✓)|`+sucℤ`|`∀ x y → sucℤ (x + y) ≡ sucℤ x + y`|
|(✓)|`+predℤ`|`∀ x y → predℤ (x + y) ≡ predℤ x + y`|
|✓|`sucℤ-inj`|`∀ x y → sucℤ x ≡ sucℤ y → x ≡ y`|
|✓|`·-nullifiesˡ`|`∀ x → 0 · x ≡ 0`|
|✓|`·-pos-suc`|`∀ x y → sucℤ x · y ≡ y + x · y`|
|✓|`·-neg1`|`∀ x → -1 · x ≡ - x`|
|✓|`·-neg-suc`|`∀ x y → predℤ x · y ≡ - y + x · y`|
