### PR TITLE
Prop truncations over sum types and (non-dependent) sigma types

### DIFF
--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -155,13 +155,10 @@ leftInv ⊎-⊥-Iso (inl _) = refl
 ⊎-⊥-≃ : A ⊎ ⊥ ≃ A
 ⊎-⊥-≃ = isoToEquiv ⊎-⊥-Iso
 
-∥∥-⊎-IdentityL : ∥ A ∥ → ∥ A ⊎ B ∥
-∥∥-⊎-IdentityL x = rec squash (λ a → ∣ inl a ∣) x
-
 ∥∥-AbsorbL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
 fun ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
   where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
-        lem (inl x) = ∥∥-⊎-IdentityL x
+        lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
         lem (inr x) = ∣ inr x ∣
 inv ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
   where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
@@ -173,14 +170,11 @@ leftInv ∥∥-AbsorbL-⊎-Iso x  = squash (inv ∥∥-AbsorbL-⊎-Iso (fun ∥�
 ∥∥-AbsorbL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
 ∥∥-AbsorbL-⊎-≃ = isoToEquiv ∥∥-AbsorbL-⊎-Iso
 
-∥∥-⊎-IdentityR : ∥ B ∥ → ∥ A ⊎ B ∥
-∥∥-⊎-IdentityR x = rec squash (λ b → ∣ inr b ∣) x
-
 ∥∥-AbsorbR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
 fun ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
   where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
         lem (inl x) = ∣ inl x ∣
-        lem (inr x) = ∥∥-⊎-IdentityR x
+        lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
 inv ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
   where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
         lem (inl x) = ∣ inl x ∣

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -7,11 +7,10 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Functions.Embedding
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Data.Empty hiding (rec)
+open import Cubical.Data.Empty
 open import Cubical.Data.Nat
-open import Cubical.HITs.PropositionalTruncation
 
-open import Cubical.Data.Sum.Base hiding (rec)
+open import Cubical.Data.Sum.Base
 
 open Iso
 
@@ -154,33 +153,3 @@ leftInv ⊎-⊥-Iso (inl _) = refl
 
 ⊎-⊥-≃ : A ⊎ ⊥ ≃ A
 ⊎-⊥-≃ = isoToEquiv ⊎-⊥-Iso
-
-∥∥-AbsorbL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
-fun ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
-  where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
-        lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
-        lem (inr x) = ∣ inr x ∣
-inv ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
-        lem (inl x) = ∣ inl ∣ x ∣ ∣
-        lem (inr x) = ∣ inr x ∣
-rightInv ∥∥-AbsorbL-⊎-Iso x = squash (fun ∥∥-AbsorbL-⊎-Iso (inv ∥∥-AbsorbL-⊎-Iso x)) x
-leftInv ∥∥-AbsorbL-⊎-Iso x  = squash (inv ∥∥-AbsorbL-⊎-Iso (fun ∥∥-AbsorbL-⊎-Iso x)) x
-
-∥∥-AbsorbL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
-∥∥-AbsorbL-⊎-≃ = isoToEquiv ∥∥-AbsorbL-⊎-Iso
-
-∥∥-AbsorbR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
-fun ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
-        lem (inl x) = ∣ inl x ∣
-        lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
-inv ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
-        lem (inl x) = ∣ inl x ∣
-        lem (inr x) = ∣ inr ∣ x ∣ ∣
-rightInv ∥∥-AbsorbR-⊎-Iso x = squash (fun ∥∥-AbsorbR-⊎-Iso (inv ∥∥-AbsorbR-⊎-Iso x)) x
-leftInv ∥∥-AbsorbR-⊎-Iso x  = squash (inv ∥∥-AbsorbR-⊎-Iso (fun ∥∥-AbsorbR-⊎-Iso x)) x
-
-∥∥-AbsorbR-⊎-≃ : ∥ A ⊎ ∥ B ∥ ∥ ≃ ∥ A ⊎ B ∥
-∥∥-AbsorbR-⊎-≃ = isoToEquiv ∥∥-AbsorbR-⊎-Iso

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -156,8 +156,7 @@ leftInv ⊎-⊥-Iso (inl _) = refl
 ⊎-⊥-≃ = isoToEquiv ⊎-⊥-Iso
 
 ∥∥-⊎-IdentityL : ∥ A ∥ → ∥ A ⊎ B ∥
-∥∥-⊎-IdentityL ∣ x ∣ = ∣ inl x ∣
-∥∥-⊎-IdentityL (squash x y i) = squash (∥∥-⊎-IdentityL x) (∥∥-⊎-IdentityL y) i
+∥∥-⊎-IdentityL x = rec squash (λ a → ∣ inl a ∣) x
 
 ∥∥-AbsorbL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
 fun ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
@@ -175,8 +174,7 @@ leftInv ∥∥-AbsorbL-⊎-Iso x  = squash (inv ∥∥-AbsorbL-⊎-Iso (fun ∥�
 ∥∥-AbsorbL-⊎-≃ = isoToEquiv ∥∥-AbsorbL-⊎-Iso
 
 ∥∥-⊎-IdentityR : ∥ B ∥ → ∥ A ⊎ B ∥
-∥∥-⊎-IdentityR ∣ x ∣ = ∣ inr x ∣
-∥∥-⊎-IdentityR (squash x y i) = squash (∥∥-⊎-IdentityR x) (∥∥-⊎-IdentityR y) i
+∥∥-⊎-IdentityR x = rec squash (λ b → ∣ inr b ∣) x
 
 ∥∥-AbsorbR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
 fun ∥∥-AbsorbR-⊎-Iso x = rec squash lem x

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -7,10 +7,11 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Functions.Embedding
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Data.Empty
+open import Cubical.Data.Empty hiding (rec)
 open import Cubical.Data.Nat
+open import Cubical.HITs.PropositionalTruncation
 
-open import Cubical.Data.Sum.Base
+open import Cubical.Data.Sum.Base hiding (rec)
 
 open Iso
 
@@ -148,8 +149,46 @@ leftInv ⊎-assoc-Iso (inr _)        = refl
 ⊎-⊥-Iso : Iso (A ⊎ ⊥) A
 fun ⊎-⊥-Iso (inl x) = x
 inv ⊎-⊥-Iso x       = inl x
-rightInv ⊎-⊥-Iso x      = refl
-leftInv ⊎-⊥-Iso (inl x) = refl
+rightInv ⊎-⊥-Iso _      = refl
+leftInv ⊎-⊥-Iso (inl _) = refl
 
 ⊎-⊥-≃ : A ⊎ ⊥ ≃ A
 ⊎-⊥-≃ = isoToEquiv ⊎-⊥-Iso
+
+∥∥-⊎-IdentityL : ∥ A ∥ → ∥ A ⊎ B ∥
+∥∥-⊎-IdentityL ∣ x ∣ = ∣ inl x ∣
+∥∥-⊎-IdentityL (squash x y i) = squash (∥∥-⊎-IdentityL x) (∥∥-⊎-IdentityL y) i
+
+∥∥-AbsorbL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
+fun ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
+  where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
+        lem (inl x) = ∥∥-⊎-IdentityL x
+        lem (inr x) = ∣ inr x ∣
+inv ∥∥-AbsorbL-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
+        lem (inl x) = ∣ inl ∣ x ∣ ∣
+        lem (inr x) = ∣ inr x ∣
+rightInv ∥∥-AbsorbL-⊎-Iso x = squash (fun ∥∥-AbsorbL-⊎-Iso (inv ∥∥-AbsorbL-⊎-Iso x)) x
+leftInv ∥∥-AbsorbL-⊎-Iso x  = squash (inv ∥∥-AbsorbL-⊎-Iso (fun ∥∥-AbsorbL-⊎-Iso x)) x
+
+∥∥-AbsorbL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
+∥∥-AbsorbL-⊎-≃ = isoToEquiv ∥∥-AbsorbL-⊎-Iso
+
+∥∥-⊎-IdentityR : ∥ B ∥ → ∥ A ⊎ B ∥
+∥∥-⊎-IdentityR ∣ x ∣ = ∣ inr x ∣
+∥∥-⊎-IdentityR (squash x y i) = squash (∥∥-⊎-IdentityR x) (∥∥-⊎-IdentityR y) i
+
+∥∥-AbsorbR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
+fun ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
+        lem (inl x) = ∣ inl x ∣
+        lem (inr x) = ∥∥-⊎-IdentityR x
+inv ∥∥-AbsorbR-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
+        lem (inl x) = ∣ inl x ∣
+        lem (inr x) = ∣ inr ∣ x ∣ ∣
+rightInv ∥∥-AbsorbR-⊎-Iso x = squash (fun ∥∥-AbsorbR-⊎-Iso (inv ∥∥-AbsorbR-⊎-Iso x)) x
+leftInv ∥∥-AbsorbR-⊎-Iso x  = squash (inv ∥∥-AbsorbR-⊎-Iso (fun ∥∥-AbsorbR-⊎-Iso x)) x
+
+∥∥-AbsorbR-⊎-≃ : ∥ A ⊎ ∥ B ∥ ∥ ≃ ∥ A ⊎ B ∥
+∥∥-AbsorbR-⊎-≃ = isoToEquiv ∥∥-AbsorbR-⊎-Iso

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -415,3 +415,38 @@ RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
 ∥∥-Idempotent-⊎ {A = A} {B = B} = ∥ ∥ A ∥ ⊎ ∥ B ∥ ∥ ≡⟨ ∥∥-IdempotentR-⊎ ⟩
                                   ∥ ∥ A ∥ ⊎ B ∥     ≡⟨ ∥∥-IdempotentL-⊎ ⟩
                                   ∥ A ⊎ B ∥         ∎
+
+∥∥-IdempotentL-×-≃ : ∥ ∥ A ∥ × B ∥ ≃ ∥ A × B ∥
+∥∥-IdempotentL-×-≃ = isoToEquiv ∥∥-IdempotentL-×-Iso
+  where ∥∥-IdempotentL-×-Iso : Iso (∥ ∥ A ∥ × B ∥) (∥ A × B ∥)
+        Iso.fun ∥∥-IdempotentL-×-Iso x = rec squash lem x
+          where lem : ∥ A ∥ × B → ∥ A × B ∥
+                lem (a , b) = rec2 squash (λ a b → ∣ a , b ∣) a ∣ b ∣
+        Iso.inv ∥∥-IdempotentL-×-Iso x = rec squash lem x
+          where lem : A × B → ∥ ∥ A ∥ × B ∥
+                lem (a , b) = ∣ ∣ a ∣ , b ∣
+        Iso.rightInv ∥∥-IdempotentL-×-Iso x = squash (Iso.fun ∥∥-IdempotentL-×-Iso (Iso.inv ∥∥-IdempotentL-×-Iso x)) x
+        Iso.leftInv ∥∥-IdempotentL-×-Iso x  = squash (Iso.inv ∥∥-IdempotentL-×-Iso (Iso.fun ∥∥-IdempotentL-×-Iso x)) x
+
+∥∥-IdempotentL-× : ∥ ∥ A ∥ × B ∥ ≡ ∥ A × B ∥
+∥∥-IdempotentL-× = ua ∥∥-IdempotentL-×-≃
+
+∥∥-IdempotentR-×-≃ : ∥ A × ∥ B ∥ ∥ ≃ ∥ A × B ∥
+∥∥-IdempotentR-×-≃ = isoToEquiv ∥∥-IdempotentR-×-Iso
+  where ∥∥-IdempotentR-×-Iso : Iso (∥ A × ∥ B ∥ ∥) (∥ A × B ∥)
+        Iso.fun ∥∥-IdempotentR-×-Iso x = rec squash lem x
+          where lem : A × ∥ B ∥ → ∥ A × B ∥
+                lem (a , b) = rec2 squash (λ a b → ∣ a , b ∣) ∣ a ∣ b
+        Iso.inv ∥∥-IdempotentR-×-Iso x = rec squash lem x
+          where lem : A × B → ∥ A × ∥ B ∥ ∥
+                lem (a , b) = ∣ a , ∣ b ∣ ∣
+        Iso.rightInv ∥∥-IdempotentR-×-Iso x = squash (Iso.fun ∥∥-IdempotentR-×-Iso (Iso.inv ∥∥-IdempotentR-×-Iso x)) x
+        Iso.leftInv ∥∥-IdempotentR-×-Iso x  = squash (Iso.inv ∥∥-IdempotentR-×-Iso (Iso.fun ∥∥-IdempotentR-×-Iso x)) x
+
+∥∥-IdempotentR-× : ∥ A × ∥ B ∥ ∥ ≡ ∥ A × B ∥
+∥∥-IdempotentR-× = ua ∥∥-IdempotentR-×-≃
+
+∥∥-Idempotent-× : {A : Type ℓ} {B : Type ℓ} → ∥ ∥ A ∥ × ∥ B ∥ ∥ ≡ ∥ A × B ∥
+∥∥-Idempotent-× {A = A} {B = B} = ∥ ∥ A ∥ × ∥ B ∥ ∥ ≡⟨ ∥∥-IdempotentR-× ⟩
+                                  ∥ ∥ A ∥ × B ∥     ≡⟨ ∥∥-IdempotentL-× ⟩
+                                  ∥ A × B ∥         ∎

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -383,12 +383,12 @@ RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
   where ∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ A′ ∥)  (∥ A ⊎ A′ ∥)
         Iso.fun ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
           where lem : ∥ A ∥ ⊎ A′ → ∥ A ⊎ A′ ∥
-                lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
+                lem (inl x) = map (λ a → inl a) x
                 lem (inr x) = ∣ inr x ∣
-        Iso.inv ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
-          where lem : A ⊎ A′ → ∥ ∥ A ∥ ⊎ A′ ∥
-                lem (inl x) = ∣ inl ∣ x ∣ ∣
-                lem (inr x) = ∣ inr x ∣
+        Iso.inv ∥∥-IdempotentL-⊎-Iso x = map lem x
+          where lem : A ⊎ A′ → ∥ A ∥ ⊎ A′
+                lem (inl x) = inl ∣ x ∣
+                lem (inr x) = inr x
         Iso.rightInv ∥∥-IdempotentL-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentL-⊎-Iso (Iso.inv ∥∥-IdempotentL-⊎-Iso x)) x
         Iso.leftInv ∥∥-IdempotentL-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentL-⊎-Iso (Iso.fun ∥∥-IdempotentL-⊎-Iso x)) x
 
@@ -401,11 +401,11 @@ RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
         Iso.fun ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
           where lem : A ⊎ ∥ A′ ∥ → ∥ A ⊎ A′ ∥
                 lem (inl x) = ∣ inl x ∣
-                lem (inr x) = rec squash (λ a → ∣ inr a ∣) x
-        Iso.inv ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
-          where lem : A ⊎ A′ → ∥ A ⊎ ∥ A′ ∥ ∥
-                lem (inl x) = ∣ inl x ∣
-                lem (inr x) = ∣ inr ∣ x ∣ ∣
+                lem (inr x) = map (λ a → inr a) x
+        Iso.inv ∥∥-IdempotentR-⊎-Iso x = map lem x
+          where lem : A ⊎ A′ → A ⊎ ∥ A′ ∥
+                lem (inl x) = inl x
+                lem (inr x) = inr ∣ x ∣
         Iso.rightInv ∥∥-IdempotentR-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentR-⊎-Iso (Iso.inv ∥∥-IdempotentR-⊎-Iso x)) x
         Iso.leftInv ∥∥-IdempotentR-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentR-⊎-Iso (Iso.fun ∥∥-IdempotentR-⊎-Iso x)) x
 
