### PR TITLE
Move --cubical and --no-import-sorts flags to agda-lib

### DIFF
--- a/Cubical/Algebra/AbGroup.agda
+++ b/Cubical/Algebra/AbGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.AbGroup where
 
 open import Cubical.Algebra.AbGroup.Base public

--- a/Cubical/Algebra/AbGroup/Base.agda
+++ b/Cubical/Algebra/AbGroup/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.AbGroup.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Algebra.agda
+++ b/Cubical/Algebra/Algebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Algebra where
 
 open import Cubical.Algebra.Algebra.Base public

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Algebra.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommAlgebra where
 
 open import Cubical.Algebra.CommAlgebra.Base public

--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommAlgebra.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing.agda
+++ b/Cubical/Algebra/CommRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing where
 
 open import Cubical.Algebra.CommRing.Base public

--- a/Cubical/Algebra/CommRing/Base.agda
+++ b/Cubical/Algebra/CommRing/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/FGIdeal.agda
+++ b/Cubical/Algebra/CommRing/FGIdeal.agda
@@ -4,7 +4,7 @@
   Parts of this should be reusable for explicit constructions
   of free modules over a finite set.
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.FGIdeal where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Ideal.agda
+++ b/Cubical/Algebra/CommRing/Ideal.agda
@@ -2,7 +2,7 @@
   This is mostly for convenience, when working with ideals
   (which are defined for general rings) in a commutative ring.
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.Ideal where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Integers.agda
+++ b/Cubical/Algebra/CommRing/Integers.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.Integers where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Localisation/Base.agda
+++ b/Cubical/Algebra/CommRing/Localisation/Base.agda
@@ -2,7 +2,7 @@
 -- at a multiplicatively closed subset and show that it
 -- has a commutative ring structure.
 
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Algebra.CommRing.Localisation.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Localisation/InvertingElements.agda
+++ b/Cubical/Algebra/CommRing/Localisation/InvertingElements.agda
@@ -6,7 +6,7 @@
 -- This fact has an important application in algebraic geometry where it's
 -- used to define the structure sheaf of a commutative ring.
 
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Algebra.CommRing.Localisation.InvertingElements where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
+++ b/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
@@ -4,7 +4,7 @@
 -- by the universal property, and give sufficient criteria for
 -- satisfying the universal property.
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.Localisation.UniversalProperty where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommRing/Properties.agda
+++ b/Cubical/Algebra/CommRing/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommRing.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/FreeCommAlgebra.agda
+++ b/Cubical/Algebra/FreeCommAlgebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Algebra.FreeCommAlgebra where
 {-

--- a/Cubical/Algebra/Group.agda
+++ b/Cubical/Algebra/Group.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group where
 
 open import Cubical.Algebra.Group.Base public

--- a/Cubical/Algebra/Group/Base.agda
+++ b/Cubical/Algebra/Group/Base.agda
@@ -3,7 +3,7 @@
 Defines groups and adds some smart constructors
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/DirProd.agda
+++ b/Cubical/Algebra/Group/DirProd.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.DirProd where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/GroupPath.agda
+++ b/Cubical/Algebra/Group/GroupPath.agda
@@ -1,5 +1,5 @@
 -- The SIP applied to groups
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.GroupPath where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/Instances/Bool.agda
+++ b/Cubical/Algebra/Group/Instances/Bool.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Instances.Bool where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/Instances/Int.agda
+++ b/Cubical/Algebra/Group/Instances/Int.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Instances.Int where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/Instances/Unit.agda
+++ b/Cubical/Algebra/Group/Instances/Unit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Instances.Unit where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/MorphismProperties.agda
+++ b/Cubical/Algebra/Group/MorphismProperties.agda
@@ -7,7 +7,7 @@ This file contains:
 - Conversion functions between different notions of group morphisms
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.MorphismProperties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/Morphisms.agda
+++ b/Cubical/Algebra/Group/Morphisms.agda
@@ -14,7 +14,7 @@ groups:
 - BijectionIso (surjective + injective)
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Morphisms where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Group/Properties.agda
+++ b/Cubical/Algebra/Group/Properties.agda
@@ -3,7 +3,7 @@
 This file contains basic theory about groups
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Group.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Matrix.agda
+++ b/Cubical/Algebra/Matrix.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Matrix where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Module.agda
+++ b/Cubical/Algebra/Module.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Module where
 
 open import Cubical.Algebra.Module.Base public

--- a/Cubical/Algebra/Module/Base.agda
+++ b/Cubical/Algebra/Module/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Module.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Monoid.agda
+++ b/Cubical/Algebra/Monoid.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Monoid where
 
 open import Cubical.Algebra.Monoid.Base public

--- a/Cubical/Algebra/Monoid/Base.agda
+++ b/Cubical/Algebra/Monoid/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Monoid.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Ring.agda
+++ b/Cubical/Algebra/Ring.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring where
 
 open import Cubical.Algebra.Ring.Base public

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Ring/Ideal.agda
+++ b/Cubical/Algebra/Ring/Ideal.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring.Ideal where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Ring/Kernel.agda
+++ b/Cubical/Algebra/Ring/Kernel.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring.Kernel where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Ring/Properties.agda
+++ b/Cubical/Algebra/Ring/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Ring/QuotientRing.agda
+++ b/Cubical/Algebra/Ring/QuotientRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Ring.QuotientRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/AlgebraExpression.agda
+++ b/Cubical/Algebra/RingSolver/AlgebraExpression.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.AlgebraExpression where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/AlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/AlmostRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.AlmostRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/CommRingAsAlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/CommRingAsAlmostRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.CommRingAsAlmostRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/CommRingEvalHom.agda
+++ b/Cubical/Algebra/RingSolver/CommRingEvalHom.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.CommRingEvalHom where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/CommRingExamples.agda
+++ b/Cubical/Algebra/RingSolver/CommRingExamples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.CommRingExamples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/CommRingHornerForms.agda
+++ b/Cubical/Algebra/RingSolver/CommRingHornerForms.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.CommRingHornerForms where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/CommRingSolver.agda
+++ b/Cubical/Algebra/RingSolver/CommRingSolver.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.CommRingSolver where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/EvaluationHomomorphism.agda
+++ b/Cubical/Algebra/RingSolver/EvaluationHomomorphism.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.EvaluationHomomorphism where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/Examples.agda
+++ b/Cubical/Algebra/RingSolver/Examples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.Examples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/HornerForms.agda
+++ b/Cubical/Algebra/RingSolver/HornerForms.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.HornerForms where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/IntAsRawRing.agda
+++ b/Cubical/Algebra/RingSolver/IntAsRawRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.IntAsRawRing where
 
 open import Cubical.Data.Nat hiding (_+_; _·_)

--- a/Cubical/Algebra/RingSolver/NatAsAlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/NatAsAlmostRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.NatAsAlmostRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/NatExamples.agda
+++ b/Cubical/Algebra/RingSolver/NatExamples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.NatExamples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/RawAlgebra.agda
+++ b/Cubical/Algebra/RingSolver/RawAlgebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.RawAlgebra where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/RawRing.agda
+++ b/Cubical/Algebra/RingSolver/RawRing.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.RawRing where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/ReflectionSolving.agda
+++ b/Cubical/Algebra/RingSolver/ReflectionSolving.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 {-
   This is inspired by/copied from:
   https://github.com/agda/agda-stdlib/blob/master/src/Tactic/MonoidSolver.agda

--- a/Cubical/Algebra/RingSolver/RingExpression.agda
+++ b/Cubical/Algebra/RingSolver/RingExpression.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.RingExpression where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/RingSolver/Solver.agda
+++ b/Cubical/Algebra/RingSolver/Solver.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.RingSolver.Solver where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Semigroup.agda
+++ b/Cubical/Algebra/Semigroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Semigroup where
 
 open import Cubical.Algebra.Semigroup.Base public

--- a/Cubical/Algebra/Semigroup/Base.agda
+++ b/Cubical/Algebra/Semigroup/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.Semigroup.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/SymmetricGroup.agda
+++ b/Cubical/Algebra/SymmetricGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.SymmetricGroup where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Categories/Adjoint.agda
+++ b/Cubical/Categories/Adjoint.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Adjoint where
 

--- a/Cubical/Categories/Category.agda
+++ b/Cubical/Categories/Category.agda
@@ -16,7 +16,7 @@
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 
 module Cubical.Categories.Category where

--- a/Cubical/Categories/Category/Base.agda
+++ b/Cubical/Categories/Category/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 
 module Cubical.Categories.Category.Base where

--- a/Cubical/Categories/Category/Properties.agda
+++ b/Cubical/Categories/Category/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 
 module Cubical.Categories.Category.Properties where

--- a/Cubical/Categories/Commutativity.agda
+++ b/Cubical/Categories/Commutativity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Commutativity where
 

--- a/Cubical/Categories/Constructions/Elements.agda
+++ b/Cubical/Categories/Constructions/Elements.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 -- The Category of Elements
 

--- a/Cubical/Categories/Constructions/Slice.agda
+++ b/Cubical/Categories/Constructions/Slice.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Morphism renaming (isIso to isIsoC)

--- a/Cubical/Categories/Equivalence.agda
+++ b/Cubical/Categories/Equivalence.agda
@@ -1,5 +1,5 @@
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Equivalence where
 

--- a/Cubical/Categories/Equivalence/Base.agda
+++ b/Cubical/Categories/Equivalence/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Equivalence.Base where
 

--- a/Cubical/Categories/Equivalence/Properties.agda
+++ b/Cubical/Categories/Equivalence/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Equivalence.Properties where
 

--- a/Cubical/Categories/Functor.agda
+++ b/Cubical/Categories/Functor.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Functor where
 

--- a/Cubical/Categories/Functor/Base.agda
+++ b/Cubical/Categories/Functor/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Functor.Base where
 

--- a/Cubical/Categories/Functor/Compose.agda
+++ b/Cubical/Categories/Functor/Compose.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Functor.Compose where
 

--- a/Cubical/Categories/Functor/Properties.agda
+++ b/Cubical/Categories/Functor/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Functor.Properties where
 

--- a/Cubical/Categories/Instances/Cospan.agda
+++ b/Cubical/Categories/Instances/Cospan.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Instances.Cospan where
 

--- a/Cubical/Categories/Instances/Functors.agda
+++ b/Cubical/Categories/Instances/Functors.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Instances.Functors where
 

--- a/Cubical/Categories/Instances/Sets.agda
+++ b/Cubical/Categories/Instances/Sets.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Instances.Sets where
 

--- a/Cubical/Categories/Limits.agda
+++ b/Cubical/Categories/Limits.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Limits where
 

--- a/Cubical/Categories/Limits/Base.agda
+++ b/Cubical/Categories/Limits/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Limits.Base where
 

--- a/Cubical/Categories/Limits/Pullback.agda
+++ b/Cubical/Categories/Limits/Pullback.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Limits.Pullback where
 

--- a/Cubical/Categories/Limits/Terminal.agda
+++ b/Cubical/Categories/Limits/Terminal.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Limits.Terminal where
 

--- a/Cubical/Categories/Morphism.agda
+++ b/Cubical/Categories/Morphism.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Morphism where
 

--- a/Cubical/Categories/NaturalTransformation.agda
+++ b/Cubical/Categories/NaturalTransformation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.NaturalTransformation where
 

--- a/Cubical/Categories/NaturalTransformation/Base.agda
+++ b/Cubical/Categories/NaturalTransformation/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.NaturalTransformation.Base where
 

--- a/Cubical/Categories/NaturalTransformation/Properties.agda
+++ b/Cubical/Categories/NaturalTransformation/Properties.agda
@@ -1,5 +1,5 @@
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.NaturalTransformation.Properties where
 

--- a/Cubical/Categories/Presheaf.agda
+++ b/Cubical/Categories/Presheaf.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --postfix-projections --safe #-}
+{-# OPTIONS --postfix-projections --safe #-}
 
 module Cubical.Categories.Presheaf where
 

--- a/Cubical/Categories/Presheaf/Base.agda
+++ b/Cubical/Categories/Presheaf/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --postfix-projections --safe #-}
+{-# OPTIONS --postfix-projections --safe #-}
 
 module Cubical.Categories.Presheaf.Base where
 

--- a/Cubical/Categories/Presheaf/KanExtension.agda
+++ b/Cubical/Categories/Presheaf/KanExtension.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 
 {-
   Kan extension of a functor C → D to a functor PreShv C ℓ → PreShv D ℓ left or right adjoint to

--- a/Cubical/Categories/Presheaf/Properties.agda
+++ b/Cubical/Categories/Presheaf/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Presheaf.Properties where
 

--- a/Cubical/Categories/Sets.agda
+++ b/Cubical/Categories/Sets.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Sets where
 

--- a/Cubical/Categories/TypesOfCategories/TypeCategory.agda
+++ b/Cubical/Categories/TypesOfCategories/TypeCategory.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --postfix-projections --safe #-}
+{-# OPTIONS --postfix-projections --safe #-}
 
 module Cubical.Categories.TypesOfCategories.TypeCategory where
 

--- a/Cubical/Categories/Yoneda.agda
+++ b/Cubical/Categories/Yoneda.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Yoneda where
 

--- a/Cubical/Codata/Conat.agda
+++ b/Cubical/Codata/Conat.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Conat where
 
 open import Cubical.Codata.Conat.Base public

--- a/Cubical/Codata/Conat/Base.agda
+++ b/Cubical/Codata/Conat/Base.agda
@@ -18,7 +18,7 @@ The first approach is chosen to exploit guarded recursion and to avoid the use
 of Sized Types.
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Codata.Conat.Base where
 
 open import Cubical.Data.Unit

--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -20,7 +20,7 @@ The standard library also defines bisimulation on conaturals:
 https://github.com/agda/agda-stdlib/blob/master/src/Codata/Conat/Bisimilarity.agda
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Codata.Conat.Properties where
 
 open import Cubical.Data.Unit

--- a/Cubical/Codata/Everything.agda
+++ b/Cubical/Codata/Everything.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Everything where
 
 open import Cubical.Codata.EverythingSafe public

--- a/Cubical/Codata/EverythingSafe.agda
+++ b/Cubical/Codata/EverythingSafe.agda
@@ -1,2 +1,2 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Codata.EverythingSafe where

--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Codata.M where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Codata/M/AsLimit/Coalg.agda
+++ b/Cubical/Codata/M/AsLimit/Coalg.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Coalg where
 

--- a/Cubical/Codata/M/AsLimit/Coalg/Base.agda
+++ b/Cubical/Codata/M/AsLimit/Coalg/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Coalg.Base where
 

--- a/Cubical/Codata/M/AsLimit/Container.agda
+++ b/Cubical/Codata/M/AsLimit/Container.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.Container where
 

--- a/Cubical/Codata/M/AsLimit/M.agda
+++ b/Cubical/Codata/M/AsLimit/M.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.M where
 

--- a/Cubical/Codata/M/AsLimit/M/Base.agda
+++ b/Cubical/Codata/M/AsLimit/M/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 -- Construction of M-types from
 -- https://arxiv.org/pdf/1504.02949.pdf

--- a/Cubical/Codata/M/AsLimit/M/Properties.agda
+++ b/Cubical/Codata/M/AsLimit/M/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.M.Properties where
 

--- a/Cubical/Codata/M/AsLimit/helper.agda
+++ b/Cubical/Codata/M/AsLimit/helper.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.helper where
 

--- a/Cubical/Codata/M/AsLimit/itree.agda
+++ b/Cubical/Codata/M/AsLimit/itree.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.itree where
 

--- a/Cubical/Codata/M/AsLimit/stream.agda
+++ b/Cubical/Codata/M/AsLimit/stream.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness --safe #-}
+{-# OPTIONS --guardedness --safe #-}
 
 module Cubical.Codata.M.AsLimit.stream where
 

--- a/Cubical/Codata/M/Bisimilarity.agda
+++ b/Cubical/Codata/M/Bisimilarity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --postfix-projections #-}
+{-# OPTIONS --postfix-projections #-}
 module Cubical.Codata.M.Bisimilarity where
 
 open import Cubical.Core.Everything

--- a/Cubical/Codata/Stream.agda
+++ b/Cubical/Codata/Stream.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Codata.Stream where
 
 open import Cubical.Codata.Stream.Base public

--- a/Cubical/Codata/Stream/Base.agda
+++ b/Cubical/Codata/Stream/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Codata.Stream.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Codata/Stream/Properties.agda
+++ b/Cubical/Codata/Stream/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --guardedness #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Codata.Stream.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Core/Everything.agda
+++ b/Cubical/Core/Everything.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Core.Everything where
 
 -- Basic primitives (some are from Agda.Primitive)

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -7,7 +7,7 @@ This file contains:
 - Glue types
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Core.Glue where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Core/Id.agda
+++ b/Cubical/Core/Id.agda
@@ -1,5 +1,5 @@
 {- This file exports the primitives of cubical Id types -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Core.Id where
 
 open import Cubical.Core.Primitives hiding ( _≡_ )

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -4,7 +4,7 @@ This file document and export the main primitives of Cubical Agda. It
 also defines some basic derived operations (composition and filling).
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Core.Primitives where
 
 open import Agda.Builtin.Cubical.Path public

--- a/Cubical/Data/BinNat.agda
+++ b/Cubical/Data/BinNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.BinNat where
 
 open import Cubical.Data.BinNat.BinNat public

--- a/Cubical/Data/BinNat/BinNat.agda
+++ b/Cubical/Data/BinNat/BinNat.agda
@@ -58,7 +58,7 @@ but it has the virtue of being a bit simpler to prove equivalent to
 http://www.cs.bham.ac.uk/~mhe/agda-new/BinaryNaturals.html
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.BinNat.BinNat where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Bool.agda
+++ b/Cubical/Data/Bool.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Bool where
 
 open import Cubical.Data.Bool.Base public

--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Bool.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Bool.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Bool/SwitchStatement.agda
+++ b/Cubical/Data/Bool/SwitchStatement.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Bool.SwitchStatement where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/DescendingList.agda
+++ b/Cubical/Data/DescendingList.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.DescendingList where
 
 open import Cubical.Data.DescendingList.Base public

--- a/Cubical/Data/DescendingList/Base.agda
+++ b/Cubical/Data/DescendingList/Base.agda
@@ -2,7 +2,7 @@
 -- Descending lists
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Cubical.Foundations.Everything
 

--- a/Cubical/Data/DescendingList/Examples.agda
+++ b/Cubical/Data/DescendingList/Examples.agda
@@ -9,7 +9,7 @@
 -- 2. "sorting" finite multisets by converting into sorted lists.
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.DescendingList.Examples where
 

--- a/Cubical/Data/DescendingList/Properties.agda
+++ b/Cubical/Data/DescendingList/Properties.agda
@@ -10,7 +10,7 @@
 -- properties by transporting those on finite multisets.
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Cubical.Foundations.Everything
 

--- a/Cubical/Data/DescendingList/Strict.agda
+++ b/Cubical/Data/DescendingList/Strict.agda
@@ -2,7 +2,7 @@
 -- Strictly descending lists
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Cubical.Core.Everything
 

--- a/Cubical/Data/DescendingList/Strict/Properties.agda
+++ b/Cubical/Data/DescendingList/Strict/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 open import Cubical.Foundations.Prelude
 

--- a/Cubical/Data/Empty.agda
+++ b/Cubical/Data/Empty.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Empty where
 
 open import Cubical.Data.Empty.Base public

--- a/Cubical/Data/Empty/Base.agda
+++ b/Cubical/Data/Empty/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Empty.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Empty/Properties.agda
+++ b/Cubical/Data/Empty/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Empty.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Equality.agda
+++ b/Cubical/Data/Equality.agda
@@ -8,7 +8,7 @@ and the inductively define equality types.
 
 TODO: reconsider naming scheme.
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Equality where
 

--- a/Cubical/Data/Fin.agda
+++ b/Cubical/Data/Fin.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Fin where
 

--- a/Cubical/Data/Fin/Base.agda
+++ b/Cubical/Data/Fin/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Fin.Base where
 

--- a/Cubical/Data/Fin/LehmerCode.agda
+++ b/Cubical/Data/Fin/LehmerCode.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 {-
 This module develops Lehmer codes, i.e. an encoding of permutations as finite integers.
 

--- a/Cubical/Data/Fin/Literals.agda
+++ b/Cubical/Data/Fin/Literals.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Fin.Literals where
 
 open import Agda.Builtin.Nat

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Fin.Properties where
 

--- a/Cubical/Data/Fin/Recursive.agda
+++ b/Cubical/Data/Fin/Recursive.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Fin.Recursive where
 

--- a/Cubical/Data/Fin/Recursive/Base.agda
+++ b/Cubical/Data/Fin/Recursive/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Fin.Recursive.Base where
 

--- a/Cubical/Data/Fin/Recursive/Properties.agda
+++ b/Cubical/Data/Fin/Recursive/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts --postfix-projections #-}
+{-# OPTIONS --safe --postfix-projections #-}
 
 module Cubical.Data.Fin.Recursive.Properties where
 

--- a/Cubical/Data/FinData.agda
+++ b/Cubical/Data/FinData.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.FinData where
 
 open import Cubical.Data.FinData.Base public

--- a/Cubical/Data/FinData/Base.agda
+++ b/Cubical/Data/FinData/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.FinData.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/FinData/Properties.agda
+++ b/Cubical/Data/FinData/Properties.agda
@@ -1,5 +1,5 @@
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.FinData.Properties where
 
 open import Cubical.Foundations.Function

--- a/Cubical/Data/FinInd.agda
+++ b/Cubical/Data/FinInd.agda
@@ -11,7 +11,7 @@ This definition is weaker than `isFinSet`.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.FinInd where
 

--- a/Cubical/Data/FinSet.agda
+++ b/Cubical/Data/FinSet.agda
@@ -9,7 +9,7 @@ prove that both formulations are equivalent.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.FinSet where
 

--- a/Cubical/Data/FinSet/Binary/Large.agda
+++ b/Cubical/Data/FinSet/Binary/Large.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
+{-# OPTIONS --safe --postfix-projections #-}
 
 module Cubical.Data.FinSet.Binary.Large where
 

--- a/Cubical/Data/FinSet/Binary/Small.agda
+++ b/Cubical/Data/FinSet/Binary/Small.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.FinSet.Binary.Small where
 

--- a/Cubical/Data/FinSet/Binary/Small/Base.agda
+++ b/Cubical/Data/FinSet/Binary/Small/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.FinSet.Binary.Small.Base where
 

--- a/Cubical/Data/FinSet/Binary/Small/Properties.agda
+++ b/Cubical/Data/FinSet/Binary/Small/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
+{-# OPTIONS --safe --postfix-projections #-}
 
 module Cubical.Data.FinSet.Binary.Small.Properties where
 

--- a/Cubical/Data/Graph.agda
+++ b/Cubical/Data/Graph.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Graph where
 
 open import Cubical.Data.Graph.Base public

--- a/Cubical/Data/Graph/Base.agda
+++ b/Cubical/Data/Graph/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Graph.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Graph.Examples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/HomotopyGroup.agda
+++ b/Cubical/Data/HomotopyGroup.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.HomotopyGroup where
 
 open import Cubical.Data.HomotopyGroup.Base public

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.HomotopyGroup.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/InfNat.agda
+++ b/Cubical/Data/InfNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.InfNat where
 
 open import Cubical.Data.InfNat.Base public

--- a/Cubical/Data/InfNat/Base.agda
+++ b/Cubical/Data/InfNat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 module Cubical.Data.InfNat.Base where
 

--- a/Cubical/Data/InfNat/Properties.agda
+++ b/Cubical/Data/InfNat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 module Cubical.Data.InfNat.Properties where
 

--- a/Cubical/Data/Int.agda
+++ b/Cubical/Data/Int.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Int where
 
 open import Cubical.Data.Int.Base public

--- a/Cubical/Data/Int/Base.agda
+++ b/Cubical/Data/Int/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Int.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 {-
 

--- a/Cubical/Data/List.agda
+++ b/Cubical/Data/List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.List where
 
 open import Cubical.Data.List.Base       public

--- a/Cubical/Data/List/Base.agda
+++ b/Cubical/Data/List/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.List.Base where
 
 open import Agda.Builtin.List public

--- a/Cubical/Data/List/Properties.agda
+++ b/Cubical/Data/List/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.List.Properties where
 
 open import Agda.Builtin.List

--- a/Cubical/Data/Maybe.agda
+++ b/Cubical/Data/Maybe.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Maybe where
 
 open import Cubical.Data.Maybe.Base public

--- a/Cubical/Data/Maybe/Base.agda
+++ b/Cubical/Data/Maybe/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Maybe.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Maybe/Properties.agda
+++ b/Cubical/Data/Maybe/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Maybe.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Nat.agda
+++ b/Cubical/Data/Nat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Nat where
 
 open import Cubical.Data.Nat.Base public

--- a/Cubical/Data/Nat/Algebra.agda
+++ b/Cubical/Data/Nat/Algebra.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 {-
 

--- a/Cubical/Data/Nat/Base.agda
+++ b/Cubical/Data/Nat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Nat.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/Nat/Coprime.agda
+++ b/Cubical/Data/Nat/Coprime.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Nat.Coprime where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Divisibility.agda
+++ b/Cubical/Data/Nat/Divisibility.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Nat.Divisibility where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/GCD.agda
+++ b/Cubical/Data/Nat/GCD.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Nat.GCD where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Literals.agda
+++ b/Cubical/Data/Nat/Literals.agda
@@ -4,7 +4,7 @@
    and negative integer literals for any type (e.g. Int, ℕ₋₁, ℕ₋₂, ℕ₊₁).
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Nat.Literals where
 
 open import Agda.Builtin.FromNat public

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Nat.Order where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Order/Recursive.agda
+++ b/Cubical/Data/Nat/Order/Recursive.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Nat.Order.Recursive where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Nat.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/NatMinusOne.agda
+++ b/Cubical/Data/NatMinusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.NatMinusOne where
 
 open import Cubical.Data.NatMinusOne.Base public

--- a/Cubical/Data/NatMinusOne/Base.agda
+++ b/Cubical/Data/NatMinusOne/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.NatMinusOne.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/NatMinusOne/Properties.agda
+++ b/Cubical/Data/NatMinusOne/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.NatMinusOne.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/NatPlusOne.agda
+++ b/Cubical/Data/NatPlusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.NatPlusOne where
 
 open import Cubical.Data.NatPlusOne.Base public

--- a/Cubical/Data/NatPlusOne/Base.agda
+++ b/Cubical/Data/NatPlusOne/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.NatPlusOne.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Data/NatPlusOne/Properties.agda
+++ b/Cubical/Data/NatPlusOne/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.NatPlusOne.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Prod.agda
+++ b/Cubical/Data/Prod.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Prod where
 
 open import Cubical.Data.Prod.Base public

--- a/Cubical/Data/Prod/Base.agda
+++ b/Cubical/Data/Prod/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Prod.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Prod.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Queue.agda
+++ b/Cubical/Data/Queue.agda
@@ -1,5 +1,5 @@
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.Queue where
 

--- a/Cubical/Data/Queue/1List.agda
+++ b/Cubical/Data/Queue/1List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Queue.1List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Base.agda
+++ b/Cubical/Data/Queue/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Queue.Base where
 
 open import Cubical.Data.Queue.1List public

--- a/Cubical/Data/Queue/Finite.agda
+++ b/Cubical/Data/Queue/Finite.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Queue.Finite where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Truncated2List.agda
+++ b/Cubical/Data/Queue/Truncated2List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Queue.Truncated2List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Untruncated2List.agda
+++ b/Cubical/Data/Queue/Untruncated2List.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Data.Queue.Untruncated2List where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Queue/Untruncated2ListInvariant.agda
+++ b/Cubical/Data/Queue/Untruncated2ListInvariant.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Queue.Untruncated2ListInvariant where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Data/Sigma.agda
+++ b/Cubical/Data/Sigma.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sigma where
 
 open import Cubical.Data.Sigma.Base public

--- a/Cubical/Data/Sigma/Base.agda
+++ b/Cubical/Data/Sigma/Base.agda
@@ -9,7 +9,7 @@ The file contains:
 - Unique existence: ∃![x ∈ A] B
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sigma.Base where
 
 open import Cubical.Core.Primitives public

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -12,7 +12,7 @@ Basic properties about Σ-types
 - Σ with a contractible base is its fiber ([Σ-contractFst, ΣUnit])
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sigma.Properties where
 
 open import Cubical.Data.Sigma.Base

--- a/Cubical/Data/SubFinSet.agda
+++ b/Cubical/Data/SubFinSet.agda
@@ -10,7 +10,7 @@ Every subfinite set is guaranteed to be a set and discrete.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.SubFinSet where
 

--- a/Cubical/Data/Sum.agda
+++ b/Cubical/Data/Sum.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sum where
 
 open import Cubical.Data.Sum.Base public

--- a/Cubical/Data/Sum/Base.agda
+++ b/Cubical/Data/Sum/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sum.Base where
 
 open import Cubical.Relation.Nullary

--- a/Cubical/Data/Sum/Properties.agda
+++ b/Cubical/Data/Sum/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Sum.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/SumFin.agda
+++ b/Cubical/Data/SumFin.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.SumFin where
 
 open import Cubical.Data.SumFin.Base public

--- a/Cubical/Data/SumFin/Base.agda
+++ b/Cubical/Data/SumFin/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.SumFin.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/SumFin/Properties.agda
+++ b/Cubical/Data/SumFin/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Data.SumFin.Properties where
 

--- a/Cubical/Data/Unit.agda
+++ b/Cubical/Data/Unit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Unit where
 
 open import Cubical.Data.Unit.Base       public

--- a/Cubical/Data/Unit/Base.agda
+++ b/Cubical/Data/Unit/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Unit.Base where
 open import Cubical.Foundations.Prelude
 

--- a/Cubical/Data/Unit/Properties.agda
+++ b/Cubical/Data/Unit/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Unit.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Data/Vec.agda
+++ b/Cubical/Data/Vec.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Vec where
 
 open import Cubical.Data.Vec.Base public

--- a/Cubical/Data/Vec/Base.agda
+++ b/Cubical/Data/Vec/Base.agda
@@ -1,6 +1,6 @@
 {- Definition of vectors. Inspired by the Agda Standard Library -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Vec.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Vec/NAry.agda
+++ b/Cubical/Data/Vec/NAry.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Vec.NAry where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Vec/Properties.agda
+++ b/Cubical/Data/Vec/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Data.Vec.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Auto.agda
+++ b/Cubical/Displayed/Auto.agda
@@ -3,7 +3,7 @@
   - Automatically generate UARel and DUARel instances
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Auto where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Base.agda
+++ b/Cubical/Displayed/Base.agda
@@ -3,7 +3,7 @@
   Definition of univalent and displayed univalent relations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Constant.agda
+++ b/Cubical/Displayed/Constant.agda
@@ -3,7 +3,7 @@
   Functions building DUARels on constant families
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Constant where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Function.agda
+++ b/Cubical/Displayed/Function.agda
@@ -3,7 +3,7 @@
   Functions building UARels and DUARels on function types
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Function where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Generic.agda
+++ b/Cubical/Displayed/Generic.agda
@@ -3,7 +3,7 @@
   Generic UARel, DUARel, and SubstRel: the path relation is always univalent
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Generic where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Morphism.agda
+++ b/Cubical/Displayed/Morphism.agda
@@ -4,7 +4,7 @@
 
   We can reindex a DUARel or SubstRel along one of these.
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Morphism where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Prop.agda
+++ b/Cubical/Displayed/Prop.agda
@@ -3,7 +3,7 @@
   Functions building UARels and DUARels on propositions / propositional families
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Prop where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Properties.agda
+++ b/Cubical/Displayed/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Record.agda
+++ b/Cubical/Displayed/Record.agda
@@ -6,7 +6,7 @@ characterizations of the field types using reflection.
 See end of file for an example.
 
 -}
-{-# OPTIONS --cubical --no-exact-split --no-import-sorts --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Record where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Sigma.agda
+++ b/Cubical/Displayed/Sigma.agda
@@ -3,7 +3,7 @@
   Functions building UARels and DUARels on Σ-types
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Sigma where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Subst.agda
+++ b/Cubical/Displayed/Subst.agda
@@ -6,7 +6,7 @@
   equial to b'.
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Displayed.Subst where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Unit.agda
+++ b/Cubical/Displayed/Unit.agda
@@ -3,7 +3,7 @@
   DUARel for the constant unit family
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Unit where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Displayed/Universe.agda
+++ b/Cubical/Displayed/Universe.agda
@@ -4,7 +4,7 @@
   - SubstRel and DUARel for the element family over the universe
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Displayed.Universe where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/Brunerie.agda
+++ b/Cubical/Experiments/Brunerie.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.Brunerie where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Experiments/CohomologyGroups.agda
+++ b/Cubical/Experiments/CohomologyGroups.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.CohomologyGroups where
 
 open import Cubical.Experiments.ZCohomologyOld.Base

--- a/Cubical/Experiments/EscardoSIP.agda
+++ b/Cubical/Experiments/EscardoSIP.agda
@@ -5,7 +5,7 @@ https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#s
 All the needed preliminary results from the lecture notes are stated and proven in this file.
 It would be interesting to compare the proves with the one in Cubical.Foundations.SIP
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.EscardoSIP where
 
 open import Cubical.Core.Everything

--- a/Cubical/Experiments/Everything.agda
+++ b/Cubical/Experiments/Everything.agda
@@ -1,6 +1,5 @@
 -- Export only the experiments that are expected to compile (without
 -- any holes)
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Experiments.Everything where
 
 open import Cubical.Experiments.Brunerie public

--- a/Cubical/Experiments/FunExtFromUA.agda
+++ b/Cubical/Experiments/FunExtFromUA.agda
@@ -1,6 +1,6 @@
 {- Voevodsky's proof that univalence implies funext -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Experiments.FunExtFromUA where
 

--- a/Cubical/Experiments/Generic.agda
+++ b/Cubical/Experiments/Generic.agda
@@ -1,6 +1,6 @@
 -- Two fun examples of generic programming using univalence
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.Generic where
 
 open import Agda.Builtin.String

--- a/Cubical/Experiments/HInt.agda
+++ b/Cubical/Experiments/HInt.agda
@@ -17,7 +17,6 @@ https://github.com/RedPRL/redtt/blob/master/library/cool/biinv-int.red
 It might be interesting to port that example one day.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.Experiments.HInt where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/HoTT-UF.agda
+++ b/Cubical/Experiments/HoTT-UF.agda
@@ -11,7 +11,7 @@ For the moment, this requires the development version of Agda.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --exact-split --safe #-}
+{-# OPTIONS --exact-split --safe #-}
 
 module Cubical.Experiments.HoTT-UF where
 

--- a/Cubical/Experiments/List.agda
+++ b/Cubical/Experiments/List.agda
@@ -8,7 +8,7 @@ Note that Agda doesn't care about the order of constructors so we
 can't do exactly the same example.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.List where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/LocalisationDefs.agda
+++ b/Cubical/Experiments/LocalisationDefs.agda
@@ -1,7 +1,7 @@
 -- This file contains several ways to define localisation
 -- and proves them all to be equivalent
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.LocalisationDefs where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/NatMinusTwo.agda
+++ b/Cubical/Experiments/NatMinusTwo.agda
@@ -11,7 +11,7 @@
    - https://github.com/agda/cubical/issues/266
    - https://github.com/agda/cubical/pull/238
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.NatMinusTwo where
 
 open import Cubical.Experiments.NatMinusTwo.Base public

--- a/Cubical/Experiments/NatMinusTwo/Base.agda
+++ b/Cubical/Experiments/NatMinusTwo/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Experiments.NatMinusTwo.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/Experiments/NatMinusTwo/Properties.agda
+++ b/Cubical/Experiments/NatMinusTwo/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Experiments.NatMinusTwo.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/NatMinusTwo/ToNatMinusOne.agda
+++ b/Cubical/Experiments/NatMinusTwo/ToNatMinusOne.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Experiments.NatMinusTwo.ToNatMinusOne where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -1,5 +1,5 @@
 -- An example of something where normalization is surprisingly slow
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.Problem where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/Rng.agda
+++ b/Cubical/Experiments/Rng.agda
@@ -3,7 +3,7 @@
 -- rings). As this file isn't used for anything at the moment this
 -- rewrite has been postponed.
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.Rng where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Experiments/ZCohomology/Benchmarks.agda
+++ b/Cubical/Experiments/ZCohomology/Benchmarks.agda
@@ -17,7 +17,7 @@ then it should be removed before the above command is run.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Experiments.ZCohomology.Benchmarks where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Experiments/ZCohomologyOld/Base.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Base where
 
 open import Cubical.Data.Int.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Connected.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Connected.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Connected where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Prelims.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Prelims.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Prelims where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Sn.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Sn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Sn where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Torus.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Torus.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Torus where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Unit.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Unit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Unit where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/Wedge.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/Wedge.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.Wedge where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Groups/WedgeOfSpheres.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Groups/WedgeOfSpheres.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Groups.WedgeOfSpheres where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/KcompPrelims.agda
+++ b/Cubical/Experiments/ZCohomologyOld/KcompPrelims.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.KcompPrelims where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/MayerVietorisUnreduced.agda
+++ b/Cubical/Experiments/ZCohomologyOld/MayerVietorisUnreduced.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.MayerVietorisUnreduced where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Experiments/ZCohomologyOld/Properties.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Properties where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -1,5 +1,5 @@
 -- This file derives some of the Cartesian Kan operations using transp
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.CartesianKanOps where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -14,7 +14,7 @@ There are more statements about equivalences in Equiv/Properties.agda:
 - if f is an equivalence then postcomposition with f is an equivalence
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv where
 
 open import Cubical.Foundations.Function

--- a/Cubical/Foundations/Equiv/Base.agda
+++ b/Cubical/Foundations/Equiv/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.Base where
 
 open import Cubical.Foundations.Function

--- a/Cubical/Foundations/Equiv/BiInvertible.agda
+++ b/Cubical/Foundations/Equiv/BiInvertible.agda
@@ -8,7 +8,7 @@ Some theory about Bi-Invertible Equivalences
 - Iso to BiInvEquiv
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.BiInvertible where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/Fiberwise.agda
+++ b/Cubical/Foundations/Equiv/Fiberwise.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.Fiberwise where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Equiv/HalfAdjoint.agda
+++ b/Cubical/Foundations/Equiv/HalfAdjoint.agda
@@ -7,7 +7,7 @@ Half adjoint equivalences ([HAEquiv])
 - Cong is an equivalence ([congEquiv])
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.HalfAdjoint where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/PathSplit.agda
+++ b/Cubical/Foundations/Equiv/PathSplit.agda
@@ -15,7 +15,7 @@ The module starts with a couple of general facts about equivalences:
 
 (those are not in 'Equiv.agda' because they need Univalence.agda (which imports Equiv.agda))
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.PathSplit where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Equiv/Properties.agda
+++ b/Cubical/Foundations/Equiv/Properties.agda
@@ -9,7 +9,7 @@ A couple of general facts about equivalences:
 - isHAEquiv is a proposition [isPropIsHAEquiv]
 (these are not in 'Equiv.agda' because they need Univalence.agda (which imports Equiv.agda))
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Equiv.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Everything.agda
+++ b/Cubical/Foundations/Everything.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Everything where
 
 -- Basic cubical prelude

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -1,7 +1,7 @@
 {-
   Definitions for functions
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Function where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -4,7 +4,7 @@ This file proves the higher groupoid structure of types
 for homogeneous and heterogeneous paths
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.GroupoidLaws where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -7,7 +7,7 @@ Basic theory about h-levels/n-types:
 - Hedberg's theorem can be found in Cubical/Relation/Nullary/DecidableEq
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.HLevels where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Id.agda
+++ b/Cubical/Foundations/Id.agda
@@ -17,7 +17,7 @@ This file contains:
 - Propositional truncation and its elimination principle
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Id where
 
 open import Cubical.Foundations.Prelude public

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -7,7 +7,7 @@ Theory about isomorphisms
 - Any isomorphism is an equivalence ([isoToEquiv])
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Isomorphism where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Path where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed.agda
+++ b/Cubical/Foundations/Pointed.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed where
 
 open import Cubical.Foundations.Pointed.Base public

--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed/FunExt.agda
+++ b/Cubical/Foundations/Pointed/FunExt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.FunExt where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -6,7 +6,7 @@ Portions of this file adapted from Nicolai Kraus' code here:
   https://bitbucket.org/nicolaikraus/agda/src/e30d70c72c6af8e62b72eefabcc57623dd921f04/trunc-inverse.lagda
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.Homogeneous where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Pointed/Homotopy.agda
+++ b/Cubical/Foundations/Pointed/Homotopy.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.Homotopy where
 
 {-

--- a/Cubical/Foundations/Pointed/Properties.agda
+++ b/Cubical/Foundations/Pointed/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Powerset.agda
+++ b/Cubical/Foundations/Powerset.agda
@@ -6,7 +6,7 @@ Escardó's lecture notes:
 https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#propositionalextensionality
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Powerset where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -20,7 +20,7 @@ This file proves a variety of basic results about paths:
 - Export universe lifting
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Prelude where
 
 open import Cubical.Core.Primitives public

--- a/Cubical/Foundations/RelationalStructure.agda
+++ b/Cubical/Foundations/RelationalStructure.agda
@@ -3,7 +3,7 @@
 Definition of what it means to be a notion of relational structure
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.RelationalStructure where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/SIP.agda
+++ b/Cubical/Foundations/SIP.agda
@@ -6,7 +6,7 @@ structure identity principle:
 https://www.cs.bham.ac.uk/~mhe/HoTT-UF-in-Agda-Lecture-Notes/HoTT-UF-Agda.html#sns
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.SIP where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Structure.agda
+++ b/Cubical/Foundations/Structure.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Structure where
 
 open import Cubical.Core.Everything

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -4,7 +4,7 @@
 - transport is an equivalence ([transportEquiv])
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Transport where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -12,7 +12,7 @@ various consequences of univalence
 - Isomorphism induction ([elimIso])
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Foundations.Univalence where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Foundations/Univalence/Universe.agda
+++ b/Cubical/Foundations/Univalence/Universe.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
+{-# OPTIONS --safe --postfix-projections #-}
 
 open import Cubical.Core.Everything
 

--- a/Cubical/Functions/Bundle.agda
+++ b/Cubical/Functions/Bundle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Bundle where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Embedding where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Fibration.agda
+++ b/Cubical/Functions/Fibration.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Fibration where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Fixpoint.agda
+++ b/Cubical/Functions/Fixpoint.agda
@@ -1,7 +1,7 @@
 {-
   Definition of function fixpoint and Kraus' lemma
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Fixpoint where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/FunExtEquiv.agda
+++ b/Cubical/Functions/FunExtEquiv.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.FunExtEquiv where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Implicit.agda
+++ b/Cubical/Functions/Implicit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Implicit where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Involution.agda
+++ b/Cubical/Functions/Involution.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Functions.Involution where
 

--- a/Cubical/Functions/Logic.agda
+++ b/Cubical/Functions/Logic.agda
@@ -8,7 +8,7 @@
 -- isProp proofs making it easier to just give them explicitly instead
 -- of having them bundled up with the type.
 --
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Logic where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Morphism.agda
+++ b/Cubical/Functions/Morphism.agda
@@ -1,7 +1,7 @@
 {-
   General lemmas about morphisms (defined as loosely as possible)
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Morphism where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Functions.Surjection where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/2GroupoidTruncation.agda
+++ b/Cubical/HITs/2GroupoidTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.2GroupoidTruncation where
 
 open import Cubical.HITs.2GroupoidTruncation.Base public

--- a/Cubical/HITs/2GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of 2-groupoid truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.2GroupoidTruncation.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/2GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/2GroupoidTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of 2-groupoid truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.2GroupoidTruncation.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/AssocList.agda
+++ b/Cubical/HITs/AssocList.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.AssocList where
 
 

--- a/Cubical/HITs/AssocList/Base.agda
+++ b/Cubical/HITs/AssocList/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.AssocList.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/AssocList/Properties.agda
+++ b/Cubical/HITs/AssocList/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.AssocList.Properties where
 
 open import Cubical.HITs.AssocList.Base as AL

--- a/Cubical/HITs/Colimit.agda
+++ b/Cubical/HITs/Colimit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Colimit where
 
 open import Cubical.HITs.Colimit.Base public

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -3,7 +3,7 @@
   Homotopy colimits of graphs
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Colimit.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Colimit.Examples where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Cost.agda
+++ b/Cubical/HITs/Cost.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Cost where
 
 open import Cubical.HITs.Cost.Base

--- a/Cubical/HITs/Cost/Base.agda
+++ b/Cubical/HITs/Cost/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Cost.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Cylinder.agda
+++ b/Cubical/HITs/Cylinder.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Cylinder where
 
 open import Cubical.HITs.Cylinder.Base public

--- a/Cubical/HITs/Cylinder/Base.agda
+++ b/Cubical/HITs/Cylinder/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Cylinder.Base where
 

--- a/Cubical/HITs/Delooping/Two/Base.agda
+++ b/Cubical/HITs/Delooping/Two/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Delooping.Two.Base where
 

--- a/Cubical/HITs/Delooping/Two/Properties.agda
+++ b/Cubical/HITs/Delooping/Two/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Delooping.Two.Properties where
 

--- a/Cubical/HITs/DunceCap.agda
+++ b/Cubical/HITs/DunceCap.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.DunceCap where
 

--- a/Cubical/HITs/DunceCap/Base.agda
+++ b/Cubical/HITs/DunceCap/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.DunceCap.Base where
 

--- a/Cubical/HITs/DunceCap/Properties.agda
+++ b/Cubical/HITs/DunceCap/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.DunceCap.Properties where
 

--- a/Cubical/HITs/FiniteMultiset.agda
+++ b/Cubical/HITs/FiniteMultiset.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.FiniteMultiset where
 
 

--- a/Cubical/HITs/FiniteMultiset/Base.agda
+++ b/Cubical/HITs/FiniteMultiset/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.FiniteMultiset.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
+++ b/Cubical/HITs/FiniteMultiset/CountExtensionality.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.FiniteMultiset.CountExtensionality where
 
 

--- a/Cubical/HITs/FiniteMultiset/Properties.agda
+++ b/Cubical/HITs/FiniteMultiset/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.FiniteMultiset.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/GroupoidTruncation.agda
+++ b/Cubical/HITs/GroupoidTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.GroupoidTruncation where
 
 open import Cubical.HITs.GroupoidTruncation.Base public

--- a/Cubical/HITs/GroupoidTruncation/Base.agda
+++ b/Cubical/HITs/GroupoidTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of groupoid truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.GroupoidTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/GroupoidTruncation/Properties.agda
+++ b/Cubical/HITs/GroupoidTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of groupoid truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.GroupoidTruncation.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Hopf.agda
+++ b/Cubical/HITs/Hopf.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Hopf where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/InfNat.agda
+++ b/Cubical/HITs/InfNat.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat where
 

--- a/Cubical/HITs/InfNat/Base.agda
+++ b/Cubical/HITs/InfNat/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat.Base where
 

--- a/Cubical/HITs/InfNat/Properties.agda
+++ b/Cubical/HITs/InfNat/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 
 module Cubical.HITs.InfNat.Properties where
 

--- a/Cubical/HITs/Interval.agda
+++ b/Cubical/HITs/Interval.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Interval where
 
 open import Cubical.HITs.Interval.Base public

--- a/Cubical/HITs/Interval/Base.agda
+++ b/Cubical/HITs/Interval/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Interval.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/BiInvInt.agda
+++ b/Cubical/HITs/Ints/BiInvInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.BiInvInt where
 
 open import Cubical.HITs.Ints.BiInvInt.Base public

--- a/Cubical/HITs/Ints/BiInvInt/Base.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Base.agda
@@ -13,7 +13,7 @@ This file contains:
 - versions of the point constructors of BiInvInt which satisfy the path constructors judgmentally
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.BiInvInt.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/BiInvInt/Properties.agda
+++ b/Cubical/HITs/Ints/BiInvInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.BiInvInt.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/DeltaInt.agda
+++ b/Cubical/HITs/Ints/DeltaInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.DeltaInt where
 
 open import Cubical.HITs.Ints.DeltaInt.Base public

--- a/Cubical/HITs/Ints/DeltaInt/Base.agda
+++ b/Cubical/HITs/Ints/DeltaInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 {-
 

--- a/Cubical/HITs/Ints/DeltaInt/Properties.agda
+++ b/Cubical/HITs/Ints/DeltaInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 {-
 

--- a/Cubical/HITs/Ints/DiffInt.agda
+++ b/Cubical/HITs/Ints/DiffInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.DiffInt where
 
 open import Cubical.HITs.Ints.DiffInt.Base public

--- a/Cubical/HITs/Ints/DiffInt/Base.agda
+++ b/Cubical/HITs/Ints/DiffInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.DiffInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/DiffInt/Properties.agda
+++ b/Cubical/HITs/Ints/DiffInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.DiffInt.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/HAEquivInt.agda
+++ b/Cubical/HITs/Ints/HAEquivInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.HAEquivInt where
 
 open import Cubical.HITs.Ints.HAEquivInt.Base public

--- a/Cubical/HITs/Ints/HAEquivInt/Base.agda
+++ b/Cubical/HITs/Ints/HAEquivInt/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.HAEquivInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/IsoInt.agda
+++ b/Cubical/HITs/Ints/IsoInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.IsoInt where
 
 open import Cubical.HITs.Ints.IsoInt.Base public

--- a/Cubical/HITs/Ints/IsoInt/Base.agda
+++ b/Cubical/HITs/Ints/IsoInt/Base.agda
@@ -6,7 +6,7 @@ This file mainly contains a proof that IsoInt ≢ Int, and ends with a
  demonstration of how the same proof strategy fails for BiInvInt.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.IsoInt.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Ints/QuoInt.agda
+++ b/Cubical/HITs/Ints/QuoInt.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.QuoInt where
 
 open import Cubical.HITs.Ints.QuoInt.Base public

--- a/Cubical/HITs/Ints/QuoInt/Base.agda
+++ b/Cubical/HITs/Ints/QuoInt/Base.agda
@@ -1,5 +1,5 @@
 -- Define the integers as a HIT by identifying +0 and -0
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.QuoInt.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Ints/QuoInt/Properties.agda
+++ b/Cubical/HITs/Ints/QuoInt/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Ints.QuoInt.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Join.agda
+++ b/Cubical/HITs/Join.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Join where
 
 open import Cubical.HITs.Join.Base public

--- a/Cubical/HITs/Join/Base.agda
+++ b/Cubical/HITs/Join/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Join.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -10,7 +10,7 @@ This file contains:
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Join.Properties where
 

--- a/Cubical/HITs/KleinBottle.agda
+++ b/Cubical/HITs/KleinBottle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.KleinBottle where
 
 open import Cubical.HITs.KleinBottle.Base public

--- a/Cubical/HITs/KleinBottle/Base.agda
+++ b/Cubical/HITs/KleinBottle/Base.agda
@@ -3,7 +3,7 @@
 Definition of the Klein bottle as a HIT
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.KleinBottle.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/KleinBottle/Properties.agda
+++ b/Cubical/HITs/KleinBottle/Properties.agda
@@ -3,7 +3,7 @@
 Definition of the Klein bottle as a HIT
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.KleinBottle.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/ListedFiniteSet.agda
+++ b/Cubical/HITs/ListedFiniteSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.ListedFiniteSet where
 
 open import Cubical.HITs.ListedFiniteSet.Base public

--- a/Cubical/HITs/ListedFiniteSet/Base.agda
+++ b/Cubical/HITs/ListedFiniteSet/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.ListedFiniteSet.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/ListedFiniteSet/Properties.agda
+++ b/Cubical/HITs/ListedFiniteSet/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.ListedFiniteSet.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Localization.agda
+++ b/Cubical/HITs/Localization.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Localization where
 
 open import Cubical.HITs.Localization.Base public

--- a/Cubical/HITs/Localization/Base.agda
+++ b/Cubical/HITs/Localization/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Localization.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Localization/Properties.agda
+++ b/Cubical/HITs/Localization/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Localization.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/MappingCones.agda
+++ b/Cubical/HITs/MappingCones.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.MappingCones where
 

--- a/Cubical/HITs/MappingCones/Base.agda
+++ b/Cubical/HITs/MappingCones/Base.agda
@@ -3,7 +3,7 @@
 Mapping cones or the homotopy cofiber/cokernel
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.MappingCones.Base where
 

--- a/Cubical/HITs/MappingCones/Properties.agda
+++ b/Cubical/HITs/MappingCones/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.MappingCones.Properties where
 

--- a/Cubical/HITs/Modulo.agda
+++ b/Cubical/HITs/Modulo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Modulo where
 

--- a/Cubical/HITs/Modulo/Base.agda
+++ b/Cubical/HITs/Modulo/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Modulo.Base where
 

--- a/Cubical/HITs/Modulo/FinEquiv.agda
+++ b/Cubical/HITs/Modulo/FinEquiv.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Modulo.FinEquiv where
 

--- a/Cubical/HITs/Modulo/Properties.agda
+++ b/Cubical/HITs/Modulo/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Modulo.Properties where
 

--- a/Cubical/HITs/Nullification.agda
+++ b/Cubical/HITs/Nullification.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Nullification where
 
 open import Cubical.HITs.Nullification.Base public

--- a/Cubical/HITs/Nullification/Base.agda
+++ b/Cubical/HITs/Nullification/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Nullification.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Nullification/Properties.agda
+++ b/Cubical/HITs/Nullification/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Nullification.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/PropositionalTruncation.agda
+++ b/Cubical/HITs/PropositionalTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.PropositionalTruncation where
 
 open import Cubical.HITs.PropositionalTruncation.Base public

--- a/Cubical/HITs/PropositionalTruncation/Base.agda
+++ b/Cubical/HITs/PropositionalTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of propositional truncation
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.PropositionalTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
+++ b/Cubical/HITs/PropositionalTruncation/MagicTrick.agda
@@ -11,7 +11,7 @@ Also see the follow-up post by Jason Gross:
   https://homotopytypetheory.org/2014/02/24/composition-is-not-what-you-think-it-is-why-nearly-invertible-isnt/
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.PropositionalTruncation.MagicTrick where
 

--- a/Cubical/HITs/PropositionalTruncation/Monad.agda
+++ b/Cubical/HITs/PropositionalTruncation/Monad.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts #-}
+{-# OPTIONS --safe #-}
 {-
 Implements the monadic interface of propositional truncation, for reasoning in do-syntax.
 -}

--- a/Cubical/HITs/PropositionalTruncation/Properties.agda
+++ b/Cubical/HITs/PropositionalTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Eliminator for propositional truncation
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.PropositionalTruncation.Properties where
 
 open import Cubical.Core.Everything

--- a/Cubical/HITs/Pushout.agda
+++ b/Cubical/HITs/Pushout.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Pushout where
 
 open import Cubical.HITs.Pushout.Base public

--- a/Cubical/HITs/Pushout/Base.agda
+++ b/Cubical/HITs/Pushout/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Pushout.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -7,7 +7,7 @@
     entirely from definitional equalities involving glue/unglue.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Pushout.Flattening where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Pushout/KrausVonRaumer.agda
+++ b/Cubical/HITs/Pushout/KrausVonRaumer.agda
@@ -6,7 +6,7 @@ https://arxiv.org/abs/1901.06022
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Pushout.KrausVonRaumer where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -10,7 +10,7 @@ This file contains:
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Pushout.Properties where
 

--- a/Cubical/HITs/RPn.agda
+++ b/Cubical/HITs/RPn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.RPn where
 
 open import Cubical.HITs.RPn.Base public

--- a/Cubical/HITs/RPn/Base.agda
+++ b/Cubical/HITs/RPn/Base.agda
@@ -6,7 +6,7 @@
            (2017) https://arxiv.org/abs/1704.05770
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.RPn.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Rationals/HITQ.agda
+++ b/Cubical/HITs/Rationals/HITQ.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.HITQ where
 
 open import Cubical.HITs.Rationals.HITQ.Base public

--- a/Cubical/HITs/Rationals/HITQ/Base.agda
+++ b/Cubical/HITs/Rationals/HITQ/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.HITQ.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Rationals/QuoQ.agda
+++ b/Cubical/HITs/Rationals/QuoQ.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.QuoQ where
 
 open import Cubical.HITs.Rationals.QuoQ.Base public

--- a/Cubical/HITs/Rationals/QuoQ/Base.agda
+++ b/Cubical/HITs/Rationals/QuoQ/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.QuoQ.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Rationals/QuoQ/Properties.agda
+++ b/Cubical/HITs/Rationals/QuoQ/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.QuoQ.Properties where
 
 open import Cubical.Foundations.Everything hiding (_⁻¹)

--- a/Cubical/HITs/Rationals/SigmaQ.agda
+++ b/Cubical/HITs/Rationals/SigmaQ.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.SigmaQ where
 
 open import Cubical.HITs.Rationals.SigmaQ.Base public

--- a/Cubical/HITs/Rationals/SigmaQ/Base.agda
+++ b/Cubical/HITs/Rationals/SigmaQ/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.SigmaQ.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Rationals/SigmaQ/Properties.agda
+++ b/Cubical/HITs/Rationals/SigmaQ/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Rationals.SigmaQ.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S1.agda
+++ b/Cubical/HITs/S1.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S1 where
 
 open import Cubical.HITs.S1.Base public

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -3,7 +3,7 @@
 Definition of the circle as a HIT with a proof that Ω(S¹) ≡ ℤ
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S1.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S1/Properties.agda
+++ b/Cubical/HITs/S1/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S1.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S2.agda
+++ b/Cubical/HITs/S2.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S2 where
 
 open import Cubical.HITs.S2.Base public

--- a/Cubical/HITs/S2/Base.agda
+++ b/Cubical/HITs/S2/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S2.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/S3.agda
+++ b/Cubical/HITs/S3.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S3 where
 
 open import Cubical.HITs.S3.Base public

--- a/Cubical/HITs/S3/Base.agda
+++ b/Cubical/HITs/S3/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.S3.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/SetQuotients.agda
+++ b/Cubical/HITs/SetQuotients.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe  #-}
+{-# OPTIONS --safe  #-}
 module Cubical.HITs.SetQuotients where
 
 open import Cubical.HITs.SetQuotients.Base public

--- a/Cubical/HITs/SetQuotients/Base.agda
+++ b/Cubical/HITs/SetQuotients/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of set quotients
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SetQuotients.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -4,7 +4,7 @@ Set quotients:
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SetQuotients.Properties where
 
 open import Cubical.HITs.SetQuotients.Base

--- a/Cubical/HITs/SetTruncation.agda
+++ b/Cubical/HITs/SetTruncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SetTruncation where
 
 open import Cubical.HITs.SetTruncation.Base public

--- a/Cubical/HITs/SetTruncation/Base.agda
+++ b/Cubical/HITs/SetTruncation/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of set truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SetTruncation.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/SetTruncation/Properties.agda
+++ b/Cubical/HITs/SetTruncation/Properties.agda
@@ -5,7 +5,7 @@ This file contains:
 - Properties of set truncations
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SetTruncation.Properties where
 
 open import Cubical.HITs.SetTruncation.Base

--- a/Cubical/HITs/SmashProduct.agda
+++ b/Cubical/HITs/SmashProduct.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SmashProduct where
 
 open import Cubical.HITs.SmashProduct.Base public

--- a/Cubical/HITs/SmashProduct/Base.agda
+++ b/Cubical/HITs/SmashProduct/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.SmashProduct.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Sn.agda
+++ b/Cubical/HITs/Sn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Sn where
 
 open import Cubical.HITs.Sn.Base public

--- a/Cubical/HITs/Sn/Base.agda
+++ b/Cubical/HITs/Sn/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Sn.Base where
 
 open import Cubical.HITs.Susp

--- a/Cubical/HITs/Sn/Properties.agda
+++ b/Cubical/HITs/Sn/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Sn.Properties where
 
 open import Cubical.Foundations.Pointed

--- a/Cubical/HITs/Susp.agda
+++ b/Cubical/HITs/Susp.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Susp where
 
 open import Cubical.HITs.Susp.Base public

--- a/Cubical/HITs/Susp/Base.agda
+++ b/Cubical/HITs/Susp/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Susp.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Susp/Properties.agda
+++ b/Cubical/HITs/Susp/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Susp.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Torus.agda
+++ b/Cubical/HITs/Torus.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Torus where
 
 open import Cubical.HITs.Torus.Base public

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -4,7 +4,7 @@ Definition of the torus as a HIT together with a proof that it is
 equivalent to two circles
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Torus.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Truncation.agda
+++ b/Cubical/HITs/Truncation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Truncation where
 
 open import Cubical.HITs.Truncation.Base public

--- a/Cubical/HITs/Truncation/Base.agda
+++ b/Cubical/HITs/Truncation/Base.agda
@@ -6,7 +6,7 @@ Note that this uses the HoTT book's indexing, so it will be off
  from `∥_∥_` in HITs.Truncation.Base by -2
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Truncation.Base where
 
 open import Cubical.Data.NatMinusOne renaming (suc₋₁ to suc)

--- a/Cubical/HITs/Truncation/FromNegTwo.agda
+++ b/Cubical/HITs/Truncation/FromNegTwo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Truncation.FromNegTwo where
 
 open import Cubical.HITs.Truncation.FromNegTwo.Base public

--- a/Cubical/HITs/Truncation/FromNegTwo/Base.agda
+++ b/Cubical/HITs/Truncation/FromNegTwo/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Truncation.FromNegTwo.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Truncation/FromNegTwo/Properties.agda
+++ b/Cubical/HITs/Truncation/FromNegTwo/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Truncation.FromNegTwo.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.HITs.Truncation.Properties where
 open import Cubical.Data.NatMinusOne

--- a/Cubical/HITs/TypeQuotients.agda
+++ b/Cubical/HITs/TypeQuotients.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.TypeQuotients where
 
 open import Cubical.HITs.TypeQuotients.Base public

--- a/Cubical/HITs/TypeQuotients/Base.agda
+++ b/Cubical/HITs/TypeQuotients/Base.agda
@@ -5,7 +5,7 @@ This file contains:
 - Definition of type quotients (i.e. non-truncated quotients)
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.TypeQuotients.Base where
 
 open import Cubical.Core.Primitives

--- a/Cubical/HITs/TypeQuotients/Properties.agda
+++ b/Cubical/HITs/TypeQuotients/Properties.agda
@@ -4,7 +4,7 @@ Type quotients:
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.TypeQuotients.Properties where
 
 open import Cubical.HITs.TypeQuotients.Base

--- a/Cubical/HITs/Wedge.agda
+++ b/Cubical/HITs/Wedge.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Wedge where
 
 open import Cubical.HITs.Wedge.Base public

--- a/Cubical/HITs/Wedge/Base.agda
+++ b/Cubical/HITs/Wedge/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.HITs.Wedge.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Homotopy/Base.agda
+++ b/Cubical/Homotopy/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Homotopy.Base where
 

--- a/Cubical/Homotopy/Connected.agda
+++ b/Cubical/Homotopy/Connected.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Homotopy.Connected where
 
 open import Cubical.Core.Everything

--- a/Cubical/Homotopy/EilenbergSteenrod.agda
+++ b/Cubical/Homotopy/EilenbergSteenrod.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Homotopy.EilenbergSteenrod where
 

--- a/Cubical/Homotopy/Freudenthal.agda
+++ b/Cubical/Homotopy/Freudenthal.agda
@@ -3,7 +3,7 @@
 Freudenthal suspension theorem
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Homotopy.Freudenthal where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Homotopy/Loopspace.agda
+++ b/Cubical/Homotopy/Loopspace.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Homotopy.Loopspace where
 

--- a/Cubical/Homotopy/MayerVietorisCofiber.agda
+++ b/Cubical/Homotopy/MayerVietorisCofiber.agda
@@ -9,7 +9,7 @@ The sequence Susp X → (B ⋁ C) → B ⊔_X C therefore induces a long exact s
 Proof is adapted from Evan Cavallo's master's thesis.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Homotopy.MayerVietorisCofiber where
 
 open import Cubical.Core.Everything

--- a/Cubical/Homotopy/WedgeConnectivity.agda
+++ b/Cubical/Homotopy/WedgeConnectivity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Homotopy.WedgeConnectivity where
 
 open import Cubical.Foundations.Everything

--- a/Cubical/Induction/WellFounded.agda
+++ b/Cubical/Induction/WellFounded.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Induction.WellFounded where
 

--- a/Cubical/Modalities/Lex.agda
+++ b/Cubical/Modalities/Lex.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --postfix-projections #-}
+{-# OPTIONS --safe --postfix-projections #-}
 
 open import Cubical.Foundations.Everything renaming (uncurry to λ⟨,⟩_)
 open import Cubical.Data.Sigma.Properties

--- a/Cubical/Modalities/Modality.agda
+++ b/Cubical/Modalities/Modality.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Modalities.Modality where
 
 {-

--- a/Cubical/Papers/RepresentationIndependence.agda
+++ b/Cubical/Papers/RepresentationIndependence.agda
@@ -10,7 +10,7 @@ Carlo Angiuli, Evan Cavallo, Anders Mörtberg, Max Zeuner
 Preprint: https://arxiv.org/abs/2009.05547
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Papers.RepresentationIndependence where
 
 

--- a/Cubical/Papers/Synthetic.agda
+++ b/Cubical/Papers/Synthetic.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Papers.Synthetic where
 
 -- Cubical synthetic homotopy theory

--- a/Cubical/Papers/ZCohomology.agda
+++ b/Cubical/Papers/ZCohomology.agda
@@ -12,7 +12,7 @@ Synthetic Cohomology Theory in Cubical Agda
 
 -- The "--safe" flag ensures that there are no postulates or
 -- unfinished goals
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Papers.ZCohomology where
 
 -- Misc.

--- a/Cubical/README.agda
+++ b/Cubical/README.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.README where
 
 ------------------------------------------------------------------------

--- a/Cubical/Reflection/Base.agda
+++ b/Cubical/Reflection/Base.agda
@@ -3,7 +3,7 @@
 Some basic utilities for reflection
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Reflection.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Reflection/RecordEquiv.agda
+++ b/Cubical/Reflection/RecordEquiv.agda
@@ -6,7 +6,7 @@
   See end of file for examples.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Reflection.RecordEquiv where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Reflection/StrictEquiv.agda
+++ b/Cubical/Reflection/StrictEquiv.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Reflection.StrictEquiv where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Binary.agda
+++ b/Cubical/Relation/Binary.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Binary where
 
 open import Cubical.Relation.Binary.Base public

--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Binary.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Relation/Binary/Poset.agda
+++ b/Cubical/Relation/Binary/Poset.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Binary.Poset where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Binary/Properties.agda
+++ b/Cubical/Relation/Binary/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Binary.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Nullary.agda
+++ b/Cubical/Relation/Nullary.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Nullary where
 
 open import Cubical.Relation.Nullary.Base public

--- a/Cubical/Relation/Nullary/Base.agda
+++ b/Cubical/Relation/Nullary/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Nullary.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Nullary/DecidableEq.agda
+++ b/Cubical/Relation/Nullary/DecidableEq.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Nullary.DecidableEq where
 
 open import Cubical.Relation.Nullary.Properties

--- a/Cubical/Relation/Nullary/HLevels.agda
+++ b/Cubical/Relation/Nullary/HLevels.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.Nullary.HLevels where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Relation/Nullary/Properties.agda
+++ b/Cubical/Relation/Nullary/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 {-
 
 Properties of nullary relations, i.e. structures on types.

--- a/Cubical/Relation/ZigZag/Applications/MultiSet.agda
+++ b/Cubical/Relation/ZigZag/Applications/MultiSet.agda
@@ -1,5 +1,5 @@
 -- We apply the theory of quasi equivalence relations (QERs) to finite multisets and association lists.
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.ZigZag.Applications.MultiSet where
 
 open import Cubical.Core.Everything

--- a/Cubical/Relation/ZigZag/Base.agda
+++ b/Cubical/Relation/ZigZag/Base.agda
@@ -1,6 +1,6 @@
 -- We define ZigZag-complete relations and prove that quasi equivalence relations
 -- give rise to equivalences on the set quotients.
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Relation.ZigZag.Base where
 
 open import Cubical.Core.Everything

--- a/Cubical/Structures/Auto.agda
+++ b/Cubical/Structures/Auto.agda
@@ -12,7 +12,7 @@ is [constant (ℕ → ℕ)] rather than [function (constant ℕ) (constant ℕ)]
 Writing [auto* (λ X → ⋯)] doesn't seem to work, but [auto* (λ (X : Type ℓ) → ⋯)] does.
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Auto where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Axioms.agda
+++ b/Cubical/Structures/Axioms.agda
@@ -5,7 +5,7 @@ Add axioms (i.e., propositions) to a structure S without changing the definition
 X ↦ Σ[ s ∈ S X ] (P X s) where (P X s) is a proposition for all X and s.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Axioms where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Constant.agda
+++ b/Cubical/Structures/Constant.agda
@@ -3,7 +3,7 @@
 Constant structure: _ ↦ A
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Constant where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Function.agda
+++ b/Cubical/Structures/Function.agda
@@ -3,7 +3,7 @@
 Functions between structures S and T: X ↦ S X → T X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Function where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/LeftAction.agda
+++ b/Cubical/Structures/LeftAction.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.LeftAction where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Macro.agda
+++ b/Cubical/Structures/Macro.agda
@@ -3,7 +3,7 @@
 Descriptor language for easily defining structures
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Macro where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Maybe.agda
+++ b/Cubical/Structures/Maybe.agda
@@ -3,7 +3,7 @@
   Maybe structure: X ↦ Maybe (S X)
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Maybe where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/MultiSet.agda
+++ b/Cubical/Structures/MultiSet.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.MultiSet where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Parameterized.agda
+++ b/Cubical/Structures/Parameterized.agda
@@ -6,7 +6,7 @@ X ↦ (a : A) → S a X
 This is more general than Structures.Function in that S can vary in A.
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Parameterized where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -3,7 +3,7 @@
 Pointed structure: X ↦ X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Pointed where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Product.agda
+++ b/Cubical/Structures/Product.agda
@@ -3,7 +3,7 @@
 Product of structures S and T: X ↦ S X × T X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Product where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Queue.agda
+++ b/Cubical/Structures/Queue.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Queue where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Record.agda
+++ b/Cubical/Structures/Record.agda
@@ -3,7 +3,7 @@
 Automatically generating proofs of UnivalentStr for records
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Record where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Auto.agda
+++ b/Cubical/Structures/Relational/Auto.agda
@@ -12,7 +12,7 @@ is [constant (ℕ → ℕ)] rather than [function (constant ℕ) (constant ℕ)]
 Writing [auto* (λ X → ⋯)] doesn't seem to work, but [auto* (λ (X : Type ℓ) → ⋯)] does.
 
 -}
-{-# OPTIONS --cubical --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Relational.Auto where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Constant.agda
+++ b/Cubical/Structures/Relational/Constant.agda
@@ -3,7 +3,7 @@
 Constant structure: _ ↦ A
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Constant where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Equalizer.agda
+++ b/Cubical/Structures/Relational/Equalizer.agda
@@ -3,7 +3,7 @@
 Equalizer of functions f g : S X ⇉ T X such that f and g act on relation structures
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Equalizer where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Function.agda
+++ b/Cubical/Structures/Relational/Function.agda
@@ -3,7 +3,7 @@
 Index a structure T a positive structure S: X ↦ S X → T X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Function where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Macro.agda
+++ b/Cubical/Structures/Relational/Macro.agda
@@ -3,7 +3,7 @@
 Descriptor language for easily defining relational structures
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Relational.Macro where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Maybe.agda
+++ b/Cubical/Structures/Relational/Maybe.agda
@@ -3,7 +3,7 @@
 Maybe structure: X ↦ Maybe (S X)
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --no-exact-split --safe #-}
+{-# OPTIONS --no-exact-split --safe #-}
 module Cubical.Structures.Relational.Maybe where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Parameterized.agda
+++ b/Cubical/Structures/Relational/Parameterized.agda
@@ -4,7 +4,7 @@ A parameterized family of structures S can be combined into a single structure:
 X ↦ (a : A) → S a X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Parameterized where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Pointed.agda
+++ b/Cubical/Structures/Relational/Pointed.agda
@@ -3,7 +3,7 @@
 Pointed structure: X ↦ X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Pointed where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Relational/Product.agda
+++ b/Cubical/Structures/Relational/Product.agda
@@ -3,7 +3,7 @@
 Product of structures S and T: X ↦ S X × T X
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Relational.Product where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/Transfer.agda
+++ b/Cubical/Structures/Transfer.agda
@@ -3,7 +3,7 @@
 Transferring properties of terms between equivalent structures
 
 -}
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.Transfer where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Structures/TypeEqvTo.agda
+++ b/Cubical/Structures/TypeEqvTo.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Structures.TypeEqvTo where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Talks/EPA2020.agda
+++ b/Cubical/Talks/EPA2020.agda
@@ -13,7 +13,7 @@ Link to video: https://vimeo.com/459020971
 -}
 
 -- To make Agda cubical add the following options
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.Talks.EPA2020 where
 
 -- The "Foundations" package contain a lot of important results (in

--- a/Cubical/WithK.agda
+++ b/Cubical/WithK.agda
@@ -9,7 +9,7 @@ incompatible flags.
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts --with-K #-}
+{-# OPTIONS --with-K #-}
 
 module Cubical.WithK where
 

--- a/Cubical/ZCohomology/Base.agda
+++ b/Cubical/ZCohomology/Base.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.ZCohomology.Base where
 
 open import Cubical.Data.Int.Base

--- a/Cubical/ZCohomology/EilenbergSteenrodZ.agda
+++ b/Cubical/ZCohomology/EilenbergSteenrodZ.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 
 module Cubical.ZCohomology.EilenbergSteenrodZ where
 

--- a/Cubical/ZCohomology/GroupStructure.agda
+++ b/Cubical/ZCohomology/GroupStructure.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.GroupStructure where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Connected.agda
+++ b/Cubical/ZCohomology/Groups/Connected.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.ZCohomology.Groups.Connected where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/KleinBottle.agda
+++ b/Cubical/ZCohomology/Groups/KleinBottle.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.KleinBottle where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Prelims.agda
+++ b/Cubical/ZCohomology/Groups/Prelims.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.Prelims where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/RP2.agda
+++ b/Cubical/ZCohomology/Groups/RP2.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.RP2 where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Sn.agda
+++ b/Cubical/ZCohomology/Groups/Sn.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.ZCohomology.Groups.Sn where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Torus.agda
+++ b/Cubical/ZCohomology/Groups/Torus.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.Torus where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Unit.agda
+++ b/Cubical/ZCohomology/Groups/Unit.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.ZCohomology.Groups.Unit where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/Wedge.agda
+++ b/Cubical/ZCohomology/Groups/Wedge.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.Wedge where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Groups/WedgeOfSpheres.agda
+++ b/Cubical/ZCohomology/Groups/WedgeOfSpheres.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.WedgeOfSpheres where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/ZCohomology/MayerVietorisUnreduced.agda
+++ b/Cubical/ZCohomology/MayerVietorisUnreduced.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe #-}
+{-# OPTIONS --safe #-}
 module Cubical.ZCohomology.MayerVietorisUnreduced where
 
 open import Cubical.ZCohomology.Base

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Properties where
 
 {-

--- a/Everythings.hs
+++ b/Everythings.hs
@@ -85,7 +85,7 @@ genEverythings =
   mapM_ (\dir -> do
     let fp = addToFP ["Cubical"] dir
     files <- getMissingFiles fp Nothing
-    let ls = ["{-# OPTIONS --cubical --no-import-sorts --safe #-}",
+    let ls = ["{-# OPTIONS --safe #-}",
               "module " ++ showFP '.' (addToFP fp "Everything") ++ " where",[]]
              ++ sort (fmap (\file -> "import " ++ showFP '.' file)
                            (delete (addToFP fp "Everything") files))

--- a/cubical.agda-lib
+++ b/cubical.agda-lib
@@ -1,3 +1,4 @@
 name: cubical-0.3
 include: .
 depend:
+flags: --cubical --no-import-sorts


### PR DESCRIPTION
The --cubical and --no-import-sorts flags will be on every file, so we can lift them out to the agda-lib file.