### PR TITLE
index structure descriptors by output and equiv structure level

### DIFF
--- a/Cubical/Experiments/Rng.agda
+++ b/Cubical/Experiments/Rng.agda
@@ -23,7 +23,7 @@ private
     ℓ ℓ' : Level
 
 module _ {ℓ} where
-  rawRngDesc : Desc ℓ
+  rawRngDesc : Desc ℓ ℓ ℓ
   rawRngDesc = autoDesc (λ (X : Type ℓ) → (X → X → X) × (X → X → X))
 
   open Macro ℓ rawRngDesc public renaming

--- a/Cubical/Structures/Auto.agda
+++ b/Cubical/Structures/Auto.agda
@@ -42,11 +42,11 @@ private
   tType : R.Term → R.Term
   tType ℓ = R.def (quote Type) [ varg ℓ ]
 
-  tTranspDesc : R.Term → R.Term
-  tTranspDesc ℓ = R.def (quote TranspDesc) [ varg ℓ ]
+  tTranspDesc : R.Term → R.Term → R.Term
+  tTranspDesc ℓ ℓ' = R.def (quote TranspDesc) (ℓ v∷ ℓ' v∷ [])
 
-  tDesc : R.Term → R.Term
-  tDesc ℓ = R.def (quote Desc) [ varg ℓ ]
+  tDesc : R.Term → R.Term → R.Term → R.Term
+  tDesc ℓ ℓ₁ ℓ₁' = R.def (quote Desc) (ℓ v∷ ℓ₁ v∷ ℓ₁' v∷ [])
 
   func : (ℓ ℓ' : Level) → Type (ℓ-suc (ℓ-max ℓ ℓ'))
   func ℓ ℓ' = Type ℓ → Type ℓ'
@@ -135,7 +135,7 @@ private
     R.inferType hole >>= λ H →
     newMeta tLevel >>= λ ℓ →
     newMeta tLevel >>= λ ℓ' →
-    R.unify (tTranspDesc ℓ) H >>
+    R.unify (tTranspDesc ℓ ℓ') H >>
     R.checkType t (tStruct ℓ ℓ') >>
     buildTranspDesc FUEL ℓ ℓ' t >>= R.unify hole
 
@@ -200,7 +200,7 @@ autoDesc' t hole =
   R.inferType hole >>= λ H →
   newMeta tLevel >>= λ ℓ →
   newMeta tLevel >>= λ ℓ' →
-  R.unify (tDesc ℓ) H >>
+  R.unify (tDesc ℓ ℓ' R.unknown) H >>
   R.checkType t (tStruct ℓ ℓ') >>
   buildDesc FUEL ℓ ℓ' t >>= R.unify hole
 
@@ -212,14 +212,14 @@ macro
   -- (S : Type ℓ → Type ℓ₁) → EquivAction (AutoStructure S)
   autoEquivAction : R.Term → R.Term → R.TC Unit
   autoEquivAction t hole =
-    newMeta (tTranspDesc R.unknown) >>= λ d →
+    newMeta (tTranspDesc R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote transpMacroAction) [ varg d ]) >>
     autoTranspDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → TransportStr (autoEquivAction S)
   autoTransportStr : R.Term → R.Term → R.TC Unit
   autoTransportStr t hole =
-    newMeta (tTranspDesc R.unknown) >>= λ d →
+    newMeta (tTranspDesc R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote transpMacroTransportStr) [ varg d ]) >>
     autoTranspDesc' t d
 
@@ -231,20 +231,20 @@ macro
   -- Removes Transp[_] annotations
   AutoStructure : R.Term → R.Term → R.TC Unit
   AutoStructure t hole =
-    newMeta (tDesc R.unknown) >>= λ d →
+    newMeta (tDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote MacroStructure) [ varg d ]) >>
     autoDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → StrEquiv (AutoStructure S) _
   AutoEquivStr : R.Term → R.Term → R.TC Unit
   AutoEquivStr t hole =
-    newMeta (tDesc R.unknown) >>= λ d →
+    newMeta (tDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote MacroEquivStr) [ varg d ]) >>
     autoDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → UnivalentStr (AutoStructure S) (AutoEquivStr S)
   autoUnivalentStr : R.Term → R.Term → R.TC Unit
   autoUnivalentStr t hole =
-    newMeta (tDesc R.unknown) >>= λ d →
+    newMeta (tDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote MacroUnivalentStr) [ varg d ]) >>
     autoDesc' t d

--- a/Cubical/Structures/Macro.agda
+++ b/Cubical/Structures/Macro.agda
@@ -22,52 +22,46 @@ open import Cubical.Structures.Parameterized
 open import Cubical.Structures.Pointed
 open import Cubical.Structures.Product
 
-data TranspDesc (ℓ : Level) : Typeω where
+data TranspDesc (ℓ : Level) : Level → Typeω where
   -- constant structure: X ↦ A
-  constant : ∀ {ℓ'} (A : Type ℓ') → TranspDesc ℓ
+  constant : ∀ {ℓ₁} (A : Type ℓ₁) → TranspDesc ℓ ℓ₁
   -- pointed structure: X ↦ X
-  var : TranspDesc ℓ
+  var : TranspDesc ℓ ℓ
   -- product of structures S,T : X ↦ (S X × T X)
-  _,_ : (d₀ : TranspDesc ℓ) (d₁ : TranspDesc ℓ) → TranspDesc ℓ
+  _,_ : ∀ {ℓ₁ ℓ₂} (d₀ : TranspDesc ℓ ℓ₁) (d₁ : TranspDesc ℓ ℓ₂) → TranspDesc ℓ (ℓ-max ℓ₁ ℓ₂)
   -- functions between structures S,T: X ↦ (S X → T X)
