### PR TITLE
Functions from set truncations

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -418,6 +418,10 @@ isSetΠ2 : (h : (x : A) (y : B x) → isSet (C x y))
         → isSet ((x : A) (y : B x) → C x y)
 isSetΠ2 h = isSetΠ λ x → isSetΠ λ y → h x y
 
+isSetΠ3 : (h : (x : A) (y : B x) (z : C x y) → isSet (D x y z))
+         → isSet ((x : A) (y : B x) (z : C x y) → D x y z)
+isSetΠ3 h = isSetΠ λ x → isSetΠ λ y → isSetΠ λ z → h x y z
+
 isGroupoidΠ : ((x : A) → isGroupoid (B x)) → isGroupoid ((x : A) → B x)
 isGroupoidΠ = isOfHLevelΠ 3
 

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -11,6 +11,7 @@ module Cubical.HITs.SetTruncation.Properties where
 open import Cubical.HITs.SetTruncation.Base
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
@@ -144,10 +145,10 @@ module rec→Gpd {A : Type ℓ} {B : Type ℓ'} (Bgpd : isGroupoid B) (f : A →
  -- ∥ A ∥₂ → H → B
  -- we first define the rhs function
  f₁ : H → B
- f₁ = Hrec.fun Bgpd f εf λ _ _ _ → refl
+ f₁ = Hrec.fun Bgpd f εᶠ λ _ _ _ → refl
   where
-  εf : (a b : A) → ∥ a ≡ b ∥ → f a ≡ f b
-  εf a b = rec→Set (Bgpd _ _) (cong f) λ p q → congFConst a b p q
+  εᶠ : (a b : A) → ∥ a ≡ b ∥ → f a ≡ f b
+  εᶠ a b = rec→Set (Bgpd _ _) (cong f) λ p q → congFConst a b p q
   -- this is the inductive step,
   -- we use that maps ∥ A ∥ → B for an hset B
   -- correspond to 2-Constant maps A → B
@@ -155,14 +156,19 @@ module rec→Gpd {A : Type ℓ} {B : Type ℓ'} (Bgpd : isGroupoid B) (f : A →
  -- Now we need to prove that H is a set.
  -- From that we immediately get the desired result...
  -- upstream lemma?:
- localHedbergLemma : {C : Type ℓ''} (P : C → Type ℓ'')
+ localHedbergLemma : {X : Type ℓ''} (P : X → Type ℓ'')
                    → (∀ x → isProp (P x))
-                   → ((x y : C) → P x → P y → x ≡ y)
+                   → ((x y : X) → P x → P y → x ≡ y)
                   --------------------------------------------------
-                   → (x : C) → P x → (y : C) → isProp (x ≡ y)
- localHedbergLemma {C = C} P Pprop P→≡ x px y = isPropRetract (λ p → subst P p px)
-                                                              ((P→≡ x x px px ∙_) ∘ (P→≡ x y px))
-                   (λ p → {!!}) (Pprop y) -- implies P→≡ x x px px ≡ refl
+                   → (x : X) → P x → (y : X) → isProp (x ≡ y)
+ localHedbergLemma {X = X} P Pprop P→≡ x px y = isPropRetract
+                   (λ p → subst P p px) (λ py → sym (P→≡ x x px px) ∙ P→≡ x y px py)
+                   isRetract (Pprop y)
+  where
+  isRetract : (p : x ≡ y) → (sym (P→≡ x x px px)) ∙ P→≡ x y px (subst P p px) ≡ p
+  isRetract p = J (λ y' p' → (sym (P→≡ x x px px)) ∙ P→≡ x y' px (subst P p' px) ≡ p')
+                  (subst (λ px' → sym (P→≡ x x px px) ∙ P→≡ x x px px' ≡ refl)
+                  (sym (substRefl {B = P} px)) (lCancel (P→≡ x x px px))) p
 
  Hset : isSet H
  Hset = HelimProp.fun (λ _ → isPropΠ λ _ → isPropIsProp) baseCaseLeft


### PR DESCRIPTION
We prove a special case of the main result of the paper *Functions out of Higher Truncations*
by Capriotti, Kraus and Vezzosi:
https://arxiv.org/abs/1507.01150

Following their "HIT proof", we show that for a type A and a groupoid B a function `f : A -> B`
induces a function from the set-truncation of A to B (i.e. a function `∥ A ∥₂ → B`) if we have
```
∀ (a b : A) (p q : a ≡ b) → cong f p ≡ cong f q
```
This will then be used to obtain the corresponding result for maps out of set-quotients into groupoids.