### PR TITLE
Basic opens

### DIFF
--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -204,6 +204,16 @@ isPropIsAlgebraHom R AS f BS = isOfHLevelRetractFromIso 1 IsAlgebraHomIsoΣ
                                          (isPropΠ λ _ → isSetAlgebra (_ , BS) _ _)
                                          (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _))
 
+isSetAlgebraHom : {R : Ring ℓ} (M : Algebra R ℓ') (N : Algebra R ℓ'')
+                → isSet (AlgebraHom M N)
+isSetAlgebraHom _ N = isSetΣ (isSetΠ (λ _ → isSetAlgebra N))
+                        λ _ → isProp→isSet (isPropIsAlgebraHom _ _ _ _)
+
+
+isSetAlgebraEquiv : {R : Ring ℓ} (M N : Algebra R ℓ')
+                  → isSet (AlgebraEquiv M N)
+isSetAlgebraEquiv M N = isSetΣ (isOfHLevel≃ 2 (isSetAlgebra M) (isSetAlgebra N))
+                          λ _ → isProp→isSet (isPropIsAlgebraHom _ _ _ _)
 
 𝒮ᴰ-Algebra : (R : Ring ℓ) → DUARel (𝒮-Univ ℓ') (AlgebraStr R) (ℓ-max ℓ ℓ')
 𝒮ᴰ-Algebra R =

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -153,6 +153,15 @@ open IsAlgebraHom
 AlgebraHom : {R : Ring ℓ} (M : Algebra R ℓ') (N : Algebra R ℓ'') → Type (ℓ-max ℓ (ℓ-max ℓ' ℓ''))
 AlgebraHom M N = Σ[ f ∈ (⟨ M ⟩ → ⟨ N ⟩) ] IsAlgebraHom (M .snd) f (N .snd)
 
+idAlgHom : {R : Ring ℓ} {A : Algebra R ℓ'} → AlgebraHom A A
+fst idAlgHom x = x
+pres0 (snd idAlgHom) = refl
+pres1 (snd idAlgHom) = refl
+pres+ (snd idAlgHom) x y = refl
+pres· (snd idAlgHom) x y = refl
+pres- (snd idAlgHom) x = refl
+pres⋆ (snd idAlgHom) r x = refl
+
 IsAlgebraEquiv : {R : Ring ℓ} {A B : Type ℓ'}
   (M : AlgebraStr R A) (e : A ≃ B) (N : AlgebraStr R B)
   → Type (ℓ-max ℓ ℓ')
@@ -163,6 +172,10 @@ AlgebraEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsAlgebraEquiv (M .snd) e
 
 _$a_ : {R : Ring ℓ} {A : Algebra R ℓ'} {B : Algebra R ℓ''} → AlgebraHom A B → ⟨ A ⟩ → ⟨ B ⟩
 f $a x = fst f x
+
+AlgebraEquiv→AlgebraHom : {R : Ring ℓ} {A B : Algebra R ℓ'}
+                        → AlgebraEquiv A B → AlgebraHom A B
+AlgebraEquiv→AlgebraHom (e , eIsHom) = e .fst , eIsHom
 
 isPropIsAlgebra : (R : Ring ℓ) {A : Type ℓ'}
   (0a 1a : A)

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -183,29 +183,26 @@ isPropIsAlgebra : (R : Ring ℓ) {A : Type ℓ'}
   (-_ : A → A)
   (_⋆_ : ⟨ R ⟩ → A → A)
   → isProp (IsAlgebra R 0a 1a _+_ _·_ -_ _⋆_)
-isPropIsAlgebra R _ _ _ _ _ _ =
+isPropIsAlgebra R _ _ _ _ _ _ = let open IsLeftModule in
   isOfHLevelRetractFromIso 1 IsAlgebraIsoΣ
     (isPropΣ
       (isPropIsLeftModule _ _ _ _ _)
-      (λ mo →
-        isProp× (isPropIsMonoid _ _)
-          (isProp× (isPropΠ3 λ _ _ _ → isProp× (mo .is-set _ _) (mo .is-set _ _))
-            (isProp× (isPropΠ3 λ _ _ _ → mo .is-set _ _)
-              (isPropΠ3 λ _ _ _ → mo .is-set _ _)))))
-  where
-  open IsLeftModule
+      (λ mo → isProp×3 (isPropIsMonoid _ _)
+                       (isPropΠ3 λ _ _ _ → isProp× (mo .is-set _ _) (mo .is-set _ _))
+                       (isPropΠ3 λ _ _ _ → mo .is-set _ _)
+                       (isPropΠ3 λ _ _ _ → mo .is-set _ _) ))
+
 
 isPropIsAlgebraHom : (R : Ring ℓ) {A : Type ℓ'} {B : Type ℓ''}
                      (AS : AlgebraStr R A) (f : A → B) (BS : AlgebraStr R B)
                    → isProp (IsAlgebraHom AS f BS)
-isPropIsAlgebraHom R AS f BS =
-  isOfHLevelRetractFromIso 1 IsAlgebraHomIsoΣ
-   (isProp× (isSetAlgebra (_ , BS) _ _)
-     (isProp× (isSetAlgebra (_ , BS) _ _)
-       (isProp× (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _)
-         (isProp× (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _)
-           (isProp× (isPropΠ λ _ → isSetAlgebra (_ , BS) _ _)
-             (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _))))))
+isPropIsAlgebraHom R AS f BS = isOfHLevelRetractFromIso 1 IsAlgebraHomIsoΣ
+                               (isProp×5 (isSetAlgebra (_ , BS) _ _)
+                                         (isSetAlgebra (_ , BS) _ _)
+                                         (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _)
+                                         (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _)
+                                         (isPropΠ λ _ → isSetAlgebra (_ , BS) _ _)
+                                         (isPropΠ2 λ _ _ → isSetAlgebra (_ , BS) _ _))
 
 
 𝒮ᴰ-Algebra : (R : Ring ℓ) → DUARel (𝒮-Univ ℓ') (AlgebraStr R) (ℓ-max ℓ ℓ')

--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -172,6 +172,4 @@ CommAlgebraPath : (R : CommRing ℓ) → (A B : CommAlgebra R ℓ') → (CommAlg
 CommAlgebraPath R = ∫ (𝒮ᴰ-CommAlgebra R) .UARel.ua
 
 isGroupoidCommAlgebra : {R : CommRing ℓ} → isGroupoid (CommAlgebra R ℓ')
-isGroupoidCommAlgebra A B = isOfHLevelRespectEquiv 2 (CommAlgebraPath _ _ _)
-                              (isSetΣ (isOfHLevel≃ 2 (isSetCommAlgebra A) (isSetCommAlgebra B))
-                               λ _ → isProp→isSet (isPropIsAlgebraHom _ _ _ _))
+isGroupoidCommAlgebra A B = isOfHLevelRespectEquiv 2 (CommAlgebraPath _ _ _) (isSetAlgebraEquiv _ _)

--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -72,6 +72,9 @@ module _ {R : CommRing ℓ} where
   CommAlgebra→CommRing (_ , commalgebrastr  _ _ _ _ _ _ (iscommalgebra isAlgebra ·-comm)) =
     _ , commringstr _ _ _ _ _ (iscommring (IsAlgebra.isRing isAlgebra) ·-comm)
 
+  isSetCommAlgebra : (A : CommAlgebra R ℓ') → isSet ⟨ A ⟩
+  isSetCommAlgebra A = isSetAlgebra (CommAlgebra→Algebra A)
+
   makeIsCommAlgebra : {A : Type ℓ'} {0a 1a : A}
                       {_+_ _·_ : A → A → A} { -_ : A → A} {_⋆_ : ⟨ R ⟩ → A → A}
                       (isSet-A : isSet A)
@@ -126,6 +129,15 @@ module _ {R : CommRing ℓ} where
   CommAlgebraEquiv : (M N : CommAlgebra R ℓ') → Type (ℓ-max ℓ ℓ')
   CommAlgebraEquiv M N = Σ[ e ∈ ⟨ M ⟩ ≃ ⟨ N ⟩ ] IsCommAlgebraEquiv (M .snd) e (N .snd)
 
+  IsCommAlgebraHom : {A B : Type ℓ'}
+    (M : CommAlgebraStr R A) (f : A → B) (N : CommAlgebraStr R B)
+    → Type (ℓ-max ℓ ℓ')
+  IsCommAlgebraHom M f N =
+    IsAlgebraHom (CommAlgebraStr→AlgebraStr M) f (CommAlgebraStr→AlgebraStr N)
+
+  CommAlgebraHom : (M N : CommAlgebra R ℓ') → Type (ℓ-max ℓ ℓ')
+  CommAlgebraHom M N = Σ[ f ∈ (⟨ M ⟩ → ⟨ N ⟩) ] IsCommAlgebraHom (M .snd) f (N .snd)
+
 isPropIsCommAlgebra : (R : CommRing ℓ) {A : Type ℓ'}
   (0a 1a : A)
   (_+_ _·_ : A → A → A)
@@ -158,3 +170,8 @@ isPropIsCommAlgebra R _ _ _ _ _ _ =
 
 CommAlgebraPath : (R : CommRing ℓ) → (A B : CommAlgebra R ℓ') → (CommAlgebraEquiv A B) ≃ (A ≡ B)
 CommAlgebraPath R = ∫ (𝒮ᴰ-CommAlgebra R) .UARel.ua
+
+isGroupoidCommAlgebra : {R : CommRing ℓ} → isGroupoid (CommAlgebra R ℓ')
+isGroupoidCommAlgebra A B = isOfHLevelRespectEquiv 2 (CommAlgebraPath _ _ _)
+                              (isSetΣ (isOfHLevel≃ 2 (isSetCommAlgebra A) (isSetCommAlgebra B))
+                               λ _ → isProp→isSet (isPropIsAlgebraHom _ _ _ _))

--- a/Cubical/Algebra/CommAlgebra/Localisation.agda
+++ b/Cubical/Algebra/CommAlgebra/Localisation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Algebra.CommAlgebra.Localisation where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommAlgebra/Localisation.agda
+++ b/Cubical/Algebra/CommAlgebra/Localisation.agda
@@ -1,0 +1,217 @@
+{-# OPTIONS --cubical --safe --no-import-sorts --experimental-lossy-unification #-}
+module Cubical.Algebra.CommAlgebra.Localisation where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.SIP
+open import Cubical.Foundations.Powerset
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Reflection.StrictEquiv
+
+open import Cubical.Structures.Axioms
+open import Cubical.Algebra.Semigroup
+open import Cubical.Algebra.Monoid
+open import Cubical.Algebra.CommRing.Base
+open import Cubical.Algebra.CommRing.Properties
+open import Cubical.Algebra.CommRing.Localisation.Base
+open import Cubical.Algebra.CommRing.Localisation.UniversalProperty
+open import Cubical.Algebra.Ring
+open import Cubical.Algebra.Algebra
+open import Cubical.Algebra.CommAlgebra.Base
+open import Cubical.Algebra.CommAlgebra.Properties
+
+open import Cubical.HITs.SetQuotients as SQ
+open import Cubical.HITs.PropositionalTruncation as PT
+
+
+private
+  variable
+    ℓ ℓ′ : Level
+
+
+
+module AlgLoc (R' : CommRing ℓ)
+              (S' : ℙ (fst R')) (SMultClosedSubset : isMultClosedSubset R' S') where
+ open isMultClosedSubset
+ private R = fst R'
+ open CommAlgebraStr
+ open IsAlgebraHom
+ open CommRingStr (snd R') renaming (_+_ to _+r_ ; _·_ to _·r_ ; ·Rid to ·rRid)
+ open RingTheory (CommRing→Ring R')
+ open CommRingTheory R'
+ open Loc R' S' SMultClosedSubset
+ open S⁻¹RUniversalProp R' S' SMultClosedSubset
+ open CommAlgChar R'
+
+
+ S⁻¹RAsCommAlg : CommAlgebra R' ℓ
+ S⁻¹RAsCommAlg = toCommAlg (S⁻¹RAsCommRing , /1AsCommRingHom)
+
+
+ hasLocAlgUniversalProp : (A : CommAlgebra R' ℓ)
+                        → (∀ s → s ∈ S' → _⋆_ (snd A) s (1a (snd A)) ∈ (CommAlgebra→CommRing A) ˣ)
+                        → Type (ℓ-suc ℓ)
+ hasLocAlgUniversalProp A _ = (B : CommAlgebra R' ℓ)
+                      → (∀ s → s ∈ S' →  _⋆_ (snd B) s (1a (snd B)) ∈ (CommAlgebra→CommRing B) ˣ)
+                      → isContr (CommAlgebraHom A B)
+
+ S⋆1⊆S⁻¹Rˣ : ∀ s → s ∈ S' → _⋆_ (snd S⁻¹RAsCommAlg) s (1a (snd S⁻¹RAsCommAlg)) ∈ S⁻¹Rˣ
+ S⋆1⊆S⁻¹Rˣ s s∈S' = subst (_∈ S⁻¹Rˣ)
+                    (cong [_] (≡-× (sym (·rRid s)) (Σ≡Prop (λ x → S' x .snd) (sym (·rRid _)))))
+                    (S/1⊆S⁻¹Rˣ s s∈S')
+
+
+ S⁻¹RHasAlgUniversalProp : hasLocAlgUniversalProp S⁻¹RAsCommAlg S⋆1⊆S⁻¹Rˣ
+ S⁻¹RHasAlgUniversalProp B' S⋆1⊆Bˣ = χᴬ , χᴬuniqueness
+  where
+  B = fromCommAlg B' .fst
+  φ = fromCommAlg B' .snd
+  open CommRingStr (snd B) renaming (_·_ to _·b_ ; 1r to 1b ; ·Lid to ·bLid)
+
+  χ : CommRingHom S⁻¹RAsCommRing B
+  χ = S⁻¹RHasUniversalProp B φ S⋆1⊆Bˣ .fst .fst
+
+  χcomp : ∀ r → fst χ (r /1) ≡ fst φ r
+  χcomp = funExt⁻ (S⁻¹RHasUniversalProp B φ S⋆1⊆Bˣ .fst .snd)
+
+  χᴬ : CommAlgebraHom S⁻¹RAsCommAlg B'
+  fst χᴬ = fst χ
+  pres0 (snd χᴬ) = IsRingHom.pres0 (snd χ)
+  pres1 (snd χᴬ) = IsRingHom.pres1 (snd χ)
+  pres+ (snd χᴬ) = IsRingHom.pres+ (snd χ)
+  pres· (snd χᴬ) = IsRingHom.pres· (snd χ)
+  pres- (snd χᴬ) = IsRingHom.pres- (snd χ)
+  pres⋆ (snd χᴬ) r x = path
+   where
+   path : fst χ ((r /1) ·ₗ x) ≡ _⋆_  (snd B') r (fst χ x)
+   path = fst χ ((r /1) ·ₗ x)             ≡⟨ IsRingHom.pres· (snd χ) _ _ ⟩
+          fst χ (r /1) ·b fst χ x         ≡⟨ cong (_·b fst χ x) (χcomp r) ⟩
+          fst φ r ·b fst χ x              ≡⟨ refl ⟩
+          _⋆_  (snd B') r 1b ·b fst χ x   ≡⟨ ⋆-lassoc (snd B') _ _ _ ⟩
+          _⋆_  (snd B') r (1b ·b fst χ x) ≡⟨ cong (_⋆_ (snd B') r) (·bLid _) ⟩
+          _⋆_  (snd B') r (fst χ x)       ∎
+
+
+  χᴬuniqueness : (ψ : CommAlgebraHom S⁻¹RAsCommAlg B') → χᴬ ≡ ψ
+  χᴬuniqueness ψ = Σ≡Prop (λ _ → isPropIsAlgebraHom _ _ _ _)
+                          (cong (fst ∘ fst) (χuniqueness (ψ' , funExt ψ'r/1≡φr)))
+   where
+   χuniqueness = S⁻¹RHasUniversalProp B φ S⋆1⊆Bˣ .snd
+
+   ψ' : CommRingHom S⁻¹RAsCommRing B
+   fst ψ' = fst ψ
+   IsRingHom.pres0 (snd ψ') = pres0 (snd ψ)
+   IsRingHom.pres1 (snd ψ') = pres1 (snd ψ)
+   IsRingHom.pres+ (snd ψ') = pres+ (snd ψ)
+   IsRingHom.pres· (snd ψ') = pres· (snd ψ)
+   IsRingHom.pres- (snd ψ') = pres- (snd ψ)
+
+   ψ'r/1≡φr : ∀ r → fst ψ (r /1) ≡ fst φ r
+   ψ'r/1≡φr r =
+    fst ψ (r /1) ≡⟨ cong (fst ψ) (sym (·ₗ-rid _)) ⟩
+    fst ψ (_⋆_ (snd S⁻¹RAsCommAlg) r (1a (snd S⁻¹RAsCommAlg))) ≡⟨ pres⋆ (snd ψ) _ _ ⟩
+    _⋆_  (snd B') r (fst ψ (1a (snd S⁻¹RAsCommAlg))) ≡⟨ cong (_⋆_ (snd B') r) (pres1 (snd ψ)) ⟩
+    _⋆_  (snd B') r 1b ∎
+
+
+ -- an immediate corrollary:
+ isContrHomS⁻¹RS⁻¹R : isContr (CommAlgebraHom S⁻¹RAsCommAlg S⁻¹RAsCommAlg)
+ isContrHomS⁻¹RS⁻¹R = S⁻¹RHasAlgUniversalProp S⁻¹RAsCommAlg S⋆1⊆S⁻¹Rˣ
+
+
+
+
+module AlgLocTwoSubsets (R' : CommRing ℓ)
+                        (S₁ : ℙ (fst R')) (S₁MultClosedSubset : isMultClosedSubset R' S₁)
+                        (S₂ : ℙ (fst R')) (S₂MultClosedSubset : isMultClosedSubset R' S₂) where
+ open isMultClosedSubset
+ open CommRingStr (snd R') hiding (is-set)
+ open RingTheory (CommRing→Ring R')
+ open Loc R' S₁ S₁MultClosedSubset renaming (S⁻¹R to S₁⁻¹R ;
+                                             S⁻¹RAsCommRing to S₁⁻¹RAsCommRing)
+ open Loc R' S₂ S₂MultClosedSubset renaming (S⁻¹R to S₂⁻¹R ;
+                                             S⁻¹RAsCommRing to S₂⁻¹RAsCommRing)
+ open AlgLoc R' S₁ S₁MultClosedSubset renaming ( S⁻¹RAsCommAlg to S₁⁻¹RAsCommAlg
+                                               ; S⋆1⊆S⁻¹Rˣ to S₁⋆1⊆S₁⁻¹Rˣ
+                                               ; S⁻¹RHasAlgUniversalProp to S₁⁻¹RHasAlgUniversalProp
+                                               ; isContrHomS⁻¹RS⁻¹R to isContrHomS₁⁻¹RS₁⁻¹R)
+ open AlgLoc R' S₂ S₂MultClosedSubset renaming ( S⁻¹RAsCommAlg to S₂⁻¹RAsCommAlg
+                                               ; S⋆1⊆S⁻¹Rˣ to S₂⋆1⊆S₂⁻¹Rˣ
+                                               ; S⁻¹RHasAlgUniversalProp to S₂⁻¹RHasAlgUniversalProp
+                                               ; isContrHomS⁻¹RS⁻¹R to isContrHomS₂⁻¹RS₂⁻¹R)
+
+ open IsAlgebraHom
+ open CommAlgebraStr ⦃...⦄
+
+ private
+  R = fst R'
+  S₁⁻¹Rˣ = S₁⁻¹RAsCommRing ˣ
+  S₂⁻¹Rˣ = S₂⁻¹RAsCommRing ˣ
+  instance
+   _ = snd S₁⁻¹RAsCommAlg
+   _ = snd S₂⁻¹RAsCommAlg
+
+
+ isContrS₁⁻¹R≡S₂⁻¹R : (∀ s₁ → s₁ ∈ S₁ → s₁ ⋆ 1a ∈ S₂⁻¹Rˣ)
+                    → (∀ s₂ → s₂ ∈ S₂ → s₂ ⋆ 1a ∈ S₁⁻¹Rˣ)
+                    → isContr (S₁⁻¹RAsCommAlg ≡ S₂⁻¹RAsCommAlg)
+ isContrS₁⁻¹R≡S₂⁻¹R S₁⊆S₂⁻¹Rˣ S₂⊆S₁⁻¹Rˣ = isOfHLevelRetractFromIso 0
+                                            (equivToIso (invEquiv (CommAlgebraPath _ _ _)))
+                                              isContrS₁⁻¹R≅S₂⁻¹R
+  where
+  χ₁ : CommAlgebraHom S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg
+  χ₁ = S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg S₁⊆S₂⁻¹Rˣ .fst
+
+  χ₂ : CommAlgebraHom S₂⁻¹RAsCommAlg S₁⁻¹RAsCommAlg
+  χ₂ = S₂⁻¹RHasAlgUniversalProp S₁⁻¹RAsCommAlg S₂⊆S₁⁻¹Rˣ .fst
+
+  χ₁∘χ₂≡id : χ₁ ∘a χ₂ ≡ idAlgHom
+  χ₁∘χ₂≡id = isContr→isProp isContrHomS₂⁻¹RS₂⁻¹R _ _
+
+  χ₂∘χ₁≡id : χ₂ ∘a χ₁ ≡ idAlgHom
+  χ₂∘χ₁≡id = isContr→isProp isContrHomS₁⁻¹RS₁⁻¹R _ _
+
+  IsoS₁⁻¹RS₂⁻¹R : Iso S₁⁻¹R S₂⁻¹R
+  Iso.fun IsoS₁⁻¹RS₂⁻¹R = fst χ₁
+  Iso.inv IsoS₁⁻¹RS₂⁻¹R = fst χ₂
+  Iso.rightInv IsoS₁⁻¹RS₂⁻¹R = funExt⁻ (cong fst χ₁∘χ₂≡id)
+  Iso.leftInv IsoS₁⁻¹RS₂⁻¹R = funExt⁻ (cong fst χ₂∘χ₁≡id)
+
+  isContrS₁⁻¹R≅S₂⁻¹R : isContr (CommAlgebraEquiv S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg)
+  isContrS₁⁻¹R≅S₂⁻¹R = center , uniqueness
+   where
+   center : CommAlgebraEquiv S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg
+   fst center = isoToEquiv IsoS₁⁻¹RS₂⁻¹R
+   pres0 (snd center) = pres0 (snd χ₁)
+   pres1 (snd center) = pres1 (snd χ₁)
+   pres+ (snd center) = pres+ (snd χ₁)
+   pres· (snd center) = pres· (snd χ₁)
+   pres- (snd center) = pres- (snd χ₁)
+   pres⋆ (snd center) = pres⋆ (snd χ₁)
+
+   uniqueness : (φ : CommAlgebraEquiv S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg) → center ≡ φ
+   uniqueness φ = Σ≡Prop (λ _ → isPropIsAlgebraHom _ _ _ _)
+                         (equivEq (cong fst
+                           (S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg S₁⊆S₂⁻¹Rˣ .snd
+                             (AlgebraEquiv→AlgebraHom φ))))
+
+
+ isPropS₁⁻¹R≡S₂⁻¹R  : isProp (S₁⁻¹RAsCommAlg ≡ S₂⁻¹RAsCommAlg)
+ isPropS₁⁻¹R≡S₂⁻¹R S₁⁻¹R≡S₂⁻¹R  =
+   isContr→isProp (isContrS₁⁻¹R≡S₂⁻¹R  S₁⊆S₂⁻¹Rˣ S₂⊆S₁⁻¹Rˣ) S₁⁻¹R≡S₂⁻¹R
+    where
+    S₁⊆S₂⁻¹Rˣ : ∀ s₁ → s₁ ∈ S₁ → s₁ ⋆ 1a ∈ S₂⁻¹Rˣ
+    S₁⊆S₂⁻¹Rˣ s₁ s₁∈S₁ =
+      transport (λ i → _⋆_ ⦃ S₁⁻¹R≡S₂⁻¹R i .snd ⦄ s₁ (1a ⦃ S₁⁻¹R≡S₂⁻¹R i .snd ⦄)
+                     ∈ (CommAlgebra→CommRing (S₁⁻¹R≡S₂⁻¹R i)) ˣ) (S₁⋆1⊆S₁⁻¹Rˣ s₁ s₁∈S₁)
+
+    S₂⊆S₁⁻¹Rˣ : ∀ s₂ → s₂ ∈ S₂ → s₂ ⋆ 1a ∈ S₁⁻¹Rˣ
+    S₂⊆S₁⁻¹Rˣ s₂ s₂∈S₂ =
+      transport (λ i → _⋆_ ⦃ (sym S₁⁻¹R≡S₂⁻¹R) i .snd ⦄ s₂ (1a ⦃ (sym S₁⁻¹R≡S₂⁻¹R) i .snd ⦄)
+                     ∈ (CommAlgebra→CommRing ((sym S₁⁻¹R≡S₂⁻¹R) i)) ˣ) (S₂⋆1⊆S₂⁻¹Rˣ s₂ s₂∈S₂)

--- a/Cubical/Algebra/CommAlgebra/Properties.agda
+++ b/Cubical/Algebra/CommAlgebra/Properties.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --safe --no-import-sorts --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Algebra.CommAlgebra.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommAlgebra/Properties.agda
+++ b/Cubical/Algebra/CommAlgebra/Properties.agda
@@ -1,0 +1,113 @@
+{-# OPTIONS --cubical --safe --no-import-sorts --experimental-lossy-unification #-}
+module Cubical.Algebra.CommAlgebra.Properties where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.SIP
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Reflection.StrictEquiv
+
+open import Cubical.Structures.Axioms
+open import Cubical.Algebra.Semigroup
+open import Cubical.Algebra.Monoid
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.Ring
+open import Cubical.Algebra.Algebra
+open import Cubical.Algebra.CommAlgebra.Base
+
+private
+  variable
+    ℓ ℓ′ : Level
+
+
+-- An R-algebra is the same as a CommRing A with a CommRingHom φ : R → A
+module CommAlgChar (R : CommRing ℓ) where
+ open Iso
+ open IsRingHom
+ open CommRingTheory
+
+
+ CommRingWithHom : Type (ℓ-suc ℓ)
+ CommRingWithHom = Σ[ A ∈ CommRing ℓ ] CommRingHom R A
+
+ toCommAlg : CommRingWithHom → CommAlgebra R ℓ
+ toCommAlg (A , φ , φIsHom) = ⟨ A ⟩ , ACommAlgStr
+  where
+  open CommRingStr (snd A)
+  ACommAlgStr : CommAlgebraStr R ⟨ A ⟩
+  CommAlgebraStr.0a ACommAlgStr = 0r
+  CommAlgebraStr.1a ACommAlgStr = 1r
+  CommAlgebraStr._+_ ACommAlgStr = _+_
+  CommAlgebraStr._·_ ACommAlgStr = _·_
+  CommAlgebraStr.- ACommAlgStr = -_
+  CommAlgebraStr._⋆_ ACommAlgStr r a = (φ r) · a
+  CommAlgebraStr.isCommAlgebra ACommAlgStr = makeIsCommAlgebra
+   is-set +Assoc +Rid +Rinv +Comm ·Assoc ·Lid ·Ldist+ ·-comm
+   (λ _ _ x → cong (λ y →  y · x) (pres· φIsHom _ _) ∙ sym (·Assoc _ _ _))
+   (λ _ _ x → cong (λ y → y · x) (pres+ φIsHom _ _) ∙ ·Ldist+ _ _ _)
+   (λ _ _ _ → ·Rdist+ _ _ _)
+   (λ x → cong (λ y → y · x) (pres1 φIsHom) ∙ ·Lid x)
+   (λ _ _ _ → sym (·Assoc _ _ _))
+
+
+ fromCommAlg : CommAlgebra R ℓ → CommRingWithHom
+ fromCommAlg A = (CommAlgebra→CommRing A) , φ , φIsHom
+  where
+  open CommRingStr (snd R) renaming (_·_ to _·r_) hiding (·Lid)
+  open CommAlgebraStr (snd A)
+  open AlgebraTheory (CommRing→Ring R) (CommAlgebra→Algebra A)
+  φ : ⟨ R ⟩ → ⟨ A ⟩
+  φ r = r ⋆ 1a
+  φIsHom : IsRingHom (CommRing→Ring R .snd) φ (CommRing→Ring (CommAlgebra→CommRing A) .snd)
+  φIsHom = makeIsRingHom (⋆-lid _) (λ _ _ → ⋆-ldist _ _ _)
+           λ x y → cong (λ a → (x ·r y) ⋆ a) (sym (·Lid _)) ∙ ⋆Dist· _ _ _ _
+
+
+ CommRingWithHomRoundTrip : (Aφ : CommRingWithHom) → fromCommAlg (toCommAlg Aφ) ≡ Aφ
+ CommRingWithHomRoundTrip (A , φ) = ΣPathP (APath , φPathP)
+  where
+  open CommRingStr
+  -- note that the proofs of the axioms might differ!
+  APath : fst (fromCommAlg (toCommAlg (A , φ))) ≡ A
+  fst (APath i) = ⟨ A ⟩
+  0r (snd (APath i)) = 0r (snd A)
+  1r (snd (APath i)) = 1r (snd A)
+  _+_ (snd (APath i)) = _+_ (snd A)
+  _·_ (snd (APath i)) = _·_ (snd A)
+  -_ (snd (APath i)) = -_ (snd A)
+  isCommRing (snd (APath i)) = isProp→PathP (λ i → isPropIsCommRing _ _ _ _ _ )
+             (isCommRing (snd (fst (fromCommAlg (toCommAlg (A , φ)))))) (isCommRing (snd A)) i
+
+  -- this only works because fst (APath i) = fst A definitionally!
+  φPathP : PathP (λ i → CommRingHom R (APath i)) (snd (fromCommAlg (toCommAlg (A , φ)))) φ
+  φPathP = RingHomEqDep _ _ _ _ _ _ λ i x → ·Rid (snd A) (fst φ x) i
+
+
+ CommAlgRoundTrip : (A : CommAlgebra R ℓ) → toCommAlg (fromCommAlg A) ≡ A
+ CommAlgRoundTrip A = ΣPathP (refl , AlgStrPathP)
+  where
+  open CommAlgebraStr ⦃...⦄
+  instance
+   _ = snd A
+  AlgStrPathP : PathP (λ i → CommAlgebraStr R ⟨ A ⟩) (snd (toCommAlg (fromCommAlg A))) (snd A)
+  CommAlgebraStr.0a (AlgStrPathP i) = 0a
+  CommAlgebraStr.1a (AlgStrPathP i) = 1a
+  CommAlgebraStr._+_ (AlgStrPathP i) = _+_
+  CommAlgebraStr._·_ (AlgStrPathP i) = _·_
+  CommAlgebraStr.-_ (AlgStrPathP i) = -_
+  CommAlgebraStr._⋆_ (AlgStrPathP i) r x = (⋆-lassoc r 1a x ∙ cong (r ⋆_) (·Lid x)) i
+  CommAlgebraStr.isCommAlgebra (AlgStrPathP i) = isProp→PathP
+    (λ i → isPropIsCommAlgebra _ _ _ _ _ _ (CommAlgebraStr._⋆_ (AlgStrPathP i)))
+    (CommAlgebraStr.isCommAlgebra (snd (toCommAlg (fromCommAlg A)))) isCommAlgebra i
+
+
+ CommAlgIso : Iso (CommAlgebra R ℓ) CommRingWithHom
+ fun CommAlgIso = fromCommAlg
+ inv CommAlgIso = toCommAlg
+ rightInv CommAlgIso = CommRingWithHomRoundTrip
+ leftInv CommAlgIso = CommAlgRoundTrip

--- a/Cubical/Algebra/CommRing/Properties.agda
+++ b/Cubical/Algebra/CommRing/Properties.agda
@@ -176,6 +176,10 @@ module Exponentiation (R' : CommRing ℓ) where
  infix 9 _^_
 
  -- and prove some laws
+ 1ⁿ≡1 : (n : ℕ) → 1r ^ n ≡ 1r
+ 1ⁿ≡1 zero = refl
+ 1ⁿ≡1 (suc n) = ·Lid _ ∙ 1ⁿ≡1 n
+
  ·-of-^-is-^-of-+ : (f : R) (m n : ℕ) → (f ^ m) · (f ^ n) ≡ f ^ (m +ℕ n)
  ·-of-^-is-^-of-+ f zero n = ·Lid _
  ·-of-^-is-^-of-+ f (suc m) n = sym (·Assoc _ _ _) ∙ cong (f ·_) (·-of-^-is-^-of-+ f m n)
@@ -192,6 +196,12 @@ module Exponentiation (R' : CommRing ℓ) where
          f · ((f ^ n) · g) · (g ^ n) ≡⟨ cong (_· (g ^ n)) (·Assoc _ _ _) ⟩
          f · (f ^ n) · g · (g ^ n)   ≡⟨ sym (·Assoc _ _ _) ⟩
          f · (f ^ n) · (g · (g ^ n)) ∎
+
+ ^-rdist-·ℕ : (f : R) (n m : ℕ) → f ^ (n ·ℕ m) ≡ (f ^ n) ^ m
+ ^-rdist-·ℕ f zero m = sym (1ⁿ≡1 m)
+ ^-rdist-·ℕ f (suc n) m =  sym (·-of-^-is-^-of-+ f m (n ·ℕ m))
+                        ∙∙ cong (f ^ m ·_) (^-rdist-·ℕ f n m)
+                        ∙∙ sym  (^-ldist-· f (f ^ n) m)
 
 
 -- like in Ring.Properties we provide helpful lemmas here

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -187,6 +187,12 @@ isPropIsRingHom R f S =
           (isProp× (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
             (isPropΠ λ _ → isSetRing (_ , S) _ _)))))
 
+RingHomEqDep : (R S T : Ring ℓ) (p : S ≡ T) (φ : RingHom R S) (ψ : RingHom R T)
+             → PathP (λ i → R .fst → p i .fst) (φ .fst) (ψ .fst)
+             → PathP (λ i → RingHom R (p i)) φ ψ
+RingHomEqDep R S T p φ ψ q = ΣPathP (q , isProp→PathP (λ _ → isPropIsRingHom _ _ _) _ _)
+
+
 𝒮ᴰ-Ring : DUARel (𝒮-Univ ℓ) RingStr ℓ
 𝒮ᴰ-Ring =
   𝒮ᴰ-Record (𝒮-Univ _) IsRingEquiv

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -163,6 +163,9 @@ RingEquiv R S = Σ[ e ∈ (⟨ R ⟩ ≃ ⟨ S ⟩) ] IsRingEquiv (R .snd) e (S 
 _$_ : {R S : Ring ℓ} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
 φ $ x = φ .fst x
 
+RingEquiv→RingHom : {A B : Ring ℓ} → RingEquiv A B → RingHom A B
+RingEquiv→RingHom (e , eIsHom) = e .fst , eIsHom
+
 isPropIsRing : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
              → isProp (IsRing 0r 1r _+_ _·_ -_)
 isPropIsRing 0r 1r _+_ _·_ -_ (isring RG RM RD) (isring SG SM SD) =

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -182,13 +182,12 @@ isPropIsRing 0r 1r _+_ _·_ -_ (isring RG RM RD) (isring SG SM SD) =
 
 isPropIsRingHom : {A : Type ℓ} {B : Type ℓ'} (R : RingStr A) (f : A → B) (S : RingStr B)
   → isProp (IsRingHom R f S)
-isPropIsRingHom R f S =
-  isOfHLevelRetractFromIso 1 IsRingHomIsoΣ
-    (isProp× (isSetRing (_ , S) _ _)
-      (isProp× (isSetRing (_ , S) _ _)
-        (isProp× (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
-          (isProp× (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
-            (isPropΠ λ _ → isSetRing (_ , S) _ _)))))
+isPropIsRingHom R f S = isOfHLevelRetractFromIso 1 IsRingHomIsoΣ
+                        (isProp×4 (isSetRing (_ , S) _ _)
+                                  (isSetRing (_ , S) _ _)
+                                  (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
+                                  (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
+                                  (isPropΠ λ _ → isSetRing (_ , S) _ _))
 
 RingHomEqDep : (R S T : Ring ℓ) (p : S ≡ T) (φ : RingHom R S) (ψ : RingHom R T)
              → PathP (λ i → R .fst → p i .fst) (φ .fst) (ψ .fst)

--- a/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
+++ b/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
@@ -48,8 +48,9 @@ private
 
 module Presheaf (A' : CommRing ℓ) where
  open CommRingStr (snd A') renaming (_·_ to _·r_ ; ·-comm to ·r-comm ; ·Assoc to ·rAssoc
-                                                 ; ·Lid to ·rLid)
+                                                 ; ·Lid to ·rLid ; ·Rid to ·rRid)
  open Exponentiation A'
+ open CommRingTheory A'
  open isMultClosedSubset
  open CommAlgebraStr ⦃...⦄
  private
@@ -95,6 +96,60 @@ module Presheaf (A' : CommRing ℓ) where
  RequivRel .transitive _ _ _ Rxy Ryz = Trans≼ _ _ _ (Rxy .fst) (Ryz .fst)
                                      , Trans≼ _ _ _  (Ryz .snd) (Rxy .snd)
 
+ RpropValued : isPropValued R
+ RpropValued x y = isProp× propTruncIsProp propTruncIsProp
+
+ powerIs≽ : (x a : A) → x ∈ ([_ⁿ|n≥0] A' a) → a ≼ x
+ powerIs≽ x a = map powerIs≽Σ
+  where
+  powerIs≽Σ : Σ[ n ∈ ℕ ] (x ≡ a ^ n) → Σ[ n ∈ ℕ ] Σ[ z ∈ A ] (a ^ n ≡ z ·r x)
+  powerIs≽Σ (n , p) = n , 1r , sym p ∙ sym (·rLid _)
+
+ module ≼ToLoc (x y : A) where
+  private
+   instance
+    _ = snd A[1/ x ]
+
+  lemma : x ≼ y → y ⋆ 1a ∈ A[1/ x ]ˣ -- y/1 ∈ A[1/x]ˣ
+  lemma = PT.rec (A[1/ x ]ˣ (y ⋆ 1a) .snd) lemmaΣ
+   where
+   path1 : (y z : A) → 1r ·r (y ·r 1r ·r z) ·r 1r ≡ z ·r y
+   path1 = solve A'
+   path2 : (xn : A) → xn ≡ 1r ·r 1r ·r (1r ·r 1r ·r xn)
+   path2 = solve A'
+
+   lemmaΣ : Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r y → y ⋆ 1a ∈ A[1/ x ]ˣ
+   lemmaΣ (n , z , p) = [ z , (x ^ n) ,  PT.∣ n , refl ∣ ] -- xⁿ≡zy → y⁻¹ ≡ z/xⁿ
+                      , eq/ _ _ ((1r , powersFormMultClosedSubset _ _ .containsOne)
+                      , (path1 _ _ ∙∙ sym p ∙∙ path2 _))
+
+ module ≼PowerToLoc (x y : A) (x≼y : x ≼ y) where
+  private
+   [yⁿ|n≥0] = [_ⁿ|n≥0] A' y
+   instance
+    _ = snd A[1/ x ]
+  lemma : ∀ (s : A) → s ∈ [yⁿ|n≥0] → s ⋆ 1a ∈ A[1/ x ]ˣ
+  lemma _ s∈[yⁿ|n≥0] = ≼ToLoc.lemma _ _ (Trans≼ _ y _ x≼y (powerIs≽ _ _ s∈[yⁿ|n≥0]))
+
+
+
+ 𝓞ᴰ : A / R → CommAlgebra A' ℓ
+ 𝓞ᴰ = rec→Gpd.fun isGroupoidCommAlgebra (λ a → A[1/ a ]) RCoh LocPathProp
+    where
+    RCoh : ∀ a b → R a b → A[1/ a ] ≡ A[1/ b ]
+    RCoh a b (a≼b , b≼a) = fst (isContrS₁⁻¹R≡S₂⁻¹R (≼PowerToLoc.lemma _ _ b≼a)
+                                                   (≼PowerToLoc.lemma _ _ a≼b))
+     where
+     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
+                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+
+    LocPathProp : ∀ a b → isProp (A[1/ a ] ≡ A[1/ b ])
+    LocPathProp a b = isPropS₁⁻¹R≡S₂⁻¹R
+     where
+     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
+                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+
+
  -- The quotient A/R corresponds to the basic opens of the Zariski topology.
  -- Multiplication lifts to the quotient and corresponds to intersection
  -- of basic opens, i.e. we get a meet-semilattice with:
@@ -116,48 +171,40 @@ module Presheaf (A' : CommRing ℓ) where
   ·r-lcoh : (x y z : A) → R x y → R (x ·r z) (y ·r z)
   ·r-lcoh x y z Rxy = ·r-lcoh-≼ x y z (Rxy .fst) , ·r-lcoh-≼ y x z (Rxy .snd)
 
+ -- The induced partial order
+ _≼/_ : A / R → A / R → Type ℓ
+ x ≼/ y = x ≡ (x ∧/ y)
 
-
- module ≼ToLoc (x y : A)  where
-  private
-   instance
-    _ = snd A[1/ x ]
-    _ = snd A[1/ y ]
-
-  lemma : x ≼ y → y ⋆ 1a ∈ A[1/ x ]ˣ -- y/1 ∈ A[1/x]ˣ
-  lemma = PT.rec (A[1/ x ]ˣ (y ⋆ 1a) .snd) lemmaΣ
-   where
-   path1 : (y z : A) → 1r ·r (y ·r 1r ·r z) ·r 1r ≡ z ·r y
-   path1 = solve A'
-   path2 : (xn : A) → xn ≡ 1r ·r 1r ·r (1r ·r 1r ·r xn)
-   path2 = solve A'
-
-   lemmaΣ : Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r y → y ⋆ 1a ∈ A[1/ x ]ˣ
-   lemmaΣ (n , z , p) = [ z , (x ^ n) ,  PT.∣ n , refl ∣ ] -- xⁿ≡zy → y⁻¹ ≡ z/xⁿ
-                      , eq/ _ _ ((1r , powersFormMultClosedSubset _ _ .containsOne)
-                      , (path1 _ _ ∙∙ sym p ∙∙ path2 _))
-
- powerIs≽ : (x a : A) → x ∈ ([_ⁿ|n≥0] A' a) → a ≼ x
- powerIs≽ x a = map powerIs≽Σ
+ -- coincides with our ≼
+ ≼/CoincidesWith≼ : ∀ (x y : A) → [ x ] ≼/ [ y ] ≡ x ≼ y
+ ≼/CoincidesWith≼ x y = [ x ] ≼/ [ y ] -- ≡⟨ refl ⟩ [ x ] ≡ [ x ·r y ]
+                      ≡⟨ isoToPath (isEquivRel→effectiveIso RpropValued RequivRel _ _) ⟩
+                        R x (x ·r y)
+                      ≡⟨ hPropExt (RpropValued _ _) propTruncIsProp ·To≼ ≼To· ⟩
+                        x ≼ y ∎
   where
-  powerIs≽Σ : Σ[ n ∈ ℕ ] (x ≡ a ^ n) → Σ[ n ∈ ℕ ] Σ[ z ∈ A ] (a ^ n ≡ z ·r x)
-  powerIs≽Σ (n , p) = n , 1r , sym p ∙ sym (·rLid _)
+  x≼xy→x≼yΣ : Σ[ n ∈ ℕ ] Σ[ z ∈ A ] x ^ n ≡ z ·r (x ·r y)
+            → Σ[ n ∈ ℕ ] Σ[ z ∈ A ] x ^ n ≡ z ·r y
+  x≼xy→x≼yΣ (n , z , p) =  n , (z ·r x) , p ∙ ·rAssoc _ _ _
+
+  ·To≼ : R x (x ·r y) → x ≼ y
+  ·To≼ (x≼xy , _) = PT.map x≼xy→x≼yΣ x≼xy
+
+  x≼y→x≼xyΣ : Σ[ n ∈ ℕ ] Σ[ z ∈ A ] x ^ n ≡ z ·r y
+            → Σ[ n ∈ ℕ ] Σ[ z ∈ A ] x ^ n ≡ z ·r (x ·r y)
+  x≼y→x≼xyΣ (n , z , p) = suc n , z , cong (x ·r_) p ∙ ·-commAssocl _ _ _
+
+  ≼To· : x ≼ y → R x ( x ·r y)
+  ≼To· x≼y = PT.map x≼y→x≼xyΣ x≼y , PT.∣ 1 , y , ·rRid _ ∙ ·r-comm _ _ ∣
 
 
- 𝓞ᴰ : A / R → CommAlgebra A' ℓ
- 𝓞ᴰ = rec→Gpd.fun isGroupoidCommAlgebra (λ a → A[1/ a ]) RCoh LocPathProp
-    where
-    RCoh : ∀ a b → R a b → A[1/ a ] ≡ A[1/ b ]
-    RCoh a b (a≼b , b≼a) = fst (isContrS₁⁻¹R≡S₂⁻¹R
-             (λ _ x∈[aⁿ|n≥0] → ≼ToLoc.lemma _ _ (Trans≼ _ a _ b≼a (powerIs≽ _ _ x∈[aⁿ|n≥0])))
-              λ _ x∈[bⁿ|n≥0] → ≼ToLoc.lemma _ _ (Trans≼ _ b _ a≼b (powerIs≽ _ _ x∈[bⁿ|n≥0])))
-     where
-     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
-                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
-
-    LocPathProp : ∀ a b → isProp (A[1/ a ] ≡ A[1/ b ])
-    LocPathProp a b = isPropS₁⁻¹R≡S₂⁻¹R
-     where
-     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
-                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
-
+ -- The restrictions:
+ ρᴰ : (x y : A / R) → x ≼/ y → CommAlgebraHom (𝓞ᴰ y) (𝓞ᴰ x)
+ ρᴰ = elimContr2 λ _ _ → isOfHLevelΠ 0
+                 λ [a]≼/[b] → ρᴰᴬ _ _ (transport (≼/CoincidesWith≼ _ _) [a]≼/[b])
+  where
+  ρᴰᴬ : (a b : A) → a ≼ b → isContr (CommAlgebraHom A[1/ b ] A[1/ a ])
+  ρᴰᴬ _ b a≼b = A[1/b]HasUniversalProp _ (≼PowerToLoc.lemma _ _ a≼b)
+   where
+   open AlgLoc A' ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+        renaming (S⁻¹RHasAlgUniversalProp to A[1/b]HasUniversalProp)

--- a/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
+++ b/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.Algebra.ZariskiLattice.BasicOpens where
 
 
@@ -25,6 +25,7 @@ open import Cubical.Relation.Nullary
 open import Cubical.Relation.Binary
 
 open import Cubical.Algebra.Ring
+open import Cubical.Algebra.Algebra
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRing.Localisation.Base
 open import Cubical.Algebra.CommRing.Localisation.UniversalProperty
@@ -197,14 +198,39 @@ module Presheaf (A' : CommRing ℓ) where
   ≼To· : x ≼ y → R x ( x ·r y)
   ≼To· x≼y = PT.map x≼y→x≼xyΣ x≼y , PT.∣ 1 , y , ·rRid _ ∙ ·r-comm _ _ ∣
 
+ Refl≼/ : isRefl _≼/_
+ Refl≼/ = SQ.elimProp (λ _ → squash/ _ _) λ _ → transport⁻ (≼/CoincidesWith≼ _ _) (Refl≼ _)
+
+ Trans≼/ : isTrans _≼/_
+ Trans≼/ = SQ.elimProp3 (λ _ _ _ → isPropΠ2 (λ _ _ → squash/ _ _))
+             λ _ _ _ [a]≼/[b] [b]≼/[c] → transport⁻ (≼/CoincidesWith≼ _ _)
+                                         (Trans≼ _ _ _ (transport (≼/CoincidesWith≼ _ _) [a]≼/[b])
+                                                       (transport (≼/CoincidesWith≼ _ _) [b]≼/[c]))
 
  -- The restrictions:
+ ρᴰᴬ : (a b : A) → a ≼ b → isContr (CommAlgebraHom A[1/ b ] A[1/ a ])
+ ρᴰᴬ _ b a≼b = A[1/b]HasUniversalProp _ (≼PowerToLoc.lemma _ _ a≼b)
+  where
+  open AlgLoc A' ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+       renaming (S⁻¹RHasAlgUniversalProp to A[1/b]HasUniversalProp)
+
+ ρᴰᴬId : ∀ (a : A) (r : a ≼ a) → ρᴰᴬ a a r .fst ≡ idAlgHom
+ ρᴰᴬId a r = ρᴰᴬ a a r .snd _
+
+ ρᴰᴬComp : ∀ (a b c : A) (l : a ≼ b) (m : b ≼ c)
+         → ρᴰᴬ a c (Trans≼ _ _ _ l m) .fst ≡ ρᴰᴬ a b l .fst ∘a ρᴰᴬ b c m .fst
+ ρᴰᴬComp a _ c l m = ρᴰᴬ a c (Trans≼ _ _ _ l m) .snd _
+
+
  ρᴰ : (x y : A / R) → x ≼/ y → CommAlgebraHom (𝓞ᴰ y) (𝓞ᴰ x)
  ρᴰ = elimContr2 λ _ _ → isOfHLevelΠ 0
                  λ [a]≼/[b] → ρᴰᴬ _ _ (transport (≼/CoincidesWith≼ _ _) [a]≼/[b])
-  where
-  ρᴰᴬ : (a b : A) → a ≼ b → isContr (CommAlgebraHom A[1/ b ] A[1/ a ])
-  ρᴰᴬ _ b a≼b = A[1/b]HasUniversalProp _ (≼PowerToLoc.lemma _ _ a≼b)
-   where
-   open AlgLoc A' ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
-        renaming (S⁻¹RHasAlgUniversalProp to A[1/b]HasUniversalProp)
+
+ ρᴰId : ∀ (x : A / R) (r : x ≼/ x) → ρᴰ x x r ≡ idAlgHom
+ ρᴰId = SQ.elimProp (λ _ → isPropΠ (λ _ → isSetAlgebraHom _ _ _ _))
+                     λ a r → ρᴰᴬId  a (transport (≼/CoincidesWith≼ _ _) r)
+
+ ρᴰComp : ∀ (x y z : A / R) (l : x ≼/ y) (m : y ≼/ z)
+        → ρᴰ x z (Trans≼/ _ _ _ l m) ≡ ρᴰ x y l ∘a ρᴰ y z m
+ ρᴰComp = SQ.elimProp3 (λ _ _ _ → isPropΠ2 (λ _ _ → isSetAlgebraHom _ _ _ _))
+                        λ a b c _ _ → sym (ρᴰᴬ a c _ .snd _) ∙ ρᴰᴬComp a b c _ _

--- a/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
+++ b/Cubical/Algebra/ZariskiLattice/BasicOpens.agda
@@ -1,0 +1,163 @@
+{-# OPTIONS --cubical --no-import-sorts --safe --experimental-lossy-unification #-}
+module Cubical.Algebra.ZariskiLattice.BasicOpens where
+
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Powerset
+open import Cubical.Foundations.Transport
+open import Cubical.Foundations.Structure
+open import Cubical.Functions.FunExtEquiv
+
+import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Bool
+open import Cubical.Data.Nat renaming ( _+_ to _+ℕ_ ; _·_ to _·ℕ_
+                                      ; +-comm to +ℕ-comm ; +-assoc to +ℕ-assoc
+                                      ; ·-assoc to ·ℕ-assoc ; ·-comm to ·ℕ-comm)
+open import Cubical.Data.Sigma.Base
+open import Cubical.Data.Sigma.Properties
+open import Cubical.Data.FinData
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Binary
+
+open import Cubical.Algebra.Ring
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.Localisation.Base
+open import Cubical.Algebra.CommRing.Localisation.UniversalProperty
+open import Cubical.Algebra.CommRing.Localisation.InvertingElements
+open import Cubical.Algebra.CommAlgebra.Base
+open import Cubical.Algebra.CommAlgebra.Properties
+open import Cubical.Algebra.CommAlgebra.Localisation
+open import Cubical.Algebra.RingSolver.ReflectionSolving
+
+open import Cubical.HITs.SetQuotients as SQ
+open import Cubical.HITs.PropositionalTruncation as PT
+
+open Iso
+open BinaryRelation
+open isEquivRel
+
+private
+  variable
+    ℓ ℓ' : Level
+
+
+module Presheaf (A' : CommRing ℓ) where
+ open CommRingStr (snd A') renaming (_·_ to _·r_ ; ·-comm to ·r-comm ; ·Assoc to ·rAssoc
+                                                 ; ·Lid to ·rLid)
+ open Exponentiation A'
+ open isMultClosedSubset
+ open CommAlgebraStr ⦃...⦄
+ private
+  A = fst A'
+
+  A[1/_] : A → CommAlgebra A' ℓ
+  A[1/ x ] = AlgLoc.S⁻¹RAsCommAlg A' ([_ⁿ|n≥0] A' x) (powersFormMultClosedSubset _ _)
+
+  A[1/_]ˣ : (x : A) → ℙ (fst A[1/ x ])
+  A[1/ x ]ˣ = (CommAlgebra→CommRing A[1/ x ]) ˣ
+
+
+ _≼_ : A → A → Type ℓ
+ x ≼ y = ∃[ n ∈ ℕ ] Σ[ z ∈ A ] x ^ n ≡ z ·r y -- rad(x) ⊆ rad(y)
+
+-- ≼ is a pre-order:
+ Refl≼ : isRefl _≼_
+ Refl≼ x = PT.∣ 1 , 1r , ·r-comm _ _ ∣
+
+ Trans≼ : isTrans _≼_
+ Trans≼ x y z = map2 Trans≼Σ
+  where
+  Trans≼Σ : Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r y
+          → Σ[ n ∈ ℕ ] Σ[ a ∈ A ] y ^ n ≡ a ·r z
+          → Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r z
+  Trans≼Σ (n , a , p) (m , b , q) = n ·ℕ m , (a ^ m ·r b) , path
+   where
+   path : x ^ (n ·ℕ m) ≡ a ^ m ·r b ·r z
+   path = x ^ (n ·ℕ m)    ≡⟨ ^-rdist-·ℕ x n m ⟩
+          (x ^ n) ^ m     ≡⟨ cong (_^ m) p ⟩
+          (a ·r y) ^ m     ≡⟨ ^-ldist-· a y m ⟩
+          a ^ m ·r y ^ m   ≡⟨ cong (a ^ m ·r_) q ⟩
+          a ^ m ·r (b ·r z) ≡⟨ ·rAssoc _ _ _ ⟩
+          a ^ m ·r b ·r z   ∎
+
+
+ R : A → A → Type ℓ
+ R x y = x ≼ y × y ≼ x -- rad(x) ≡ rad(y)
+
+ RequivRel : isEquivRel R
+ RequivRel .reflexive x = Refl≼ x , Refl≼ x
+ RequivRel .symmetric _ _ Rxy = (Rxy .snd) , (Rxy .fst)
+ RequivRel .transitive _ _ _ Rxy Ryz = Trans≼ _ _ _ (Rxy .fst) (Ryz .fst)
+                                     , Trans≼ _ _ _  (Ryz .snd) (Rxy .snd)
+
+ -- The quotient A/R corresponds to the basic opens of the Zariski topology.
+ -- Multiplication lifts to the quotient and corresponds to intersection
+ -- of basic opens, i.e. we get a meet-semilattice with:
+ _∧/_ : A / R → A / R → A / R
+ _∧/_ = setQuotSymmBinOp (RequivRel .reflexive) (RequivRel .transitive) _·r_ ·r-comm ·r-lcoh
+  where
+  ·r-lcoh-≼ : (x y z : A) → x ≼ y → (x ·r z) ≼ (y ·r z)
+  ·r-lcoh-≼ x y z = map ·r-lcoh-≼Σ
+   where
+   path : (x z a y zn : A) →  x ·r z ·r (a ·r y ·r zn) ≡ x ·r zn ·r a ·r (y ·r z)
+   path = solve A'
+
+   ·r-lcoh-≼Σ : Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r y
+              → Σ[ n ∈ ℕ ] Σ[ a ∈ A ] (x ·r z) ^ n ≡ a ·r (y ·r z)
+   ·r-lcoh-≼Σ  (n , a , p) = suc n , (x ·r z ^ n ·r a) , (cong (x ·r z ·r_) (^-ldist-· _ _ _)
+                                                       ∙∙ cong (λ v → x ·r z ·r (v ·r z ^ n)) p
+                                                       ∙∙ path _ _ _ _ _)
+
+  ·r-lcoh : (x y z : A) → R x y → R (x ·r z) (y ·r z)
+  ·r-lcoh x y z Rxy = ·r-lcoh-≼ x y z (Rxy .fst) , ·r-lcoh-≼ y x z (Rxy .snd)
+
+
+
+ module ≼ToLoc (x y : A)  where
+  private
+   instance
+    _ = snd A[1/ x ]
+    _ = snd A[1/ y ]
+
+  lemma : x ≼ y → y ⋆ 1a ∈ A[1/ x ]ˣ -- y/1 ∈ A[1/x]ˣ
+  lemma = PT.rec (A[1/ x ]ˣ (y ⋆ 1a) .snd) lemmaΣ
+   where
+   path1 : (y z : A) → 1r ·r (y ·r 1r ·r z) ·r 1r ≡ z ·r y
+   path1 = solve A'
+   path2 : (xn : A) → xn ≡ 1r ·r 1r ·r (1r ·r 1r ·r xn)
+   path2 = solve A'
+
+   lemmaΣ : Σ[ n ∈ ℕ ] Σ[ a ∈ A ] x ^ n ≡ a ·r y → y ⋆ 1a ∈ A[1/ x ]ˣ
+   lemmaΣ (n , z , p) = [ z , (x ^ n) ,  PT.∣ n , refl ∣ ] -- xⁿ≡zy → y⁻¹ ≡ z/xⁿ
+                      , eq/ _ _ ((1r , powersFormMultClosedSubset _ _ .containsOne)
+                      , (path1 _ _ ∙∙ sym p ∙∙ path2 _))
+
+ powerIs≽ : (x a : A) → x ∈ ([_ⁿ|n≥0] A' a) → a ≼ x
+ powerIs≽ x a = map powerIs≽Σ
+  where
+  powerIs≽Σ : Σ[ n ∈ ℕ ] (x ≡ a ^ n) → Σ[ n ∈ ℕ ] Σ[ z ∈ A ] (a ^ n ≡ z ·r x)
+  powerIs≽Σ (n , p) = n , 1r , sym p ∙ sym (·rLid _)
+
+
+ 𝓞ᴰ : A / R → CommAlgebra A' ℓ
+ 𝓞ᴰ = rec→Gpd.fun isGroupoidCommAlgebra (λ a → A[1/ a ]) RCoh LocPathProp
+    where
+    RCoh : ∀ a b → R a b → A[1/ a ] ≡ A[1/ b ]
+    RCoh a b (a≼b , b≼a) = fst (isContrS₁⁻¹R≡S₂⁻¹R
+             (λ _ x∈[aⁿ|n≥0] → ≼ToLoc.lemma _ _ (Trans≼ _ a _ b≼a (powerIs≽ _ _ x∈[aⁿ|n≥0])))
+              λ _ x∈[bⁿ|n≥0] → ≼ToLoc.lemma _ _ (Trans≼ _ b _ a≼b (powerIs≽ _ _ x∈[bⁿ|n≥0])))
+     where
+     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
+                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+
+    LocPathProp : ∀ a b → isProp (A[1/ a ] ≡ A[1/ b ])
+    LocPathProp a b = isPropS₁⁻¹R≡S₂⁻¹R
+     where
+     open AlgLocTwoSubsets A' ([_ⁿ|n≥0] A' a) (powersFormMultClosedSubset _ _)
+                              ([_ⁿ|n≥0] A' b) (powersFormMultClosedSubset _ _)
+

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -29,7 +29,7 @@ HLevel = ℕ
 
 private
   variable
-    ℓ ℓ' ℓ'' ℓ''' : Level
+    ℓ ℓ' ℓ'' ℓ''' ℓ'''' ℓ''''' : Level
     A : Type ℓ
     B : A → Type ℓ
     C : (x : A) → B x → Type ℓ
@@ -350,6 +350,16 @@ isProp×2 pA pB pC = isProp× pA (isProp× pB pC)
 isProp×3 : {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {D : Type ℓ'''}
          → isProp A → isProp B → isProp C → isProp D → isProp (A × B × C × D)
 isProp×3 pA pB pC pD = isProp×2 pA pB (isProp× pC pD)
+
+isProp×4 : {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {D : Type ℓ'''} {E : Type ℓ''''}
+         → isProp A → isProp B → isProp C → isProp D → isProp E → isProp (A × B × C × D × E)
+isProp×4 pA pB pC pD pE = isProp×3 pA pB pC (isProp× pD pE)
+
+isProp×5 : {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {D : Type ℓ'''} {E : Type ℓ''''} {F : Type ℓ'''''}
+         → isProp A → isProp B → isProp C → isProp D → isProp E → isProp F
+         → isProp (A × B × C × D × E × F)
+isProp×5 pA pB pC pD pE pF = isProp×4 pA pB pC pD (isProp× pE pF)
+
 
 isOfHLevel× : ∀ {A : Type ℓ} {B : Type ℓ'} n → isOfHLevel n A → isOfHLevel n B
                                              → isOfHLevel n (A × B)

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -67,6 +67,17 @@ elimProp3 : ((x y z : A / R ) → isProp (D x y z))
 elimProp3 Dprop f = elimProp (λ x → isPropΠ2 (λ y z → Dprop x y z))
                              (λ x → elimProp2 (λ y z → Dprop [ x ] y z) (f x))
 
+-- sometimes more convenient:
+elimContr : (∀ (a : A) → isContr (B [ a ]))
+          → (x : A / R) → B x
+elimContr Bcontr = elimProp (elimProp (λ _ → isPropIsProp) λ _ → isContr→isProp (Bcontr _))
+                             λ _ → Bcontr _ .fst
+
+elimContr2 : (∀ (a b : A) → isContr (C [ a ] [ b ]))
+           → (x y : A / R) → C x y
+elimContr2 Ccontr = elimContr λ _ → isOfHLevelΠ 0
+                   (elimContr λ _ → inhProp→isContr (Ccontr _ _) isPropIsContr)
+
 -- lemma 6.10.2 in hott book
 []surjective : (x : A / R) → ∃[ a ∈ A ] [ a ] ≡ x
 []surjective = elimProp (λ x → squash) (λ a → ∣ a , refl ∣)


### PR DESCRIPTION
This if the first pull request for a formalization of a constructive approach to affine schemes.
We define the basic opens of the Zariski spectrum synthetically as the meet-semilattice of elements of the base ring modulo equating two elements that generate the same radical ideal.
Because our structure (pre-)sheaf is then a map from a set-quotient into a groupoid we have to use a special recursor and write it as a map into commutative algebras over the base ring instead of commutative rings.