### PR TITLE
Fix Agda version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)
 file.
 
-If you want to use Agda 2.6.3 instead of the latest development version, you
+If you want to use Agda 2.6.1.3 instead of the latest development version, you
 can check out the tag `v0.2` of this library.
 
 If you want to use Agda 2.6.0.1 instead of the latest development version, you


### PR DESCRIPTION
The README says something about "Agda 2.6.3", but I think it's supposed to read "Agda 2.6.1.3".

The label of version 0.2 of the library also mentions "Agda 2.6.3", but I don't think I can propose an edit to that in this PR; the maintainers should be able to edit the label themselves.