### PR TITLE
Add explicit --guardedness flags to modules that use it

### DIFF
--- a/Cubical/Codata/Conat.agda
+++ b/Cubical/Codata/Conat.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --guardedness #-}
+
 module Cubical.Codata.Conat where
 
 open import Cubical.Codata.Conat.Base public

--- a/Cubical/Codata/Everything.agda
+++ b/Cubical/Codata/Everything.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --guardedness #-}
+
 module Cubical.Codata.Everything where
 
 open import Cubical.Codata.EverythingSafe public

--- a/Cubical/Codata/M/Bisimilarity.agda
+++ b/Cubical/Codata/M/Bisimilarity.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --postfix-projections #-}
+{-# OPTIONS --postfix-projections --guardedness #-}
 module Cubical.Codata.M.Bisimilarity where
 
 open import Cubical.Core.Everything

--- a/Cubical/Codata/Stream.agda
+++ b/Cubical/Codata/Stream.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --guardedness #-}
+
 module Cubical.Codata.Stream where
 
 open import Cubical.Codata.Stream.Base public

--- a/Cubical/README.agda
+++ b/Cubical/README.agda
@@ -1,3 +1,5 @@
+{-# OPTIONS --guardedness #-}
+
 module Cubical.README where
 
 ------------------------------------------------------------------------

--- a/Cubical/Talks/EPA2020.agda
+++ b/Cubical/Talks/EPA2020.agda
@@ -13,7 +13,7 @@ Link to video: https://vimeo.com/459020971
 -}
 
 -- To make Agda cubical add the following options
-{-# OPTIONS --safe #-}
+{-# OPTIONS --safe --guardedness #-}
 module Cubical.Talks.EPA2020 where
 
 -- The "Foundations" package contain a lot of important results (in

--- a/Everythings.hs
+++ b/Everythings.hs
@@ -85,7 +85,7 @@ genEverythings =
   mapM_ (\dir -> do
     let fp = addToFP ["Cubical"] dir
     files <- getMissingFiles fp Nothing
-    let ls = ["{-# OPTIONS --safe #-}",
+    let ls = ["{-# OPTIONS --safe --guardedness #-}",
               "module " ++ showFP '.' (addToFP fp "Everything") ++ " where",[]]
              ++ sort (fmap (\file -> "import " ++ showFP '.' file)
                            (delete (addToFP fp "Everything") files))


### PR DESCRIPTION
Soon the `--guardedness` flag will no longer be enabled by default in Agda, so here are the required changes for making the cubical library compatible.