### PR TITLE
Simplify the truncation path space calculation a bit

### DIFF
--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -239,6 +239,10 @@ subst2 B p q b = transport (λ i → B (p i) (q i)) b
 substRefl : (px : B x) → subst B refl px ≡ px
 substRefl px = transportRefl px
 
+subst-filler : (B : A → Type ℓ') (p : x ≡ y) (b : B x)
+  → PathP (λ i → B (p i)) b (subst B p b)
+subst-filler B p = transport-filler (cong B p)
+
 funExt : {B : A → I → Type ℓ'}
   {f : (x : A) → B x i0} {g : (x : A) → B x i1}
   → ((x : A) → PathP (B x) (f x) (g x))

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -358,15 +358,16 @@ Iso.leftInv (truncOfProdIso (suc n)) = elim (λ _ → isOfHLevelPath (suc n) (is
 
 module ΩTrunc {X : Type ℓ} {n : HLevel} where
   {- We define the fibration P to show a more general result  -}
+  Ph : ∥ X ∥ (2 + n) → ∥ X ∥ (2 + n) → TypeOfHLevel ℓ (suc n)
+  Ph x y =  rec2 (isOfHLevelTypeOfHLevel (suc n))
+                 (λ a b → ∥ a ≡ b ∥ (suc n) , isOfHLevelTrunc (suc n)) x y
+
   P : ∥ X ∥ (2 + n) → ∥ X ∥ (2 + n) → Type ℓ
-  P x y =  rec2 (isOfHLevelTypeOfHLevel (suc n))
-                (λ a b → ∥ a ≡ b ∥ (suc n) , isOfHLevelTrunc (suc n)) x y .fst
+  P x y = Ph x y .fst
 
   {- We will need P to be of hLevel n + 3  -}
   hLevelP : (a b : ∥ X ∥ (2 + n)) → isOfHLevel (2 + n) (P a b)
-  hLevelP  =
-    elim2 (λ x y → isProp→isOfHLevelSuc (suc n) (isPropIsOfHLevel (2 + n)))
-          (λ a b → isOfHLevelSuc (suc n) (isOfHLevelTrunc (suc n)))
+  hLevelP x y = isOfHLevelSuc (suc n) (Ph x y .snd)
 
   {- decode function from P x y to x ≡ y -}
   decode-fun : (x y : ∥ X ∥ (2 + n)) → P x y → x ≡ y

--- a/Cubical/HITs/Truncation/Properties.agda
+++ b/Cubical/HITs/Truncation/Properties.agda
@@ -358,16 +358,16 @@ Iso.leftInv (truncOfProdIso (suc n)) = elim (λ _ → isOfHLevelPath (suc n) (is
 
 module ΩTrunc {X : Type ℓ} {n : HLevel} where
   {- We define the fibration P to show a more general result  -}
-  Ph : ∥ X ∥ (2 + n) → ∥ X ∥ (2 + n) → TypeOfHLevel ℓ (suc n)
-  Ph x y =  rec2 (isOfHLevelTypeOfHLevel (suc n))
-                 (λ a b → ∥ a ≡ b ∥ (suc n) , isOfHLevelTrunc (suc n)) x y
+  Code : ∥ X ∥ (2 + n) → ∥ X ∥ (2 + n) → TypeOfHLevel ℓ (suc n)
+  Code x y =  rec2 (isOfHLevelTypeOfHLevel (suc n))
+                (λ a b → ∥ a ≡ b ∥ (suc n) , isOfHLevelTrunc (suc n)) x y
 
   P : ∥ X ∥ (2 + n) → ∥ X ∥ (2 + n) → Type ℓ
-  P x y = Ph x y .fst
+  P x y = Code x y .fst
 
   {- We will need P to be of hLevel n + 3  -}
   hLevelP : (a b : ∥ X ∥ (2 + n)) → isOfHLevel (2 + n) (P a b)
-  hLevelP x y = isOfHLevelSuc (suc n) (Ph x y .snd)
+  hLevelP x y = isOfHLevelSuc (suc n) (Code x y .snd)
 
   {- decode function from P x y to x ≡ y -}
   decode-fun : (x y : ∥ X ∥ (2 + n)) → P x y → x ≡ y
@@ -387,7 +387,7 @@ module ΩTrunc {X : Type ℓ} {n : HLevel} where
   encode-fun : (x y : ∥ X ∥ (2 + n)) → x ≡ y → P x y
   encode-fun x y p = subst (P x) p (r x)
 
-  {- We need the following two lemmas on the functions behaviour for refl -}
+  {- We need the following lemma on the functions behaviour for refl -}
   dec-refl : (x : ∥ X ∥ (2 + n)) → decode-fun x x (r x) ≡ refl
   dec-refl =
     elim (λ x → isOfHLevelSuc (1 + n)
@@ -396,28 +396,26 @@ module ΩTrunc {X : Type ℓ} {n : HLevel} where
                      (decode-fun x x (r x)) refl))
          (λ _ → refl)
 
-  enc-refl : (x : ∥ X ∥ (2 + n)) → encode-fun x x refl ≡ r x
-  enc-refl x = transportRefl (r x)
-
   {- decode-fun is a right-inverse -}
   P-rinv : (u v : ∥ X ∥ (2 + n)) (x : Path (∥ X ∥ (2 + n)) u v)
          → decode-fun u v (encode-fun u v x) ≡ x
-  P-rinv u v = J (λ y p → decode-fun u y (encode-fun u y p) ≡ p)
-                 (cong (decode-fun u u) (enc-refl u) ∙ dec-refl u)
+  P-rinv u v p =
+    transport
+      (λ i → decode-fun u (p i) (subst-filler (P u) p (r u) i) ≡ (λ j → p (i ∧ j)))
+      (dec-refl u)
 
   {- decode-fun is a left-inverse -}
   P-linv : (u v : ∥ X ∥ (2 + n)) (x : P u v)
          → encode-fun u v (decode-fun u v x) ≡ x
   P-linv =
     elim2 (λ x y → isOfHLevelΠ (2 + n) (λ z → isOfHLevelSuc (2 + n) (hLevelP x y) _ _))
-          helper
+      (λ a b → elim (λ p → hLevelP ∣ a ∣ ∣ b ∣ _ _) (helper a b))
     where
-    helper : (a b : X) (p : P ∣ a ∣ ∣ b ∣)
-           → encode-fun _ _ (decode-fun ∣ a ∣ ∣ b ∣ p) ≡ p
-    helper a b =
-      elim (λ x → hLevelP ∣ a ∣ ∣ b ∣ _ _)
-           (J (λ y p → encode-fun ∣ a ∣ ∣ y ∣ (decode-fun _ _ ∣ p ∣) ≡ ∣ p ∣)
-              (enc-refl ∣ a ∣))
+    helper : (a b : X) (p : a ≡ b) → encode-fun _ _ (decode-fun ∣ a ∣ ∣ b ∣ (∣ p ∣)) ≡ ∣ p ∣
+    helper a b p =
+      transport
+        (λ i → subst-filler (P ∣ a ∣) (cong ∣_∣ p) ∣ refl ∣ i ≡ ∣ (λ j → p (i ∧ j)) ∣)
+        refl
 
   {- The final Iso established -}
   IsoFinal : (x y : ∥ X ∥ (2 + n)) → Iso (x ≡ y) (P x y)
@@ -427,10 +425,11 @@ module ΩTrunc {X : Type ℓ} {n : HLevel} where
   Iso.leftInv (IsoFinal x y) = P-rinv x y
 
   +P : (x y z : ∥ X ∥ (2 + n)) → (P x y) → (P y z) → P x z
-  +P = elim3 (λ x _ z → isOfHLevelΠ (2 + n) λ _ → isOfHLevelΠ (2 + n) λ _ → hLevelP x z)
-                      λ a b c → rec (isOfHLevelΠ (suc n) λ _ → isOfHLevelTrunc (suc n))
-                        λ p → rec (isOfHLevelTrunc (suc n))
-                        λ q → ∣ p ∙ q ∣
+  +P =
+    elim3 (λ x _ z → isOfHLevelΠ (2 + n) λ _ → isOfHLevelΠ (2 + n) λ _ → hLevelP x z) λ a b c →
+    rec (isOfHLevelΠ (suc n) λ _ → isOfHLevelTrunc (suc n)) λ p →
+    rec (isOfHLevelTrunc (suc n)) λ q →
+    ∣ p ∙ q ∣
 
   +P-funct : (x y z : ∥ X ∥ (2 + n)) (p : x ≡ y) (q : y ≡ z)
           → +P x y z (Iso.fun (IsoFinal x y) p) (Iso.fun (IsoFinal y z) q)


### PR DESCRIPTION
Two things:
- We were reproving the truncation level of the Codes fibration, which is already true by construction
- Used `transport-filler` (or corresponding `subst-filler` I added) rather than `J` to avoid some `transportRefl`s