### PR TITLE
Add type signature to abstract definition

### DIFF
--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -104,8 +104,11 @@ module BinaryRelation {ℓ ℓ' : Level} {A : Type ℓ} (R : Rel A A ℓ') where
       abstract
         f : (x : A) → a ≡ x → R a x
         f x p = invEq (u a x) p
+
         t : singl a → relSinglAt a
         t (x , p) = x , f x p
+
+        q : isContr (relSinglAt a)
         q = isOfHLevelRespectEquiv 0 (t , totalEquiv _ _ f λ x → invEquiv (u a x) .snd)
                                    (isContrSingl a)
 


### PR DESCRIPTION
Add a type signature to a certain abstract definition. This probably became necessary due to https://github.com/agda/agda/commit/5a721264941f3ceeb2be61c9a142714d3f481393?