@@ -422,10 +422,10 @@ RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
   where ∥∥-IdempotentL-×-Iso : Iso (∥ ∥ A ∥ × A′ ∥) (∥ A × A′ ∥)
         Iso.fun ∥∥-IdempotentL-×-Iso x = rec squash lem x
           where lem : ∥ A ∥ × A′ → ∥ A × A′ ∥
-                lem (a , a′) = rec2 squash (λ a a′ → ∣ a , a′ ∣) a ∣ a′ ∣
-        Iso.inv ∥∥-IdempotentL-×-Iso x = rec squash lem x
-          where lem : A × A′ → ∥ ∥ A ∥ × A′ ∥
-                lem (a , a′) = ∣ ∣ a ∣ , a′ ∣
+                lem (a , a′) = map2 (λ a a′ → a , a′) a ∣ a′ ∣
+        Iso.inv ∥∥-IdempotentL-×-Iso x = map lem x
+          where lem : A × A′ → ∥ A ∥ × A′
+                lem (a , a′) = ∣ a ∣ , a′
         Iso.rightInv ∥∥-IdempotentL-×-Iso x = squash (Iso.fun ∥∥-IdempotentL-×-Iso (Iso.inv ∥∥-IdempotentL-×-Iso x)) x
         Iso.leftInv ∥∥-IdempotentL-×-Iso x  = squash (Iso.inv ∥∥-IdempotentL-×-Iso (Iso.fun ∥∥-IdempotentL-×-Iso x)) x
 
