### PR TITLE
Add literals for Fin

### DIFF
--- a/Cubical/Data/Fin.agda
+++ b/Cubical/Data/Fin.agda
@@ -2,5 +2,6 @@
 
 module Cubical.Data.Fin where
 
-open import Cubical.Data.Fin.Base public
+open import Cubical.Data.Fin.Base       public
 open import Cubical.Data.Fin.Properties public
+open import Cubical.Data.Fin.Literals   public

--- a/Cubical/Data/Fin/Base.agda
+++ b/Cubical/Data/Fin/Base.agda
@@ -9,6 +9,7 @@ open import Cubical.Foundations.HLevels
 import Cubical.Data.Empty as ⊥
 open import Cubical.Data.Nat using (ℕ; zero; suc)
 open import Cubical.Data.Nat.Order
+open import Cubical.Data.Nat.Order.Recursive using () renaming (_≤_ to _≤′_)
 open import Cubical.Data.Sigma
 open import Cubical.Data.Sum using (_⊎_; _⊎?_; inl; inr)
 
@@ -44,6 +45,12 @@ toℕ = fst
 -- ... and injective.
 toℕ-injective : ∀{fj fk : Fin k} → toℕ fj ≡ toℕ fk → fj ≡ fk
 toℕ-injective {fj = fj} {fk} = Σ≡Prop (λ _ → m≤n-isProp)
+
+-- Conversion from ℕ with a recursive definition of ≤
+
+fromℕ≤ : (m n : ℕ) → m ≤′ n → Fin (suc n)
+fromℕ≤ zero    _       _    = fzero
+fromℕ≤ (suc m) (suc n) m≤n = fsuc (fromℕ≤ m n m≤n)
 
 -- A case analysis helper for induction.
 fsplit

--- a/Cubical/Data/Fin/Literals.agda
+++ b/Cubical/Data/Fin/Literals.agda
@@ -1,11 +1,12 @@
 {-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
 module Cubical.Data.Fin.Literals where
 
-open import Cubical.Data.Nat.Literals public
-open import Cubical.Data.Fin.Base
-  using (Fin; fromℕ≤)
 open import Agda.Builtin.Nat
   using (suc)
+open import Agda.Builtin.FromNat
+  renaming (Number to HasFromNat)
+open import Cubical.Data.Fin.Base
+  using (Fin; fromℕ≤)
 open import Cubical.Data.Nat.Order.Recursive
   using (_≤_)
 

--- a/Cubical/Data/Fin/Literals.agda
+++ b/Cubical/Data/Fin/Literals.agda
@@ -1,0 +1,17 @@
+{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+module Cubical.Data.Fin.Literals where
+
+open import Cubical.Data.Nat.Literals public
+open import Cubical.Data.Fin.Base
+  using (Fin; fromℕ≤)
+open import Agda.Builtin.Nat
+  using (suc)
+open import Cubical.Data.Nat.Order.Recursive
+  using (_≤_)
+
+instance
+  fromFin : {n : _} → HasFromNat (Fin (suc n))
+  fromFin {n} = record
+    { Constraint = λ m → m ≤ n
+    ; fromNat    = λ m ⦃ m≤n ⦄ → fromℕ≤ m n m≤n
+    }

--- a/Cubical/Data/Fin/Literals.agda
+++ b/Cubical/Data/Fin/Literals.agda
@@ -11,8 +11,8 @@ open import Cubical.Data.Nat.Order.Recursive
   using (_≤_)
 
 instance
-  fromFin : {n : _} → HasFromNat (Fin (suc n))
-  fromFin {n} = record
+  fromNatFin : {n : _} → HasFromNat (Fin (suc n))
+  fromNatFin {n} = record
     { Constraint = λ m → m ≤ n
     ; fromNat    = λ m ⦃ m≤n ⦄ → fromℕ≤ m n m≤n
     }


### PR DESCRIPTION
I just copy the example from the official documentation on [Literal Overloading](https://agda.readthedocs.io/en/v2.6.1.1/language/literal-overloading.html#literal-overloading), as I want to avoid some clumsy symbols for `Fin`.