### PR TITLE
More flexibel reflection solving

### DIFF
--- a/Cubical/Algebra/RingSolver/Examples.agda
+++ b/Cubical/Algebra/RingSolver/Examples.agda
@@ -11,8 +11,17 @@ private
   variable
     ℓ : Level
 
+
+module _ (R : CommRing ℓ) where
+   open CommRingStr (snd R)
+   test : (x : fst R) → 0r ≡ 0r
+   test x = 0r ≡⟨ solveInPlace R x ⟩ 0r  ∎
+
 module Test (R : CommRing ℓ) where
   open CommRingStr (snd R)
+
+  _ : 0r ≡ 0r
+  _ = solve R
 
   _ :   1r · (1r + 0r)
       ≡ (1r · 0r) + 1r

--- a/Cubical/Algebra/RingSolver/Examples.agda
+++ b/Cubical/Algebra/RingSolver/Examples.agda
@@ -12,11 +12,6 @@ private
     ℓ : Level
 
 
-module _ (R : CommRing ℓ) where
-   open CommRingStr (snd R)
-   test : (x : fst R) → 0r ≡ 0r
-   test x = 0r ≡⟨ solveInPlace R x ⟩ 0r  ∎
-
 module Test (R : CommRing ℓ) where
   open CommRingStr (snd R)
 
@@ -59,3 +54,10 @@ module Test (R : CommRing ℓ) where
   _ : (x y : (fst R)) → x ≡ y
   _ = solve R
   -}
+
+module TestInPlaceSolving (R : CommRing ℓ) where
+   open CommRingStr (snd R)
+
+   test : (x : fst R) → x + 0r ≡ 0r + x
+   test x = solveInPlace R x
+

--- a/Cubical/Algebra/RingSolver/ReflectionSolving.agda
+++ b/Cubical/Algebra/RingSolver/ReflectionSolving.agda
@@ -260,4 +260,3 @@ macro
 
 fromℤ : (R : CommRing ℓ) → ℤ → fst R
 fromℤ = scalar
-


### PR DESCRIPTION
This is an attempt to solve #521. So far, it is possible to use one variable from context. Like in 
the following example:

`testWithOneVariabl : (x : fst R) → x + 0r ≡ 0r + x
 testWithOneVariabl` x = solveInPlace R x`  

It doesn't work with equational reasoning so far. Somehow the right hand side of the equation to solve is just `_`.