### PR TITLE
Make level arguments to universes of algebras explicit

### DIFF
--- a/Cubical/Algebra/AbGroup/Base.agda
+++ b/Cubical/Algebra/AbGroup/Base.agda
@@ -52,8 +52,8 @@ record AbGroupStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsAbGroup isAbGroup public
 
-AbGroup : Type (ℓ-suc ℓ)
-AbGroup = TypeWithStr _ AbGroupStr
+AbGroup : ∀ ℓ → Type (ℓ-suc ℓ)
+AbGroup ℓ = TypeWithStr ℓ AbGroupStr
 
 makeIsAbGroup : {G : Type ℓ} {0g : G} {_+_ : G → G → G} { -_ : G → G}
               (is-setG : isSet G)
@@ -71,7 +71,7 @@ makeAbGroup : {G : Type ℓ} (0g : G) (_+_ : G → G → G) (-_ : G → G)
             (rid : (x : G) → x + 0g ≡ x)
             (rinv : (x : G) → x + (- x) ≡ 0g)
             (comm    : (x y : G) → x + y ≡ y + x)
-          → AbGroup
+          → AbGroup ℓ
 makeAbGroup 0g _+_ -_ is-setG assoc rid rinv comm =
   _ , abgroupstr 0g _+_ -_ (makeIsAbGroup is-setG assoc rid rinv comm)
 
@@ -85,11 +85,11 @@ AbGroupStr→GroupStr A ._·_ = A ._+_
 AbGroupStr→GroupStr A .inv = A .-_
 AbGroupStr→GroupStr A .isGroup = A .isAbGroup .isGroup
 
-AbGroup→Group : AbGroup {ℓ} → Group
+AbGroup→Group : AbGroup ℓ → Group ℓ
 fst (AbGroup→Group A) = fst A
 snd (AbGroup→Group A) = AbGroupStr→GroupStr (snd A)
 
-Group→AbGroup : (G : Group {ℓ}) → ((x y : fst G) → _·_ (snd G) x y ≡ _·_ (snd G) y x) → AbGroup
+Group→AbGroup : (G : Group ℓ) → ((x y : fst G) → _·_ (snd G) x y ≡ _·_ (snd G) y x) → AbGroup ℓ
 fst (Group→AbGroup G comm) = fst G
 AbGroupStr.0g (snd (Group→AbGroup G comm)) = 1g (snd G)
 AbGroupStr._+_ (snd (Group→AbGroup G comm)) = _·_ (snd G)
@@ -97,17 +97,17 @@ AbGroupStr.- snd (Group→AbGroup G comm) = inv (snd G)
 IsAbGroup.isGroup (AbGroupStr.isAbGroup (snd (Group→AbGroup G comm))) = isGroup (snd G)
 IsAbGroup.comm (AbGroupStr.isAbGroup (snd (Group→AbGroup G comm))) = comm
 
-isSetAbGroup : (A : AbGroup {ℓ}) → isSet ⟨ A ⟩
+isSetAbGroup : (A : AbGroup ℓ) → isSet ⟨ A ⟩
 isSetAbGroup A = isSetGroup (AbGroup→Group A)
 