@@ -437,10 +437,10 @@ RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
   where ∥∥-IdempotentR-×-Iso : Iso (∥ A × ∥ A′ ∥ ∥) (∥ A × A′ ∥)
         Iso.fun ∥∥-IdempotentR-×-Iso x = rec squash lem x
           where lem : A × ∥ A′ ∥ → ∥ A × A′ ∥
-                lem (a , a′) = rec2 squash (λ a a′ → ∣ a , a′ ∣) ∣ a ∣ a′
-        Iso.inv ∥∥-IdempotentR-×-Iso x = rec squash lem x
-          where lem : A × A′ → ∥ A × ∥ A′ ∥ ∥
-                lem (a , a′) = ∣ a , ∣ a′ ∣ ∣
+                lem (a , a′) = map2 (λ a a′ → a , a′) ∣ a ∣ a′
+        Iso.inv ∥∥-IdempotentR-×-Iso x = map lem x
+          where lem : A × A′ → A × ∥ A′ ∥
+                lem (a , a′) = a , ∣ a′ ∣
         Iso.rightInv ∥∥-IdempotentR-×-Iso x = squash (Iso.fun ∥∥-IdempotentR-×-Iso (Iso.inv ∥∥-IdempotentR-×-Iso x)) x
         Iso.leftInv ∥∥-IdempotentR-×-Iso x  = squash (Iso.inv ∥∥-IdempotentR-×-Iso (Iso.fun ∥∥-IdempotentR-×-Iso x)) x
 

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -24,8 +24,9 @@ open import Cubical.HITs.PropositionalTruncation.Base
 
 private
   variable
