### PR TITLE
Optimizing mostly hlevel

### DIFF
--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -247,8 +247,9 @@ leftInv (Σ-cong-iso-snd isom) (x , y') = ΣPathP (refl , leftInv (isom x) y')
 ΣPathTransport {B = B} a b = Σ[ p ∈ (fst a ≡ fst b) ] transport (λ i → B (p i)) (snd a) ≡ snd b
 
 IsoΣPathTransportPathΣ : (a b : Σ A B) → Iso (ΣPathTransport a b) (a ≡ b)
-IsoΣPathTransportPathΣ {B = B} a b = compIso (Σ-cong-iso-snd (λ p → invIso (equivToIso (PathP≃Path (λ i → B (p i)) _ _))))
-         ΣPathIsoPathΣ
+IsoΣPathTransportPathΣ {B = B} a b =
+  compIso (Σ-cong-iso-snd (λ p → invIso (PathPIsoPath (λ i → B (p i)) _ _)))
+          ΣPathIsoPathΣ
 
 ΣPathTransport≃PathΣ : (a b : Σ A B) → ΣPathTransport a b ≃ (a ≡ b)
 ΣPathTransport≃PathΣ {B = B} a b = isoToEquiv (IsoΣPathTransportPathΣ a b)

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -72,16 +72,20 @@ isOfHLevelPlus : (m : HLevel) → isOfHLevel n A → isOfHLevel (m + n) A
 isOfHLevelPlus zero hA = hA
 isOfHLevelPlus (suc m) hA = isOfHLevelSuc _ (isOfHLevelPlus m hA)
 
-isOfHLevelPlus' : (m : HLevel) → isOfHLevel m A → isOfHLevel (m + n) A
-isOfHLevelPlus' {A = A} {n = n} m hA = subst (λ m → isOfHLevel m A) (+-comm n m) (isOfHLevelPlus n hA )
-
 isContr→isOfHLevel : (n : HLevel) → isContr A → isOfHLevel n A
-isContr→isOfHLevel {A = A} n cA = isOfHLevelPlus' 0 cA
+isContr→isOfHLevel zero cA = cA
+isContr→isOfHLevel (suc n) cA = isOfHLevelSuc _ (isContr→isOfHLevel n cA)
 
 isProp→isOfHLevelSuc : (n : HLevel) → isProp A → isOfHLevel (suc n) A
-isProp→isOfHLevelSuc {A = A} n pA = isOfHLevelPlus' 1 pA
+isProp→isOfHLevelSuc zero pA = pA
+isProp→isOfHLevelSuc (suc n) pA = isOfHLevelSuc _ (isProp→isOfHLevelSuc n pA)
 
--- hlevel of path and dependent path types
+isOfHLevelPlus' : (m : HLevel) → isOfHLevel m A → isOfHLevel (m + n) A
+isOfHLevelPlus' {n = n} 0 = isContr→isOfHLevel n
+isOfHLevelPlus' {n = n} 1 = isProp→isOfHLevelSuc n
+isOfHLevelPlus' {n = n} (suc (suc m)) hA a₀ a₁ = isOfHLevelPlus' (suc m) (hA a₀ a₁)
+
+-- hlevel of path types
 
 isProp→isContrPath : isProp A → (x y : A) → isContr (x ≡ y)
 isProp→isContrPath h x y = h x y , isProp→isSet h x y _