-  function : (d₀ : TranspDesc ℓ) (d₁ : TranspDesc ℓ) → TranspDesc ℓ
+  function : ∀ {ℓ₁ ℓ₂} (d₀ : TranspDesc ℓ ℓ₁) (d₁ : TranspDesc ℓ ℓ₂) → TranspDesc ℓ (ℓ-max ℓ₁ ℓ₂)
   -- Maybe on a structure S: X ↦ Maybe (S X)
-  maybe : TranspDesc ℓ → TranspDesc ℓ
+  maybe : ∀ {ℓ₁} → TranspDesc ℓ ℓ₁ → TranspDesc ℓ ℓ₁
   -- arbitrary transport structure
-  foreign : ∀ {ℓ'} {S : Type ℓ → Type ℓ'} (α : EquivAction S) → TransportStr α → TranspDesc ℓ
+  foreign : ∀ {ℓ₁} {S : Type ℓ → Type ℓ₁} (α : EquivAction S) → TransportStr α → TranspDesc ℓ ℓ₁
 
-data Desc (ℓ : Level) : Typeω where
+data Desc (ℓ : Level) : Level → Level → Typeω where
   -- constant structure: X ↦ A
-  constant : ∀ {ℓ'} (A : Type ℓ') → Desc ℓ
+  constant : ∀ {ℓ₁} (A : Type ℓ₁) → Desc ℓ ℓ₁ ℓ₁
   -- pointed structure: X ↦ X
-  var : Desc ℓ
+  var : Desc ℓ ℓ ℓ
   -- product of structures S,T : X ↦ (S X × T X)
-  _,_ : (d₀ : Desc ℓ) (d₁ : Desc ℓ) → Desc ℓ
+  _,_ : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
+    → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁' ℓ₂')
   -- functions between structures S,T : X ↦ (S X → T X)
-  function : (d₀ : Desc ℓ) (d₁ : Desc ℓ) → Desc ℓ
+  function : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
+    → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ (ℓ-max ℓ₁' ℓ₂'))
   -- functions between structures S,T where S is functorial : X ↦ (S X → T X)
-  function+ : (d₀ : TranspDesc ℓ) (d₁ : Desc ℓ) → Desc ℓ
+  function+ : ∀ {ℓ₁ ℓ₂ ℓ₂'} (d₀ : TranspDesc ℓ ℓ₁) (d₁ : Desc ℓ ℓ₂ ℓ₂') → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ ℓ₂')
   -- Maybe on a structure S: X ↦ Maybe (S X)