-AbGroupHom : (G : AbGroup {ℓ}) (H : AbGroup {ℓ'}) → Type (ℓ-max ℓ ℓ')
+AbGroupHom : (G : AbGroup ℓ) (H : AbGroup ℓ') → Type (ℓ-max ℓ ℓ')
 AbGroupHom G H = GroupHom (AbGroup→Group G) (AbGroup→Group H)
 
 IsAbGroupEquiv : {A : Type ℓ} {B : Type ℓ'}
   (G : AbGroupStr A) (e : A ≃ B) (H : AbGroupStr B) → Type (ℓ-max ℓ ℓ')
 IsAbGroupEquiv G e H = IsGroupHom (AbGroupStr→GroupStr G) (e .fst) (AbGroupStr→GroupStr H)
 
-AbGroupEquiv : (G : AbGroup {ℓ}) (H : AbGroup {ℓ'}) → Type (ℓ-max ℓ ℓ')
+AbGroupEquiv : (G : AbGroup ℓ) (H : AbGroup ℓ') → Type (ℓ-max ℓ ℓ')
 AbGroupEquiv G H = Σ[ e ∈ (G .fst ≃ H .fst) ] IsAbGroupEquiv (G .snd) e (H .snd)
 
 isPropIsAbGroup : {G : Type ℓ} (0g : G) (_+_ : G → G → G) (- : G → G)
@@ -134,12 +134,12 @@ isPropIsAbGroup 0g _+_ -_ (isabgroup GG GC) (isabgroup HG HC) =
   open IsGroupHom
 
 -- Extract the characterization of equality of groups
-AbGroupPath : (G H : AbGroup {ℓ}) → (AbGroupEquiv G H) ≃ (G ≡ H)
+AbGroupPath : (G H : AbGroup ℓ) → (AbGroupEquiv G H) ≃ (G ≡ H)
 AbGroupPath = ∫ 𝒮ᴰ-AbGroup .UARel.ua
 
 -- TODO: Induced structure results are temporarily inconvenient while we transition between algebra
 -- representations
-module _ (G : AbGroup {ℓ}) {A : Type ℓ} (m : A → A → A)
+module _ (G : AbGroup ℓ) {A : Type ℓ} (m : A → A → A)
   (e : ⟨ G ⟩ ≃ A)
   (p· : ∀ x y → e .fst (G .snd ._+_ x y) ≡ m (e .fst x) (e .fst y))
   where
@@ -159,7 +159,7 @@ module _ (G : AbGroup {ℓ}) {A : Type ℓ} (m : A → A → A)
         (UARel.≅→≡ (autoUARel (Σ[ B ∈ Type ℓ ] (B → B → B))) (e , p·))
         (G.0g , G.-_ , G.isAbGroup)
 
-  InducedAbGroup : AbGroup
+  InducedAbGroup : AbGroup ℓ
   InducedAbGroup .fst = A
   InducedAbGroup .snd ._+_ = m
   InducedAbGroup .snd .0g = inducedΣ .fst
@@ -173,13 +173,13 @@ open IsMonoid
 open IsSemigroup
 open IsGroup
 
-dirProdAb : AbGroup {ℓ} → AbGroup {ℓ'} → AbGroup
+dirProdAb : AbGroup ℓ → AbGroup ℓ' → AbGroup (ℓ-max ℓ ℓ')
 dirProdAb A B =
   Group→AbGroup (DirProd (AbGroup→Group A) (AbGroup→Group B))
                  λ p q → ΣPathP (comm (isAbGroup (snd A)) _ _
                                 , comm (isAbGroup (snd B)) _ _)
 
-trivialAbGroup : ∀ {ℓ} → AbGroup {ℓ}
+trivialAbGroup : ∀ {ℓ} → AbGroup ℓ
 fst trivialAbGroup = Unit*
 0g (snd trivialAbGroup) = tt*
 _+_ (snd trivialAbGroup) _ _ = tt*

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -28,11 +28,11 @@ open Iso
 
 private
   variable
-    ℓ : Level
+    ℓ ℓ' ℓ'' ℓ''' : Level
 
-record IsAlgebra (R : Ring {ℓ}) {A : Type ℓ}
+record IsAlgebra (R : Ring ℓ) {A : Type ℓ'}
                  (0a 1a : A) (_+_ _·_ : A → A → A) (-_ : A → A)
-                 (_⋆_ : ⟨ R ⟩ → A → A) : Type ℓ where
+                 (_⋆_ : ⟨ R ⟩ → A → A) : Type (ℓ-max ℓ ℓ') where
 
   constructor isalgebra
 
@@ -54,7 +54,7 @@ record IsAlgebra (R : Ring {ℓ}) {A : Type ℓ}
 
 unquoteDecl IsAlgebraIsoΣ = declareRecordIsoΣ IsAlgebraIsoΣ (quote IsAlgebra)
 
-record AlgebraStr (R : Ring {ℓ}) (A : Type ℓ) : Type ℓ where
+record AlgebraStr (R : Ring ℓ) (A : Type ℓ') : Type (ℓ-max ℓ ℓ') where
 
   constructor algebrastr
 
@@ -69,30 +69,30 @@ record AlgebraStr (R : Ring {ℓ}) (A : Type ℓ) : Type ℓ where
 
   open IsAlgebra isAlgebra public
 
-Algebra : (R : Ring {ℓ}) → Type (ℓ-suc ℓ)
-Algebra {ℓ} R = Σ[ A ∈ Type ℓ ] AlgebraStr R A
+Algebra : (R : Ring ℓ) → ∀ ℓ' → Type (ℓ-max ℓ (ℓ-suc ℓ'))
+Algebra R ℓ' = Σ[ A ∈ Type ℓ' ] AlgebraStr R A
 
-module commonExtractors {R : Ring {ℓ}} where
+module commonExtractors {R : Ring ℓ} where
 
-  Algebra→Module : (A : Algebra R) → LeftModule R
+  Algebra→Module : (A : Algebra R ℓ') → LeftModule R ℓ'
   Algebra→Module (_ , algebrastr A _ _ _ _ _ (isalgebra isLeftModule _ _ _ _)) =
     _ , leftmodulestr A _ _ _ isLeftModule
 
-  Algebra→Ring : (A : Algebra R) → Ring {ℓ}
+  Algebra→Ring : (A : Algebra R ℓ') → Ring ℓ'
   Algebra→Ring (_ , str) = _ , ringstr _ _ _ _ _ (IsAlgebra.isRing (AlgebraStr.isAlgebra str))
 
-  Algebra→AbGroup : (A : Algebra R) → AbGroup {ℓ}
+  Algebra→AbGroup : (A : Algebra R ℓ') → AbGroup ℓ'
   Algebra→AbGroup A = LeftModule→AbGroup (Algebra→Module A)
 
-  Algebra→Monoid : (A : Algebra R) → Monoid {ℓ}
+  Algebra→Monoid : (A : Algebra R ℓ') → Monoid ℓ'
   Algebra→Monoid A = Ring→Monoid (Algebra→Ring A)
 
-  isSetAlgebra : (A : Algebra R) → isSet ⟨ A ⟩
+  isSetAlgebra : (A : Algebra R ℓ') → isSet ⟨ A ⟩
   isSetAlgebra A = isSetAbGroup (Algebra→AbGroup A)
 
   open RingStr (snd R) using (1r; ·Ldist+) renaming (_+_ to _+r_; _·_ to _·s_)
 
-  makeIsAlgebra : {A : Type ℓ} {0a 1a : A}
+  makeIsAlgebra : {A : Type ℓ'} {0a 1a : A}
                   {_+_ _·_ : A → A → A} { -_ : A → A} {_⋆_ : ⟨ R ⟩ → A → A}
                   (isSet-A : isSet A)
                   (+-assoc :  (x y z : A) → x + (y + z) ≡ (x + y) + z)
@@ -126,9 +126,9 @@ module commonExtractors {R : Ring {ℓ}} where
 
 open commonExtractors public
 
-record IsAlgebraHom {R : Ring {ℓ}} {A B : Type ℓ}
+record IsAlgebraHom {R : Ring ℓ} {A : Type ℓ'} {B : Type ℓ''}
   (M : AlgebraStr R A) (f : A → B) (N : AlgebraStr R B)
-  : Type ℓ
+  : Type (ℓ-max ℓ (ℓ-max ℓ' ℓ''))
   where
 
   -- Shorter qualified names
@@ -146,21 +146,21 @@ record IsAlgebraHom {R : Ring {ℓ}} {A B : Type ℓ}
 
 open IsAlgebraHom
 
-AlgebraHom : {R : Ring {ℓ}} (M N : Algebra R) → Type ℓ
+AlgebraHom : {R : Ring ℓ} (M : Algebra R ℓ') (N : Algebra R ℓ'') → Type (ℓ-max ℓ (ℓ-max ℓ' ℓ''))
 AlgebraHom M N = Σ[ f ∈ (⟨ M ⟩ → ⟨ N ⟩) ] IsAlgebraHom (M .snd) f (N .snd)
 
-IsAlgebraEquiv : {R : Ring {ℓ}} {A B : Type ℓ}
+IsAlgebraEquiv : {R : Ring ℓ} {A B : Type ℓ'}
   (M : AlgebraStr R A) (e : A ≃ B) (N : AlgebraStr R B)
-  → Type ℓ
+  → Type (ℓ-max ℓ ℓ')
 IsAlgebraEquiv M e N = IsAlgebraHom M (e .fst) N
 
-AlgebraEquiv : {R : Ring {ℓ}} (M N : Algebra R) → Type ℓ
+AlgebraEquiv : {R : Ring ℓ} (M N : Algebra R ℓ') → Type (ℓ-max ℓ ℓ')
 AlgebraEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsAlgebraEquiv (M .snd) e (N .snd)
 
-_$a_ : {R : Ring {ℓ}} {A B : Algebra R} → AlgebraHom A B → ⟨ A ⟩ → ⟨ B ⟩
+_$a_ : {R : Ring ℓ} {A : Algebra R ℓ'} {B : Algebra R ℓ''} → AlgebraHom A B → ⟨ A ⟩ → ⟨ B ⟩
 f $a x = fst f x
 
-isPropIsAlgebra : (R : Ring {ℓ}) {A : Type ℓ}
+isPropIsAlgebra : (R : Ring ℓ) {A : Type ℓ'}
   (0a 1a : A)
   (_+_ _·_ : A → A → A)
   (-_ : A → A)
@@ -178,7 +178,7 @@ isPropIsAlgebra R _ _ _ _ _ _ =
   where
   open IsLeftModule
 
-𝒮ᴰ-Algebra : (R : Ring {ℓ}) → DUARel (𝒮-Univ ℓ) (AlgebraStr R) ℓ
+𝒮ᴰ-Algebra : (R : Ring ℓ) → DUARel (𝒮-Univ ℓ') (AlgebraStr R) (ℓ-max ℓ ℓ')
 𝒮ᴰ-Algebra R =
   𝒮ᴰ-Record (𝒮-Univ _) (IsAlgebraEquiv {R = R})
     (fields:
@@ -196,10 +196,11 @@ isPropIsAlgebra R _ _ _ _ _ _ =
   nul = autoDUARel (𝒮-Univ _) (λ A → A)
   bin = autoDUARel (𝒮-Univ _) (λ A → A → A → A)
 
-AlgebraPath : {R : Ring {ℓ}} (A B : Algebra R) → (AlgebraEquiv A B) ≃ (A ≡ B)
-AlgebraPath {ℓ} {R} = ∫ (𝒮ᴰ-Algebra R) .UARel.ua
+AlgebraPath : {R : Ring ℓ} (A B : Algebra R ℓ') → (AlgebraEquiv A B) ≃ (A ≡ B)
+AlgebraPath {R = R} = ∫ (𝒮ᴰ-Algebra R) .UARel.ua
 
-compIsAlgebraHom : {R : Ring {ℓ}} {A B C : Algebra R} {g : ⟨ B ⟩ → ⟨ C ⟩} {f : ⟨ A ⟩ → ⟨ B ⟩}
+compIsAlgebraHom : {R : Ring ℓ} {A : Algebra R ℓ'} {B : Algebra R ℓ''} {C : Algebra R ℓ'''}
+  {g : ⟨ B ⟩ → ⟨ C ⟩} {f : ⟨ A ⟩ → ⟨ B ⟩}
   → IsAlgebraHom (B .snd) g (C .snd)
   → IsAlgebraHom (A .snd) f (B .snd)
   → IsAlgebraHom (A .snd) (g ∘ f) (C .snd)
@@ -210,12 +211,12 @@ compIsAlgebraHom {g = g} {f} gh fh .pres· x y = cong g (fh .pres· x y) ∙ gh 
 compIsAlgebraHom {g = g} {f} gh fh .pres- x = cong g (fh .pres- x) ∙ gh .pres- (f x)
 compIsAlgebraHom {g = g} {f} gh fh .pres⋆ r x = cong g (fh .pres⋆ r x) ∙ gh .pres⋆ r (f x)
 
-_∘a_ : {R : Ring {ℓ}} {A B C : Algebra R}
+_∘a_ : {R : Ring ℓ} {A : Algebra R ℓ'} {B : Algebra R ℓ''} {C : Algebra R ℓ'''}
        → AlgebraHom B C → AlgebraHom A B → AlgebraHom A C
 _∘a_  g f .fst = g .fst ∘ f .fst
 _∘a_  g f .snd = compIsAlgebraHom (g .snd) (f .snd)
 
-module AlgebraTheory (R : Ring {ℓ}) (A : Algebra R) where
+module AlgebraTheory (R : Ring ℓ) (A : Algebra R ℓ') where
   open RingStr (snd R) renaming (_+_ to _+r_)
   open AlgebraStr (A .snd)
 

--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -23,12 +23,12 @@ open import Cubical.Reflection.RecordEquiv
 
 private
   variable
-    ℓ ℓ′ : Level
+    ℓ ℓ' : Level
 
-record IsCommAlgebra (R : CommRing {ℓ}) {A : Type ℓ}
+record IsCommAlgebra (R : CommRing ℓ) {A : Type ℓ'}
                      (0a : A) (1a : A)
                      (_+_ : A → A → A) (_·_ : A → A → A) (-_ : A → A)
-                     (_⋆_ : ⟨ R ⟩ → A → A) : Type ℓ where
+                     (_⋆_ : ⟨ R ⟩ → A → A) : Type (ℓ-max ℓ ℓ') where
 
   constructor iscommalgebra
 
@@ -40,7 +40,7 @@ record IsCommAlgebra (R : CommRing {ℓ}) {A : Type ℓ}
 
 unquoteDecl IsCommAlgebraIsoΣ = declareRecordIsoΣ IsCommAlgebraIsoΣ (quote IsCommAlgebra)
 
-record CommAlgebraStr (R : CommRing {ℓ}) (A : Type ℓ) : Type ℓ where
+record CommAlgebraStr (R : CommRing ℓ) (A : Type ℓ') : Type (ℓ-max ℓ ℓ') where
 
   constructor commalgebrastr
 
@@ -55,24 +55,24 @@ record CommAlgebraStr (R : CommRing {ℓ}) (A : Type ℓ) : Type ℓ where
 
   open IsCommAlgebra isCommAlgebra public
 
-CommAlgebra : (R : CommRing {ℓ}) → Type (ℓ-suc ℓ)
-CommAlgebra {ℓ} R = Σ[ A ∈ Type ℓ ] CommAlgebraStr R A
+CommAlgebra : (R : CommRing ℓ) → ∀ ℓ' → Type (ℓ-max ℓ (ℓ-suc ℓ'))
+CommAlgebra R ℓ' = Σ[ A ∈ Type ℓ' ] CommAlgebraStr R A
 
-module _ {R : CommRing {ℓ}} where
+module _ {R : CommRing ℓ} where
   open CommRingStr (snd R) using (1r) renaming (_+_ to _+r_; _·_ to _·s_)
 
-  CommAlgebraStr→AlgebraStr : {A : Type ℓ} → CommAlgebraStr R A → AlgebraStr (CommRing→Ring R) A
+  CommAlgebraStr→AlgebraStr : {A : Type ℓ'} → CommAlgebraStr R A → AlgebraStr (CommRing→Ring R) A
   CommAlgebraStr→AlgebraStr (commalgebrastr _ _ _ _ _ _ (iscommalgebra isAlgebra ·-comm)) =
     algebrastr _ _ _ _ _ _ isAlgebra
 
-  CommAlgebra→Algebra : (A : CommAlgebra R) → Algebra (CommRing→Ring R)
+  CommAlgebra→Algebra : (A : CommAlgebra R ℓ') → Algebra (CommRing→Ring R) ℓ'
   CommAlgebra→Algebra (_ , str) = (_ , CommAlgebraStr→AlgebraStr str)
 
-  CommAlgebra→CommRing : (A : CommAlgebra R) → CommRing {ℓ}
+  CommAlgebra→CommRing : (A : CommAlgebra R ℓ') → CommRing ℓ'
   CommAlgebra→CommRing (_ , commalgebrastr  _ _ _ _ _ _ (iscommalgebra isAlgebra ·-comm)) =
     _ , commringstr _ _ _ _ _ (iscommring (IsAlgebra.isRing isAlgebra) ·-comm)
 
-  makeIsCommAlgebra : {A : Type ℓ} {0a 1a : A}
+  makeIsCommAlgebra : {A : Type ℓ'} {0a 1a : A}
                       {_+_ _·_ : A → A → A} { -_ : A → A} {_⋆_ : ⟨ R ⟩ → A → A}
                       (isSet-A : isSet A)
                       (+-assoc :  (x y z : A) → x + (y + z) ≡ (x + y) + z)
@@ -89,7 +89,7 @@ module _ {R : CommRing {ℓ}} where
                       (⋆-lid   : (x : A) → 1r ⋆ x ≡ x)
                       (⋆-lassoc : (r : ⟨ R ⟩) (x y : A) → (r ⋆ x) · y ≡ r ⋆ (x · y))
                     → IsCommAlgebra R 0a 1a _+_ _·_ -_ _⋆_
-  makeIsCommAlgebra {A} {0a} {1a} {_+_} {_·_} { -_} {_⋆_} isSet-A
+  makeIsCommAlgebra {A = A} {0a} {1a} {_+_} {_·_} { -_} {_⋆_} isSet-A
                     +-assoc +-rid +-rinv +-comm
                     ·-assoc ·-lid ·-ldist-+ ·-comm
                     ⋆-assoc ⋆-ldist ⋆-rdist ⋆-lid ⋆-lassoc
@@ -117,16 +117,16 @@ module _ {R : CommRing {ℓ}} where
                    x · (r ⋆ y) ∎)
      ·-comm
 
-  IsCommAlgebraEquiv : {A B : Type ℓ}
+  IsCommAlgebraEquiv : {A B : Type ℓ'}
     (M : CommAlgebraStr R A) (e : A ≃ B) (N : CommAlgebraStr R B)
-    → Type ℓ
+    → Type (ℓ-max ℓ ℓ')
   IsCommAlgebraEquiv M e N =
     IsAlgebraHom (CommAlgebraStr→AlgebraStr M) (e .fst) (CommAlgebraStr→AlgebraStr N)
 
-  CommAlgebraEquiv : (M N : CommAlgebra R) → Type ℓ
+  CommAlgebraEquiv : (M N : CommAlgebra R ℓ') → Type (ℓ-max ℓ ℓ')
   CommAlgebraEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsCommAlgebraEquiv (M .snd) e (N .snd)
 
-isPropIsCommAlgebra : (R : CommRing {ℓ}) {A : Type ℓ}
+isPropIsCommAlgebra : (R : CommRing ℓ) {A : Type ℓ'}
   (0a 1a : A)
   (_+_ _·_ : A → A → A)
   (-_ : A → A)
@@ -137,7 +137,7 @@ isPropIsCommAlgebra R _ _ _ _ _ _ =
     (isPropΣ (isPropIsAlgebra _ _ _ _ _ _ _)
       (λ alg → isPropΠ2 λ _ _ → alg .IsAlgebra.is-set _ _))
 
-𝒮ᴰ-CommAlgebra : (R : CommRing {ℓ}) → DUARel (𝒮-Univ ℓ) (CommAlgebraStr R) ℓ
+𝒮ᴰ-CommAlgebra : (R : CommRing ℓ) → DUARel (𝒮-Univ ℓ') (CommAlgebraStr R) (ℓ-max ℓ ℓ')
 𝒮ᴰ-CommAlgebra R =
   𝒮ᴰ-Record (𝒮-Univ _) (IsCommAlgebraEquiv {R = R})
     (fields:
@@ -156,5 +156,5 @@ isPropIsCommAlgebra R _ _ _ _ _ _ =
   nul = autoDUARel (𝒮-Univ _) (λ A → A)
   bin = autoDUARel (𝒮-Univ _) (λ A → A → A → A)
 
-CommAlgebraPath : (R : CommRing {ℓ}) → (A B : CommAlgebra R) → (CommAlgebraEquiv A B) ≃ (A ≡ B)
+CommAlgebraPath : (R : CommRing ℓ) → (A B : CommAlgebra R ℓ') → (CommAlgebraEquiv A B) ≃ (A ≡ B)
 CommAlgebraPath R = ∫ (𝒮ᴰ-CommAlgebra R) .UARel.ua

--- a/Cubical/Algebra/CommRing/Base.agda
+++ b/Cubical/Algebra/CommRing/Base.agda
@@ -57,8 +57,8 @@ record CommRingStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsCommRing isCommRing public
 
-CommRing : Type (ℓ-suc ℓ)
-CommRing = TypeWithStr _ CommRingStr
+CommRing : ∀ ℓ → Type (ℓ-suc ℓ)
+CommRing ℓ = TypeWithStr ℓ CommRingStr
 
 
 makeIsCommRing : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R} { -_ : R → R}
@@ -87,24 +87,24 @@ makeCommRing : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R →
                (·-rid : (x : R) → x · 1r ≡ x)
                (·-rdist-+ : (x y z : R) → x · (y + z) ≡ (x · y) + (x · z))
                (·-comm : (x y : R) → x · y ≡ y · x)
-             → CommRing
+             → CommRing ℓ
 makeCommRing 0r 1r _+_ _·_ -_ is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm =
   _ , commringstr _ _ _ _ _ (makeIsCommRing is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm)
 
 CommRingStr→RingStr : {A : Type ℓ} → CommRingStr A → RingStr A
 CommRingStr→RingStr (commringstr _ _ _ _ _ H) = ringstr _ _ _ _ _ (IsCommRing.isRing H)
 
-CommRing→Ring : CommRing {ℓ} → Ring
+CommRing→Ring : CommRing ℓ → Ring ℓ
 CommRing→Ring (_ , commringstr _ _ _ _ _ H) = _ , ringstr _ _ _ _ _ (IsCommRing.isRing H)
 
-CommRingHom : (R : CommRing {ℓ}) (S : CommRing {ℓ'}) → Type (ℓ-max ℓ ℓ')
+CommRingHom : (R : CommRing ℓ) (S : CommRing ℓ') → Type (ℓ-max ℓ ℓ')
 CommRingHom R S = RingHom (CommRing→Ring R) (CommRing→Ring S)
 
 IsCommRingEquiv : {A : Type ℓ} {B : Type ℓ'}
   (R : CommRingStr A) (e : A ≃ B) (S : CommRingStr B) → Type (ℓ-max ℓ ℓ')
 IsCommRingEquiv R e S = IsRingHom (CommRingStr→RingStr R) (e .fst) (CommRingStr→RingStr S)
 
-CommRingEquiv : (R : CommRing {ℓ}) (S : CommRing {ℓ'}) → Type (ℓ-max ℓ ℓ')
+CommRingEquiv : (R : CommRing ℓ) (S : CommRing ℓ') → Type (ℓ-max ℓ ℓ')
 CommRingEquiv R S = Σ[ e ∈ (R .fst ≃ S .fst) ] IsCommRingEquiv (R .snd) e (S .snd)
 
 isPropIsCommRing : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
@@ -137,8 +137,8 @@ isPropIsCommRing 0r 1r _+_ _·_ -_ (iscommring RR RC) (iscommring SR SC) =
   null = autoDUARel (𝒮-Univ _) (λ A → A)
   bin = autoDUARel (𝒮-Univ _) (λ A → A → A → A)
 
-CommRingPath : (R S : CommRing {ℓ}) → CommRingEquiv R S ≃ (R ≡ S)
+CommRingPath : (R S : CommRing ℓ) → CommRingEquiv R S ≃ (R ≡ S)
 CommRingPath = ∫ 𝒮ᴰ-CommRing .UARel.ua
 
-isSetCommRing : ((R , str) : CommRing {ℓ}) → isSet R
+isSetCommRing : ((R , str) : CommRing ℓ) → isSet R
 isSetCommRing (R , str) = str .CommRingStr.is-set

--- a/Cubical/Algebra/CommRing/FGIdeal.agda
+++ b/Cubical/Algebra/CommRing/FGIdeal.agda
@@ -27,7 +27,7 @@ private
   variable
     ℓ : Level
 
-module _ (Ring@(R , str) : CommRing {ℓ}) (r : R) where
+module _ (Ring@(R , str) : CommRing ℓ) (r : R) where
   infixr 5 _holds
   _holds : hProp ℓ → Type ℓ
   P holds = fst P

--- a/Cubical/Algebra/CommRing/Ideal.agda
+++ b/Cubical/Algebra/CommRing/Ideal.agda
@@ -18,10 +18,10 @@ private
   variable
     ℓ : Level
 
-IdealsIn : (R : CommRing {ℓ}) → Type _
+IdealsIn : (R : CommRing ℓ) → Type _
 IdealsIn R = IdealsInRing (CommRing→Ring R)
 
-module _ (Ring@(R , str) : CommRing {ℓ}) where
+module _ (Ring@(R , str) : CommRing ℓ) where
   open CommRingStr str
   makeIdeal : (I : R → hProp ℓ)
               → (+-closed : {x y : R} → x ∈ I → y ∈ I → (x + y) ∈ I)

--- a/Cubical/Algebra/CommRing/Integers.agda
+++ b/Cubical/Algebra/CommRing/Integers.agda
@@ -12,7 +12,7 @@ open import Cubical.HITs.Ints.BiInvInt
     +-comm to +ℤ-comm
   )
 
-BiInvIntAsCommRing : CommRing {ℓ-zero}
+BiInvIntAsCommRing : CommRing ℓ-zero
 BiInvIntAsCommRing =
   makeCommRing
     zero (suc zero) _+ℤ_ _·_ _-ℤ_

--- a/Cubical/Algebra/CommRing/Localisation/Base.agda
+++ b/Cubical/Algebra/CommRing/Localisation/Base.agda
@@ -43,14 +43,14 @@ private
 
 
 -- A multiplicatively closed subset is assumed to contain 1
-record isMultClosedSubset (R' : CommRing {ℓ}) (S' : ℙ (fst R')) : Type ℓ where
+record isMultClosedSubset (R' : CommRing ℓ) (S' : ℙ (fst R')) : Type ℓ where
  constructor
    multclosedsubset
  field
    containsOne : (R' .snd .CommRingStr.1r) ∈ S'
    multClosed : ∀ {s t} → s ∈ S' → t ∈ S' → ((snd R') .CommRingStr._·_ s t) ∈ S'
 
-module Loc (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMultClosedSubset R' S') where
+module Loc (R' : CommRing ℓ) (S' : ℙ (fst R')) (SMultClosedSubset : isMultClosedSubset R' S') where
  open isMultClosedSubset
  private R = fst R'
  open CommRingStr (snd R')
@@ -280,7 +280,7 @@ module Loc (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMult
 
 
  -- Commutative ring structure on S⁻¹R
- S⁻¹RAsCommRing : CommRing
+ S⁻¹RAsCommRing : CommRing ℓ
  S⁻¹RAsCommRing = S⁻¹R , S⁻¹RCommRingStr
   where
   open CommRingStr

--- a/Cubical/Algebra/CommRing/Localisation/InvertingElements.agda
+++ b/Cubical/Algebra/CommRing/Localisation/InvertingElements.agda
@@ -51,7 +51,7 @@ private
     ℓ ℓ' : Level
     A : Type ℓ
 
-module _(R' : CommRing {ℓ}) where
+module _(R' : CommRing ℓ) where
  open isMultClosedSubset
  private R = fst R'
  open CommRingStr (snd R')
@@ -73,7 +73,7 @@ module _(R' : CommRing {ℓ}) where
  R[1/ f ] = Loc.S⁻¹R R' [ f ⁿ|n≥0] (powersFormMultClosedSubset f)
 
 
- R[1/_]AsCommRing : R → CommRing {ℓ}
+ R[1/_]AsCommRing : R → CommRing ℓ
  R[1/ f ]AsCommRing = Loc.S⁻¹RAsCommRing R' [ f ⁿ|n≥0] (powersFormMultClosedSubset f)
 
  -- A useful lemma: (gⁿ/1)≡(g/1)ⁿ in R[1/f]
@@ -111,7 +111,7 @@ module _(R' : CommRing {ℓ}) where
 
 
 
-module DoubleLoc (R' : CommRing {ℓ}) (f g : (fst R')) where
+module DoubleLoc (R' : CommRing ℓ) (f g : (fst R')) where
  open isMultClosedSubset
  open CommRingStr (snd R')
  open CommRingTheory R'

--- a/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
+++ b/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
@@ -46,7 +46,7 @@ private
     ℓ ℓ' : Level
 
 
-module _ (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMultClosedSubset R' S') where
+module _ (R' : CommRing ℓ) (S' : ℙ (fst R')) (SMultClosedSubset : isMultClosedSubset R' S') where
  open isMultClosedSubset
  private R = fst R'
  open CommRingStr (snd R') hiding (is-set)
@@ -55,14 +55,14 @@ module _ (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMultCl
 
 
 
- hasLocUniversalProp : (A : CommRing {ℓ}) (φ : CommRingHom R' A)
+ hasLocUniversalProp : (A : CommRing ℓ) (φ : CommRingHom R' A)
                      → (∀ s → s ∈ S' → fst φ s ∈ A ˣ)
                      → Type (ℓ-suc ℓ)
- hasLocUniversalProp A φ _ = (B : CommRing {ℓ}) (ψ : CommRingHom R' B)
+ hasLocUniversalProp A φ _ = (B : CommRing ℓ) (ψ : CommRingHom R' B)
                            → (∀ s → s ∈ S' → fst ψ s ∈ B ˣ)
                            → ∃![ χ ∈ CommRingHom A B ] (fst χ) ∘ (fst φ) ≡ (fst ψ)
 
- UniversalPropIsProp : (A : CommRing {ℓ}) (φ : CommRingHom R' A)
+ UniversalPropIsProp : (A : CommRing ℓ) (φ : CommRingHom R' A)
                      → (φS⊆Aˣ : ∀ s → s ∈ S' → fst φ s ∈ A ˣ)
                      → isProp (hasLocUniversalProp A φ φS⊆Aˣ)
  UniversalPropIsProp A φ φS⊆Aˣ = isPropΠ3 (λ _ _ _ → isPropIsContr)
@@ -360,7 +360,7 @@ module _ (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMultCl
  open S⁻¹RUniversalProp
  open Loc R' S' SMultClosedSubset
 
- record PathToS⁻¹R (A' : CommRing {ℓ}) (φ : CommRingHom R' A') : Type ℓ where
+ record PathToS⁻¹R (A' : CommRing ℓ) (φ : CommRingHom R' A') : Type ℓ where
   constructor
    pathtoS⁻¹R
   open Units A' renaming (Rˣ to Aˣ)
@@ -370,7 +370,7 @@ module _ (R' : CommRing {ℓ}) (S' : ℙ (fst R')) (SMultClosedSubset : isMultCl
    kerφ⊆annS : ∀ r → fst φ r ≡ 0a → ∃[ s ∈ S ] (s .fst) · r ≡ 0r
    surχ : ∀ a → ∃[ x ∈ R × S ] fst φ (x .fst) ·A (fst φ (x .snd .fst) ⁻¹) ⦃ φS⊆Aˣ _ (x .snd .snd) ⦄ ≡ a
 
- S⁻¹RChar : (A' : CommRing {ℓ}) (φ : CommRingHom R' A')
+ S⁻¹RChar : (A' : CommRing ℓ) (φ : CommRingHom R' A')
           → PathToS⁻¹R A' φ
           → S⁻¹RAsCommRing ≡ A'
  S⁻¹RChar A' φ cond = CommRingPath S⁻¹RAsCommRing A' .fst

--- a/Cubical/Algebra/CommRing/Properties.agda
+++ b/Cubical/Algebra/CommRing/Properties.agda
@@ -28,7 +28,7 @@ private
   variable
     ℓ : Level
 
-module Units (R' : CommRing {ℓ}) where
+module Units (R' : CommRing ℓ) where
  open CommRingStr (snd R')
  open RingTheory (CommRing→Ring R')
  private R = fst R'
@@ -132,10 +132,10 @@ module Units (R' : CommRing {ℓ}) where
 
 
 -- some convenient notation
-_ˣ : (R' : CommRing {ℓ}) → ℙ (R' .fst)
+_ˣ : (R' : CommRing ℓ) → ℙ (R' .fst)
 R' ˣ = Units.Rˣ R'
 
-module RingHomRespUnits {A' B' : CommRing {ℓ}} (φ : CommRingHom A' B') where
+module RingHomRespUnits {A' B' : CommRing ℓ} (φ : CommRingHom A' B') where
  open Units A' renaming (Rˣ to Aˣ ; _⁻¹ to _⁻¹ᵃ ; ·-rinv to ·A-rinv ; ·-linv to ·A-linv)
  private A = fst A'
  open CommRingStr (snd A') renaming (_·_ to _·A_ ; 1r to 1a)
@@ -164,7 +164,7 @@ module RingHomRespUnits {A' B' : CommRing {ℓ}} (φ : CommRingHom A' B') where
   (f r) ⁻¹ᵇ                         ∎
 
 
-module Exponentiation (R' : CommRing {ℓ}) where
+module Exponentiation (R' : CommRing ℓ) where
  open CommRingStr (snd R')
  private R = fst R'
 
@@ -195,7 +195,7 @@ module Exponentiation (R' : CommRing {ℓ}) where
 
 
 -- like in Ring.Properties we provide helpful lemmas here
-module CommRingTheory (R' : CommRing {ℓ}) where
+module CommRingTheory (R' : CommRing ℓ) where
  open CommRingStr (snd R')
  private R = fst R'
 

--- a/Cubical/Algebra/FreeCommAlgebra.agda
+++ b/Cubical/Algebra/FreeCommAlgebra.agda
@@ -41,12 +41,12 @@ open import Cubical.HITs.SetTruncation
 
 private
   variable
-    ℓ ℓ′ : Level
+    ℓ ℓ' ℓ'' : Level
 
-module Construction (R : CommRing {ℓ}) where
+module Construction (R : CommRing ℓ) where
   open CommRingStr (snd R) using (1r; 0r) renaming (_+_ to _+r_; _·_ to _·r_)
 
-  data R[_] (I : Type ℓ′) : Type (ℓ-max ℓ ℓ′) where
+  data R[_] (I : Type ℓ') : Type (ℓ-max ℓ ℓ') where
     var : I → R[ I ]
     const : ⟨ R ⟩ → R[ I ]
     _+_ : R[ I ] → R[ I ] → R[ I ]
@@ -69,57 +69,54 @@ module Construction (R : CommRing {ℓ}) where
 
     0-trunc : (x y : R[ I ]) (p q : x ≡ y) → p ≡ q
 
-  _⋆_ : {I : Type ℓ′} → ⟨ R ⟩ → R[ I ] → R[ I ]
+  _⋆_ : {I : Type ℓ'} → ⟨ R ⟩ → R[ I ] → R[ I ]
   r ⋆ x = const r · x
 
-  ⋆-assoc : {I : Type ℓ′} → (s t : ⟨ R ⟩) (x : R[ I ]) → (s ·r t) ⋆ x ≡ s ⋆ (t ⋆ x)
+  ⋆-assoc : {I : Type ℓ'} → (s t : ⟨ R ⟩) (x : R[ I ]) → (s ·r t) ⋆ x ≡ s ⋆ (t ⋆ x)
   ⋆-assoc s t x = const (s ·r t) · x       ≡⟨ cong (λ u → u · x) (·HomConst _ _) ⟩
                   (const s · const t) · x  ≡⟨ sym (·-assoc _ _ _) ⟩
                   const s · (const t · x)  ≡⟨ refl ⟩
                   s ⋆ (t ⋆ x) ∎
 
-  ⋆-ldist-+ : {I : Type ℓ′} → (s t : ⟨ R ⟩) (x : R[ I ]) → (s +r t) ⋆ x ≡ (s ⋆ x) + (t ⋆ x)
+  ⋆-ldist-+ : {I : Type ℓ'} → (s t : ⟨ R ⟩) (x : R[ I ]) → (s +r t) ⋆ x ≡ (s ⋆ x) + (t ⋆ x)
   ⋆-ldist-+ s t x = (s +r t) ⋆ x             ≡⟨ cong (λ u → u · x) (+HomConst _ _) ⟩
                     (const s + const t) · x  ≡⟨ ldist _ _ _ ⟩
                     (s ⋆ x) + (t ⋆ x) ∎
 
-  ⋆-rdist-+ : {I : Type ℓ′} → (s : ⟨ R ⟩) (x y : R[ I ]) → s ⋆ (x + y) ≡ (s ⋆ x) + (s ⋆ y)
+  ⋆-rdist-+ : {I : Type ℓ'} → (s : ⟨ R ⟩) (x y : R[ I ]) → s ⋆ (x + y) ≡ (s ⋆ x) + (s ⋆ y)
   ⋆-rdist-+ s x y = const s · (x + y)             ≡⟨ ·-comm _ _ ⟩
                     (x + y) · const s             ≡⟨ ldist _ _ _ ⟩
                     (x · const s) + (y · const s) ≡⟨ cong (λ u → u + (y · const s)) (·-comm _ _) ⟩
                     (s ⋆ x) + (y · const s)       ≡⟨ cong (λ u → (s ⋆ x) + u) (·-comm _ _)  ⟩
                     (s ⋆ x) + (s ⋆ y) ∎
 
-  ⋆-assoc-· : {I : Type ℓ′} → (s : ⟨ R ⟩) (x y : R[ I ]) → (s ⋆ x) · y ≡ s ⋆ (x · y)
+  ⋆-assoc-· : {I : Type ℓ'} → (s : ⟨ R ⟩) (x y : R[ I ]) → (s ⋆ x) · y ≡ s ⋆ (x · y)
   ⋆-assoc-· s x y = (s ⋆ x) · y ≡⟨ sym (·-assoc _ _ _) ⟩
                     s ⋆ (x · y) ∎
 
-  0a : {I : Type ℓ′} → R[ I ]
+  0a : {I : Type ℓ'} → R[ I ]
   0a = (const 0r)
 
-  1a : {I : Type ℓ′} → R[ I ]
+  1a : {I : Type ℓ'} → R[ I ]
   1a = (const 1r)
 
-  isCommAlgebra : {I : Type ℓ} → IsCommAlgebra
-                                   R {A = R[ I ]}
-                                   0a 1a
-                                   _+_ _·_ -_ _⋆_
+  isCommAlgebra : {I : Type ℓ'} → IsCommAlgebra R {A = R[ I ]} 0a 1a _+_ _·_ -_ _⋆_
   isCommAlgebra = makeIsCommAlgebra 0-trunc
                                     +-assoc +-rid +-rinv +-comm
                                     ·-assoc ·-lid ldist ·-comm
                                     ⋆-assoc ⋆-ldist-+ ⋆-rdist-+ ·-lid ⋆-assoc-·
 
-_[_] : (R : CommRing {ℓ}) (I : Type ℓ) → CommAlgebra R
+_[_] : (R : CommRing ℓ) (I : Type ℓ') → CommAlgebra R (ℓ-max ℓ ℓ')
 (R [ I ]) = R[ I ] , commalgebrastr 0a 1a _+_ _·_ -_ _⋆_ isCommAlgebra
   where
   open Construction R
 
-module Theory {R : CommRing {ℓ}} {I : Type ℓ} where
+module Theory {R : CommRing ℓ} {I : Type ℓ'} where
   open CommRingStr (snd R)
          using (0r; 1r)
          renaming (_·_ to _·r_; _+_ to _+r_; ·-comm to ·r-comm; ·Rid to ·r-rid)
 
-  module _ (A : CommAlgebra R) (φ : I → ⟨ A ⟩) where
+  module _ (A : CommAlgebra R ℓ'') (φ : I → ⟨ A ⟩) where
     open CommAlgebraStr (A .snd)
     open AlgebraTheory (CommRing→Ring R) (CommAlgebra→Algebra A)
     open Construction using (var; const) renaming (_+_ to _+c_; -_ to -c_; _·_ to _·c_)
@@ -188,7 +185,7 @@ module Theory {R : CommRing {ℓ}} {I : Type ℓ} where
         r ⋆ (1a · inducedMap x) ≡⟨ cong (λ u → r ⋆ u) (·Lid (inducedMap x)) ⟩
         r ⋆ inducedMap x ∎
 
-  module _ (A : CommAlgebra R) where
+  module _ (A : CommAlgebra R ℓ'') where
     open CommAlgebraStr (A .snd)
     open AlgebraTheory (CommRing→Ring R) (CommAlgebra→Algebra A)
     open Construction using (var; const) renaming (_+_ to _+c_; -_ to -c_; _·_ to _·c_)
@@ -203,7 +200,7 @@ module Theory {R : CommRing {ℓ}} {I : Type ℓ} where
                      → evaluateAt (inducedHom A φ) ≡ φ
     mapRetrievable φ = refl
 
-    proveEq : ∀ {X : Type ℓ} (isSetX : isSet X) (f g : ⟨ R [ I ] ⟩ → X)
+    proveEq : ∀ {X : Type ℓ''} (isSetX : isSet X) (f g : ⟨ R [ I ] ⟩ → X)
               → (var-eq : (x : I) → f (var x) ≡ g (var x))
               → (const-eq : (r : ⟨ R ⟩) → f (const r) ≡ g (const r))
               → (+-eq : (x y : ⟨ R [ I ] ⟩) → (eq-x : f x ≡ g x) → (eq-y : f y ≡ g y)
@@ -419,17 +416,17 @@ module Theory {R : CommRing {ℓ}} {I : Type ℓ} where
       module f = IsAlgebraHom (f .snd)
 
 
-evaluateAt : {R : CommRing {ℓ}} {I : Type ℓ} (A : CommAlgebra R)
+evaluateAt : {R : CommRing ℓ} {I : Type ℓ'} (A : CommAlgebra R ℓ'')
              (f : AlgebraHom (CommAlgebra→Algebra (R [ I ])) (CommAlgebra→Algebra A))
              → (I → ⟨ A ⟩)
 evaluateAt A f x = f $a (Construction.var x)
 
-inducedHom : {R : CommRing {ℓ}} {I : Type ℓ} (A : CommAlgebra R)
+inducedHom : {R : CommRing ℓ} {I : Type ℓ'} (A : CommAlgebra R ℓ'')
              (φ : I → ⟨ A ⟩)
              → AlgebraHom (CommAlgebra→Algebra (R [ I ])) (CommAlgebra→Algebra A)
 inducedHom A φ = Theory.inducedHom A φ
 
-module _ {R : CommRing {ℓ}} {A B : CommAlgebra R} where
+module _ {R : CommRing ℓ} {A B : CommAlgebra R ℓ''} where
   A′ = CommAlgebra→Algebra A
   B′ = CommAlgebra→Algebra B
   R′ = (CommRing→Ring R)
@@ -441,7 +438,7 @@ module _ {R : CommRing {ℓ}} {A B : CommAlgebra R} where
          ↓          ↓
     Hom(R[I],B) → (I → B)
   -}
-  naturalR : {I : Type ℓ} (ψ : AlgebraHom A′ B′)
+  naturalR : {I : Type ℓ'} (ψ : AlgebraHom A′ B′)
              (f : AlgebraHom (CommAlgebra→Algebra (R [ I ])) A′)
              → (ν ψ) ∘ evaluateAt A f ≡ evaluateAt B (ψ ∘a f)
   naturalR ψ f = refl
@@ -451,7 +448,7 @@ module _ {R : CommRing {ℓ}} {A B : CommAlgebra R} where
          ↓          ↓
     Hom(R[J],A) → (J → A)
   -}
-  naturalL : {I J : Type ℓ} (φ : J → I)
+  naturalL : {I J : Type ℓ'} (φ : J → I)
              (f : AlgebraHom (CommAlgebra→Algebra (R [ I ])) A′)
              → (evaluateAt A f) ∘ φ
                ≡ evaluateAt A (f ∘a (inducedHom (R [ I ]) (λ x → Construction.var (φ x))))

--- a/Cubical/Algebra/Group/Base.agda
+++ b/Cubical/Algebra/Group/Base.agda
@@ -39,7 +39,7 @@ record IsGroup {G : Type ℓ}
   invr : (x : G) → x · inv x ≡ 1g
   invr x = inverse x .fst
 
-record GroupStr (G : Type ℓ) : Type (ℓ-suc ℓ) where
+record GroupStr (G : Type ℓ) : Type ℓ where
 
   constructor groupstr
 
@@ -53,16 +53,16 @@ record GroupStr (G : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsGroup isGroup public
 
-Group : Type (ℓ-suc ℓ)
-Group = TypeWithStr _ GroupStr
+Group : ∀ ℓ → Type (ℓ-suc ℓ)
+Group ℓ = TypeWithStr ℓ GroupStr
 
 Group₀ : Type₁
-Group₀ = Group {ℓ-zero}
+Group₀ = Group ℓ-zero
 
-group : (G : Type ℓ) (1g : G) (_·_ : G → G → G) (inv : G → G) (h : IsGroup 1g _·_ inv) → Group
+group : (G : Type ℓ) (1g : G) (_·_ : G → G → G) (inv : G → G) (h : IsGroup 1g _·_ inv) → Group ℓ
 group G 1g _·_ inv h = G , groupstr 1g _·_ inv h
 
-isSetGroup : (G : Group {ℓ}) → isSet ⟨ G ⟩
+isSetGroup : (G : Group ℓ) → isSet ⟨ G ⟩
 isSetGroup G = GroupStr.isGroup (snd G) .IsGroup.isMonoid .IsMonoid.isSemigroup .IsSemigroup.is-set
 
 makeIsGroup : {G : Type ℓ} {e : G} {_·_ : G → G → G} { inv : G → G}
@@ -83,7 +83,7 @@ makeGroup : {G : Type ℓ} (e : G) (_·_ : G → G → G) (inv : G → G)
             (lid : (x : G) → e · x ≡ x)
             (rinv : (x : G) → x · inv x ≡ e)
             (linv : (x : G) → inv x · x ≡ e)
-          → Group
+          → Group ℓ
 makeGroup e _·_ inv is-setG assoc rid lid rinv linv = _ , helper
   where
   helper : GroupStr _
@@ -100,7 +100,7 @@ makeGroup-right : {A : Type ℓ}
   → (assoc : ∀ a b c → a · (b · c) ≡ (a · b) · c)
   → (rUnit : ∀ a → a · 1g ≡ a)
   → (rCancel : ∀ a → a · inv a ≡ 1g)
-  → Group
+  → Group ℓ
 makeGroup-right 1g _·_ inv set assoc rUnit rCancel =
   makeGroup 1g _·_ inv set assoc rUnit lUnit rCancel lCancel
   where
@@ -145,7 +145,7 @@ makeGroup-left : {A : Type ℓ}
   → (assoc : ∀ a b c → a · (b · c) ≡ (a · b) · c)
   → (lUnit : ∀ a → 1g · a ≡ a)
   → (lCancel : ∀ a → (inv a) · a ≡ 1g)
-  → Group
+  → Group ℓ
 makeGroup-left 1g _·_ inv set assoc lUnit lCancel =
   makeGroup 1g _·_ inv set assoc rUnit lUnit rCancel lCancel
   where

--- a/Cubical/Algebra/Group/DirProd.agda
+++ b/Cubical/Algebra/Group/DirProd.agda
@@ -13,7 +13,7 @@ open IsGroup hiding (rid ; lid ; invr ; invl)
 open IsMonoid hiding (rid ; lid)
 open IsSemigroup
 
-DirProd : ∀ {ℓ ℓ'} → Group {ℓ} → Group {ℓ'} → Group
+DirProd : ∀ {ℓ ℓ'} → Group ℓ → Group ℓ' → Group (ℓ-max ℓ ℓ')
 fst (DirProd G H) = fst G × fst H
 1g (snd (DirProd G H)) = (1g (snd G)) , (1g (snd H))
 _·_ (snd (DirProd G H)) x y = _·_ (snd G) (fst x) (fst y)

--- a/Cubical/Algebra/Group/EilenbergMacLane1.agda
+++ b/Cubical/Algebra/Group/EilenbergMacLane1.agda
@@ -21,7 +21,7 @@ open import Cubical.HITs.EilenbergMacLane1
 private
   variable ℓ : Level
 
-module _ (Ĝ : Group {ℓ}) where
+module _ (Ĝ : Group ℓ) where
   private
     G = fst Ĝ
   open GroupStr (snd Ĝ)

--- a/Cubical/Algebra/Group/GroupPath.agda
+++ b/Cubical/Algebra/Group/GroupPath.agda
@@ -47,12 +47,12 @@ open IsGroupHom
   open GroupStr
   open IsGroupHom
 
-GroupPath : (M N : Group {ℓ}) → GroupEquiv M N ≃ (M ≡ N)
+GroupPath : (M N : Group ℓ) → GroupEquiv M N ≃ (M ≡ N)
 GroupPath = ∫ 𝒮ᴰ-Group .UARel.ua
 
 -- TODO: Induced structure results are temporarily inconvenient while we transition between algebra
 -- representations
-module _ (G : Group {ℓ}) {A : Type ℓ} (m : A → A → A)
+module _ (G : Group ℓ) {A : Type ℓ} (m : A → A → A)
   (e : ⟨ G ⟩ ≃ A)
   (p· : ∀ x y → e .fst (G .snd ._·_ x y) ≡ m (e .fst x) (e .fst y))
   where
@@ -72,7 +72,7 @@ module _ (G : Group {ℓ}) {A : Type ℓ} (m : A → A → A)
         (UARel.≅→≡ (autoUARel (Σ[ B ∈ Type ℓ ] (B → B → B))) (e , p·))
         (G.1g , G.inv , G.isGroup)
 
-  InducedGroup : Group
+  InducedGroup : Group ℓ
   InducedGroup .fst = A
   InducedGroup .snd ._·_ = m
   InducedGroup .snd .1g = inducedΣ .fst
@@ -82,11 +82,11 @@ module _ (G : Group {ℓ}) {A : Type ℓ} (m : A → A → A)
   InducedGroupPath : G ≡ InducedGroup
   InducedGroupPath = GroupPath _ _ .fst (e , makeIsGroupHom p·)
 
-uaGroup : {G H : Group {ℓ}} → GroupEquiv G H → G ≡ H
+uaGroup : {G H : Group ℓ} → GroupEquiv G H → G ≡ H
 uaGroup {G = G} {H = H} = equivFun (GroupPath G H)
 
 -- Group-ua functoriality
-Group≡ : (G H : Group {ℓ}) → (
+Group≡ : (G H : Group ℓ) → (
   Σ[ p ∈ ⟨ G ⟩ ≡ ⟨ H ⟩ ]
   Σ[ q ∈ PathP (λ i → p i) (1g (snd G)) (1g (snd H)) ]
   Σ[ r ∈ PathP (λ i → p i → p i → p i) (_·_ (snd G)) (_·_ (snd H)) ]
@@ -101,7 +101,7 @@ Group≡ G H = isoToEquiv theIso
   rightInv theIso _ = refl
   leftInv theIso _ = refl
 
-caracGroup≡ : {G H : Group {ℓ}} (p q : G ≡ H) → cong ⟨_⟩ p ≡ cong ⟨_⟩ q → p ≡ q
+caracGroup≡ : {G H : Group ℓ} (p q : G ≡ H) → cong ⟨_⟩ p ≡ cong ⟨_⟩ q → p ≡ q
 caracGroup≡ {G = G} {H = H} p q P =
   sym (transportTransport⁻ (ua (Group≡ G H)) p)
                                    ∙∙ cong (transport (ua (Group≡ G H))) helper
@@ -116,10 +116,10 @@ caracGroup≡ {G = G} {H = H} p q P =
                          λ _ → isOfHLevelPathP 1 (isPropIsGroup _ _ _) _ _)
                (transportRefl (cong ⟨_⟩ p) ∙ P ∙ sym (transportRefl (cong ⟨_⟩ q)))
 
-uaGroupId : (G : Group {ℓ}) → uaGroup (idGroupEquiv {G = G}) ≡ refl
+uaGroupId : (G : Group ℓ) → uaGroup (idGroupEquiv {G = G}) ≡ refl
 uaGroupId G = caracGroup≡ _ _ uaIdEquiv
 
-uaCompGroupEquiv : {F G H : Group {ℓ}} (f : GroupEquiv F G) (g : GroupEquiv G H)
+uaCompGroupEquiv : {F G H : Group ℓ} (f : GroupEquiv F G) (g : GroupEquiv G H)
                  → uaGroup (compGroupEquiv f g) ≡ uaGroup f ∙ uaGroup g
 uaCompGroupEquiv f g = caracGroup≡ _ _ (
   cong ⟨_⟩ (uaGroup (compGroupEquiv f g))

--- a/Cubical/Algebra/Group/Instances/Bool.agda
+++ b/Cubical/Algebra/Group/Instances/Bool.agda
@@ -46,7 +46,7 @@ inverse (isGroup (snd Bool)) true = refl , refl
 -- Proof that any Group equivalent to Bool as types is also isomorhic to Bool as groups.
 open GroupStr renaming (assoc to assocG)
 
-module _ {ℓ : Level} {A : Group {ℓ}} (e : Iso (fst A) BoolType) where
+module _ {ℓ : Level} {A : Group ℓ} (e : Iso (fst A) BoolType) where
   private
     discreteA : Discrete (typ A)
     discreteA = IsoPresDiscrete (invIso e) _≟_

--- a/Cubical/Algebra/Group/Instances/Unit.agda
+++ b/Cubical/Algebra/Group/Instances/Unit.agda
@@ -25,32 +25,32 @@ Unit = UnitType , groupstr tt (λ _ _ → tt) (λ _ → tt)
 open Iso
 
 -- The trivial group is a unit.
-lUnitGroupIso : {G : Group {ℓ}} → GroupIso (DirProd Unit G) G
+lUnitGroupIso : {G : Group ℓ} → GroupIso (DirProd Unit G) G
 fun (fst lUnitGroupIso) = snd
 inv (fst lUnitGroupIso) g = tt , g
 rightInv (fst lUnitGroupIso) _ = refl
 leftInv (fst lUnitGroupIso) _ = refl
 snd lUnitGroupIso = makeIsGroupHom λ _ _ → refl
 
-rUnitGroupIso : {G : Group {ℓ}} → GroupIso (DirProd G Unit) G
+rUnitGroupIso : {G : Group ℓ} → GroupIso (DirProd G Unit) G
 fun (fst rUnitGroupIso) = fst
 inv (fst rUnitGroupIso) g = g , tt
 rightInv (fst rUnitGroupIso) _ = refl
 leftInv (fst rUnitGroupIso) _ = refl
 snd rUnitGroupIso = makeIsGroupHom λ _ _ → refl
 
-lUnitGroupEquiv : {G : Group {ℓ}} → GroupEquiv (DirProd Unit G) G
+lUnitGroupEquiv : {G : Group ℓ} → GroupEquiv (DirProd Unit G) G
 lUnitGroupEquiv = GroupIso→GroupEquiv lUnitGroupIso
 
-rUnitGroupEquiv : ∀ {ℓ} {G : Group {ℓ}} → GroupEquiv (DirProd G Unit) G
+rUnitGroupEquiv : ∀ {ℓ} {G : Group ℓ} → GroupEquiv (DirProd G Unit) G
 rUnitGroupEquiv = GroupIso→GroupEquiv rUnitGroupIso
 
-contrGroupIsoUnit : {G : Group {ℓ}} → isContr ⟨ G ⟩ → GroupIso G Unit
+contrGroupIsoUnit : {G : Group ℓ} → isContr ⟨ G ⟩ → GroupIso G Unit
 fun (fst (contrGroupIsoUnit contr)) _ = tt
 inv (fst (contrGroupIsoUnit contr)) _ = fst contr
 rightInv (fst (contrGroupIsoUnit contr)) _ = refl
 leftInv (fst (contrGroupIsoUnit contr)) x = snd contr x
 snd (contrGroupIsoUnit contr) = makeIsGroupHom λ _ _ → refl
 
-contrGroupEquivUnit : {G : Group {ℓ}} → isContr ⟨ G ⟩ → GroupEquiv G Unit
+contrGroupEquivUnit : {G : Group ℓ} → isContr ⟨ G ⟩ → GroupEquiv G Unit
 contrGroupEquivUnit contr = GroupIso→GroupEquiv (contrGroupIsoUnit contr)

--- a/Cubical/Algebra/Group/IsomorphismTheorems.agda
+++ b/Cubical/Algebra/Group/IsomorphismTheorems.agda
@@ -29,7 +29,7 @@ private
     ℓ : Level
 
 -- The first isomorphism theorem: im ϕ ≃ G / ker ϕ
-module _ {G H : Group {ℓ}} (ϕ : GroupHom G H) where
+module _ {G H : Group ℓ} (ϕ : GroupHom G H) where
 
   open isSubgroup
   open Iso
@@ -39,7 +39,7 @@ module _ {G H : Group {ℓ}} (ϕ : GroupHom G H) where
     kerϕ : NormalSubgroup G
     kerϕ = kerSubgroup ϕ , isNormalKer ϕ
 
-    imϕ : Group
+    imϕ : Group ℓ
     imϕ = imGroup ϕ
 
     module G = GroupStr (snd G)

--- a/Cubical/Algebra/Group/MorphismProperties.agda
+++ b/Cubical/Algebra/Group/MorphismProperties.agda
@@ -30,7 +30,7 @@ open import Cubical.HITs.PropositionalTruncation hiding (map)
 private
   variable
     ℓ ℓ' ℓ'' ℓ''' : Level
-    F G H : Group {ℓ}
+    F G H : Group ℓ
 
 open Iso
 open GroupStr
@@ -79,7 +79,7 @@ module _ {A : Type ℓ} {B : Type ℓ'} {G : GroupStr A} {f : A → B} {H : Grou
 
 
 -- H-level results
-isPropIsGroupHom : (G : Group {ℓ}) (H : Group {ℓ'}) {f : ⟨ G ⟩ → ⟨ H ⟩}
+isPropIsGroupHom : (G : Group ℓ) (H : Group ℓ') {f : ⟨ G ⟩ → ⟨ H ⟩}
                  → isProp (IsGroupHom (G .snd) f (H .snd))
 isPropIsGroupHom G H =
   isOfHLevelRetractFromIso 1 IsGroupHomIsoΣ
@@ -162,7 +162,7 @@ compGroupHom : GroupHom F G → GroupHom G H → GroupHom F H
 fst (compGroupHom f g) = fst g ∘ fst f
 snd (compGroupHom f g) = isGroupHomComp f g
 
-GroupHomDirProd : {A : Group {ℓ}} {B : Group {ℓ'}} {C : Group {ℓ''}} {D : Group {ℓ'''}}
+GroupHomDirProd : {A : Group ℓ} {B : Group ℓ'} {C : Group ℓ''} {D : Group ℓ'''}
                 → GroupHom A C → GroupHom B D → GroupHom (DirProd A B) (DirProd C D)
 fst (GroupHomDirProd mf1 mf2) = map-× (fst mf1) (fst mf2)
 snd (GroupHomDirProd mf1 mf2) = makeIsGroupHom λ _ _ → ≡-× (mf1 .snd .pres· _ _) (mf2 .snd .pres· _ _)
@@ -204,7 +204,7 @@ snd (invGroupEquiv f) = isGroupHomInv f
     isInj-f : (x y : ⟨ G ⟩) → f' x ≡ f' y → x ≡ y
     isInj-f x y = invEq (_ , isEquiv→isEmbedding (snd (fst f)) x y)
 
-GroupEquivDirProd : {A : Group {ℓ}} {B : Group {ℓ'}} {C : Group {ℓ''}} {D : Group {ℓ'''}}
+GroupEquivDirProd : {A : Group ℓ} {B : Group ℓ'} {C : Group ℓ''} {D : Group ℓ'''}
                   → GroupEquiv A C → GroupEquiv B D
                   → GroupEquiv (DirProd A B) (DirProd C D)
 fst (GroupEquivDirProd eq1 eq2) = ≃-× (fst eq1) (fst eq2)
@@ -247,7 +247,7 @@ snd (invGroupIso iso1) = isGroupHomInv iso1
     isInj-f : (x y : ⟨ G ⟩) → f' x ≡ f' y → x ≡ y
     isInj-f x y p = sym (leftInv (fst f) _) ∙∙ cong g p ∙∙ leftInv (fst f) _
 
-GroupIsoDirProd : {G : Group {ℓ}} {H : Group {ℓ'}} {A : Group {ℓ''}} {B : Group {ℓ'''}}
+GroupIsoDirProd : {G : Group ℓ} {H : Group ℓ'} {A : Group ℓ''} {B : Group ℓ'''}
                 → GroupIso G H → GroupIso A B → GroupIso (DirProd G A) (DirProd H B)
 fun (fst (GroupIsoDirProd iso1 iso2)) prod =
   fun (fst iso1) (fst prod) , fun (fst iso2) (snd prod)

--- a/Cubical/Algebra/Group/Morphisms.agda
+++ b/Cubical/Algebra/Group/Morphisms.agda
@@ -49,17 +49,17 @@ record IsGroupHom {A : Type ℓ} {B : Type ℓ'}
 
 unquoteDecl IsGroupHomIsoΣ = declareRecordIsoΣ IsGroupHomIsoΣ (quote IsGroupHom)
 
-GroupHom : (G : Group {ℓ}) (H : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
+GroupHom : (G : Group ℓ) (H : Group ℓ') → Type (ℓ-max ℓ ℓ')
 GroupHom G H = Σ[ f ∈ (G .fst → H .fst) ] IsGroupHom (G .snd) f (H .snd)
 
-GroupIso : (G : Group {ℓ}) (H : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
+GroupIso : (G : Group ℓ) (H : Group ℓ') → Type (ℓ-max ℓ ℓ')
 GroupIso G H = Σ[ e ∈ Iso (G .fst) (H .fst) ] IsGroupHom (G .snd) (e .Iso.fun) (H .snd)
 
 IsGroupEquiv : {A : Type ℓ} {B : Type ℓ'}
   (M : GroupStr A) (e : A ≃ B) (N : GroupStr B) → Type (ℓ-max ℓ ℓ')
 IsGroupEquiv M e N = IsGroupHom M (e .fst) N
 
-GroupEquiv : (G : Group {ℓ}) (H : Group {ℓ'}) → Type (ℓ-max ℓ ℓ')
+GroupEquiv : (G : Group ℓ) (H : Group ℓ') → Type (ℓ-max ℓ ℓ')
 GroupEquiv G H = Σ[ e ∈ (G .fst ≃ H .fst) ] IsGroupEquiv (G .snd) e (H .snd)
 
 -- Image, kernel, surjective, injective, and bijections
@@ -69,7 +69,7 @@ open GroupStr
 
 private
   variable
-    G H : Group {ℓ}
+    G H : Group ℓ
 
 isInIm : GroupHom G H → ⟨ H ⟩ → Type _
 isInIm {G = G} ϕ h = ∃[ g ∈ ⟨ G ⟩ ] ϕ .fst g ≡ h
@@ -93,7 +93,7 @@ isMono : GroupHom G H → Type _
 isMono {G = G} f = {x y : ⟨ G ⟩} → f .fst x ≡ f .fst y → x ≡ y
 
 -- Group bijections
-record BijectionIso (G : Group {ℓ}) (H : Group {ℓ'}) : Type (ℓ-max ℓ ℓ') where
+record BijectionIso (G : Group ℓ) (H : Group ℓ') : Type (ℓ-max ℓ ℓ') where
 
   constructor bijIso
 

--- a/Cubical/Algebra/Group/Properties.agda
+++ b/Cubical/Algebra/Group/Properties.agda
@@ -36,7 +36,7 @@ IsGroup.inverse (isPropIsGroup 0g _+_ -_ g1 g2 i) =
   isPropInv = isPropΠ λ _ → isProp× (isSetG _ _) (isSetG _ _)
 
 
-module GroupTheory (G : Group {ℓ}) where
+module GroupTheory (G : Group ℓ) where
   open GroupStr (snd G)
   abstract
     ·CancelL : (a : ⟨ G ⟩) {b c : ⟨ G ⟩} → a · b ≡ a · c → b ≡ c

--- a/Cubical/Algebra/Group/QuotientGroup.agda
+++ b/Cubical/Algebra/Group/QuotientGroup.agda
@@ -27,7 +27,7 @@ private
   variable
     ℓ : Level
 
-module _ (G' : Group {ℓ}) (H' : Subgroup G') (Hnormal : isNormal H') where
+module _ (G' : Group ℓ) (H' : Subgroup G') (Hnormal : isNormal H') where
 
   open BinaryRelation
   open isSubgroup (snd H')
@@ -94,12 +94,12 @@ module _ (G' : Group {ℓ}) (H' : Subgroup G') (Hnormal : isNormal H') where
   ·/H-invr : (a : G/H) → (a ·/H inv/H a) ≡ 1/H
   ·/H-invr = elimProp (λ x → squash/ _ _) λ x → cong [_] (invr x)
 
-  asGroup : Group {ℓ}
+  asGroup : Group ℓ
   asGroup = makeGroup-right 1/H _·/H_ inv/H squash/ ·/H-assoc ·/H-rid ·/H-invr
 
 
-_/_ : (G : Group {ℓ}) → (H : NormalSubgroup G) → Group {ℓ}
+_/_ : (G : Group ℓ) → (H : NormalSubgroup G) → Group ℓ
 G / H = asGroup G (H .fst) (H .snd)
 
-[_]/G : {G : Group {ℓ}} {H : NormalSubgroup G} → ⟨ G ⟩ → ⟨ G / H ⟩
+[_]/G : {G : Group ℓ} {H : NormalSubgroup G} → ⟨ G ⟩ → ⟨ G / H ⟩
 [ x ]/G = [ x ]

--- a/Cubical/Algebra/Group/Subgroup.agda
+++ b/Cubical/Algebra/Group/Subgroup.agda
@@ -28,7 +28,7 @@ private
     ℓ : Level
 
 -- We assume an ambient group
-module _ (G' : Group {ℓ}) where
+module _ (G' : Group ℓ) where
 
   open GroupStr (snd G')
   private G = ⟨ G' ⟩
@@ -55,7 +55,7 @@ module _ (G' : Group {ℓ}) where
   isSetSubgroup : isSet Subgroup
   isSetSubgroup = isSetΣ isSetℙ λ x → isProp→isSet (isPropIsSubgroup x)
 
-  Subgroup→Group : Subgroup → Group {ℓ}
+  Subgroup→Group : Subgroup → Group ℓ
   Subgroup→Group (H , Hh) = makeGroup-right 1HG _·HG_ invHG isSetHG assocHG ridHG invrHG
     where
     HG = Σ[ x ∈ G ] ⟨ H x ⟩
@@ -80,10 +80,10 @@ module _ (G' : Group {ℓ}) where
     invrHG : (x : HG) → x ·HG invHG x ≡ 1HG
     invrHG (x , Hx) = ΣPathP (invr x , isProp→PathP (λ i → H (invr x i) .snd) _ _)
 
-⟪_⟫ : {G' : Group {ℓ}} → Subgroup G' → ℙ (G' .fst)
+⟪_⟫ : {G' : Group ℓ} → Subgroup G' → ℙ (G' .fst)
 ⟪ H , _ ⟫ = H
 
-module _ {G' : Group {ℓ}} where
+module _ {G' : Group ℓ} where
 
   open GroupStr (snd G')
   open isSubgroup
@@ -142,12 +142,12 @@ module _ {G' : Group {ℓ}} where
     (g · inv g)      ≡⟨ invr g ⟩
     1g ∎
 
-NormalSubgroup : (G : Group {ℓ}) → Type _
+NormalSubgroup : (G : Group ℓ) → Type _
 NormalSubgroup G = Σ[ G ∈ Subgroup G ] isNormal G
 
 
 -- Can one get this to work with different universes for G and H?
-module _ {G H : Group {ℓ}} (ϕ : GroupHom G H) where
+module _ {G H : Group ℓ} (ϕ : GroupHom G H) where
 
   open isSubgroup
   open GroupTheory
@@ -170,7 +170,7 @@ module _ {G H : Group {ℓ}} (ϕ : GroupHom G H) where
   imSubgroup : Subgroup H
   imSubgroup = imSubset , isSubgroupIm
 
-  imGroup : Group {ℓ}
+  imGroup : Group ℓ
   imGroup = Subgroup→Group _ imSubgroup
 
   kerSubset : ℙ ⟨ G ⟩

--- a/Cubical/Algebra/Matrix.agda
+++ b/Cubical/Algebra/Matrix.agda
@@ -76,7 +76,7 @@ FinMatrix≡VecMatrix : (A : Type ℓ) (m n : ℕ) → FinMatrix A m n ≡ VecMa
 FinMatrix≡VecMatrix _ _ _ = ua FinMatrix≃VecMatrix
 
 -- Define abelian group structure on matrices
-module FinMatrixAbGroup (G' : AbGroup {ℓ}) where
+module FinMatrixAbGroup (G' : AbGroup ℓ) where
 
   open AbGroupStr (snd G') renaming ( is-set to isSetG )
   private G = ⟨ G' ⟩
@@ -117,7 +117,7 @@ module FinMatrixAbGroup (G' : AbGroup {ℓ}) where
                    → addFinMatrix M N ≡ addFinMatrix N M
   addFinMatrixComm M N i k l = comm (M k l) (N k l) i
 
-  FinMatrixAbGroup : (m n : ℕ) → AbGroup {ℓ}
+  FinMatrixAbGroup : (m n : ℕ) → AbGroup ℓ
   FinMatrixAbGroup m n =
     makeAbGroup {G = FinMatrix G m n} zeroFinMatrix addFinMatrix negFinMatrix
                 isSetFinMatrix addFinMatrixAssoc addFinMatrix0r
@@ -126,7 +126,7 @@ module FinMatrixAbGroup (G' : AbGroup {ℓ}) where
 
 -- Define a abelian group structure on vector matrices and prove that
 -- it is equal to FinMatrixAbGroup using the SIP
-module _ (G' : AbGroup {ℓ}) where
+module _ (G' : AbGroup ℓ) where
 
   open AbGroupStr (snd G')
   private G = ⟨ G' ⟩
@@ -162,7 +162,7 @@ module _ (G' : AbGroup {ℓ}) where
 
   -- Combine everything to get an induced abelian group structure of
   -- VecMatrix that is equal to the one on FinMatrix
-  VecMatrixAbGroup : (m n : ℕ) → AbGroup
+  VecMatrixAbGroup : (m n : ℕ) → AbGroup ℓ
   VecMatrixAbGroup m n =
     InducedAbGroup (FinMatrixAbGroup G' m n) addVecMatrix
       FinMatrix≃VecMatrix (FinMatrix→VecMatrixHomAdd m n)
@@ -175,7 +175,7 @@ module _ (G' : AbGroup {ℓ}) where
 
 -- Define identity matrix and matrix multiplication for FinMatrix and
 -- prove that square matrices form a ring
-module _ (R' : Ring {ℓ}) where
+module _ (R' : Ring ℓ) where
 
   open RingStr (snd R') renaming ( is-set to isSetR )
   open RingTheory R'
@@ -293,7 +293,7 @@ module _ (R' : Ring {ℓ}) where
     ∑ (λ k → M i k · K k j + N i k · K k j)           ≡⟨ sumVecSplit (λ k → M i k · K k j) (λ k → N i k · K k j) ⟩
     ∑ (λ k → M i k · K k j) + ∑ (λ k → N i k · K k j) ∎
 
-  FinMatrixRing : (n : ℕ) → Ring {ℓ}
+  FinMatrixRing : (n : ℕ) → Ring ℓ
   FinMatrixRing n =
     makeRing {R = FinMatrix R n n} zeroFinMatrix oneFinMatrix addFinMatrix
              mulFinMatrix negFinMatrix isSetFinMatrix addFinMatrixAssoc

--- a/Cubical/Algebra/Module/Base.agda
+++ b/Cubical/Algebra/Module/Base.agda
@@ -25,13 +25,13 @@ open Iso
 
 private
   variable
-    ℓ : Level
+    ℓ ℓ' : Level
 
-record IsLeftModule (R : Ring {ℓ}) {M : Type ℓ}
+record IsLeftModule (R : Ring ℓ) {M : Type ℓ'}
   (0m : M)
   (_+_ : M → M → M)
   (-_ : M → M)
-  (_⋆_ : ⟨ R ⟩ → M → M) : Type ℓ where
+  (_⋆_ : ⟨ R ⟩ → M → M) : Type (ℓ-max ℓ ℓ') where
 
   constructor ismodule
 
@@ -61,7 +61,7 @@ record IsLeftModule (R : Ring {ℓ}) {M : Type ℓ}
 
 unquoteDecl IsLeftModuleIsoΣ = declareRecordIsoΣ IsLeftModuleIsoΣ (quote IsLeftModule)
 
-record LeftModuleStr (R : Ring {ℓ}) (A : Type ℓ) : Type ℓ where
+record LeftModuleStr (R : Ring ℓ) (A : Type ℓ') : Type (ℓ-max ℓ ℓ') where
 
   constructor leftmodulestr
 
@@ -74,21 +74,21 @@ record LeftModuleStr (R : Ring {ℓ}) (A : Type ℓ) : Type ℓ where
 
   open IsLeftModule isLeftModule public
 
-LeftModule : (R : Ring {ℓ}) → Type (ℓ-suc ℓ)
-LeftModule {ℓ} R = Σ[ A ∈ Type ℓ ] LeftModuleStr R A
+LeftModule : (R : Ring ℓ) → ∀ ℓ' → Type (ℓ-max ℓ (ℓ-suc ℓ'))
+LeftModule R ℓ' = Σ[ A ∈ Type ℓ' ] LeftModuleStr R A
 
-module _ {R : Ring {ℓ}} where
+module _ {R : Ring ℓ} where
 
-  LeftModule→AbGroup : (M : LeftModule R) → AbGroup {ℓ}
+  LeftModule→AbGroup : (M : LeftModule R ℓ') → AbGroup ℓ'
   LeftModule→AbGroup (_ , leftmodulestr _ _ _ _ isLeftModule) =
                      _ , abgroupstr _ _ _ (IsLeftModule.+-isAbGroup isLeftModule)
 
-  isSetLeftModule : (M : LeftModule R) → isSet ⟨ M ⟩
+  isSetLeftModule : (M : LeftModule R ℓ') → isSet ⟨ M ⟩
   isSetLeftModule M = isSetAbGroup (LeftModule→AbGroup M)
 
   open RingStr (snd R) using (1r) renaming (_+_ to _+r_; _·_ to _·s_)
 
-  makeIsLeftModule : {M : Type ℓ} {0m : M}
+  makeIsLeftModule : {M : Type ℓ'} {0m : M}
                   {_+_ : M → M → M} { -_ : M → M} {_⋆_ : ⟨ R ⟩ → M → M}
                   (isSet-M : isSet M)
                   (+-assoc :  (x y z : M) → x + (y + z) ≡ (x + y) + z)
@@ -103,9 +103,9 @@ module _ {R : Ring {ℓ}} where
   makeIsLeftModule isSet-M +-assoc +-rid +-rinv +-comm ⋆-assoc ⋆-ldist ⋆-rdist ⋆-lid =
     ismodule (makeIsAbGroup isSet-M +-assoc +-rid +-rinv +-comm) ⋆-assoc ⋆-ldist ⋆-rdist ⋆-lid
 
-record IsLeftModuleHom {R : Ring {ℓ}} {A B : Type ℓ}
+record IsLeftModuleHom {R : Ring ℓ} {A B : Type ℓ'}
   (M : LeftModuleStr R A) (f : A → B) (N : LeftModuleStr R B)
-  : Type ℓ
+  : Type (ℓ-max ℓ ℓ')
   where
 
   -- Shorter qualified names
@@ -119,18 +119,18 @@ record IsLeftModuleHom {R : Ring {ℓ}} {A B : Type ℓ}
     pres- : (x : A) → f (M.- x) ≡ N.- (f x)
     pres⋆ : (r : ⟨ R ⟩) (y : A) → f (r M.⋆ y) ≡ r N.⋆ f y
 
-LeftModuleHom : {R : Ring {ℓ}} (M N : LeftModule R) → Type ℓ
+LeftModuleHom : {R : Ring ℓ} (M N : LeftModule R ℓ') → Type (ℓ-max ℓ ℓ')
 LeftModuleHom M N = Σ[ f ∈ (⟨ M ⟩ → ⟨ N ⟩) ] IsLeftModuleHom (M .snd) f (N .snd)
 
-IsLeftModuleEquiv : {R : Ring {ℓ}} {A B : Type ℓ}
+IsLeftModuleEquiv : {R : Ring ℓ} {A B : Type ℓ'}
   (M : LeftModuleStr R A) (e : A ≃ B) (N : LeftModuleStr R B)
-  → Type ℓ
+  → Type (ℓ-max ℓ ℓ')
 IsLeftModuleEquiv M e N = IsLeftModuleHom M (e .fst) N
 
-LeftModuleEquiv : {R : Ring {ℓ}} (M N : LeftModule R) → Type ℓ
+LeftModuleEquiv : {R : Ring ℓ} (M N : LeftModule R ℓ') → Type (ℓ-max ℓ ℓ')
 LeftModuleEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsLeftModuleEquiv (M .snd) e (N .snd)
 
-isPropIsLeftModule : (R : Ring {ℓ}) {M : Type ℓ}
+isPropIsLeftModule : (R : Ring ℓ) {M : Type ℓ'}
   (0m : M)
   (_+_ : M → M → M)
   (-_ : M → M)
@@ -147,7 +147,7 @@ isPropIsLeftModule R _ _ _ _ =
   where
   open IsAbGroup
 
-𝒮ᴰ-LeftModule : (R : Ring {ℓ}) → DUARel (𝒮-Univ ℓ) (LeftModuleStr R) ℓ
+𝒮ᴰ-LeftModule : (R : Ring ℓ) → DUARel (𝒮-Univ ℓ') (LeftModuleStr R) (ℓ-max ℓ ℓ')
 𝒮ᴰ-LeftModule R =
   𝒮ᴰ-Record (𝒮-Univ _) (IsLeftModuleEquiv {R = R})
     (fields:
@@ -160,6 +160,6 @@ isPropIsLeftModule R _ _ _ _ =
   open LeftModuleStr
   open IsLeftModuleHom
 
-LeftModulePath : {R : Ring {ℓ}} (M N : LeftModule R) → (LeftModuleEquiv M N) ≃ (M ≡ N)
-LeftModulePath {ℓ} {R} = ∫ (𝒮ᴰ-LeftModule R) .UARel.ua
+LeftModulePath : {R : Ring ℓ} (M N : LeftModule R ℓ') → (LeftModuleEquiv M N) ≃ (M ≡ N)
+LeftModulePath {R = R} = ∫ (𝒮ᴰ-LeftModule R) .UARel.ua
 

--- a/Cubical/Algebra/Monoid/Base.agda
+++ b/Cubical/Algebra/Monoid/Base.agda
@@ -45,7 +45,7 @@ record IsMonoid {A : Type ℓ} (ε : A) (_·_ : A → A → A) : Type ℓ where
 
 unquoteDecl IsMonoidIsoΣ = declareRecordIsoΣ IsMonoidIsoΣ (quote IsMonoid)
 
-record MonoidStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
+record MonoidStr (A : Type ℓ) : Type ℓ where
   constructor monoidstr
 
   field
@@ -57,15 +57,10 @@ record MonoidStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsMonoid isMonoid public
 
-  -- semigrp : Semigroup
-  -- semigrp = record { isSemigroup = isSemigroup }
+Monoid : ∀ ℓ → Type (ℓ-suc ℓ)
+Monoid ℓ = TypeWithStr ℓ MonoidStr
 
-  -- open Semigroup semigrp public
-
-Monoid : Type (ℓ-suc ℓ)
-Monoid = TypeWithStr _ MonoidStr
-
-monoid : (A : Type ℓ) (ε : A) (_·_ : A → A → A) (h : IsMonoid ε _·_) → Monoid
+monoid : (A : Type ℓ) (ε : A) (_·_ : A → A → A) (h : IsMonoid ε _·_) → Monoid ℓ
 monoid A ε _·_ h = A , monoidstr ε _·_ h
 
 -- Easier to use constructors
@@ -84,7 +79,7 @@ makeMonoid : {M : Type ℓ} (ε : M) (_·_ : M → M → M)
              (assoc : (x y z : M) → x · (y · z) ≡ (x · y) · z)
              (rid : (x : M) → x · ε ≡ x)
              (lid : (x : M) → ε · x ≡ x)
-           → Monoid
+           → Monoid ℓ
 makeMonoid ε _·_ is-setM assoc rid lid =
   monoid _ ε _·_ (makeIsMonoid is-setM assoc rid lid)
 
@@ -104,7 +99,7 @@ record IsMonoidEquiv {A : Type ℓ} {B : Type ℓ}
     presε : equivFun e M.ε ≡ N.ε
     isHom : (x y : A) → equivFun e (x M.· y) ≡ equivFun e x N.· equivFun e y
 
-MonoidEquiv : (M N : Monoid {ℓ}) → Type ℓ
+MonoidEquiv : (M N : Monoid ℓ) → Type ℓ
 MonoidEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsMonoidEquiv (M .snd) e (N .snd)
 
 -- We now extract the important results from the above module
@@ -129,10 +124,10 @@ isPropIsMonoid ε _·_ =
   open MonoidStr
   open IsMonoidEquiv
 
-MonoidPath : (M N : Monoid {ℓ}) → MonoidEquiv M N ≃ (M ≡ N)
+MonoidPath : (M N : Monoid ℓ) → MonoidEquiv M N ≃ (M ≡ N)
 MonoidPath = ∫ 𝒮ᴰ-Monoid .UARel.ua
 
-module MonoidTheory {ℓ} (M : Monoid {ℓ}) where
+module MonoidTheory {ℓ} (M : Monoid ℓ) where
 
   open MonoidStr (snd M)
 

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -92,10 +92,10 @@ record RingStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsRing isRing public
 
-Ring : Type (ℓ-suc ℓ)
-Ring = TypeWithStr _ RingStr
+Ring : ∀ ℓ → Type (ℓ-suc ℓ)
+Ring ℓ = TypeWithStr ℓ RingStr
 
-isSetRing : (R : Ring {ℓ}) → isSet ⟨ R ⟩
+isSetRing : (R : Ring ℓ) → isSet ⟨ R ⟩
 isSetRing R = R .snd .RingStr.isRing .IsRing.·IsMonoid .IsMonoid.isSemigroup .IsSemigroup.is-set
 
 makeIsRing : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R} { -_ : R → R}
@@ -126,7 +126,7 @@ makeRing : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
            (·-lid : (x : R) → 1r · x ≡ x)
            (·-rdist-+ : (x y z : R) → x · (y + z) ≡ (x · y) + (x · z))
            (·-ldist-+ : (x y z : R) → (x + y) · z ≡ (x · z) + (y · z))
-         → Ring
+         → Ring ℓ
 makeRing 0r 1r _+_ _·_ -_ is-setR assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-lid ·-rdist-+ ·-ldist-+ =
   _ , ringstr 0r 1r _+_ _·_ -_
        (makeIsRing is-setR assoc +-rid +-rinv +-comm
@@ -150,17 +150,17 @@ record IsRingHom {A : Type ℓ} {B : Type ℓ'} (R : RingStr A) (f : A → B) (S
 
 unquoteDecl IsRingHomIsoΣ = declareRecordIsoΣ IsRingHomIsoΣ (quote IsRingHom)
 
-RingHom : (R : Ring {ℓ}) (S : Ring {ℓ'}) → Type (ℓ-max ℓ ℓ')
+RingHom : (R : Ring ℓ) (S : Ring ℓ') → Type (ℓ-max ℓ ℓ')
 RingHom R S = Σ[ f ∈ (⟨ R ⟩ → ⟨ S ⟩) ] IsRingHom (R .snd) f (S .snd)
 
 IsRingEquiv : {A : Type ℓ} {B : Type ℓ'} (M : RingStr A) (e : A ≃ B) (N : RingStr B)
   → Type (ℓ-max ℓ ℓ')
 IsRingEquiv M e N = IsRingHom M (e .fst) N
 
-RingEquiv : (R : Ring {ℓ}) (S : Ring {ℓ'}) → Type (ℓ-max ℓ ℓ')
+RingEquiv : (R : Ring ℓ) (S : Ring ℓ') → Type (ℓ-max ℓ ℓ')
 RingEquiv R S = Σ[ e ∈ (⟨ R ⟩ ≃ ⟨ S ⟩) ] IsRingEquiv (R .snd) e (S .snd)
 
-_$_ : {R S : Ring {ℓ}} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
+_$_ : {R S : Ring ℓ} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
 φ $ x = φ .fst x
 
 isPropIsRing : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
@@ -206,24 +206,24 @@ isPropIsRingHom R f S =
   un = autoDUARel (𝒮-Univ _) (λ A → A → A)
   bin = autoDUARel (𝒮-Univ _) (λ A → A → A → A)
 
-RingPath : (R S : Ring {ℓ}) → RingEquiv R S ≃ (R ≡ S)
+RingPath : (R S : Ring ℓ) → RingEquiv R S ≃ (R ≡ S)
 RingPath = ∫ 𝒮ᴰ-Ring .UARel.ua
 
 -- Rings have an abelian group and a monoid
 
-Ring→AbGroup : Ring {ℓ} → AbGroup {ℓ}
+Ring→AbGroup : Ring ℓ → AbGroup ℓ
 Ring→AbGroup (A , ringstr _ _ _ _ _ R) = A , abgroupstr _ _ _ (IsRing.+IsAbGroup R)
 
-Ring→Group : Ring {ℓ} → Group {ℓ}
+Ring→Group : Ring ℓ → Group ℓ
 Ring→Group = AbGroup→Group ∘ Ring→AbGroup
 
-Ring→Monoid : Ring {ℓ} → Monoid {ℓ}
+Ring→Monoid : Ring ℓ → Monoid ℓ
 Ring→Monoid (A , ringstr _ _ _ _ _ R) = monoid _ _ _ (IsRing.·IsMonoid R)
 
 -- Smart constructor for ring homomorphisms
 -- that infers the other equations from pres1, pres+, and pres·
 
-module _ {R : Ring {ℓ}} {S : Ring {ℓ'}} {f : ⟨ R ⟩ → ⟨ S ⟩} where
+module _ {R : Ring ℓ} {S : Ring ℓ'} {f : ⟨ R ⟩ → ⟨ S ⟩} where
 
   private
     module R = RingStr (R .snd)

--- a/Cubical/Algebra/Ring/Ideal.agda
+++ b/Cubical/Algebra/Ring/Ideal.agda
@@ -15,7 +15,7 @@ private
   variable
     ℓ : Level
 
-module _ (R' : Ring {ℓ}) where
+module _ (R' : Ring ℓ) where
 
   open RingStr (snd R')
   private R = ⟨ R' ⟩
@@ -77,5 +77,5 @@ module _ (R' : Ring {ℓ}) where
   zeroIdeal : Ideal
   zeroIdeal = zeroSubset , isIdealZeroIdeal
 
-IdealsIn : (R : Ring {ℓ}) → Type _
+IdealsIn : (R : Ring ℓ) → Type _
 IdealsIn {ℓ} R = Σ[ I ∈ ℙ ⟨ R ⟩ ] isIdeal R I

--- a/Cubical/Algebra/Ring/Kernel.agda
+++ b/Cubical/Algebra/Ring/Kernel.agda
@@ -15,7 +15,7 @@ private
   variable
     ℓ : Level
 
-module _ {{R S : Ring {ℓ}}} (f′ : RingHom R S) where
+module _ {{R S : Ring ℓ}} (f′ : RingHom R S) where
   open IsRingHom (f′ .snd)
   open RingStr ⦃...⦄
   open isIdeal

--- a/Cubical/Algebra/Ring/Properties.agda
+++ b/Cubical/Algebra/Ring/Properties.agda
@@ -29,7 +29,7 @@ private
   that should become obsolete or subject to change once we have a
   ring solver (see https://github.com/agda/cubical/issues/297)
 -}
-module RingTheory (R' : Ring {ℓ}) where
+module RingTheory (R' : Ring ℓ) where
 
   open RingStr (snd R')
   private R = ⟨ R' ⟩
@@ -156,7 +156,7 @@ module RingTheory (R' : Ring {ℓ}) where
   ·-assoc2 : (x y z w : R) → (x · y) · (z · w) ≡ x · (y · z) · w
   ·-assoc2 x y z w = ·Assoc (x · y) z w ∙ cong (_· w) (sym (·Assoc x y z))
 
-module HomTheory {R S : Ring {ℓ}} (f′ : RingHom  R S) where
+module HomTheory {R S : Ring ℓ} (f′ : RingHom  R S) where
   open RingTheory ⦃...⦄
   open RingStr ⦃...⦄
   open IsRingHom (f′ .snd)
@@ -180,7 +180,7 @@ module HomTheory {R S : Ring {ℓ}} (f′ : RingHom  R S) where
           0r            ∎
 
 
-module _{R S : Ring {ℓ}} (φ ψ : RingHom R S) where
+module _{R S : Ring ℓ} (φ ψ : RingHom R S) where
  open RingStr ⦃...⦄
  open IsRingHom
  private

--- a/Cubical/Algebra/Ring/QuotientRing.agda
+++ b/Cubical/Algebra/Ring/QuotientRing.agda
@@ -16,7 +16,7 @@ private
   variable
     ℓ : Level
 
-module _ (R' : Ring {ℓ}) (I : ⟨ R' ⟩  → hProp ℓ) (I-isIdeal : isIdeal R' I) where
+module _ (R' : Ring ℓ) (I : ⟨ R' ⟩  → hProp ℓ) (I-isIdeal : isIdeal R' I) where
   open RingStr (snd R')
   private R = ⟨ R' ⟩
   open isIdeal I-isIdeal
@@ -173,19 +173,19 @@ module _ (R' : Ring {ℓ}) (I : ⟨ R' ⟩  → hProp ℓ) (I-isIdeal : isIdeal 
         eq : (x y z : R) → [ x ] ·/I ([ y ] +/I [ z ]) ≡ ([ x ] ·/I [ y ]) +/I ([ x ] ·/I [ z ])
         eq x y z i = [ ·Rdist+ x y z i ]
 
-  asRing : Ring {ℓ}
+  asRing : Ring ℓ
   asRing = makeRing 0/I 1/I _+/I_ _·/I_ -/I isSetR/I
                     +/I-assoc +/I-rid +/I-rinv +/I-comm
                     ·/I-assoc ·/I-rid ·/I-lid /I-rdist /I-ldist
 
-_/_ : (R : Ring {ℓ}) → (I : IdealsIn R) → Ring {ℓ}
+_/_ : (R : Ring ℓ) → (I : IdealsIn R) → Ring ℓ
 R / (I , IisIdeal) = asRing R I IisIdeal
 
-[_]/I : {R : Ring {ℓ}} {I : IdealsIn R} → (a : ⟨ R ⟩) → ⟨ R / I ⟩
+[_]/I : {R : Ring ℓ} {I : IdealsIn R} → (a : ⟨ R ⟩) → ⟨ R / I ⟩
 [ a ]/I = [ a ]
 
 
-module UniversalProperty (R : Ring {ℓ}) (I : IdealsIn R) where
+module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
   open RingStr ⦃...⦄
   open RingTheory ⦃...⦄
   Iₛ = fst I
@@ -194,7 +194,7 @@ module UniversalProperty (R : Ring {ℓ}) (I : IdealsIn R) where
       _ = R
       _ = snd R
 
-  module _ {S : Ring {ℓ}} (φ : RingHom R S) where
+  module _ {S : Ring ℓ} (φ : RingHom R S) where
     open IsRingHom
     open HomTheory φ
     private

--- a/Cubical/Algebra/RingSolver/AlgebraExpression.agda
+++ b/Cubical/Algebra/RingSolver/AlgebraExpression.agda
@@ -19,14 +19,14 @@ infixl 7 -'_
 infixl 8 _·'_
 
 -- Expression in an R-Algebra A with n variables
-data Expr {ℓ} (R : RawRing {ℓ}) (A : Type ℓ′) (n : ℕ) : Type ℓ where
+data Expr {ℓ} (R : RawRing ℓ) (A : Type ℓ′) (n : ℕ) : Type ℓ where
   K : ⟨ R ⟩ → Expr R A n
   ∣ : Fin n → Expr R A n
   _+'_ : Expr R A n → Expr R A n → Expr R A n
   _·'_ : Expr R A n → Expr R A n → Expr R A n
   -'_ : Expr R A n → Expr R A n
 
-module Eval (R : RawRing {ℓ}) (A : RawAlgebra R ℓ′) where
+module Eval (R : RawRing ℓ) (A : RawAlgebra R ℓ′) where
   open import Cubical.Data.Vec
   open RawAlgebra A renaming (scalar to scalarₐ)
 

--- a/Cubical/Algebra/RingSolver/AlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/AlmostRing.agda
@@ -49,7 +49,7 @@ record IsAlmostRing {R : Type ℓ}
     hiding
       ( is-set ) -- We only want to export one proof of this
 
-record AlmostRing : Type (ℓ-suc ℓ) where
+record AlmostRing ℓ : Type (ℓ-suc ℓ) where
 
   constructor almostring
 
@@ -78,13 +78,13 @@ record AlmostRing : Type (ℓ-suc ℓ) where
   x - y = x + (- y)
 
 -- Extractor for the carrier type
-⟨_⟩ : AlmostRing → Type ℓ
+⟨_⟩ : AlmostRing ℓ → Type ℓ
 ⟨_⟩ = AlmostRing.Carrier
 
-isSetAlmostRing : (R : AlmostRing {ℓ}) → isSet ⟨ R ⟩
+isSetAlmostRing : (R : AlmostRing ℓ) → isSet ⟨ R ⟩
 isSetAlmostRing R = R .AlmostRing.isAlmostRing .IsAlmostRing.·IsMonoid .IsMonoid.isSemigroup .IsSemigroup.is-set
 
-module Theory (R : AlmostRing {ℓ}) where
+module Theory (R : AlmostRing ℓ) where
   open AlmostRing R
 
   0IsSelfinverse : - 0r ≡ 0r

--- a/Cubical/Algebra/RingSolver/CommRingAsAlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/CommRingAsAlmostRing.agda
@@ -17,7 +17,7 @@ private
 
 open Cubical.Algebra.Ring.Properties.RingTheory
 
-CommRingAsAlmostRing : CommRing {ℓ} → AlmostRing {ℓ}
+CommRingAsAlmostRing : CommRing ℓ → AlmostRing ℓ
 CommRingAsAlmostRing {ℓ}
   (R , commringstr _ _ _ _ _
          (iscommring (isring
@@ -25,7 +25,7 @@ CommRingAsAlmostRing {ℓ}
                        ·-isMonoid dist)
                      ·-comm)) =
   let
-    R' : CommRing {ℓ}
+    R' : CommRing ℓ
     R' = (R , commringstr _ _ _ _ _
          (iscommring (isring
                        (isabgroup (isgroup +-isMonoid inverse) +-comm) ·-isMonoid dist)

--- a/Cubical/Algebra/RingSolver/CommRingEvalHom.agda
+++ b/Cubical/Algebra/RingSolver/CommRingEvalHom.agda
@@ -17,7 +17,7 @@ private
   variable
     ℓ : Level
 
-module HomomorphismProperties (R : CommRing {ℓ}) where
+module HomomorphismProperties (R : CommRing ℓ) where
   private
     νR = CommRing→RawℤAlgebra R
   open CommRingStr (snd R)

--- a/Cubical/Algebra/RingSolver/CommRingExamples.agda
+++ b/Cubical/Algebra/RingSolver/CommRingExamples.agda
@@ -16,7 +16,7 @@ private
   variable
     ℓ : Level
 
-module MultivariateSolving (R : CommRing {ℓ}) where
+module MultivariateSolving (R : CommRing ℓ) where
   -- In scope for debuggin:
 
   -- In scope for solver use:

--- a/Cubical/Algebra/RingSolver/CommRingHornerForms.agda
+++ b/Cubical/Algebra/RingSolver/CommRingHornerForms.agda
@@ -121,7 +121,7 @@ module IteratedHornerOperations (A : RawAlgebra ℤAsRawRing ℓ) where
         then (Q ⋆ S)
         else (z ·X+ 0ₕ) +ₕ (Q ⋆ S)
 
-  asRawRing : (n : ℕ) → RawRing {ℓ}
+  asRawRing : (n : ℕ) → RawRing ℓ
   RawRing.Carrier (asRawRing n) = IteratedHornerForms A n
   RawRing.0r (asRawRing n) = 0ₕ
   RawRing.1r (asRawRing n) = 1ₕ

--- a/Cubical/Algebra/RingSolver/CommRingSolver.agda
+++ b/Cubical/Algebra/RingSolver/CommRingSolver.agda
@@ -18,7 +18,7 @@ private
   variable
     ℓ : Level
 
-module EqualityToNormalform (R : CommRing {ℓ}) where
+module EqualityToNormalform (R : CommRing ℓ) where
   νR = CommRing→RawℤAlgebra R
   open CommRingStr (snd R)
   open RingTheory (CommRing→Ring R)
@@ -152,17 +152,17 @@ module EqualityToNormalform (R : CommRing {ℓ}) where
     eval _ (normalize _ e₂) xs ≡⟨ isEqualToNormalform _ e₂ xs ⟩
     ⟦ e₂ ⟧ xs ∎
 
-ℤExpr : (R : CommRing {ℓ}) (n : ℕ)
+ℤExpr : (R : CommRing ℓ) (n : ℕ)
         → _
 ℤExpr R n = EqualityToNormalform.ℤExpr R n
 
-solve : (R : CommRing {ℓ})
+solve : (R : CommRing ℓ)
         {n : ℕ} (e₁ e₂ : ℤExpr R n) (xs : Vec (fst R) n)
         (p : eval n (EqualityToNormalform.normalize R n e₁) xs ≡ eval n (EqualityToNormalform.normalize R n e₂) xs)
         → _
 solve R = EqualityToNormalform.solve R
 
-module VarNames3 (R : CommRing {ℓ}) where
+module VarNames3 (R : CommRing ℓ) where
   X1 : ℤExpr R 3
   X1 = ∣ Fin.zero
 
@@ -172,7 +172,7 @@ module VarNames3 (R : CommRing {ℓ}) where
   X3 : ℤExpr R 3
   X3 = ∣ (suc (suc Fin.zero))
 
-module VarNames4 (R : CommRing {ℓ}) where
+module VarNames4 (R : CommRing ℓ) where
   X1 : ℤExpr R 4
   X1 = ∣ Fin.zero
 
@@ -185,7 +185,7 @@ module VarNames4 (R : CommRing {ℓ}) where
   X4 : ℤExpr R 4
   X4 = ∣ (suc (suc (suc Fin.zero)))
 
-module VarNames5 (R : CommRing {ℓ}) where
+module VarNames5 (R : CommRing ℓ) where
   X1 : ℤExpr R 5
   X1 = ∣ Fin.zero
 
@@ -201,7 +201,7 @@ module VarNames5 (R : CommRing {ℓ}) where
   X5 : ℤExpr R 5
   X5 = ∣ (suc (suc (suc (suc Fin.zero))))
 
-module VarNames6 (R : CommRing {ℓ}) where
+module VarNames6 (R : CommRing ℓ) where
   X1 : ℤExpr R 6
   X1 = ∣ Fin.zero
 

--- a/Cubical/Algebra/RingSolver/EvaluationHomomorphism.agda
+++ b/Cubical/Algebra/RingSolver/EvaluationHomomorphism.agda
@@ -15,7 +15,7 @@ private
   variable
     ℓ : Level
 
-module HomomorphismProperties (R : AlmostRing {ℓ}) where
+module HomomorphismProperties (R : AlmostRing ℓ) where
   private
     νR = AlmostRing→RawRing R
   open AlmostRing R

--- a/Cubical/Algebra/RingSolver/Examples.agda
+++ b/Cubical/Algebra/RingSolver/Examples.agda
@@ -10,7 +10,7 @@ private
   variable
     ℓ : Level
 
-module Test (R : CommRing {ℓ}) where
+module Test (R : CommRing ℓ) where
   open CommRingStr (snd R)
 
   _ :   1r · (1r + 0r)

--- a/Cubical/Algebra/RingSolver/HornerForms.agda
+++ b/Cubical/Algebra/RingSolver/HornerForms.agda
@@ -33,13 +33,13 @@ private
 
 -}
 
-data IteratedHornerForms (R : RawRing {ℓ}) : ℕ → Type ℓ where
+data IteratedHornerForms (R : RawRing ℓ) : ℕ → Type ℓ where
   const : ⟨ R ⟩ → IteratedHornerForms R ℕ.zero
   0H : {n : ℕ} → IteratedHornerForms R (ℕ.suc n)
   _·X+_ : {n : ℕ} → IteratedHornerForms R (ℕ.suc n) → IteratedHornerForms R n
                   → IteratedHornerForms R (ℕ.suc n)
 
-eval : {R : RawRing {ℓ}} (n : ℕ) (P : IteratedHornerForms R n)
+eval : {R : RawRing ℓ} (n : ℕ) (P : IteratedHornerForms R n)
              → Vec ⟨ R ⟩ n → ⟨ R ⟩
 eval ℕ.zero (const r) [] = r
 eval {R = R} .(ℕ.suc _) 0H (_ ∷ _) = RawRing.0r R
@@ -47,7 +47,7 @@ eval {R = R} (ℕ.suc n) (P ·X+ Q) (x ∷ xs) =
   let open RawRing R
   in (eval (ℕ.suc n) P (x ∷ xs)) · x + eval n Q xs
 
-module IteratedHornerOperations (R : RawRing {ℓ}) where
+module IteratedHornerOperations (R : RawRing ℓ) where
   open RawRing R
 
   private
@@ -102,7 +102,7 @@ module IteratedHornerOperations (R : RawRing {ℓ}) where
         then (Q ⋆ S)
         else (z ·X+ 0ₕ) +ₕ (Q ⋆ S)
 
-  asRawRing : (n : ℕ) → RawRing {ℓ}
+  asRawRing : (n : ℕ) → RawRing ℓ
   RawRing.Carrier (asRawRing n) = IteratedHornerForms R n
   RawRing.0r (asRawRing n) = 0ₕ
   RawRing.1r (asRawRing n) = 1ₕ
@@ -110,9 +110,9 @@ module IteratedHornerOperations (R : RawRing {ℓ}) where
   RawRing._·_ (asRawRing n) = _·ₕ_
   RawRing.- (asRawRing n) =  -ₕ
 
-Variable : (n : ℕ) (R : RawRing {ℓ}) (k : Fin n) → IteratedHornerForms R n
+Variable : (n : ℕ) (R : RawRing ℓ) (k : Fin n) → IteratedHornerForms R n
 Variable n R k = IteratedHornerOperations.X R n k
 
-Constant : (n : ℕ) (R : RawRing {ℓ}) (r : ⟨ R ⟩) → IteratedHornerForms R n
+Constant : (n : ℕ) (R : RawRing ℓ) (r : ⟨ R ⟩) → IteratedHornerForms R n
 Constant ℕ.zero R r = const r
 Constant (ℕ.suc n) R r = IteratedHornerOperations.0ₕ R ·X+ Constant n R r

--- a/Cubical/Algebra/RingSolver/IntAsRawRing.agda
+++ b/Cubical/Algebra/RingSolver/IntAsRawRing.agda
@@ -8,7 +8,7 @@ open import Cubical.Data.Int.Base renaming (Int to ℤ) public
 open import Cubical.Foundations.Prelude
 open import Cubical.Algebra.RingSolver.RawRing
 
-ℤAsRawRing : RawRing {ℓ-zero}
+ℤAsRawRing : RawRing ℓ-zero
 ℤAsRawRing = rawring ℤ (pos zero) (pos (suc zero)) _+_ _·_ (λ k → - k)
 
 +Ridℤ : (k : ℤ) → (pos zero) + k ≡ k

--- a/Cubical/Algebra/RingSolver/NatAsAlmostRing.agda
+++ b/Cubical/Algebra/RingSolver/NatAsAlmostRing.agda
@@ -9,7 +9,7 @@ open import Cubical.Algebra.Monoid
 open import Cubical.Algebra.AbGroup
 
 
-ℕAsAlmostRing : AlmostRing {ℓ-zero}
+ℕAsAlmostRing : AlmostRing ℓ-zero
 ℕAsAlmostRing = almostring ℕ 0 1 _+_ _·_ (λ n → n) (isalmostring
                     (ismonoid (issemigroup isSetℕ +-assoc) (λ n → (+-zero n) , refl))
                     (ismonoid (issemigroup isSetℕ ·-assoc) λ n → (·-identityʳ n) , (·-identityˡ n))

--- a/Cubical/Algebra/RingSolver/NatExamples.agda
+++ b/Cubical/Algebra/RingSolver/NatExamples.agda
@@ -132,7 +132,7 @@ module MultivariateSolving where
               in solve lhs rhs (x ∷ y ∷ z ∷ []) {!!}
   -}
 
-module ExamplesForArbitraryRings (R : AlmostRing {ℓ}) where
+module ExamplesForArbitraryRings (R : AlmostRing ℓ) where
   open AlmostRing R
   open EqualityToNormalform R
 

--- a/Cubical/Algebra/RingSolver/RawAlgebra.agda
+++ b/Cubical/Algebra/RingSolver/RawAlgebra.agda
@@ -18,7 +18,7 @@ private
   variable
     ℓ ℓ′ : Level
 
-record RawAlgebra (R : RawRing {ℓ}) (ℓ′ : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ′)) where
+record RawAlgebra (R : RawRing ℓ) (ℓ′ : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ′)) where
 
   constructor rawalgebra
 
@@ -35,13 +35,13 @@ record RawAlgebra (R : RawRing {ℓ}) (ℓ′ : Level) : Type (ℓ-suc (ℓ-max 
   infixl 7 -_
   infixl 6 _+_
 
-⟨_⟩ : {R : RawRing {ℓ}} → RawAlgebra R ℓ′ → Type ℓ′
+⟨_⟩ : {R : RawRing ℓ} → RawAlgebra R ℓ′ → Type ℓ′
 ⟨_⟩ = RawAlgebra.Carrier
 
 {-
   Mapping to integer scalars and its (homorphism) properties.
 -}
-module _ (R : CommRing {ℓ}) where
+module _ (R : CommRing ℓ) where
   open CommRingStr (snd R)
   open Cubical.Algebra.Ring.RingTheory (CommRing→Ring R)
 
@@ -175,6 +175,6 @@ module _ (R : CommRing {ℓ}) where
     (- 1r + scalar (negsuc n)) · scalar l          ≡[ i ]⟨ lemma-1 n i · scalar l ⟩
     scalar (negsuc (ℕ.suc n)) · scalar l ∎
 
-CommRing→RawℤAlgebra : CommRing {ℓ} → RawAlgebra ℤAsRawRing ℓ
+CommRing→RawℤAlgebra : CommRing ℓ → RawAlgebra ℤAsRawRing ℓ
 CommRing→RawℤAlgebra (R , commringstr 0r 1r _+_ _·_ -_ isCommRing) =
   rawalgebra R (scalar ((R , commringstr 0r 1r _+_ _·_ -_ isCommRing))) 0r 1r _+_ _·_ -_

--- a/Cubical/Algebra/RingSolver/RawRing.agda
+++ b/Cubical/Algebra/RingSolver/RawRing.agda
@@ -11,7 +11,7 @@ private
   variable
     ℓ : Level
 
-record RawRing : Type (ℓ-suc ℓ) where
+record RawRing ℓ : Type (ℓ-suc ℓ) where
 
   constructor rawring
 
@@ -27,9 +27,9 @@ record RawRing : Type (ℓ-suc ℓ) where
   infixl 7 -_
   infixl 6 _+_
 
-⟨_⟩ : RawRing → Type ℓ
+⟨_⟩ : RawRing ℓ → Type ℓ
 ⟨_⟩ = RawRing.Carrier
 
-AlmostRing→RawRing : AlmostRing {ℓ} → RawRing {ℓ}
+AlmostRing→RawRing : AlmostRing ℓ → RawRing ℓ
 AlmostRing→RawRing (almostring Carrier 0r 1r _+_ _·_ -_ isAlmostRing) =
                    rawring Carrier 0r 1r _+_ _·_ -_

--- a/Cubical/Algebra/RingSolver/ReflectionSolving.agda
+++ b/Cubical/Algebra/RingSolver/ReflectionSolving.agda
@@ -74,7 +74,7 @@ private
            ∷ variableList (rev varInfos)
            ∷ varg (def (quote refl) []) ∷ [])
 
-module pr (R : CommRing {ℓ}) {n : ℕ} where
+module pr (R : CommRing ℓ) {n : ℕ} where
   private
     νR = CommRing→RawℤAlgebra R
 
@@ -204,5 +204,5 @@ macro
   solve : Term → Term → TC _
   solve = solve-macro
 
-fromℤ : (R : CommRing {ℓ}) → ℤ → fst R
+fromℤ : (R : CommRing ℓ) → ℤ → fst R
 fromℤ = scalar

--- a/Cubical/Algebra/RingSolver/RingExpression.agda
+++ b/Cubical/Algebra/RingSolver/RingExpression.agda
@@ -26,7 +26,7 @@ data Expr {ℓ} (A : Type ℓ) (n : ℕ) : Type ℓ where
 --  _⊛_ : Expr A n → ℕ → Expr A n    -- exponentiation
   ⊝_ : Expr A n → Expr A n
 
-module Eval (R : RawRing {ℓ}) where
+module Eval (R : RawRing ℓ) where
   open import Cubical.Data.Vec
   open RawRing R
 

--- a/Cubical/Algebra/RingSolver/Solver.agda
+++ b/Cubical/Algebra/RingSolver/Solver.agda
@@ -17,7 +17,7 @@ private
   variable
     ℓ : Level
 
-module EqualityToNormalform (R : AlmostRing {ℓ}) where
+module EqualityToNormalform (R : AlmostRing ℓ) where
   νR = AlmostRing→RawRing R
   open AlmostRing R
   open Theory R

--- a/Cubical/Algebra/Semigroup/Base.agda
+++ b/Cubical/Algebra/Semigroup/Base.agda
@@ -44,7 +44,7 @@ record IsSemigroup {A : Type ℓ} (_·_ : A → A → A) : Type ℓ where
 
 unquoteDecl IsSemigroupIsoΣ = declareRecordIsoΣ IsSemigroupIsoΣ (quote IsSemigroup)
 
-record SemigroupStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
+record SemigroupStr (A : Type ℓ) : Type ℓ where
 
   constructor semigroupstr
 
@@ -56,10 +56,10 @@ record SemigroupStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsSemigroup isSemigroup public
 
-Semigroup : Type (ℓ-suc ℓ)
-Semigroup = TypeWithStr _ SemigroupStr
+Semigroup : ∀ ℓ → Type (ℓ-suc ℓ)
+Semigroup ℓ = TypeWithStr ℓ SemigroupStr
 
-semigroup : (A : Type ℓ) (_·_ : A → A → A) (h : IsSemigroup _·_) → Semigroup
+semigroup : (A : Type ℓ) (_·_ : A → A → A) (h : IsSemigroup _·_) → Semigroup ℓ
 semigroup A _·_ h = A , semigroupstr _·_ h
 
 record IsSemigroupEquiv {A : Type ℓ} {B : Type ℓ}
@@ -79,7 +79,7 @@ open SemigroupStr
 open IsSemigroup
 open IsSemigroupEquiv
 
-SemigroupEquiv : (M N : Semigroup {ℓ}) → Type ℓ
+SemigroupEquiv : (M N : Semigroup ℓ) → Type ℓ
 SemigroupEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsSemigroupEquiv (M .snd) e (N .snd)
 
 isPropIsSemigroup : {A : Type ℓ} (_·_ : A → A → A) → isProp (IsSemigroup _·_)
@@ -96,5 +96,5 @@ isPropIsSemigroup _·_ =
       data[ _·_ ∣ autoDUARel _ _ ∣ isHom ]
       prop[ isSemigroup ∣ (λ _ _ → isPropIsSemigroup _) ])
 
-SemigroupPath : (M N : Semigroup {ℓ}) → SemigroupEquiv M N ≃ (M ≡ N)
+SemigroupPath : (M N : Semigroup ℓ) → SemigroupEquiv M N ≃ (M ≡ N)
 SemigroupPath = ∫ 𝒮ᴰ-Semigroup .UARel.ua

--- a/Cubical/Algebra/SymmetricGroup.agda
+++ b/Cubical/Algebra/SymmetricGroup.agda
@@ -16,11 +16,11 @@ private
   variable
     ℓ : Level
 
-Symmetric-Group : (X : Type ℓ) → isSet X → Group {ℓ}
+Symmetric-Group : (X : Type ℓ) → isSet X → Group ℓ
 Symmetric-Group X isSetX = makeGroup (idEquiv X) compEquiv invEquiv (isOfHLevel≃ 2 isSetX isSetX)
   compEquiv-assoc compEquivEquivId compEquivIdEquiv invEquiv-is-rinv invEquiv-is-linv
 
 -- Finite symmetrics groups
 
-Sym : ℕ → Group
+Sym : ℕ → Group _
 Sym n = Symmetric-Group (Fin n) isSetFin

--- a/Cubical/Data/HomotopyGroup/Base.agda
+++ b/Cubical/Data/HomotopyGroup/Base.agda
@@ -13,7 +13,7 @@ open import Cubical.Homotopy.Loopspace
 
 open import Cubical.HITs.SetTruncation as SetTrunc
 
-π^_ : ∀ {ℓ} → ℕ → Pointed ℓ → Group
+π^_ : ∀ {ℓ} → ℕ → Pointed ℓ → Group ℓ
 π^_ {ℓ} n p = makeGroup e _⨀_ _⁻¹ setTruncIsSet assoc rUnit lUnit rCancel lCancel
   where
     n' : ℕ

--- a/Cubical/Experiments/ZCohomologyOld/Properties.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Properties.agda
@@ -443,7 +443,7 @@ open IsMonoid
 open GroupStr
 open IsGroupHom
 
-coHomGr : ∀ {ℓ} (n : ℕ) (A : Type ℓ) → Group {ℓ}
+coHomGr : ∀ {ℓ} (n : ℕ) (A : Type ℓ) → Group ℓ
 coHomGr n A = coHom n A , coHomGrnA
   where
   coHomGrnA : GroupStr (coHom n A)
@@ -456,7 +456,7 @@ coHomGr n A = coHom n A , coHomGrnA
       helper : IsGroup {G = coHom n A} (0ₕ n) (λ x y → x +[ n ]ₕ y) (λ x → -[ n ]ₕ x)
       helper = makeIsGroup § (λ x y z → sym (assocₕ n x y z)) (rUnitₕ n) (lUnitₕ n) (rCancelₕ n) (lCancelₕ n)
 
-×coHomGr : (n : ℕ) (A : Type ℓ) (B : Type ℓ') → Group
+×coHomGr : (n : ℕ) (A : Type ℓ) (B : Type ℓ') → Group _
 ×coHomGr n A B = DirProd (coHomGr n A) (coHomGr n B)
 
 coHomFun : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} (n : ℕ) (f : A → B) → coHom n B → coHom n A

--- a/Cubical/HITs/EilenbergMacLane1/Base.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Base.agda
@@ -14,7 +14,7 @@ open import Cubical.Algebra.Group.Base
 private
   variable ℓ : Level
 
-module _ (Group@(G , str) : Group {ℓ}) where
+module _ (Group@(G , str) : Group ℓ) where
   open GroupStr str
 
   data EM₁ : Type ℓ where

--- a/Cubical/HITs/EilenbergMacLane1/Properties.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Properties.agda
@@ -27,7 +27,7 @@ private
   variable
     ℓG ℓ : Level
 
-module _ ((G , str) : Group {ℓG}) where
+module _ ((G , str) : Group ℓG) where
 
   open GroupStr str
 

--- a/Cubical/Homotopy/EilenbergSteenrod.agda
+++ b/Cubical/Homotopy/EilenbergSteenrod.agda
@@ -30,7 +30,7 @@ open import Cubical.Data.Int
 open import Cubical.Algebra.Group hiding (Int ; Bool)
 open import Cubical.Algebra.AbGroup
 
-record coHomTheory {ℓ ℓ' : Level} (H : (n : Int) → Pointed ℓ → AbGroup {ℓ'}) : Type (ℓ-suc (ℓ-max ℓ ℓ'))
+record coHomTheory {ℓ ℓ' : Level} (H : (n : Int) → Pointed ℓ → AbGroup ℓ') : Type (ℓ-suc (ℓ-max ℓ ℓ'))
   where
   Boolℓ : Pointed ℓ
   Boolℓ = Lift Bool , lift true

--- a/Cubical/Papers/RepresentationIndependence.agda
+++ b/Cubical/Papers/RepresentationIndependence.agda
@@ -237,7 +237,7 @@ open Matrices.FinMatrixAbGroup using (addFinMatrix ; addFinMatrixComm) public
 -- example (not in the library)
 open import Cubical.Data.Int renaming (Int to ℤ ; isSetInt to isSetℤ) hiding (-_)
 
-ℤ-AbGroup : AbGroup
+ℤ-AbGroup : AbGroup ℓ-zero
 ℤ-AbGroup = makeAbGroup {G = ℤ} 0 _+_ -_ isSetℤ +-assoc (λ x _ → x) rem +-comm
     where
     -_ : ℤ → ℤ

--- a/Cubical/ZCohomology/EilenbergSteenrodZ.agda
+++ b/Cubical/ZCohomology/EilenbergSteenrodZ.agda
@@ -78,12 +78,12 @@ SuspCohomElim {A = A} n {B = B} isprop f =
                                   ∙∙ sym (rUnit refl)))
 
 -- (Reduced) cohomology functor
-coHomFunctor : {ℓ : Level}  (n : Int) → Pointed ℓ → AbGroup {ℓ}
+coHomFunctor : {ℓ : Level}  (n : Int) → Pointed ℓ → AbGroup ℓ
 coHomFunctor (pos n) = coHomRedGroup n
 coHomFunctor (negsuc n) _ = trivialAbGroup
 
--- Alternative definition with reduced groups replaced by unrecued one for n ≥ 1
-coHomFunctor' : {ℓ : Level} (n : Int) → Pointed ℓ → AbGroup {ℓ}
+-- Alternative definition with reduced groups replaced by unreduced one for n ≥ 1
+coHomFunctor' : {ℓ : Level} (n : Int) → Pointed ℓ → AbGroup ℓ
 coHomFunctor' (pos zero) = coHomFunctor 0
 coHomFunctor' (pos (suc n)) A = coHomGroup (suc n) (typ A)
 coHomFunctor' (negsuc n) = coHomFunctor (negsuc n)

--- a/Cubical/ZCohomology/GroupStructure.agda
+++ b/Cubical/ZCohomology/GroupStructure.agda
@@ -589,7 +589,7 @@ open IsMonoid
 open GroupStr
 open IsGroupHom
 
-coHomGr : (n : ℕ) (A : Type ℓ) → Group {ℓ}
+coHomGr : (n : ℕ) (A : Type ℓ) → Group ℓ
 coHomGr n A = coHom n A , coHomGrnA
   where
   coHomGrnA : GroupStr (coHom n A)
@@ -602,10 +602,10 @@ coHomGr n A = coHom n A , coHomGrnA
       helper : IsGroup {G = coHom n A} (0ₕ n) (λ x y → x +[ n ]ₕ y) (λ x → -[ n ]ₕ x)
       helper = makeIsGroup § (assocₕ n) (rUnitₕ n) (lUnitₕ n) (rCancelₕ n) (lCancelₕ n)
 
-×coHomGr : (n : ℕ) (A : Type ℓ) (B : Type ℓ') → Group
+×coHomGr : (n : ℕ) (A : Type ℓ) (B : Type ℓ') → Group _
 ×coHomGr n A B = DirProd (coHomGr n A) (coHomGr n B)
 
-coHomGroup : (n : ℕ) (A : Type ℓ) → AbGroup {ℓ}
+coHomGroup : (n : ℕ) (A : Type ℓ) → AbGroup ℓ
 fst (coHomGroup n A) = coHom n A
 AbGroupStr.0g (snd (coHomGroup n A)) = 0ₕ n
 AbGroupStr._+_ (snd (coHomGroup n A)) = _+ₕ_ {n = n}
@@ -615,7 +615,7 @@ IsAbGroup.comm (AbGroupStr.isAbGroup (snd (coHomGroup n A))) = commₕ n
 
 -- Reduced cohomology group (direct def)
 
-coHomRedGroupDir : (n : ℕ) (A : Pointed ℓ) → AbGroup {ℓ}
+coHomRedGroupDir : (n : ℕ) (A : Pointed ℓ) → AbGroup ℓ
 fst (coHomRedGroupDir n A) = coHomRed n A
 AbGroupStr.0g (snd (coHomRedGroupDir n A)) = 0ₕ∙ n
 AbGroupStr._+_ (snd (coHomRedGroupDir n A)) = _+ₕ∙_ {n = n}
@@ -627,7 +627,7 @@ IsAbGroup.isGroup (AbGroupStr.isAbGroup (snd (coHomRedGroupDir n A))) = helper
     helper = makeIsGroup § (assocₕ∙ n) (rUnitₕ∙ n) (lUnitₕ∙ n) (rCancelₕ∙ n) (lCancelₕ∙ n)
 IsAbGroup.comm (AbGroupStr.isAbGroup (snd (coHomRedGroupDir n A))) = commₕ∙ n
 
-coHomRedGrDir : (n : ℕ) (A : Pointed ℓ) → Group {ℓ}
+coHomRedGrDir : (n : ℕ) (A : Pointed ℓ) → Group ℓ
 coHomRedGrDir n A = AbGroup→Group (coHomRedGroupDir n A)
 
 -- Induced map
@@ -645,7 +645,7 @@ snd (coHomMorph n f) = makeIsGroupHom (helper n)
 
 -- Alternative definition of cohomology using ΩKₙ instead. Useful for breaking proofs of group isos
 -- up into smaller parts
-coHomGrΩ : ∀ {ℓ} (n : ℕ) (A : Type ℓ) → Group {ℓ}
+coHomGrΩ : ∀ {ℓ} (n : ℕ) (A : Type ℓ) → Group ℓ
 coHomGrΩ n A = ∥ (A → typ (Ω (coHomK-ptd (suc n)))) ∥₂ , coHomGrnA
   where
   coHomGrnA : GroupStr ∥ (A → typ (Ω (coHomK-ptd (suc n)))) ∥₂

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -233,7 +233,7 @@ coHomGr≅coHomRedGr : ∀ {ℓ} (n : ℕ) (A : Pointed ℓ)
 fst (coHomGr≅coHomRedGr n A) = isoToEquiv (Iso-coHom-coHomRed n)
 snd (coHomGr≅coHomRedGr n A) = makeIsGroupHom (+∙≡+ n)
 
-coHomRedGroup : ∀ {ℓ} (n : ℕ) (A : Pointed ℓ) → AbGroup {ℓ}
+coHomRedGroup : ∀ {ℓ} (n : ℕ) (A : Pointed ℓ) → AbGroup ℓ
 coHomRedGroup zero A = coHomRedGroupDir zero A
 coHomRedGroup (suc n) A =
   InducedAbGroup (coHomGroup (suc n) (typ A))


### PR DESCRIPTION
These almost always need to be given, so they're better explicit than implicit. Also generalizes the structures with two carriers (such as `Module`) so that they can have different levels.