-    ℓ : Level
+    ℓ ℓ′ : Level
     A B C : Type ℓ
+    A′ : Type ℓ′
 
 ∥∥-isPropDep : (P : A → Type ℓ) → isOfHLevelDep 1 (λ x → ∥ P x ∥)
 ∥∥-isPropDep P = isOfHLevel→isOfHLevelDep 1 (λ _ → squash)
@@ -377,76 +378,76 @@ elim→Gpd {A = A} P Pgpd f kf 3kf t = rec→Gpd (Pgpd t) g 3kg t
 RecHSet : (P : A → TypeOfHLevel ℓ 2) → 3-Constant P → ∥ A ∥ → TypeOfHLevel ℓ 2
 RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
 
-∥∥-IdempotentL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
+∥∥-IdempotentL-⊎-≃ : ∥ ∥ A ∥ ⊎ A′ ∥ ≃ ∥ A ⊎ A′ ∥
 ∥∥-IdempotentL-⊎-≃ = isoToEquiv ∥∥-IdempotentL-⊎-Iso
-  where ∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
+  where ∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ A′ ∥)  (∥ A ⊎ A′ ∥)
         Iso.fun ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
-          where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
+          where lem : ∥ A ∥ ⊎ A′ → ∥ A ⊎ A′ ∥
                 lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
                 lem (inr x) = ∣ inr x ∣
         Iso.inv ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
