### PR TITLE
Emacs-lisp code for deleting whitespaces on save

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,15 @@ When preparing a PR here are some general guidelines:
   editing files by adding `(setq-default show-trailing-whitespace t)`
   to `~/.emacs`. The command `M-x delete-trailing-whitespace` is also
   very useful. It is possible to add a hook that runs this command
-  automatically when saving Agda files.
+  automatically when saving Agda files, by adding the following to your
+  `~/.emacs`:
+  `;; delete trailing whitespace before saving in agda-mode
+   (defun agda-mode-delete-whitespace-before-save ()
+   	  (when (eq major-mode 'agda2-mode)
+    	  	(delete-trailing-whitespace)))
+
+    (add-hook 'before-save-hook #'agda-mode-delete-whitespace-before-save)
+  `
 
 - Use copattern-matching when instantiating records for efficiency.
   This seems especially important when constructing Iso's.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,13 +66,14 @@ When preparing a PR here are some general guidelines:
   very useful. It is possible to add a hook that runs this command
   automatically when saving Agda files, by adding the following to your
   `~/.emacs`:
-  `;; delete trailing whitespace before saving in agda-mode
-   (defun agda-mode-delete-whitespace-before-save ()
-   	  (when (eq major-mode 'agda2-mode)
-    	  	(delete-trailing-whitespace)))
+  ```
+  ;; delete trailing whitespace before saving in agda-mode
+  (defun agda-mode-delete-whitespace-before-save ()
+    (when (eq major-mode 'agda2-mode)
+    	(delete-trailing-whitespace)))
 
-    (add-hook 'before-save-hook #'agda-mode-delete-whitespace-before-save)
-  `
+  (add-hook 'before-save-hook #'agda-mode-delete-whitespace-before-save)
+  ```
 
 - Use copattern-matching when instantiating records for efficiency.
   This seems especially important when constructing Iso's.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ When preparing a PR here are some general guidelines:
   ;; delete trailing whitespace before saving in agda-mode
   (defun agda-mode-delete-whitespace-before-save ()
     (when (eq major-mode 'agda2-mode)
-    	(delete-trailing-whitespace)))
+      (delete-trailing-whitespace)))
 
   (add-hook 'before-save-hook #'agda-mode-delete-whitespace-before-save)
   ```


### PR DESCRIPTION
This PR adds emacs-lisp code for the .emacs to the part of CONTRIBUTING.md, that formerly just claimed that code like this exists.