@@ -100,18 +104,6 @@ isOfHLevelPath'⁻ (suc n) h = h
 isOfHLevelPath : (n : HLevel) → isOfHLevel n A → (x y : A) → isOfHLevel n (x ≡ y)
 isOfHLevelPath 0 h x y = isContr→isContrPath h x y
 isOfHLevelPath (suc n) h x y = isOfHLevelSuc n (isOfHLevelPath' n h x y)
-
-isOfHLevelPathP' : {A : I → Type ℓ} (n : HLevel)
-                   → isOfHLevel (suc n) (A i1)
-                   → (x : A i0) (y : A i1) → isOfHLevel n (PathP A x y)
-isOfHLevelPathP' {A = A} n h x y = transport⁻ (λ i → isOfHLevel n (PathP≡Path A x y i))
-                                              (isOfHLevelPath' n h _ _)
-
-isOfHLevelPathP : {A : I → Type ℓ} (n : HLevel)
-                  → isOfHLevel n (A i1)
-                  → (x : A i0) (y : A i1) → isOfHLevel n (PathP A x y)
-isOfHLevelPathP {A = A} n h x y = transport⁻ (λ i → isOfHLevel n (PathP≡Path A x y i))
-                                             (isOfHLevelPath n h _ _)
 
 -- h-level of isOfHLevel
 
@@ -132,45 +124,6 @@ isPropIs2Groupoid = isPropIsOfHLevel 4
 
 TypeOfHLevel≡ : (n : HLevel) {X Y : TypeOfHLevel ℓ n} → ⟨ X ⟩ ≡ ⟨ Y ⟩ → X ≡ Y
 TypeOfHLevel≡ n = Σ≡Prop (λ _ → isPropIsOfHLevel n)
-
-
--- Fillers for cubes from h-level
-
-isSet→isSet' : isSet A → isSet' A
-isSet→isSet' {A = A} Aset a₀₋ a₁₋ a₋₀ a₋₁ =
-  transport⁻ (PathP≡Path (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋) (Aset _ _ _ _)
-
-isSet'→isSet : isSet' A → isSet A
-isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
-
-isSet→SquareP :
-  {A : I → I → Type ℓ}
-  (isSet : (i j : I) → isSet (A i j))
-  {a₀₀ : A i0 i0} {a₀₁ : A i0 i1} (a₀₋ : PathP (λ j → A i0 j) a₀₀ a₀₁)
-  {a₁₀ : A i1 i0} {a₁₁ : A i1 i1} (a₁₋ : PathP (λ j → A i1 j) a₁₀ a₁₁)
-  (a₋₀ : PathP (λ i → A i i0) a₀₀ a₁₀) (a₋₁ : PathP (λ i → A i i1) a₀₁ a₁₁)
-  → SquareP A a₀₋ a₁₋ a₋₀ a₋₁
-isSet→SquareP isset a₀₋ a₁₋ a₋₀ a₋₁ =
-  transport (sym (PathP≡Path _ _ _))
-            (isOfHLevelPathP' 1 (isset _ _) _ _ _ _ )
-
-isGroupoid→isGroupoid' : isGroupoid A → isGroupoid' A
-isGroupoid→isGroupoid' {A = A} Agpd a₀₋₋ a₁₋₋ a₋₀₋ a₋₁₋ a₋₋₀ a₋₋₁ =
-  transport⁻ (PathP≡Path (λ i → Square (a₋₀₋ i) (a₋₁₋ i) (a₋₋₀ i) (a₋₋₁ i)) a₀₋₋ a₁₋₋)
-    (isGroupoid→isPropSquare _ _ _ _ _ _)
-  where
-  isGroupoid→isPropSquare :
-    {a₀₀ a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁)
-    {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)
-    (a₋₀ : a₀₀ ≡ a₁₀) (a₋₁ : a₀₁ ≡ a₁₁)
-    → isProp (Square a₀₋ a₁₋ a₋₀ a₋₁)
-  isGroupoid→isPropSquare a₀₋ a₁₋ a₋₀ a₋₁ =
-    transport⁻
-      (cong isProp (PathP≡Path (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋))
-      (Agpd _ _ _ _)
-
-isGroupoid'→isGroupoid : isGroupoid' A → isGroupoid A
-isGroupoid'→isGroupoid Agpd' x y p q r s = Agpd' r s refl refl refl refl
 
 -- hlevels are preserved by retracts (and consequently equivalences)
 
@@ -290,6 +243,54 @@ isContrRetractOfConstFun : {A : Type ℓ} {B : Type ℓ'} (b₀ : B)
 fst (isContrRetractOfConstFun b₀ ret) = ret .fst b₀
 snd (isContrRetractOfConstFun b₀ ret) y = ret .snd y
 
+-- h-level of dependent path types
+
+isOfHLevelPathP' : {A : I → Type ℓ} (n : HLevel)
+                   → isOfHLevel (suc n) (A i1)
+                   → (x : A i0) (y : A i1) → isOfHLevel n (PathP A x y)
+isOfHLevelPathP' {A = A} n h x y =
+  isOfHLevelRetractFromIso n (PathPIsoPath _ x y) (isOfHLevelPath' n h _ _)
+
+isOfHLevelPathP : {A : I → Type ℓ} (n : HLevel)
+                  → isOfHLevel n (A i1)
+                  → (x : A i0) (y : A i1) → isOfHLevel n (PathP A x y)
+isOfHLevelPathP {A = A} n h x y =
+  isOfHLevelRetractFromIso n (PathPIsoPath _ x y) (isOfHLevelPath n h _ _)
+
+-- Fillers for cubes from h-level
+
+isSet→isSet' : isSet A → isSet' A
+isSet→isSet' {A = A} Aset a₀₋ a₁₋ a₋₀ a₋₁ =
+  transport⁻ (PathP≡Path (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋) (Aset _ _ _ _)
+
+isSet'→isSet : isSet' A → isSet A
+isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl
+
+isSet→SquareP :
+  {A : I → I → Type ℓ}
+  (isSet : (i j : I) → isSet (A i j))
+  {a₀₀ : A i0 i0} {a₀₁ : A i0 i1} (a₀₋ : PathP (λ j → A i0 j) a₀₀ a₀₁)
+  {a₁₀ : A i1 i0} {a₁₁ : A i1 i1} (a₁₋ : PathP (λ j → A i1 j) a₁₀ a₁₁)
+  (a₋₀ : PathP (λ i → A i i0) a₀₀ a₁₀) (a₋₁ : PathP (λ i → A i i1) a₀₁ a₁₁)
+  → SquareP A a₀₋ a₁₋ a₋₀ a₋₁
+isSet→SquareP isset a₀₋ a₁₋ a₋₀ a₋₁ =
+  PathPIsoPath _ _ _ .Iso.inv (isOfHLevelPathP' 1 (isset _ _) _ _ _ _ )
+
+isGroupoid→isGroupoid' : isGroupoid A → isGroupoid' A
+isGroupoid→isGroupoid' {A = A} Agpd a₀₋₋ a₁₋₋ a₋₀₋ a₋₁₋ a₋₋₀ a₋₋₁ =
+  PathPIsoPath (λ i → Square (a₋₀₋ i) (a₋₁₋ i) (a₋₋₀ i) (a₋₋₁ i)) a₀₋₋ a₁₋₋ .Iso.inv
+    (isGroupoid→isPropSquare _ _ _ _ _ _)
+  where
+  isGroupoid→isPropSquare :
+    {a₀₀ a₀₁ : A} (a₀₋ : a₀₀ ≡ a₀₁)
+    {a₁₀ a₁₁ : A} (a₁₋ : a₁₀ ≡ a₁₁)
+    (a₋₀ : a₀₀ ≡ a₁₀) (a₋₁ : a₀₁ ≡ a₁₁)
+    → isProp (Square a₀₋ a₁₋ a₋₀ a₋₁)
+  isGroupoid→isPropSquare a₀₋ a₁₋ a₋₀ a₋₁ =
+    isOfHLevelRetractFromIso 1 (PathPIsoPath (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋) (Agpd _ _ _ _)
+
+isGroupoid'→isGroupoid : isGroupoid' A → isGroupoid A
+isGroupoid'→isGroupoid Agpd' x y p q r s = Agpd' r s refl refl refl refl
 -- h-level of Σ-types
 
 isContrΣ : isContr A → ((x : A) → isContr (B x)) → isContr (Σ A B)
@@ -444,7 +445,7 @@ isOfHLevelΠ⁻ : ∀ {A : Type ℓ} {B : Type ℓ'} n
 isOfHLevelΠ⁻ 0 h x = fst h x , λ y → funExt⁻ (snd h (const y)) x
 isOfHLevelΠ⁻ 1 h x y z = funExt⁻ (h (const y) (const z)) x
 isOfHLevelΠ⁻ (suc (suc n)) h x y z =
-  isOfHLevelΠ⁻ (suc n) (subst (isOfHLevel (suc n)) (sym funExtPath) (h (const y) (const z))) x
+  isOfHLevelΠ⁻ (suc n) (isOfHLevelRetractFromIso (suc n) funExtIso (h _ _)) x
 
 -- h-level of A ≃ B and A ≡ B
 
@@ -458,7 +459,7 @@ isOfHLevel≃ zero {A = A} {B = B} hA hB = isContr→Equiv hA hB , contr
 
 isOfHLevel≃ (suc n) {A = A} {B = B} hA hB =
   isOfHLevelΣ (suc n) (isOfHLevelΠ _ λ _ → hB)
-              λ a → isOfHLevelPlus' 1 (isPropIsEquiv a)
+              (λ f → isProp→isOfHLevelSuc n (isPropIsEquiv f))
 
 isOfHLevel≡ : ∀ n → {A B : Type ℓ} (hA : isOfHLevel n A) (hB : isOfHLevel n B) →
   isOfHLevel n (A ≡ B)

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -260,8 +260,7 @@ isOfHLevelPathP {A = A} n h x y =
 -- Fillers for cubes from h-level
 
 isSet→isSet' : isSet A → isSet' A
-isSet→isSet' {A = A} Aset a₀₋ a₁₋ a₋₀ a₋₁ =
-  transport⁻ (PathP≡Path (λ i → a₋₀ i ≡ a₋₁ i) a₀₋ a₁₋) (Aset _ _ _ _)
+isSet→isSet' Aset _ _ _ _ = toPathP (Aset _ _ _ _)
 
 isSet'→isSet : isSet' A → isSet A
 isSet'→isSet {A = A} Aset' x y p q = Aset' p q refl refl

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -29,59 +29,57 @@ PathP≡Path⁻ : ∀ (P : I → Type ℓ) (p : P i0) (q : P i1) →
              PathP P p q ≡ Path (P i0) p (transport⁻ (λ i → P i) q)
 PathP≡Path⁻ P p q i = PathP (λ j → P (~ i ∧ j)) p (transport⁻-filler (λ j → P j) q i)
 
-PathP≃Path : ∀ (P : I → Type ℓ) (p : P i0) (q : P i1) →
-             PathP P p q ≃ Path (P i1) (transport (λ i → P i) p) q
-PathP≃Path P p q = transportEquiv (PathP≡Path P p q)
+PathPIsoPath : ∀ (A : I → Type ℓ) (x : A i0) (y : A i1) → Iso (PathP A x y) (transport (λ i → A i) x ≡ y)
+PathPIsoPath A x y .Iso.fun = fromPathP
+PathPIsoPath A x y .Iso.inv = toPathP
+PathPIsoPath A x y .Iso.rightInv q k i =
+  hcomp
+    (λ j → λ
+      { (i = i0) → slide (j ∨ ~ k)
+      ; (i = i1) → q j
+      ; (k = i0) → transp (λ l → A (i ∨ l)) i (fromPathPFiller j)
+      ; (k = i1) → ∧∨Square i j
+      })
+    (transp (λ l → A (i ∨ ~ k ∨ l)) (i ∨ ~ k)
+      (transp (λ l → (A (i ∨ (~ k ∧ l)))) (k ∨ i)
+        (transp (λ l → A (i ∧ l)) (~ i)
+          x)))
+  where
+  fromPathPFiller : _
+  fromPathPFiller =
+    hfill
+      (λ j → λ
+        { (i = i0) → x
+        ; (i = i1) → q j })
+      (inS (transp (λ j → A (i ∧ j)) (~ i) x))
 
--- Alternative more unfolded proof
-toPathP-isEquiv : ∀ (A : I → Type ℓ) {x y} → isEquiv (toPathP {A = A} {x} {y})
-toPathP-isEquiv A {x} {y} = isoToIsEquiv (iso toPathP fromPathP to-from from-to)
- where
-   to-from : ∀ (p : PathP A x y) → toPathP (fromPathP p) ≡ p
-   to-from p h i = outS (hcomp-unique (λ { j (i = i0) → x ; j (i = i1) → fromPathP p j })
-                                  (inS (transp (λ j → A (i ∧ j)) (~ i) x))
-                                  \ h → inS (sq1 h i))
-                        h
-      where
-        sq1 : (\ h → A [ x ≡ transp (\ j → A (h ∨ j)) h (p h) ]) [ (\ i → transp (λ j → A (i ∧ j)) (~ i) x) ≡ p ]
-        sq1 = \ h i → comp (\ z → (hcomp (\ w →
-                                                    \ { (z = i1) → A (i ∧ (w ∨ h))
-                                                      ; (z = i0) → A (i ∧ h)
-                                                      ; (i = i0) → A i0
-                                                      ; (i = i1) → A (h ∨ (w ∧ z))
-                                                      ; (h = i0) → A (i ∧ (w ∧ z))
-                                                      ; (h = i1) → A i})
-                                                   ((A (i ∧ h)))))
-                                          (\ z → \ { (i = i0) → x
-                                                   ; (i = i1) → transp (\ j → A (h ∨ (z ∧ j))) (h ∨ ~ z) (p h)
-                                                   ; (h = i0) → transp (λ j → A ((i ∧ z) ∧ j)) (~ (i ∧ z)) x
-                                                   ; (h = i1) → p i })
-                                (p (i ∧ h))
-   from-to : ∀ (q : transp (\ i → A i) i0 x ≡ y) → fromPathP (toPathP {A = A} q) ≡ q
-   from-to q = (\ h i → outS (transp-hcomp i {A' = A i1} (\ j → inS (A (i ∨ j)))
-                                           ((λ { j (i = i0) → x ; j (i = i1) → q j }))
-                                           (inS ((transp (λ j → A (i ∧ j)) (~ i) x))))
-                             h)
-             ∙ (\ h i → outS (hcomp-unique {A = A i1} ((λ { j (i = i0) → transp (\ i → A i) i0 x ; j (i = i1) → q j }))
-                                      (inS ((transp (λ j → A (i ∨ j)) i (transp (λ j → A (i ∧ j)) (~ i) x))))
-                                      \ h → inS (sq2 h i))
-                             h)
-             ∙ sym (lUnit q)
-     where
-       sq2 : (\ h → transp (\ i → A i) i0 x ≡ q h) [ (\ i → transp (\ j → A (i ∨ j)) i (transp (\ j → A (i ∧ j)) (~ i) x)) ≡ refl ∙ q ]
-       sq2 = \ h i → comp (\ z → hcomp (\ w → \ { (i = i1) → A i1
-                                              ; (i = i0) → A (h ∨ (w ∧ z))
-                                              ; (h = i0) → A (i ∨ (w ∧ z))
-                                              ; (h = i1) → A i1
-                                              ; (z = i0) → A (i ∨ h)
-                                              ; (z = i1) → A ((i ∨ h) ∨ w) })
-                                             (A (i ∨ h)))
-                 (\ z → \ { (i = i0) → transp (λ j → A ((z ∨ h) ∧ j)) (~ z ∧ ~ h) x
-                          ; (i = i1) → q (z ∧ h)
-                          ; (h = i1) → compPath-filler refl q z i
-                          ; (h = i0) → transp (\ j → A (i ∨ (z ∧ j))) (i ∨ ~ z) (transp (\ j → A (i ∧ j)) (~ i) x)
-                          })
-                          (transp (\ j → A ((i ∨ h) ∧ j)) (~ (i ∨ h)) x)
+  slide : I → _
+  slide i = transp (λ l → A (i ∨ l)) i (transp (λ l → A (i ∧ l)) (~ i) x)
+
+  ∧∨Square : I → I → _
+  ∧∨Square i j =
+    hcomp
+      (λ l → λ
+        { (i = i0) → slide j
+        ; (i = i1) → q (j ∧ l)
+        ; (j = i0) → slide i
+        ; (j = i1) → q (i ∧ l)
+        })
+      (slide (i ∨ j))
+PathPIsoPath A x y .Iso.leftInv q k i =
+  outS
+    (hcomp-unique
+      (λ j → λ
+        { (i = i0) → x
+        ; (i = i1) → transp (λ l → A (j ∨ l)) j (q j)
+        })
+      (inS (transp (λ l → A (i ∧ l)) (~ i) x))
+      (λ j → inS (transp (λ l → A (i ∧ (j ∨ l))) (~ i ∨ j) (q (i ∧ j)))))
+    k
+
+PathP≃Path : (A : I → Type ℓ) (x : A i0) (y : A i1) →
+             PathP A x y ≃ (transport (λ i → A i) x ≡ y)
+PathP≃Path A x y = isoToEquiv (PathPIsoPath A x y)
 
 PathP≡compPath : ∀ {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) (r : x ≡ z)
                  → (PathP (λ i → x ≡ q i) p r) ≡ (p ∙ q ≡ r)

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -446,8 +446,10 @@ module ΩTrunc {X : Type ℓ} {n : HLevel} where
                         ∙ λ i → ∣ rUnit (transportRefl (transportRefl (transport (λ _ → a ≡ a) refl) (~ i)) (~ i)) (~ i) ∣
 
 PathIdTruncIso : {a b : A} (n : HLevel) → Iso (Path (∥ A ∥ (suc n)) ∣ a ∣ ∣ b ∣) (∥ a ≡ b ∥ n)
-PathIdTruncIso zero = isContr→Iso ((isOfHLevelTrunc 1 _ _)
-                    , isOfHLevelPath 1 (isOfHLevelTrunc 1) ∣ _ ∣ ∣ _ ∣ _) (isOfHLevelUnit* 0)
+PathIdTruncIso zero =
+  isContr→Iso
+    (isOfHLevelTrunc 1 _ _ , isOfHLevelPath 1 (isOfHLevelTrunc 1) ∣ _ ∣ ∣ _ ∣ _)
+    (isOfHLevelUnit* 0)
 PathIdTruncIso (suc n) = ΩTrunc.IsoFinal ∣ _ ∣ ∣ _ ∣
 
 PathIdTrunc : {a b : A} (n : HLevel) → (Path (∥ A ∥ (suc n)) ∣ a ∣ ∣ b ∣) ≡ (∥ a ≡ b ∥ n)

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -169,16 +169,7 @@ isConnectedPath : ∀ {ℓ} (n : HLevel) {A : Type ℓ}
   → (a₀ a₁ : A) → isConnected n (a₀ ≡ a₁)
 isConnectedPath zero connA a₀ a₁ = isContrUnit*
 isConnectedPath (suc n) {A = A} connA a₀ a₁ =
-  isContrRetract
-    (Trunc.rec {B = Path (hLevelTrunc (2 + n) A) ∣ a₀ ∣ ∣ a₁ ∣} (isOfHLevelTrunc (2 + n) _ _) (cong ∣_∣))
-    (λ p → transport (λ i → Trunc.rec (isOfHLevelTypeOfHLevel (suc n))
-                                        (λ a → (hLevelTrunc (suc n) (a ≡ a₁))
-                                               , isOfHLevelTrunc (suc n)) (p (~ i)) .fst)
-            ∣ refl ∣)
-    (Trunc.elim (λ _ → isOfHLevelPath (suc n) (isOfHLevelTrunc (suc n)) _ _)
-                (J (λ a₁ p → transport (λ i → HubAndSpoke (p (~ i) ≡ a₁) n) ∣ (λ _ → a₁) ∣ ≡ ∣ p ∣)
-                   (transportRefl ∣ refl ∣)))
-    (isContr→isContrPath connA _ _)
+  isOfHLevelRetractFromIso 0 (invIso (PathIdTruncIso (suc n))) (isContr→isContrPath connA _ _)
 
 isConnectedPathP : ∀ {ℓ} (n : HLevel) {A : I → Type ℓ}
   → isConnected (suc n) (A i1)


### PR DESCRIPTION
- Transport `isOfHLevel` proofs using retracts instead of `subst` when possible
- "Smaller" proof of the isomorphism between heterogeneous and homogeneous paths (about the same amount of code as the old "unfolded" proof, but smaller if unfolded all the way)
- Rewrite `isConnectedPath` à la #539 (but without redefining `isConnected`)