-          where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
+          where lem : A ⊎ A′ → ∥ ∥ A ∥ ⊎ A′ ∥
                 lem (inl x) = ∣ inl ∣ x ∣ ∣
                 lem (inr x) = ∣ inr x ∣
         Iso.rightInv ∥∥-IdempotentL-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentL-⊎-Iso (Iso.inv ∥∥-IdempotentL-⊎-Iso x)) x
         Iso.leftInv ∥∥-IdempotentL-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentL-⊎-Iso (Iso.fun ∥∥-IdempotentL-⊎-Iso x)) x
 
-∥∥-IdempotentL-⊎ : ∥ ∥ A ∥ ⊎ B ∥ ≡ ∥ A ⊎ B ∥
+∥∥-IdempotentL-⊎ : ∥ ∥ A ∥ ⊎ A′ ∥ ≡ ∥ A ⊎ A′ ∥
 ∥∥-IdempotentL-⊎ = ua ∥∥-IdempotentL-⊎-≃
 
-∥∥-IdempotentR-⊎-≃ : ∥ A ⊎ ∥ B ∥ ∥ ≃ ∥ A ⊎ B ∥
+∥∥-IdempotentR-⊎-≃ : ∥ A ⊎ ∥ A′ ∥ ∥ ≃ ∥ A ⊎ A′ ∥
 ∥∥-IdempotentR-⊎-≃ = isoToEquiv ∥∥-IdempotentR-⊎-Iso
-  where ∥∥-IdempotentR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
+  where ∥∥-IdempotentR-⊎-Iso : Iso (∥ A ⊎ ∥ A′ ∥ ∥) (∥ A ⊎ A′ ∥)
         Iso.fun ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
-          where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
+          where lem : A ⊎ ∥ A′ ∥ → ∥ A ⊎ A′ ∥
                 lem (inl x) = ∣ inl x ∣
-                lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
+                lem (inr x) = rec squash (λ a → ∣ inr a ∣) x
         Iso.inv ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
-          where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
+          where lem : A ⊎ A′ → ∥ A ⊎ ∥ A′ ∥ ∥
                 lem (inl x) = ∣ inl x ∣
                 lem (inr x) = ∣ inr ∣ x ∣ ∣
         Iso.rightInv ∥∥-IdempotentR-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentR-⊎-Iso (Iso.inv ∥∥-IdempotentR-⊎-Iso x)) x
         Iso.leftInv ∥∥-IdempotentR-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentR-⊎-Iso (Iso.fun ∥∥-IdempotentR-⊎-Iso x)) x
 
-∥∥-IdempotentR-⊎ : ∥ A ⊎ ∥ B ∥ ∥ ≡ ∥ A ⊎ B ∥
+∥∥-IdempotentR-⊎ : ∥ A ⊎ ∥ A′ ∥ ∥ ≡ ∥ A ⊎ A′ ∥
 ∥∥-IdempotentR-⊎ = ua ∥∥-IdempotentR-⊎-≃
 
-∥∥-Idempotent-⊎ : {A : Type ℓ} {B : Type ℓ} → ∥ ∥ A ∥ ⊎ ∥ B ∥ ∥ ≡ ∥ A ⊎ B ∥
-∥∥-Idempotent-⊎ {A = A} {B = B} = ∥ ∥ A ∥ ⊎ ∥ B ∥ ∥ ≡⟨ ∥∥-IdempotentR-⊎ ⟩
-                                  ∥ ∥ A ∥ ⊎ B ∥     ≡⟨ ∥∥-IdempotentL-⊎ ⟩
-                                  ∥ A ⊎ B ∥         ∎
+∥∥-Idempotent-⊎ : {A : Type ℓ} {A′ : Type ℓ′} → ∥ ∥ A ∥ ⊎ ∥ A′ ∥ ∥ ≡ ∥ A ⊎ A′ ∥
+∥∥-Idempotent-⊎ {A = A} {A′} = ∥ ∥ A ∥ ⊎ ∥ A′ ∥ ∥ ≡⟨ ∥∥-IdempotentR-⊎ ⟩
+                               ∥ ∥ A ∥ ⊎ A′ ∥     ≡⟨ ∥∥-IdempotentL-⊎ ⟩
+                               ∥ A ⊎ A′ ∥         ∎
 