-  maybe : Desc ℓ → Desc ℓ
+  maybe : ∀ {ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Desc ℓ ℓ₁ ℓ₁'
   -- univalent structure from transport structure
-  transpDesc : TranspDesc ℓ → Desc ℓ
+  transpDesc : ∀ {ℓ₁} → TranspDesc ℓ ℓ₁ → Desc ℓ ℓ₁ ℓ₁
   -- arbitrary univalent notion of structure
-  foreign : ∀ {ℓ' ℓ''} {S : Type ℓ → Type ℓ'} (ι : StrEquiv S ℓ'') → UnivalentStr S ι → Desc ℓ
+  foreign : ∀ {ℓ₁ ℓ₁'} {S : Type ℓ → Type ℓ₁} (ι : StrEquiv S ℓ₁') → UnivalentStr S ι → Desc ℓ ℓ₁ ℓ₁'
 
 infixr 4 _,_
 
 {- Transport structures -}
 
-transpMacroLevel : ∀ {ℓ} → TranspDesc ℓ → Level
-transpMacroLevel (constant {ℓ'} x) = ℓ'
-transpMacroLevel {ℓ} var = ℓ
-transpMacroLevel {ℓ} (d₀ , d₁) = ℓ-max (transpMacroLevel d₀) (transpMacroLevel d₁)
-transpMacroLevel (function d₀ d₁) = ℓ-max (transpMacroLevel d₀) (transpMacroLevel d₁)
-transpMacroLevel (maybe d) = transpMacroLevel d
-transpMacroLevel (foreign {ℓ'} α τ) = ℓ'
-
 -- Structure defined by a transport descriptor
-TranspMacroStructure : ∀ {ℓ} (d : TranspDesc ℓ) → Type ℓ → Type (transpMacroLevel d)
+TranspMacroStructure : ∀ {ℓ ℓ₁} → TranspDesc ℓ ℓ₁ → Type ℓ → Type ℓ₁
 TranspMacroStructure (constant A) X = A
 TranspMacroStructure var X = X
 TranspMacroStructure (d₀ , d₁) X = TranspMacroStructure d₀ X × TranspMacroStructure d₁ X
@@ -76,7 +70,7 @@ TranspMacroStructure (maybe d) = MaybeStructure (TranspMacroStructure d)
 TranspMacroStructure (foreign {S = S} α τ) = S
 
 -- Action defined by a transport descriptor
-transpMacroAction : ∀ {ℓ} (d : TranspDesc ℓ) → EquivAction (TranspMacroStructure d)
+transpMacroAction : ∀ {ℓ ℓ₁} (d : TranspDesc ℓ ℓ₁) → EquivAction (TranspMacroStructure d)
 transpMacroAction (constant A) = constantEquivAction A
 transpMacroAction var = pointedEquivAction
 transpMacroAction (d₀ , d₁) = productEquivAction (transpMacroAction d₀) (transpMacroAction d₁)
@@ -86,7 +80,7 @@ transpMacroAction (maybe d) = maybeEquivAction (transpMacroAction d)
 transpMacroAction (foreign α _) = α
 
 -- Action defines a transport structure
-transpMacroTransportStr : ∀ {ℓ} (d : TranspDesc ℓ) → TransportStr (transpMacroAction d)
+transpMacroTransportStr : ∀ {ℓ ℓ₁} (d : TranspDesc ℓ ℓ₁) → TransportStr (transpMacroAction d)
 transpMacroTransportStr (constant A) = constantTransportStr A
 transpMacroTransportStr var = pointedTransportStr
 transpMacroTransportStr (d₀ , d₁) =
@@ -103,28 +97,8 @@ transpMacroTransportStr (foreign α τ) = τ
 
 {- General structures -}
 
-macroStrLevel : ∀ {ℓ} → Desc ℓ → Level
-macroStrLevel (constant {ℓ'} x) = ℓ'
-macroStrLevel {ℓ} var = ℓ
-macroStrLevel {ℓ} (d₀ , d₁) = ℓ-max (macroStrLevel d₀) (macroStrLevel d₁)
-macroStrLevel {ℓ} (function+ d₀ d₁) = ℓ-max (transpMacroLevel d₀) (macroStrLevel d₁)
-macroStrLevel (function d₀ d₁) = ℓ-max (macroStrLevel d₀) (macroStrLevel d₁)
-macroStrLevel (maybe d) = macroStrLevel d
-macroStrLevel (transpDesc d) = transpMacroLevel d
-macroStrLevel (foreign {ℓ'} _ _) = ℓ'
-
-macroEquivLevel : ∀ {ℓ} → Desc ℓ → Level
-macroEquivLevel (constant {ℓ'} x) = ℓ'
-macroEquivLevel {ℓ} var = ℓ
-macroEquivLevel (d₀ , d₁) = ℓ-max (macroEquivLevel d₀) (macroEquivLevel d₁)
-macroEquivLevel {ℓ} (function+ d₀ d₁) = ℓ-max (transpMacroLevel d₀) (macroEquivLevel d₁)
-macroEquivLevel (function d₀ d₁) = ℓ-max (macroStrLevel d₀) (ℓ-max (macroEquivLevel d₀) (macroEquivLevel d₁))
-macroEquivLevel (maybe d) = macroEquivLevel d
-macroEquivLevel (transpDesc d) = transpMacroLevel d
-macroEquivLevel (foreign {ℓ'' = ℓ''} _ _) = ℓ''
-
 -- Structure defined by a descriptor
-MacroStructure : ∀ {ℓ} (d : Desc ℓ) → Type ℓ → Type (macroStrLevel d)
+MacroStructure : ∀ {ℓ ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Type ℓ → Type ℓ₁
 MacroStructure (constant A) X = A
 MacroStructure var X = X
 MacroStructure (d₀ , d₁) X = MacroStructure d₀ X × MacroStructure d₁ X
@@ -135,7 +109,7 @@ MacroStructure (transpDesc d) = TranspMacroStructure d
 MacroStructure (foreign {S = S} _ _) = S
 
 -- Notion of structured equivalence defined by a descriptor
-MacroEquivStr : ∀ {ℓ} → (d : Desc ℓ) → StrEquiv {ℓ} (MacroStructure d) (macroEquivLevel d)
+MacroEquivStr : ∀ {ℓ ℓ₁ ℓ₁'} → (d : Desc ℓ ℓ₁ ℓ₁') → StrEquiv (MacroStructure d) ℓ₁'
 MacroEquivStr (constant A) = ConstantEquivStr A
 MacroEquivStr var = PointedEquivStr
 MacroEquivStr (d₀ , d₁) = ProductEquivStr (MacroEquivStr d₀) (MacroEquivStr d₁)
@@ -146,7 +120,7 @@ MacroEquivStr (transpDesc d) = EquivAction→StrEquiv (transpMacroAction d)
 MacroEquivStr (foreign ι _) = ι
 
 -- Proof that structure induced by descriptor is univalent
-MacroUnivalentStr : ∀ {ℓ} → (d : Desc ℓ) → UnivalentStr (MacroStructure d) (MacroEquivStr d)
+MacroUnivalentStr : ∀ {ℓ ℓ₁ ℓ₁'} → (d : Desc ℓ ℓ₁ ℓ₁') → UnivalentStr (MacroStructure d) (MacroEquivStr d)
 MacroUnivalentStr (constant A) = constantUnivalentStr A
 MacroUnivalentStr var = pointedUnivalentStr
 MacroUnivalentStr (d₀ , d₁) =
@@ -167,7 +141,7 @@ MacroUnivalentStr (transpDesc d) =
 MacroUnivalentStr (foreign _ θ) = θ
 
 -- Module for easy importing
-module Macro ℓ (d : Desc ℓ) where
+module Macro ℓ {ℓ₁ ℓ₁'} (d : Desc ℓ ℓ₁ ℓ₁') where
 
   structure = MacroStructure d
   equiv = MacroEquivStr d

--- a/Cubical/Structures/Macro.agda
+++ b/Cubical/Structures/Macro.agda
@@ -15,12 +15,15 @@ open import Cubical.Functions.FunExtEquiv
 open import Cubical.Data.Sigma
 open import Cubical.Data.Maybe
 
+open import Cubical.Structures.Axioms
 open import Cubical.Structures.Constant
 open import Cubical.Structures.Function
 open import Cubical.Structures.Maybe
 open import Cubical.Structures.Parameterized
 open import Cubical.Structures.Pointed
 open import Cubical.Structures.Product
+
+{- Transport structures -}
 
 data TranspDesc (ℓ : Level) : Level → Typeω where
   -- constant structure: X ↦ A
@@ -35,30 +38,6 @@ data TranspDesc (ℓ : Level) : Level → Typeω where
   maybe : ∀ {ℓ₁} → TranspDesc ℓ ℓ₁ → TranspDesc ℓ ℓ₁
   -- arbitrary transport structure
   foreign : ∀ {ℓ₁} {S : Type ℓ → Type ℓ₁} (α : EquivAction S) → TransportStr α → TranspDesc ℓ ℓ₁
-
-data Desc (ℓ : Level) : Level → Level → Typeω where
-  -- constant structure: X ↦ A
-  constant : ∀ {ℓ₁} (A : Type ℓ₁) → Desc ℓ ℓ₁ ℓ₁
-  -- pointed structure: X ↦ X
-  var : Desc ℓ ℓ ℓ
-  -- product of structures S,T : X ↦ (S X × T X)
-  _,_ : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
-    → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁' ℓ₂')
-  -- functions between structures S,T : X ↦ (S X → T X)
-  function : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
-    → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ (ℓ-max ℓ₁' ℓ₂'))
-  -- functions between structures S,T where S is functorial : X ↦ (S X → T X)
-  function+ : ∀ {ℓ₁ ℓ₂ ℓ₂'} (d₀ : TranspDesc ℓ ℓ₁) (d₁ : Desc ℓ ℓ₂ ℓ₂') → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ ℓ₂')
-  -- Maybe on a structure S: X ↦ Maybe (S X)
-  maybe : ∀ {ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Desc ℓ ℓ₁ ℓ₁'
-  -- univalent structure from transport structure
-  transpDesc : ∀ {ℓ₁} → TranspDesc ℓ ℓ₁ → Desc ℓ ℓ₁ ℓ₁
-  -- arbitrary univalent notion of structure
-  foreign : ∀ {ℓ₁ ℓ₁'} {S : Type ℓ → Type ℓ₁} (ι : StrEquiv S ℓ₁') → UnivalentStr S ι → Desc ℓ ℓ₁ ℓ₁'
-
-infixr 4 _,_
-
-{- Transport structures -}
 
 -- Structure defined by a transport descriptor
 TranspMacroStructure : ∀ {ℓ ℓ₁} → TranspDesc ℓ ℓ₁ → Type ℓ → Type ℓ₁
@@ -97,16 +76,44 @@ transpMacroTransportStr (foreign α τ) = τ
 
 {- General structures -}
 
--- Structure defined by a descriptor
-MacroStructure : ∀ {ℓ ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Type ℓ → Type ℓ₁
-MacroStructure (constant A) X = A
-MacroStructure var X = X
-MacroStructure (d₀ , d₁) X = MacroStructure d₀ X × MacroStructure d₁ X
-MacroStructure (function+ d₀ d₁) X = TranspMacroStructure d₀ X → MacroStructure d₁ X
-MacroStructure (function d₀ d₁) X = MacroStructure d₀ X → MacroStructure d₁ X
-MacroStructure (maybe d) = MaybeStructure (MacroStructure d)
-MacroStructure (transpDesc d) = TranspMacroStructure d
-MacroStructure (foreign {S = S} _ _) = S
+mutual
+  data Desc (ℓ : Level) : Level → Level → Typeω where
+    -- constant structure: X ↦ A
+    constant : ∀ {ℓ₁} (A : Type ℓ₁) → Desc ℓ ℓ₁ ℓ₁
+    -- pointed structure: X ↦ X
+    var : Desc ℓ ℓ ℓ
+    -- product of structures S,T : X ↦ (S X × T X)
+    _,_ : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
+      → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁' ℓ₂')
+    -- functions between structures S,T : X ↦ (S X → T X)
+    function : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} (d₀ : Desc ℓ ℓ₁ ℓ₁') (d₁ : Desc ℓ ℓ₂ ℓ₂')
+      → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ (ℓ-max ℓ₁' ℓ₂'))
+    -- functions between structures S,T where S is functorial : X ↦ (S X → T X)
+    function+ : ∀ {ℓ₁ ℓ₂ ℓ₂'} (d₀ : TranspDesc ℓ ℓ₁) (d₁ : Desc ℓ ℓ₂ ℓ₂') → Desc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ ℓ₂')
+    -- Maybe on a structure S: X ↦ Maybe (S X)
+    maybe : ∀ {ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Desc ℓ ℓ₁ ℓ₁'
+    -- add axioms to a structure
+    axioms : ∀ {ℓ₁ ℓ₁' ℓ₂} (d : Desc ℓ ℓ₁ ℓ₁') (ax : ∀ X → MacroStructure d X → Type ℓ₂)
+      → (∀ X s → isProp (ax X s))
+      → Desc ℓ (ℓ-max ℓ₁ ℓ₂) ℓ₁'
+    -- univalent structure from transport structure
+    transpDesc : ∀ {ℓ₁} → TranspDesc ℓ ℓ₁ → Desc ℓ ℓ₁ ℓ₁
+    -- arbitrary univalent notion of structure
+    foreign : ∀ {ℓ₁ ℓ₁'} {S : Type ℓ → Type ℓ₁} (ι : StrEquiv S ℓ₁') → UnivalentStr S ι → Desc ℓ ℓ₁ ℓ₁'
+
+  infixr 4 _,_
+
+  -- Structure defined by a descriptor
+  MacroStructure : ∀ {ℓ ℓ₁ ℓ₁'} → Desc ℓ ℓ₁ ℓ₁' → Type ℓ → Type ℓ₁
+  MacroStructure (constant A) X = A
+  MacroStructure var X = X
+  MacroStructure (d₀ , d₁) X = MacroStructure d₀ X × MacroStructure d₁ X
+  MacroStructure (function+ d₀ d₁) X = TranspMacroStructure d₀ X → MacroStructure d₁ X
+  MacroStructure (function d₀ d₁) X = MacroStructure d₀ X → MacroStructure d₁ X
+  MacroStructure (maybe d) = MaybeStructure (MacroStructure d)
+  MacroStructure (axioms d ax _) = AxiomsStructure (MacroStructure d) ax
+  MacroStructure (transpDesc d) = TranspMacroStructure d
+  MacroStructure (foreign {S = S} _ _) = S
 
 -- Notion of structured equivalence defined by a descriptor
 MacroEquivStr : ∀ {ℓ ℓ₁ ℓ₁'} → (d : Desc ℓ ℓ₁ ℓ₁') → StrEquiv (MacroStructure d) ℓ₁'
@@ -116,6 +123,7 @@ MacroEquivStr (d₀ , d₁) = ProductEquivStr (MacroEquivStr d₀) (MacroEquivSt
 MacroEquivStr (function+ d₀ d₁) = FunctionEquivStr+ (transpMacroAction d₀) (MacroEquivStr d₁)
 MacroEquivStr (function d₀ d₁) = FunctionEquivStr (MacroEquivStr d₀) (MacroEquivStr d₁)
 MacroEquivStr (maybe d) = MaybeEquivStr (MacroEquivStr d)
+MacroEquivStr (axioms d ax _) = AxiomsEquivStr (MacroEquivStr d) ax
 MacroEquivStr (transpDesc d) = EquivAction→StrEquiv (transpMacroAction d)
 MacroEquivStr (foreign ι _) = ι
 
@@ -136,6 +144,7 @@ MacroUnivalentStr (function d₀ d₁) =
     (MacroEquivStr d₀) (MacroUnivalentStr d₀)
     (MacroEquivStr d₁) (MacroUnivalentStr d₁)
 MacroUnivalentStr (maybe d) = maybeUnivalentStr (MacroEquivStr d) (MacroUnivalentStr d)
+MacroUnivalentStr (axioms d _ isPropAx) = axiomsUnivalentStr (MacroEquivStr d) isPropAx (MacroUnivalentStr d)
 MacroUnivalentStr (transpDesc d) =
   TransportStr→UnivalentStr (transpMacroAction d) (transpMacroTransportStr d)
 MacroUnivalentStr (foreign _ θ) = θ

--- a/Cubical/Structures/Record.agda
+++ b/Cubical/Structures/Record.agda
@@ -183,11 +183,11 @@ private
       isom .rightInv = fwdBwd A B e
       isom .leftInv = bwdFwd A B e
 
-  ExplicitUnivalentDesc : ∀ ℓ → (d : M.Desc ℓ) → Type _
+  ExplicitUnivalentDesc : ∀ ℓ {ℓ₁ ℓ₁'} → (d : M.Desc ℓ ℓ₁ ℓ₁') → Type _
   ExplicitUnivalentDesc _ d =
     ExplicitUnivalentStr (M.MacroStructure d) (M.MacroEquivStr d)
 
-  explicitUnivalentDesc : ∀ ℓ → (d : M.Desc ℓ) → ExplicitUnivalentDesc ℓ d
+  explicitUnivalentDesc : ∀ ℓ {ℓ₁ ℓ₁'} → (d : M.Desc ℓ ℓ₁ ℓ₁') → ExplicitUnivalentDesc ℓ d
   explicitUnivalentDesc _ d A B e = M.MacroUnivalentStr d e
 
 -- Internal record specification type

--- a/Cubical/Structures/Relational/Auto.agda
+++ b/Cubical/Structures/Relational/Auto.agda
@@ -26,6 +26,7 @@ open import Cubical.Data.Maybe
 open import Cubical.Structures.Relational.Macro as Macro
 
 import Agda.Builtin.Reflection as R
+open import Cubical.Reflection.Base
 
 -- Magic number
 private
@@ -38,17 +39,6 @@ abstract
 
 -- Some reflection utilities
 private
-  _>>=_ = R.bindTC
-  _<|>_ = R.catchTC
-
-  _>>_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → R.TC A → R.TC B → R.TC B
-  f >> g = f >>= λ _ → g
-
-  infixl 4 _>>=_ _>>_ _<|>_
-
-  varg : ∀ {ℓ} {A : Type ℓ} → A → R.Arg A
-  varg = R.arg (R.arg-info R.visible R.relevant)
-
   tLevel = R.def (quote Level) []
 
   tType : R.Term → R.Term
@@ -57,19 +47,17 @@ private
   thSet : R.Term → R.Term
   thSet ℓ = R.def (quote hSet) [ varg ℓ ]
 
-  tPosRelDesc : R.Term → R.Term
-  tPosRelDesc ℓ = R.def (quote PosRelDesc) [ varg ℓ ]
+  tPosRelDesc : R.Term → R.Term → R.Term
+  tPosRelDesc ℓ ℓ₁ = R.def (quote PosRelDesc) (ℓ v∷ ℓ₁ v∷ [])
 
-  tRelDesc : R.Term → R.Term
-  tRelDesc ℓ = R.def (quote RelDesc) [ varg ℓ ]
+  tRelDesc : R.Term → R.Term → R.Term → R.Term
+  tRelDesc ℓ ℓ₁ ℓ₁' = R.def (quote RelDesc) (ℓ v∷ ℓ₁ v∷ ℓ₁' v∷ [])
 
   func : (ℓ ℓ' : Level) → Type (ℓ-suc (ℓ-max ℓ ℓ'))
   func ℓ ℓ' = Type ℓ → Type ℓ'
 
   tStruct : R.Term → R.Term → R.Term
   tStruct ℓ ℓ' = R.def (quote func) (varg ℓ ∷ varg ℓ' ∷ [])
-
-  newMeta = R.checkType R.unknown
 
 -- We try to build a descriptor by unifying the provided structure with combinators we're aware of. We
 -- redefine the structure combinators as the *Shape terms below so that we don't depend on the specific way
@@ -141,7 +129,7 @@ private
     R.inferType hole >>= λ H →
     newMeta tLevel >>= λ ℓ →
     newMeta tLevel >>= λ ℓ' →
-    R.unify (tPosRelDesc ℓ) H >>
+    R.unify (tPosRelDesc ℓ ℓ') H >>
     R.checkType t (tStruct ℓ ℓ') >>
     buildPosRelDesc FUEL ℓ ℓ' t >>= R.unify hole
 
@@ -208,7 +196,7 @@ private
     R.inferType hole >>= λ H →
     newMeta tLevel >>= λ ℓ →
     newMeta tLevel >>= λ ℓ' →
-    R.unify (tRelDesc ℓ) H >>
+    R.unify (tRelDesc ℓ ℓ' R.unknown) H >>
     R.checkType t (tStruct ℓ ℓ') >>
     buildRelDesc FUEL ℓ ℓ' t >>= R.unify hole
 
@@ -225,27 +213,27 @@ macro
   -- Sanity check: should be the identity
   AutoStructure : R.Term → R.Term → R.TC Unit
   AutoStructure t hole =
-    newMeta (tRelDesc R.unknown) >>= λ d →
+    newMeta (tRelDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote RelMacroStructure) [ varg d ]) >>
     autoRelDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → StrRel S _
   AutoRelStr : R.Term → R.Term → R.TC Unit
   AutoRelStr t hole =
-    newMeta (tRelDesc R.unknown) >>= λ d →
+    newMeta (tRelDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote RelMacroRelStr) [ varg d ]) >>
     autoRelDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → SuitableStrRel S (AutoStrRel S)
   autoSuitableRel : R.Term → R.Term → R.TC Unit
   autoSuitableRel t hole =
-    newMeta (tRelDesc R.unknown) >>= λ d →
+    newMeta (tRelDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote relMacroSuitableRel) [ varg d ]) >>
     autoRelDesc' t d
 
   -- (S : Type ℓ → Type ℓ₁) → StrRelMatchesEquiv (AutoRelStr S) (AutoEquivStr S)
   autoMatchesEquiv : R.Term → R.Term → R.TC Unit
   autoMatchesEquiv t hole =
-    newMeta (tRelDesc R.unknown) >>= λ d →
+    newMeta (tRelDesc R.unknown R.unknown R.unknown) >>= λ d →
     R.unify hole (R.def (quote relMacroMatchesEquiv) [ varg d ]) >>
     autoRelDesc' t d

--- a/Cubical/Structures/Relational/Macro.agda
+++ b/Cubical/Structures/Relational/Macro.agda
@@ -23,45 +23,45 @@ open import Cubical.Structures.Relational.Product
 open import Cubical.Structures.Macro
 open import Cubical.Structures.Maybe
 
-data PosRelDesc (ℓ : Level) : Typeω where
+data PosRelDesc (ℓ : Level) : Level → Typeω where
   -- constant structure: X ↦ A
-  constant : ∀ {ℓ'} → hSet ℓ' → PosRelDesc ℓ
+  constant : ∀ {ℓ₁} → hSet ℓ₁ → PosRelDesc ℓ ℓ₁
   -- pointed structure: X ↦ X
-  var : PosRelDesc ℓ
+  var : PosRelDesc ℓ ℓ
   -- product of structures S,T : X ↦ (S X × T X)
-  _,_ : PosRelDesc ℓ  → PosRelDesc ℓ  → PosRelDesc ℓ
+  _,_ : ∀ {ℓ₁ ℓ₂} → PosRelDesc ℓ ℓ₁ → PosRelDesc ℓ ℓ₂ → PosRelDesc ℓ (ℓ-max ℓ₁ ℓ₂)
   -- Maybe on a structure S: X ↦ Maybe (S X)
-  maybe : PosRelDesc ℓ → PosRelDesc ℓ
+  maybe : ∀ {ℓ₁} → PosRelDesc ℓ ℓ₁ → PosRelDesc ℓ ℓ₁
 
-data RelDesc (ℓ : Level) : Typeω where
+data RelDesc (ℓ : Level) : Level → Level → Typeω where
   -- constant structure: X ↦ A
-  constant : ∀ {ℓ'} → hSet ℓ' → RelDesc ℓ
+  constant : ∀ {ℓ₁} → hSet ℓ₁ → RelDesc ℓ ℓ₁ ℓ₁
   -- pointed structure: X ↦ X
-  var : RelDesc ℓ
+  var : RelDesc ℓ ℓ ℓ
   -- product of structures S,T : X ↦ (S X × T X)
-  _,_ : RelDesc ℓ  → RelDesc ℓ  → RelDesc ℓ
+  _,_ : ∀ {ℓ₁ ℓ₁' ℓ₂ ℓ₂'} → RelDesc ℓ ℓ₁ ℓ₁' → RelDesc ℓ ℓ₂ ℓ₂' → RelDesc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁' ℓ₂')
   -- structure S parameterized by constant A : X ↦ (A → S X)
-  param : ∀ {ℓ'} → (A : Type ℓ') → RelDesc ℓ  → RelDesc ℓ
+  param : ∀ {ℓ₁ ℓ₂ ℓ₂'} → (A : Type ℓ₁) → RelDesc ℓ ℓ₂ ℓ₂' → RelDesc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ ℓ₂')
   -- function from positive structure S to T: X ↦ (S X → T X)
-  function+ : PosRelDesc ℓ → RelDesc ℓ → RelDesc ℓ
+  function+ : ∀ {ℓ₁ ℓ₂ ℓ₂'} → PosRelDesc ℓ ℓ₁ → RelDesc ℓ ℓ₂ ℓ₂' → RelDesc ℓ (ℓ-max ℓ₁ ℓ₂) (ℓ-max ℓ₁ ℓ₂')
   -- Maybe on a structure S: X ↦ Maybe (S X)
-  maybe : RelDesc ℓ → RelDesc ℓ
+  maybe : ∀ {ℓ₁ ℓ₁'} → RelDesc ℓ ℓ₁ ℓ₁' → RelDesc ℓ ℓ₁ ℓ₁'
 
 infixr 4 _,_
 
-posRelDesc→TranspDesc : ∀ {ℓ} → PosRelDesc ℓ → TranspDesc ℓ
+posRelDesc→TranspDesc : ∀ {ℓ ℓ₁} → PosRelDesc ℓ ℓ₁ → TranspDesc ℓ ℓ₁
 posRelDesc→TranspDesc (constant A) = constant (A .fst)
 posRelDesc→TranspDesc var = var
 posRelDesc→TranspDesc (d₀ , d₁) = posRelDesc→TranspDesc d₀ , posRelDesc→TranspDesc d₁
 posRelDesc→TranspDesc (maybe d) = maybe (posRelDesc→TranspDesc d)
 
-posRelDesc→RelDesc : ∀ {ℓ} → PosRelDesc ℓ → RelDesc ℓ
+posRelDesc→RelDesc : ∀ {ℓ ℓ₁} → PosRelDesc ℓ ℓ₁ → RelDesc ℓ ℓ₁ ℓ₁
 posRelDesc→RelDesc (constant A) = constant A
 posRelDesc→RelDesc var = var
 posRelDesc→RelDesc (d₀ , d₁) = posRelDesc→RelDesc d₀ , posRelDesc→RelDesc d₁
 posRelDesc→RelDesc (maybe d) = maybe (posRelDesc→RelDesc d)
 
-relDesc→Desc : ∀ {ℓ} → RelDesc ℓ → Desc ℓ
+relDesc→Desc : ∀ {ℓ ℓ₁ ℓ₁'} → RelDesc ℓ ℓ₁ ℓ₁' → Desc ℓ ℓ₁ ℓ₁'
 relDesc→Desc (constant A) = constant (A .fst)
 relDesc→Desc var = var
 relDesc→Desc (d₀ , d₁) = relDesc→Desc d₀ , relDesc→Desc d₁
@@ -69,46 +69,23 @@ relDesc→Desc (param A d) = function+ (constant A) (relDesc→Desc d)
 relDesc→Desc (function+ d₀ d₁) = function+ (posRelDesc→TranspDesc d₀) (relDesc→Desc d₁)
 relDesc→Desc (maybe d) = maybe (relDesc→Desc d)
 
-{- Universe level calculations -}
-
-posRelMacroStrLevel : ∀ {ℓ} → PosRelDesc ℓ → Level
-posRelMacroStrLevel d = transpMacroLevel (posRelDesc→TranspDesc d)
-
-relMacroStrLevel : ∀ {ℓ} → RelDesc ℓ → Level
-relMacroStrLevel d = macroStrLevel (relDesc→Desc d)
-
-posRelMacroRelLevel : ∀ {ℓ} → PosRelDesc ℓ → Level
-posRelMacroRelLevel (constant {ℓ'} A) = ℓ'
-posRelMacroRelLevel {ℓ} var = ℓ
-posRelMacroRelLevel (d₀ , d₁) = ℓ-max (posRelMacroRelLevel d₀) (posRelMacroRelLevel d₁)
-posRelMacroRelLevel (maybe d) = posRelMacroRelLevel d
-
-relMacroRelLevel : ∀ {ℓ} → RelDesc ℓ → Level
-relMacroRelLevel (constant {ℓ'} A) = ℓ'
-relMacroRelLevel {ℓ} var = ℓ
-relMacroRelLevel (d₀ , d₁) = ℓ-max (relMacroRelLevel d₀) (relMacroRelLevel d₁)
-relMacroRelLevel (param {ℓ'} A d) = ℓ-max ℓ' (relMacroRelLevel d)
-relMacroRelLevel (function+ d₀ d₁) =
-  ℓ-max (posRelMacroStrLevel d₀) (ℓ-max (posRelMacroRelLevel d₀) (relMacroRelLevel d₁))
-relMacroRelLevel (maybe d) = relMacroRelLevel d
-
 {- Definition of structure -}
 
-PosRelMacroStructure : ∀ {ℓ} (d : PosRelDesc ℓ) → Type ℓ → Type (posRelMacroStrLevel d)
+PosRelMacroStructure : ∀ {ℓ ℓ₁} (d : PosRelDesc ℓ ℓ₁) → Type ℓ → Type ℓ₁
 PosRelMacroStructure d = TranspMacroStructure (posRelDesc→TranspDesc d)
 
-RelMacroStructure : ∀ {ℓ} (d : RelDesc ℓ) → Type ℓ → Type (relMacroStrLevel d)
+RelMacroStructure : ∀ {ℓ ℓ₁ ℓ₁'} (d : RelDesc ℓ ℓ₁ ℓ₁') → Type ℓ → Type ℓ₁
 RelMacroStructure d = MacroStructure (relDesc→Desc d)
 
 {- Notion of structured relation defined by a descriptor -}
 
-PosRelMacroRelStr : ∀ {ℓ} (d : PosRelDesc ℓ) → StrRel {ℓ} (PosRelMacroStructure d) (posRelMacroRelLevel d)
+PosRelMacroRelStr : ∀ {ℓ ℓ₁} (d : PosRelDesc ℓ ℓ₁) → StrRel (PosRelMacroStructure d) ℓ₁
 PosRelMacroRelStr (constant A) = ConstantRelStr A
 PosRelMacroRelStr var = PointedRelStr
 PosRelMacroRelStr (d₀ , d₁) = ProductRelStr (PosRelMacroRelStr d₀) (PosRelMacroRelStr d₁)
 PosRelMacroRelStr (maybe d) = MaybeRelStr (PosRelMacroRelStr d)
 
-RelMacroRelStr : ∀ {ℓ} (d : RelDesc ℓ) → StrRel {ℓ} (RelMacroStructure d) (relMacroRelLevel d)
+RelMacroRelStr : ∀ {ℓ ℓ₁ ℓ₁'} (d : RelDesc ℓ ℓ₁ ℓ₁') → StrRel (RelMacroStructure d) ℓ₁'
 RelMacroRelStr (constant A) = ConstantRelStr A
 RelMacroRelStr var = PointedRelStr
 RelMacroRelStr (d₀ , d₁) = ProductRelStr (RelMacroRelStr d₀) (RelMacroRelStr d₁)
@@ -119,21 +96,21 @@ RelMacroRelStr (maybe d) = MaybeRelStr (RelMacroRelStr d)
 
 {- Proof that structure induced by descriptor is suitable or positive -}
 
-posRelMacroSuitableRel : ∀ {ℓ} (d : PosRelDesc ℓ) → SuitableStrRel _ (PosRelMacroRelStr d)
+posRelMacroSuitableRel : ∀ {ℓ ℓ₁} (d : PosRelDesc ℓ ℓ₁) → SuitableStrRel _ (PosRelMacroRelStr d)
 posRelMacroSuitableRel (constant A) = constantSuitableRel A
 posRelMacroSuitableRel var = pointedSuitableRel
 posRelMacroSuitableRel (d₀ , d₁) =
   productSuitableRel (posRelMacroSuitableRel d₀) (posRelMacroSuitableRel d₁)
 posRelMacroSuitableRel (maybe d) = maybeSuitableRel (posRelMacroSuitableRel d)
 
-posRelMacroPositiveRel : ∀ {ℓ} (d : PosRelDesc ℓ) → PositiveStrRel (posRelMacroSuitableRel d)
+posRelMacroPositiveRel : ∀ {ℓ ℓ₁} (d : PosRelDesc ℓ ℓ₁) → PositiveStrRel (posRelMacroSuitableRel d)
 posRelMacroPositiveRel (constant A) = constantPositiveRel A
 posRelMacroPositiveRel var = pointedPositiveRel
 posRelMacroPositiveRel (d₀ , d₁) =
   productPositiveRel (posRelMacroPositiveRel d₀) (posRelMacroPositiveRel d₁)
 posRelMacroPositiveRel (maybe d) = maybePositiveRel (posRelMacroPositiveRel d)
 
-relMacroSuitableRel : ∀ {ℓ} (d : RelDesc ℓ) → SuitableStrRel _ (RelMacroRelStr d)
+relMacroSuitableRel : ∀ {ℓ ℓ₁ ℓ₁'} (d : RelDesc ℓ ℓ₁ ℓ₁') → SuitableStrRel _ (RelMacroRelStr d)
 relMacroSuitableRel (constant A) = constantSuitableRel A
 relMacroSuitableRel var = pointedSuitableRel
 relMacroSuitableRel (d₀ , d₁) = productSuitableRel (relMacroSuitableRel d₀) (relMacroSuitableRel d₁)
@@ -144,7 +121,7 @@ relMacroSuitableRel (maybe d) = maybeSuitableRel (relMacroSuitableRel d)
 
 {- Proof that structured relations and equivalences agree -}
 
-posRelMacroMatchesEquiv : ∀ {ℓ} (d : PosRelDesc ℓ)
+posRelMacroMatchesEquiv : ∀ {ℓ ℓ₁} (d : PosRelDesc ℓ ℓ₁)
   → StrRelMatchesEquiv (PosRelMacroRelStr d) (EquivAction→StrEquiv (transpMacroAction (posRelDesc→TranspDesc d)))
 posRelMacroMatchesEquiv (constant A) _ _ _ = idEquiv _
 posRelMacroMatchesEquiv var _ _ _ = idEquiv _
@@ -158,7 +135,7 @@ posRelMacroMatchesEquiv (maybe d) =
     (PosRelMacroRelStr d) (transpMacroAction (posRelDesc→TranspDesc d))
     (posRelMacroMatchesEquiv d)
 
-relMacroMatchesEquiv : ∀ {ℓ} (d : RelDesc ℓ)
+relMacroMatchesEquiv : ∀ {ℓ ℓ₁ ℓ₁'} (d : RelDesc ℓ ℓ₁ ℓ₁')
   → StrRelMatchesEquiv (RelMacroRelStr d) (MacroEquivStr (relDesc→Desc d))
 relMacroMatchesEquiv (constant A) = constantRelMatchesEquiv A
 relMacroMatchesEquiv var = pointedRelMatchesEquiv
@@ -177,7 +154,7 @@ relMacroMatchesEquiv (maybe d) =
   maybeRelMatchesEquiv (RelMacroRelStr d) (relMacroMatchesEquiv d)
 
 -- Module for easy importing
-module RelMacro ℓ (d : RelDesc ℓ) where
+module RelMacro ℓ {ℓ₁ ℓ₁'} (d : RelDesc ℓ ℓ₁ ℓ₁') where
   relation = RelMacroRelStr d
   suitable = relMacroSuitableRel d
   matches = relMacroMatchesEquiv d


### PR DESCRIPTION
The `Desc` data type, which describes a grammar for building up compound structures, was parameterized only by the universe level of the induced structure's input (`ℓ` where `S : Type ℓ → Type ℓ'`). This PR adds indices for the universe level of the output and the type of structured equivalences, which were previously calculated after the fact by functions `macroStrLevel : ∀ {ℓ} → Desc ℓ → Level ` and `macroEquivLevel : ∀ {ℓ} → Desc ℓ → Level`. I believe Agda previously didn't allow inductive families indexed by `Level`, but it's possible now.