### PR TITLE
Use more copatterns in Cubical.Foundations.Pointed

### DIFF
--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -23,10 +23,13 @@ _→∙_ : ∀{ℓ ℓ'} → (A : Pointed ℓ) (B : Pointed ℓ') → Type (ℓ-
 (A , a) →∙ (B , b) = Σ[ f ∈ (A → B) ] f a ≡ b
 
 _→∙_∙ : ∀{ℓ ℓ'} → (A : Pointed ℓ) (B : Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
-A →∙ B ∙  = (A →∙ B) , (λ x → pt B) , refl
+(A →∙ B ∙) .fst = A →∙ B
+(A →∙ B ∙) .snd .fst x = pt B
+(A →∙ B ∙) .snd .snd = refl
 
 idfun∙ : ∀ {ℓ} (A : Pointed ℓ) → A →∙ A
-idfun∙ A = (λ x → x) , refl
+idfun∙ A .fst x = x
+idfun∙ A .snd = refl
 
 {- HIT allowing for pattern matching on pointed types -}
 data Pointer {ℓ} (A : Pointed ℓ) : Type ℓ where
@@ -48,7 +51,8 @@ Pointed≡Pointer : ∀ {ℓ} {A : Pointed ℓ} → typ A ≡ Pointer A
 Pointed≡Pointer = isoToPath IsoPointedPointer
 
 Pointer∙ : ∀ {ℓ} (A : Pointed ℓ) → Pointed ℓ
-Pointer∙ A = Pointer A , pt₀
+Pointer∙ A .fst = Pointer A
+Pointer∙ A .snd = pt₀
 
 Pointed≡∙Pointer : ∀ {ℓ} {A : Pointed ℓ} → A ≡ (Pointer A , pt₀)
 Pointed≡∙Pointer {A = A} i = (Pointed≡Pointer {A = A} i) , helper i
@@ -64,4 +68,5 @@ pointerFun f (id i) = (cong ⌊_⌋ (snd f) ∙ id) i
 
 pointerFun∙ : ∀ {ℓ ℓ'} {A : Pointed ℓ} {B : Pointed ℓ'} (f : A →∙ B)
              → Pointer∙ A →∙ Pointer∙ B
-pointerFun∙ f = (pointerFun f) , refl
+pointerFun∙ f .fst = pointerFun f
+pointerFun∙ f .snd = refl

--- a/Cubical/Foundations/Pointed/FunExt.agda
+++ b/Cubical/Foundations/Pointed/FunExt.agda
@@ -17,18 +17,20 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
 
   -- pointed function extensionality
   funExt∙P : {f g : Π∙ A B ptB} → f ∙∼P g → f ≡ g
-  funExt∙P (h , h∙) i = (λ x → h x i) , h∙ i
+  funExt∙P (h , h∙) i .fst x = h x i
+  funExt∙P (h , h∙) i .snd = h∙ i
 
   -- inverse of pointed function extensionality
   funExt∙P⁻ : {f g : Π∙ A B ptB} → f ≡ g → f ∙∼P g
-  funExt∙P⁻ p = (λ a i → p i .fst a) , λ i → p i .snd
+  funExt∙P⁻ p .fst a i = p i .fst a
+  funExt∙P⁻ p .snd i = p i .snd
 
   -- function extensionality is an isomorphism, PathP version
   funExt∙PIso : (f g : Π∙ A B ptB) → Iso (f ∙∼P g) (f ≡ g)
   Iso.fun (funExt∙PIso f g)  = funExt∙P {f = f} {g = g}
   Iso.inv (funExt∙PIso f g) = funExt∙P⁻ {f = f} {g = g}
-  Iso.rightInv (funExt∙PIso f g) = λ p i j → (λ a → p j .fst a) , λ k → p j .snd k
-  Iso.leftInv (funExt∙PIso f g) = λ h _ → h
+  Iso.rightInv (funExt∙PIso f g) p i j = p j
+  Iso.leftInv (funExt∙PIso f g) h _ = h
 
   -- transformed to equivalence
   funExt∙P≃ : (f g : Π∙ A B ptB) → (f ∙∼P g) ≃ (f ≡ g)

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -28,11 +28,14 @@ isHomogeneous {ℓ} (A , x) = ∀ y → Path (Pointed ℓ) (A , x) (A , y)
 
 isHomogeneousPi : ∀ {ℓ ℓ'} {A : Type ℓ} {B∙ : A → Pointed ℓ'}
                  → (∀ a → isHomogeneous (B∙ a)) → isHomogeneous (Πᵘ∙ A B∙)
-isHomogeneousPi h f i = (∀ a → typ (h a (f a) i)) , (λ a → pt (h a (f a) i))
+isHomogeneousPi h f i .fst = ∀ a → typ (h a (f a) i)
+isHomogeneousPi h f i .snd a = pt (h a (f a) i)
 
 isHomogeneousProd : ∀ {ℓ ℓ'} {A∙ : Pointed ℓ} {B∙ : Pointed ℓ'}
                    → isHomogeneous A∙ → isHomogeneous B∙ → isHomogeneous (A∙ ×∙ B∙)
-isHomogeneousProd hA hB (a , b) i = (typ (hA a i)) × (typ (hB b i)) , (pt (hA a i) , pt (hB b i))
+isHomogeneousProd hA hB (a , b) i .fst = typ (hA a i) × typ (hB b i)
+isHomogeneousProd hA hB (a , b) i .snd .fst = pt (hA a i)
+isHomogeneousProd hA hB (a , b) i .snd .snd = pt (hB b i)
 
 isHomogeneousPath : ∀ {ℓ} (A : Type ℓ) {x y : A} (p : x ≡ y) → isHomogeneous ((x ≡ y) , p)
 isHomogeneousPath A {x} {y} p q

--- a/Cubical/Foundations/Pointed/Homotopy.agda
+++ b/Cubical/Foundations/Pointed/Homotopy.agda
@@ -39,7 +39,7 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
   -- Proof that f ∙∼ g ≃ f ∙∼P g
   -- using equivalence of the total map of φ
   private
-    module _ {f g : Π∙ A B ptB} (H : f .fst ∼ g .fst) where
+    module _ (f g : Π∙ A B ptB) (H : f .fst ∼ g .fst) where
       -- convenient notation
       f₁ = fst f
       f₂ = snd f
@@ -59,6 +59,7 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
       p = H ⋆
       r = f₂
       s = g₂
+
       P≡Q : P ≡ Q
       P≡Q =
         p ≡ r ∙ s ⁻¹
@@ -85,26 +86,21 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
       φ = transport P≡Q
 
     -- The total map corresponding to φ
-    totφ : {f g : Π∙ A B ptB} → f ∙∼ g → f ∙∼P g
-    totφ {f = f} {g = g} (p₁ , p₂) .fst = p₁
-    totφ {f = f} {g = g} (p₁ , p₂) .snd = φ {f = f} {g = g} p₁ p₂
+    totφ : (f g : Π∙ A B ptB) → f ∙∼ g → f ∙∼P g
+    totφ f g p .fst = p .fst
+    totφ f g p .snd = φ f g (p .fst) (p .snd)
 
   -- transformation of the homotopies using totφ
-  ∙∼→∙∼P : {f g : Π∙ A B ptB} → (f ∙∼ g) → (f ∙∼P g)
-  ∙∼→∙∼P {f = f} {g = g} = totφ {f = f} {g = g}
+  ∙∼→∙∼P : (f g : Π∙ A B ptB) → (f ∙∼ g) → (f ∙∼P g)
+  ∙∼→∙∼P f g = totφ f g
 
   -- Proof that ∙∼ and ∙∼P are equivalent using the fiberwise equivalence φ
   ∙∼≃∙∼P : (f g : Π∙ A B ptB) → (f ∙∼ g) ≃ (f ∙∼P g)
-  ∙∼≃∙∼P f g .fst = ∙∼→∙∼P {f = f} {g = g}
-  ∙∼≃∙∼P f g .snd =
-    totalEquiv (P {f = f} {g = g})
-      (Q {f = f} {g = g})
-      (φ {f = f} {g = g})
-      λ H → isEquivTransport (P≡Q H)
+  ∙∼≃∙∼P f g = Σ-cong-equiv-snd (λ H → transportEquiv (P≡Q f g H))
 
   -- inverse of ∙∼→∙∼P extracted from the equivalence
   ∙∼P→∙∼ : {f g : Π∙ A B ptB} → f ∙∼P g → f ∙∼ g
-  ∙∼P→∙∼ {f = f} {g = g} = equivFun (invEquiv (∙∼≃∙∼P f g))
+  ∙∼P→∙∼ {f = f} {g = g} = invEq (∙∼≃∙∼P f g)
 
   -- ∙∼≃∙∼P transformed to a path
   ∙∼≡∙∼P : (f g : Π∙ A B ptB) → (f ∙∼ g) ≡ (f ∙∼P g)
@@ -112,16 +108,14 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
 
   -- Verifies that the pointed homotopies actually correspond
   -- to their Σ-type versions
-  {-
   _∙∼Σ_ : (f g : Π∙ A B ptB) → Type (ℓ-max ℓ ℓ')
-  f ∙∼Σ g = Σ[ H ∈ f .fst ∼ g .fst ] (P {f = f} {g = g} H)
+  f ∙∼Σ g = Σ[ H ∈ f .fst ∼ g .fst ] (P f g H)
 
   _∙∼PΣ_ : (f g : Π∙ A B ptB) → Type (ℓ-max ℓ ℓ')
-  f ∙∼PΣ g = Σ[ H ∈ f .fst ∼ g .fst ] (Q {f = f} {g = g} H)
+  f ∙∼PΣ g = Σ[ H ∈ f .fst ∼ g .fst ] (Q f g H)
 
   ∙∼≡∙∼Σ : (f g : Π∙ A B ptB) → f ∙∼ g ≡ f ∙∼Σ g
   ∙∼≡∙∼Σ f g = refl
 
   ∙∼P≡∙∼PΣ : (f g : Π∙ A B ptB) → f ∙∼P g ≡ f ∙∼PΣ g
   ∙∼P≡∙∼PΣ f g = refl
-  -}

--- a/Cubical/Foundations/Pointed/Homotopy.agda
+++ b/Cubical/Foundations/Pointed/Homotopy.agda
@@ -60,23 +60,24 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
       r = f₂
       s = g₂
       P≡Q : P ≡ Q
-      P≡Q = p ≡ r ∙ s ⁻¹
-              ≡⟨ isoToPath (symIso p (r ∙ s ⁻¹)) ⟩
-            r ∙ s ⁻¹ ≡ p
-              ≡⟨ cong (r ∙ s ⁻¹ ≡_) (rUnit p ∙∙ cong (p ∙_) (sym (rCancel s)) ∙∙ assoc p s (s ⁻¹)) ⟩
-            r ∙ s ⁻¹ ≡ (p ∙ s) ∙ s ⁻¹
-              ≡⟨ sym (ua (compr≡Equiv r (p ∙ s) (s ⁻¹))) ⟩
-            r ≡ p ∙ s
-              ≡⟨ ua (compl≡Equiv (p ⁻¹) r (p ∙ s)) ⟩
-            p ⁻¹ ∙ r ≡ p ⁻¹ ∙ (p ∙ s)
-              ≡⟨ cong (p ⁻¹ ∙ r ≡_ ) (assoc (p ⁻¹) p s ∙∙ (cong (_∙ s) (lCancel p)) ∙∙ sym (lUnit s)) ⟩
-            p ⁻¹ ∙ r ≡ s
-              ≡⟨ cong (λ z → p ⁻¹ ∙ z ≡ s) (rUnit r) ⟩
-            p ⁻¹ ∙ (r ∙ refl) ≡ s
-              ≡⟨ cong (_≡ s) (sym (doubleCompPath-elim' (p ⁻¹) r refl)) ⟩
-            p ⁻¹ ∙∙ r ∙∙ refl ≡ s
-              ≡⟨ sym (ua (Square≃doubleComp r s p refl)) ⟩
-            PathP (λ i → p i ≡ ptB) r s ∎
+      P≡Q =
+        p ≡ r ∙ s ⁻¹
+          ≡⟨ isoToPath (symIso p (r ∙ s ⁻¹)) ⟩
+        r ∙ s ⁻¹ ≡ p
+          ≡⟨ cong (r ∙ s ⁻¹ ≡_) (rUnit p ∙∙ cong (p ∙_) (sym (rCancel s)) ∙∙ assoc p s (s ⁻¹)) ⟩
+        r ∙ s ⁻¹ ≡ (p ∙ s) ∙ s ⁻¹
+          ≡⟨ sym (ua (compr≡Equiv r (p ∙ s) (s ⁻¹))) ⟩
+        r ≡ p ∙ s
+          ≡⟨ ua (compl≡Equiv (p ⁻¹) r (p ∙ s)) ⟩
+        p ⁻¹ ∙ r ≡ p ⁻¹ ∙ (p ∙ s)
+          ≡⟨ cong (p ⁻¹ ∙ r ≡_ ) (assoc (p ⁻¹) p s ∙∙ (cong (_∙ s) (lCancel p)) ∙∙ sym (lUnit s)) ⟩
+        p ⁻¹ ∙ r ≡ s
+          ≡⟨ cong (λ z → p ⁻¹ ∙ z ≡ s) (rUnit r) ⟩
+        p ⁻¹ ∙ (r ∙ refl) ≡ s
+          ≡⟨ cong (_≡ s) (sym (doubleCompPath-elim' (p ⁻¹) r refl)) ⟩
+        p ⁻¹ ∙∙ r ∙∙ refl ≡ s
+          ≡⟨ sym (ua (Square≃doubleComp r s p refl)) ⟩
+        PathP (λ i → p i ≡ ptB) r s ∎
 
       -- φ is a fiberwise transformation (H : f ∼ g) → P H → Q H
       -- φ is even a fiberwise equivalence by P≡Q
@@ -85,7 +86,8 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
 
     -- The total map corresponding to φ
     totφ : {f g : Π∙ A B ptB} → f ∙∼ g → f ∙∼P g
-    totφ {f = f} {g = g} (p₁ , p₂) = p₁ , φ {f = f} {g = g} p₁ p₂
+    totφ {f = f} {g = g} (p₁ , p₂) .fst = p₁
+    totφ {f = f} {g = g} (p₁ , p₂) .snd = φ {f = f} {g = g} p₁ p₂
 
   -- transformation of the homotopies using totφ
   ∙∼→∙∼P : {f g : Π∙ A B ptB} → (f ∙∼ g) → (f ∙∼P g)
@@ -93,10 +95,12 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
 
   -- Proof that ∙∼ and ∙∼P are equivalent using the fiberwise equivalence φ
   ∙∼≃∙∼P : (f g : Π∙ A B ptB) → (f ∙∼ g) ≃ (f ∙∼P g)
-  ∙∼≃∙∼P f g = ∙∼→∙∼P {f = f} {g = g} , totalEquiv (P {f = f} {g = g})
-                                                    (Q {f = f} {g = g})
-                                                    (φ {f = f} {g = g})
-                                                    λ H → isEquivTransport (P≡Q H)
+  ∙∼≃∙∼P f g .fst = ∙∼→∙∼P {f = f} {g = g}
+  ∙∼≃∙∼P f g .snd =
+    totalEquiv (P {f = f} {g = g})
+      (Q {f = f} {g = g})
+      (φ {f = f} {g = g})
+      λ H → isEquivTransport (P≡Q H)
 
   -- inverse of ∙∼→∙∼P extracted from the equivalence
   ∙∼P→∙∼ : {f g : Π∙ A B ptB} → f ∙∼P g → f ∙∼ g

--- a/Cubical/Foundations/Pointed/Homotopy.agda
+++ b/Cubical/Foundations/Pointed/Homotopy.agda
@@ -59,26 +59,24 @@ module _ {A : Pointed ℓ} {B : typ A → Type ℓ'} {ptB : B (pt A)} where
       p = H ⋆
       r = f₂
       s = g₂
-
       P≡Q : P ≡ Q
-      P≡Q =
-        p ≡ r ∙ s ⁻¹
-          ≡⟨ isoToPath (symIso p (r ∙ s ⁻¹)) ⟩
-        r ∙ s ⁻¹ ≡ p
-          ≡⟨ cong (r ∙ s ⁻¹ ≡_) (rUnit p ∙∙ cong (p ∙_) (sym (rCancel s)) ∙∙ assoc p s (s ⁻¹)) ⟩
-        r ∙ s ⁻¹ ≡ (p ∙ s) ∙ s ⁻¹
-          ≡⟨ sym (ua (compr≡Equiv r (p ∙ s) (s ⁻¹))) ⟩
-        r ≡ p ∙ s
-          ≡⟨ ua (compl≡Equiv (p ⁻¹) r (p ∙ s)) ⟩
-        p ⁻¹ ∙ r ≡ p ⁻¹ ∙ (p ∙ s)
-          ≡⟨ cong (p ⁻¹ ∙ r ≡_ ) (assoc (p ⁻¹) p s ∙∙ (cong (_∙ s) (lCancel p)) ∙∙ sym (lUnit s)) ⟩
-        p ⁻¹ ∙ r ≡ s
-          ≡⟨ cong (λ z → p ⁻¹ ∙ z ≡ s) (rUnit r) ⟩
-        p ⁻¹ ∙ (r ∙ refl) ≡ s
-          ≡⟨ cong (_≡ s) (sym (doubleCompPath-elim' (p ⁻¹) r refl)) ⟩
-        p ⁻¹ ∙∙ r ∙∙ refl ≡ s
-          ≡⟨ sym (ua (Square≃doubleComp r s p refl)) ⟩
-        PathP (λ i → p i ≡ ptB) r s ∎
+      P≡Q = p ≡ r ∙ s ⁻¹
+              ≡⟨ isoToPath (symIso p (r ∙ s ⁻¹)) ⟩
+            r ∙ s ⁻¹ ≡ p
+              ≡⟨ cong (r ∙ s ⁻¹ ≡_) (rUnit p ∙∙ cong (p ∙_) (sym (rCancel s)) ∙∙ assoc p s (s ⁻¹)) ⟩
+            r ∙ s ⁻¹ ≡ (p ∙ s) ∙ s ⁻¹
+              ≡⟨ sym (ua (compr≡Equiv r (p ∙ s) (s ⁻¹))) ⟩
+            r ≡ p ∙ s
+              ≡⟨ ua (compl≡Equiv (p ⁻¹) r (p ∙ s)) ⟩
+            p ⁻¹ ∙ r ≡ p ⁻¹ ∙ (p ∙ s)
+              ≡⟨ cong (p ⁻¹ ∙ r ≡_ ) (assoc (p ⁻¹) p s ∙∙ (cong (_∙ s) (lCancel p)) ∙∙ sym (lUnit s)) ⟩
+            p ⁻¹ ∙ r ≡ s
+              ≡⟨ cong (λ z → p ⁻¹ ∙ z ≡ s) (rUnit r) ⟩
+            p ⁻¹ ∙ (r ∙ refl) ≡ s
+              ≡⟨ cong (_≡ s) (sym (doubleCompPath-elim' (p ⁻¹) r refl)) ⟩
+            p ⁻¹ ∙∙ r ∙∙ refl ≡ s
+              ≡⟨ sym (ua (Square≃doubleComp r s p refl)) ⟩
+            PathP (λ i → p i ≡ ptB) r s ∎
 
       -- φ is a fiberwise transformation (H : f ∼ g) → P H → Q H
       -- φ is even a fiberwise equivalence by P≡Q

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -56,16 +56,16 @@ id∙ A .snd = refl
 
 -- constant pointed map
 const∙ : (A : Pointed ℓA) (B : Pointed ℓB) → (A →∙ B)
-const∙ _ (_ , b) .fst _ = b
-const∙ _ (_ , b) .snd = refl
+const∙ _ B .fst _ = B .snd
+const∙ _ B .snd = refl
 
 -- left identity law for pointed maps
 ∘∙-idˡ : {A : Pointed ℓA} {B : Pointed ℓB} (f : A →∙ B) → f ∘∙ id∙ A ≡ f
-∘∙-idˡ (_ , f∙) = ΣPathP ( refl , (lUnit f∙) ⁻¹ )
+∘∙-idˡ f = ΣPathP ( refl , (lUnit (f .snd)) ⁻¹ )
 
 -- right identity law for pointed maps
 ∘∙-idʳ : {A : Pointed ℓA} {B : Pointed ℓB} (f : A →∙ B) → id∙ B ∘∙ f ≡ f
-∘∙-idʳ (_ , f∙) = ΣPathP ( refl , (rUnit f∙) ⁻¹ )
+∘∙-idʳ f = ΣPathP ( refl , (rUnit (f .snd)) ⁻¹ )
 
 -- associativity for composition of pointed maps
 ∘∙-assoc : {A : Pointed ℓA} {B : Pointed ℓB} {C : Pointed ℓC} {D : Pointed ℓD}

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -19,35 +19,45 @@ private
 
 -- the unpointed Π-type becomes a pointed type if the fibers are all pointed
 Πᵘ∙ : (A : Type ℓ) (B : A → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
-Πᵘ∙ A B = (∀ a → typ (B a)) , (λ a → pt (B a))
+Πᵘ∙ A B .fst = ∀ a → typ (B a)
+Πᵘ∙ A B .snd a = pt (B a)
 
 -- if the base and all fibers are pointed, we have the pointed pointed Π-type
 Πᵖ∙ : (A : Pointed ℓ) (B : typ A → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
-Πᵖ∙ A B = Π∙ A (typ ∘ B) (pt (B (pt A))), ((λ a → pt (B a)) , refl)
+Πᵖ∙ A B .fst = Π∙ A (typ ∘ B) (pt (B (pt A)))
+Πᵖ∙ A B  .snd .fst a = pt (B a)
+Πᵖ∙ A B  .snd .snd = refl
 
 -- the default pointed Σ-type is just the Σ-type, but as a pointed type
 Σ∙ : (A : Pointed ℓ) (B : typ A → Type ℓ') (ptB : B (pt A)) → Pointed (ℓ-max ℓ ℓ')
-Σ∙ A B ptB = (Σ[ a ∈ typ A ] B a) , (pt A , ptB)
+Σ∙ A B ptB .fst = Σ[ a ∈ typ A ] B a
+Σ∙ A B ptB .snd .fst = pt A
+Σ∙ A B ptB .snd .snd = ptB
 
 -- version if B is a family of pointed types
 Σᵖ∙ : (A : Pointed ℓ) (B : typ A → Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
 Σᵖ∙ A B = Σ∙ A (typ ∘ B) (pt (B (pt A)))
 
 _×∙_ : (A∙ : Pointed ℓ) (B∙ : Pointed ℓ') → Pointed (ℓ-max ℓ ℓ')
-A∙ ×∙ B∙ = ((typ A∙) × (typ B∙)) , (pt A∙ , pt B∙)
+(A∙ ×∙ B∙) .fst = (typ A∙) × (typ B∙)
+(A∙ ×∙ B∙) .snd .fst = pt A∙
+(A∙ ×∙ B∙) .snd .snd = pt B∙
 
 -- composition of pointed maps
 _∘∙_ : {A : Pointed ℓA} {B : Pointed ℓB} {C : Pointed ℓC}
        (g : B →∙ C) (f : A →∙ B) → (A →∙ C)
-(g , g∙) ∘∙ (f , f∙) = (λ x → g (f  x)) , ((cong g f∙) ∙ g∙)
+((g , g∙) ∘∙ (f , f∙)) .fst x = g (f  x)
+((g , g∙) ∘∙ (f , f∙)) .snd = (cong g f∙) ∙ g∙
 
 -- pointed identity
 id∙ : (A : Pointed ℓA) → (A →∙ A)
-id∙ A = ((λ x → x) , refl)
+id∙ A .fst x = x
+id∙ A .snd = refl
 
 -- constant pointed map
 const∙ : (A : Pointed ℓA) (B : Pointed ℓB) → (A →∙ B)
-const∙ _ (_ , b) = (λ _ → b) , refl
+const∙ _ (_ , b) .fst _ = b
+const∙ _ (_ , b) .snd = refl
 
 -- left identity law for pointed maps
 ∘∙-idˡ : {A : Pointed ℓA} {B : Pointed ℓB} (f : A →∙ B) → f ∘∙ id∙ A ≡ f
@@ -71,20 +81,3 @@ const∙ _ (_ , b) = (λ _ → b) , refl
         (cong h (cong g f∙) ∙ cong h g∙) ∙ h∙
         ≡⟨ cong (λ p → p ∙ h∙) ((cong-∙ h (cong g f∙) g∙) ⁻¹) ⟩
         (cong h (cong g f∙ ∙ g∙) ∙ h∙) ∎ )
-
-
--- →∙ is a special case of Π∙,
--- but they're not exactly judgementally equal
-module _ {A : Pointed ℓ} {B : Pointed ℓ'} where
-
-  B₁ = fst B
-  B₂ = snd B
-
-  →∙→Π∙ : (f : A →∙ B) → Π∙ A (λ _ → B₁) B₂
-  →∙→Π∙ f = f
-
-  Π∙→→∙ : (f : Π∙ A (λ _ → B₁) B₂) → A →∙ B
-  Π∙→→∙ f = f
-
-  →Π∙Iso : Iso (A →∙ B) (Π∙ A (λ _ → B₁) B₂)
-  →Π∙Iso = iso (λ f → f) (λ f → f) (λ _ → refl) λ _ → refl


### PR DESCRIPTION
Also cleaned up some miscellaneous stuff in `Cubical.Foundations.Pointed.Homotopy`.