-∥∥-IdempotentL-×-≃ : ∥ ∥ A ∥ × B ∥ ≃ ∥ A × B ∥
+∥∥-IdempotentL-×-≃ : ∥ ∥ A ∥ × A′ ∥ ≃ ∥ A × A′ ∥
 ∥∥-IdempotentL-×-≃ = isoToEquiv ∥∥-IdempotentL-×-Iso
-  where ∥∥-IdempotentL-×-Iso : Iso (∥ ∥ A ∥ × B ∥) (∥ A × B ∥)
+  where ∥∥-IdempotentL-×-Iso : Iso (∥ ∥ A ∥ × A′ ∥) (∥ A × A′ ∥)
         Iso.fun ∥∥-IdempotentL-×-Iso x = rec squash lem x
-          where lem : ∥ A ∥ × B → ∥ A × B ∥
-                lem (a , b) = rec2 squash (λ a b → ∣ a , b ∣) a ∣ b ∣
+          where lem : ∥ A ∥ × A′ → ∥ A × A′ ∥
+                lem (a , a′) = rec2 squash (λ a a′ → ∣ a , a′ ∣) a ∣ a′ ∣
         Iso.inv ∥∥-IdempotentL-×-Iso x = rec squash lem x
-          where lem : A × B → ∥ ∥ A ∥ × B ∥
-                lem (a , b) = ∣ ∣ a ∣ , b ∣
+          where lem : A × A′ → ∥ ∥ A ∥ × A′ ∥
+                lem (a , a′) = ∣ ∣ a ∣ , a′ ∣
         Iso.rightInv ∥∥-IdempotentL-×-Iso x = squash (Iso.fun ∥∥-IdempotentL-×-Iso (Iso.inv ∥∥-IdempotentL-×-Iso x)) x
         Iso.leftInv ∥∥-IdempotentL-×-Iso x  = squash (Iso.inv ∥∥-IdempotentL-×-Iso (Iso.fun ∥∥-IdempotentL-×-Iso x)) x
 
-∥∥-IdempotentL-× : ∥ ∥ A ∥ × B ∥ ≡ ∥ A × B ∥
+∥∥-IdempotentL-× : ∥ ∥ A ∥ × A′ ∥ ≡ ∥ A × A′ ∥
 ∥∥-IdempotentL-× = ua ∥∥-IdempotentL-×-≃
 
-∥∥-IdempotentR-×-≃ : ∥ A × ∥ B ∥ ∥ ≃ ∥ A × B ∥
+∥∥-IdempotentR-×-≃ : ∥ A × ∥ A′ ∥ ∥ ≃ ∥ A × A′ ∥
 ∥∥-IdempotentR-×-≃ = isoToEquiv ∥∥-IdempotentR-×-Iso
-  where ∥∥-IdempotentR-×-Iso : Iso (∥ A × ∥ B ∥ ∥) (∥ A × B ∥)
+  where ∥∥-IdempotentR-×-Iso : Iso (∥ A × ∥ A′ ∥ ∥) (∥ A × A′ ∥)
         Iso.fun ∥∥-IdempotentR-×-Iso x = rec squash lem x
-          where lem : A × ∥ B ∥ → ∥ A × B ∥
-                lem (a , b) = rec2 squash (λ a b → ∣ a , b ∣) ∣ a ∣ b
+          where lem : A × ∥ A′ ∥ → ∥ A × A′ ∥
+                lem (a , a′) = rec2 squash (λ a a′ → ∣ a , a′ ∣) ∣ a ∣ a′
         Iso.inv ∥∥-IdempotentR-×-Iso x = rec squash lem x
-          where lem : A × B → ∥ A × ∥ B ∥ ∥
-                lem (a , b) = ∣ a , ∣ b ∣ ∣
+          where lem : A × A′ → ∥ A × ∥ A′ ∥ ∥
+                lem (a , a′) = ∣ a , ∣ a′ ∣ ∣
         Iso.rightInv ∥∥-IdempotentR-×-Iso x = squash (Iso.fun ∥∥-IdempotentR-×-Iso (Iso.inv ∥∥-IdempotentR-×-Iso x)) x
         Iso.leftInv ∥∥-IdempotentR-×-Iso x  = squash (Iso.inv ∥∥-IdempotentR-×-Iso (Iso.fun ∥∥-IdempotentR-×-Iso x)) x
 
-∥∥-IdempotentR-× : ∥ A × ∥ B ∥ ∥ ≡ ∥ A × B ∥
+∥∥-IdempotentR-× : ∥ A × ∥ A′ ∥ ∥ ≡ ∥ A × A′ ∥
 ∥∥-IdempotentR-× = ua ∥∥-IdempotentR-×-≃
 
