### PR TITLE
Major speedup in ZCohomology.Groups.Wedge

### DIFF
--- a/Cubical/ZCohomology/Groups/Wedge.agda
+++ b/Cubical/ZCohomology/Groups/Wedge.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.Wedge where
 
 open import Cubical.ZCohomology.Base
@@ -97,7 +97,7 @@ module _ {ℓ ℓ'} (A : Pointed ℓ) (B : Pointed ℓ') where
                                                      {A = λ i → (fst (id2 (~ i)) (pt A) ≡ snd (id2 (~ i)) (pt B))}
                                                        (isConnectedPath 2 (isConnectedSubtr 3 n
                                                                           (subst (λ m → isConnected m (coHomK (2 + n))) (+-comm 3 n)
-                                                                                 (isConnectedKn (1 + n)))) _ _)
+                                                                                 (isConnectedKn (suc n)))) _ _)
                                                        (p ∙ sym q) id1 .fst))
                                                        (Iso.fun PathIdTrunc₀Iso y))}))
       theIso : Iso ∥ (Σ[ f ∈ (typ A → coHomK (2 + n)) × (typ B → coHomK (2 + n)) ] (fst f) (pt A) ≡ (snd f) (pt B)) ∥₂


### PR DESCRIPTION
I was tinkering with the ZCohomology files to figure out what was so slow, and I found that the Wedge file is **~10x faster** with the `--experimental-lossy-unification` flag, which "enables heuristically unifying `f es = f es'` by unifying `es = es'`, even when it could lose solutions." (The other change in this patch is needed to convince the lossy unifier to accept a definition.)

```
Cubical.ZCohomology.Groups.Wedge                  1,574ms 
```

You may want to consult with @Saizan before using this; I'm not sure if the flag is long for this world.

And no, the other ZCohomology files don't get faster with this flag. /cc @aljungstrom