### PR TITLE
Redundant isPropIsSurjection definitions

### DIFF
--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -44,8 +44,8 @@ private
 isEmbedding : (A → B) → Type _
 isEmbedding f = ∀ w x → isEquiv {A = w ≡ x} (cong f)
 
-isEmbeddingIsProp : isProp (isEmbedding f)
-isEmbeddingIsProp {f = f} = isPropΠ2 λ _ _ → isPropIsEquiv (cong f)
+isPropIsEmbedding : isProp (isEmbedding f)
+isPropIsEmbedding {f = f} = isPropΠ2 λ _ _ → isPropIsEquiv (cong f)
 
 -- If A and B are h-sets, then injective functions between
 -- them are embeddings.
@@ -152,7 +152,7 @@ isEmbedding≡hasPropFibers
       (iso isEmbedding→hasPropFibers
            hasPropFibers→isEmbedding
            (λ _ → hasPropFibersIsProp _ _)
-           (λ _ → isEmbeddingIsProp _ _))
+           (λ _ → isPropIsEmbedding _ _))
 
 isEquiv→hasPropFibers : isEquiv f → hasPropFibers f
 isEquiv→hasPropFibers e b = isContr→isProp (equiv-proof e b)
@@ -246,7 +246,7 @@ Subset→Embedding→Subset _ = funExt λ x → Σ≡Prop (λ _ → isPropIsProp
 
 Embedding→Subset→Embedding : {X : Type ℓ} → retract (Embedding→Subset {ℓ} {X}) (Subset→Embedding {ℓ} {X})
 Embedding→Subset→Embedding {ℓ = ℓ} {X = X} (A , f , ψ) =
-  cong (equivFun Σ-assoc-≃) (Σ≡Prop (λ _ → isEmbeddingIsProp) (retEq (fibrationEquiv X ℓ) (A , f)))
+  cong (equivFun Σ-assoc-≃) (Σ≡Prop (λ _ → isPropIsEmbedding) (retEq (fibrationEquiv X ℓ) (A , f)))
 
 Subset≃Embedding : {X : Type ℓ} → ℙ X ≃ (Σ[ A ∈ Type ℓ ] (A ↪ X))
 Subset≃Embedding = isoToEquiv (iso Subset→Embedding Embedding→Subset
@@ -409,7 +409,7 @@ module EmbeddingIdentityPrinciple {B : Type ℓ} {ℓ₁} (f g : Embedding B ℓ
   isEmbeddingToFibr w x = fullEquiv .snd where
     -- carefully managed such that (cong toFibr) is the equivalence
     fullEquiv : (w ≡ x) ≃ (toFibr w ≡ toFibr x)
-    fullEquiv = compEquiv (congEquiv (invEquiv Σ-assoc-≃)) (invEquiv (Σ≡PropEquiv (λ _ → isEmbeddingIsProp)))
+    fullEquiv = compEquiv (congEquiv (invEquiv Σ-assoc-≃)) (invEquiv (Σ≡PropEquiv (λ _ → isPropIsEmbedding)))
 
   EmbeddingIP : f≃g ≃ (f ≡ g)
   EmbeddingIP =

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -28,8 +28,8 @@ A ↠ B = Σ[ f ∈ (A → B) ] isSurjection f
 section→isSurjection : {g : B → A} → section f g → isSurjection f
 section→isSurjection {g = g} s b = ∣ g b , s b ∣
 
-isSurjectionIsProp : isProp (isSurjection f)
-isSurjectionIsProp = isPropΠ λ _ → squash
+isPropIsSurjection : isProp (isSurjection f)
+isPropIsSurjection = isPropΠ λ _ → squash
 
 isEquiv→isSurjection : isEquiv f → isSurjection f
 isEquiv→isSurjection e b = ∣ fst (equiv-proof e b) ∣
@@ -54,7 +54,7 @@ isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjectio
 isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
-  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isSurjectionIsProp) _ _)
+  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isPropIsSurjection) _ _)
   (λ _ → isPropIsEquiv _ _ _))
 
 -- obs: for epi⇒surjective to go through we require a stronger

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -28,8 +28,8 @@ A ↠ B = Σ[ f ∈ (A → B) ] isSurjection f
 section→isSurjection : {g : B → A} → section f g → isSurjection f
 section→isSurjection {g = g} s b = ∣ g b , s b ∣
 
-isSurjectionIsProp : isProp (isSurjection f)
-isSurjectionIsProp = isPropΠ λ _ → squash
+isPropIsSurjection : isProp (isSurjection f)
+isPropIsSurjection = isPropΠ λ _ → squash
 
 isEquiv→isSurjection : isEquiv f → isSurjection f
 isEquiv→isSurjection e b = ∣ fst (equiv-proof e b) ∣
@@ -54,11 +54,8 @@ isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjectio
 isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
-  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isSurjectionIsProp) _ _)
+  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isPropIsSurjection) _ _)
   (λ _ → isPropIsEquiv _ _ _))
-
-isPropIsSurjection : isProp (isSurjection f)
-isPropIsSurjection = isPropΠ λ _ → propTruncIsProp
 
 -- obs: for epi⇒surjective to go through we require a stronger
 -- hypothesis that one would expect:

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -54,7 +54,7 @@ isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjectio
 isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
-  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isPropIsSurjection) _ _)
+  (λ _ → isOfHLevelΣ 1 isPropIsEmbedding (\ _ → isPropIsSurjection) _ _)
   (λ _ → isPropIsEquiv _ _ _))
 
 -- obs: for epi⇒surjective to go through we require a stronger

--- a/Cubical/Functions/Surjection.agda
+++ b/Cubical/Functions/Surjection.agda
@@ -28,8 +28,8 @@ A ↠ B = Σ[ f ∈ (A → B) ] isSurjection f
 section→isSurjection : {g : B → A} → section f g → isSurjection f
 section→isSurjection {g = g} s b = ∣ g b , s b ∣
 
-isPropIsSurjection : isProp (isSurjection f)
-isPropIsSurjection = isPropΠ λ _ → squash
+isSurjectionIsProp : isProp (isSurjection f)
+isSurjectionIsProp = isPropΠ λ _ → squash
 
 isEquiv→isSurjection : isEquiv f → isSurjection f
 isEquiv→isSurjection e b = ∣ fst (equiv-proof e b) ∣
@@ -54,7 +54,7 @@ isEquiv≃isEmbedding×isSurjection : isEquiv f ≃ isEmbedding f × isSurjectio
 isEquiv≃isEmbedding×isSurjection = isoToEquiv (iso
   isEquiv→isEmbedding×isSurjection
   isEmbedding×isSurjection→isEquiv
-  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isPropIsSurjection) _ _)
+  (λ _ → isOfHLevelΣ 1 isEmbeddingIsProp (\ _ → isSurjectionIsProp) _ _)
   (λ _ → isPropIsEquiv _ _ _))
 
 -- obs: for epi⇒surjective to go through we require a stronger


### PR DESCRIPTION
Removed one of the two redundant isPropIsSurjection definitions. Not sure why there were two.