-∥∥-Idempotent-× : {A : Type ℓ} {B : Type ℓ} → ∥ ∥ A ∥ × ∥ B ∥ ∥ ≡ ∥ A × B ∥
-∥∥-Idempotent-× {A = A} {B = B} = ∥ ∥ A ∥ × ∥ B ∥ ∥ ≡⟨ ∥∥-IdempotentR-× ⟩
-                                  ∥ ∥ A ∥ × B ∥     ≡⟨ ∥∥-IdempotentL-× ⟩
-                                  ∥ A × B ∥         ∎
+∥∥-Idempotent-× : {A : Type ℓ} {A′ : Type ℓ′} → ∥ ∥ A ∥ × ∥ A′ ∥ ∥ ≡ ∥ A × A′ ∥
+∥∥-Idempotent-× {A = A} {A′} = ∥ ∥ A ∥ × ∥ A′ ∥ ∥ ≡⟨ ∥∥-IdempotentR-× ⟩
+                               ∥ ∥ A ∥ × A′ ∥     ≡⟨ ∥∥-IdempotentL-× ⟩
+                               ∥ A × A′ ∥         ∎

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -18,6 +18,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 
 open import Cubical.Data.Sigma
+open import Cubical.Data.Sum hiding (rec ; elim ; map)
 
 open import Cubical.HITs.PropositionalTruncation.Base
 
@@ -375,3 +376,44 @@ elim→Gpd {A = A} P Pgpd f kf 3kf t = rec→Gpd (Pgpd t) g 3kg t
 
 RecHSet : (P : A → TypeOfHLevel ℓ 2) → 3-Constant P → ∥ A ∥ → TypeOfHLevel ℓ 2
 RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
+
+∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
+Iso.fun ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
+  where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
+        lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
+        lem (inr x) = ∣ inr x ∣
+Iso.inv ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
+        lem (inl x) = ∣ inl ∣ x ∣ ∣
+        lem (inr x) = ∣ inr x ∣
+Iso.rightInv ∥∥-IdempotentL-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentL-⊎-Iso (Iso.inv ∥∥-IdempotentL-⊎-Iso x)) x
+Iso.leftInv ∥∥-IdempotentL-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentL-⊎-Iso (Iso.fun ∥∥-IdempotentL-⊎-Iso x)) x
+
+∥∥-IdempotentL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
+∥∥-IdempotentL-⊎-≃ = isoToEquiv ∥∥-IdempotentL-⊎-Iso
+
+∥∥-IdempotentL-⊎ : ∥ ∥ A ∥ ⊎ B ∥ ≡ ∥ A ⊎ B ∥
+∥∥-IdempotentL-⊎ = ua ∥∥-IdempotentL-⊎-≃
+
+∥∥-IdempotentR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
+Iso.fun ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
+        lem (inl x) = ∣ inl x ∣
+        lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
+Iso.inv ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
+  where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
+        lem (inl x) = ∣ inl x ∣
+        lem (inr x) = ∣ inr ∣ x ∣ ∣
+Iso.rightInv ∥∥-IdempotentR-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentR-⊎-Iso (Iso.inv ∥∥-IdempotentR-⊎-Iso x)) x
+Iso.leftInv ∥∥-IdempotentR-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentR-⊎-Iso (Iso.fun ∥∥-IdempotentR-⊎-Iso x)) x
+
+∥∥-IdempotentR-⊎-≃ : ∥ A ⊎ ∥ B ∥ ∥ ≃ ∥ A ⊎ B ∥
+∥∥-IdempotentR-⊎-≃ = isoToEquiv ∥∥-IdempotentR-⊎-Iso
+
+∥∥-IdempotentR-⊎ : ∥ A ⊎ ∥ B ∥ ∥ ≡ ∥ A ⊎ B ∥
+∥∥-IdempotentR-⊎ = ua ∥∥-IdempotentR-⊎-≃
+
+∥∥-Idempotent-⊎ : {A : Type ℓ} {B : Type ℓ} → ∥ ∥ A ∥ ⊎ ∥ B ∥ ∥ ≡ ∥ A ⊎ B ∥
+∥∥-Idempotent-⊎ {A = A} {B = B} = ∥ ∥ A ∥ ⊎ ∥ B ∥ ∥ ≡⟨ ∥∥-IdempotentR-⊎ ⟩
+                                  ∥ ∥ A ∥ ⊎ B ∥     ≡⟨ ∥∥-IdempotentL-⊎ ⟩
+                                  ∥ A ⊎ B ∥         ∎

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -377,38 +377,36 @@ elim→Gpd {A = A} P Pgpd f kf 3kf t = rec→Gpd (Pgpd t) g 3kg t
 RecHSet : (P : A → TypeOfHLevel ℓ 2) → 3-Constant P → ∥ A ∥ → TypeOfHLevel ℓ 2
 RecHSet P 3kP = rec→Gpd (isOfHLevelTypeOfHLevel 2) P 3kP
 
-∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
-Iso.fun ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
-  where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
-        lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
-        lem (inr x) = ∣ inr x ∣
-Iso.inv ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
-        lem (inl x) = ∣ inl ∣ x ∣ ∣
-        lem (inr x) = ∣ inr x ∣
-Iso.rightInv ∥∥-IdempotentL-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentL-⊎-Iso (Iso.inv ∥∥-IdempotentL-⊎-Iso x)) x
-Iso.leftInv ∥∥-IdempotentL-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentL-⊎-Iso (Iso.fun ∥∥-IdempotentL-⊎-Iso x)) x
-
 ∥∥-IdempotentL-⊎-≃ : ∥ ∥ A ∥ ⊎ B ∥ ≃ ∥ A ⊎ B ∥
 ∥∥-IdempotentL-⊎-≃ = isoToEquiv ∥∥-IdempotentL-⊎-Iso
+  where ∥∥-IdempotentL-⊎-Iso : Iso (∥ ∥ A ∥ ⊎ B ∥)  (∥ A ⊎ B ∥)
+        Iso.fun ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
+          where lem : ∥ A ∥ ⊎ B → ∥ A ⊎ B ∥
+                lem (inl x) = rec squash (λ a → ∣ inl a ∣) x
+                lem (inr x) = ∣ inr x ∣
+        Iso.inv ∥∥-IdempotentL-⊎-Iso x = rec squash lem x
+          where lem : A ⊎ B → ∥ ∥ A ∥ ⊎ B ∥
+                lem (inl x) = ∣ inl ∣ x ∣ ∣
+                lem (inr x) = ∣ inr x ∣
+        Iso.rightInv ∥∥-IdempotentL-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentL-⊎-Iso (Iso.inv ∥∥-IdempotentL-⊎-Iso x)) x
+        Iso.leftInv ∥∥-IdempotentL-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentL-⊎-Iso (Iso.fun ∥∥-IdempotentL-⊎-Iso x)) x
 
 ∥∥-IdempotentL-⊎ : ∥ ∥ A ∥ ⊎ B ∥ ≡ ∥ A ⊎ B ∥
 ∥∥-IdempotentL-⊎ = ua ∥∥-IdempotentL-⊎-≃
 
-∥∥-IdempotentR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
-Iso.fun ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
-        lem (inl x) = ∣ inl x ∣
-        lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
-Iso.inv ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
-  where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
-        lem (inl x) = ∣ inl x ∣
-        lem (inr x) = ∣ inr ∣ x ∣ ∣
-Iso.rightInv ∥∥-IdempotentR-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentR-⊎-Iso (Iso.inv ∥∥-IdempotentR-⊎-Iso x)) x
-Iso.leftInv ∥∥-IdempotentR-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentR-⊎-Iso (Iso.fun ∥∥-IdempotentR-⊎-Iso x)) x
-
 ∥∥-IdempotentR-⊎-≃ : ∥ A ⊎ ∥ B ∥ ∥ ≃ ∥ A ⊎ B ∥
 ∥∥-IdempotentR-⊎-≃ = isoToEquiv ∥∥-IdempotentR-⊎-Iso
+  where ∥∥-IdempotentR-⊎-Iso : Iso (∥ A ⊎ ∥ B ∥ ∥) (∥ A ⊎ B ∥)
+        Iso.fun ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
+          where lem : A ⊎ ∥ B ∥ → ∥ A ⊎ B ∥
+                lem (inl x) = ∣ inl x ∣
+                lem (inr x) = rec squash (λ b → ∣ inr b ∣) x
+        Iso.inv ∥∥-IdempotentR-⊎-Iso x = rec squash lem x
+          where lem : A ⊎ B → ∥ A ⊎ ∥ B ∥ ∥
+                lem (inl x) = ∣ inl x ∣
+                lem (inr x) = ∣ inr ∣ x ∣ ∣
+        Iso.rightInv ∥∥-IdempotentR-⊎-Iso x = squash (Iso.fun ∥∥-IdempotentR-⊎-Iso (Iso.inv ∥∥-IdempotentR-⊎-Iso x)) x
+        Iso.leftInv ∥∥-IdempotentR-⊎-Iso x  = squash (Iso.inv ∥∥-IdempotentR-⊎-Iso (Iso.fun ∥∥-IdempotentR-⊎-Iso x)) x
 
 ∥∥-IdempotentR-⊎ : ∥ A ⊎ ∥ B ∥ ∥ ≡ ∥ A ⊎ B ∥
 ∥∥-IdempotentR-⊎ = ua ∥∥-IdempotentR-⊎-≃


### PR DESCRIPTION
Adds some basic identities for propositional truncations over sum types and non-dependent sigma types. Namely, applying idempotence into both types.

Not entirely happy with the names of these.