### PR TITLE
[work-in-progress] Add abelian categories

### DIFF
--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -6,52 +6,76 @@ module Cubical.Categories.Abelian.Base where
 open import Agda.Primitive using (Level)
 open import Cubical.Algebra.AbGroup.Base using (AbGroupStr)
 open import Cubical.Categories.Category.Base using (Precategory; _[_,_]; comp')
+open import Cubical.Categories.Limits.Base using (isProduct; isCoproduct)
 open import Cubical.Categories.Limits.Terminal using (isInitial; isFinal)
 open import Cubical.Foundations.Prelude using (Type; ℓ-suc; ℓ-max; _≡_)
-
 
 private
   variable
     ℓ ℓ' : Level
 
-open Precategory
+module _ (C : Precategory ℓ ℓ') where
+  open Precategory
+
+  -- Preadditive categories
+  record isPreadditive : Type (ℓ-max ℓ (ℓ-suc ℓ')) where --(ℓ-suc (ℓ-max ℓ ℓ')) where
+    open AbGroupStr
+    -- open Precategory
+
+    field
+  --    C : Precategory ℓ ℓ'
+      AbEnriched : (x y : ob C) → AbGroupStr (C [ x , y ])
+      
+      distl : (x y z : ob C) → (f : C [ y , z ]) → (g h : C [ x , y ]) →
+        f ∘⟨ C ⟩ (_+_ (AbEnriched x y) g h) ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ g) (f ∘⟨ C ⟩ h)
+        -- f ∘ (g + h) ≡ (f ∘ g) + (f ∘ h)
+
+      distr : (x y z : ob C) → (f g : C [ y , z ]) → (h : C [ x , y ]) →
+        (_+_ (AbEnriched y z) f g) ∘⟨ C ⟩ h ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ h) (g ∘⟨ C ⟩ h)
+        -- (f + g) ∘ h ≡ (f ∘ h) + (g ∘ h)
 
 
--- Preadditive categories
-record isPreadditive (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ (ℓ-suc ℓ')) where --(ℓ-suc (ℓ-max ℓ ℓ')) where
-  open AbGroupStr
-  -- open Precategory
-
-  field
---    C : Precategory ℓ ℓ'
-    AbEnriched : (x y : ob C) → AbGroupStr (C [ x , y ])
-    
-    distl : (x y z : ob C) → (f : C [ y , z ]) → (g h : C [ x , y ]) →
-      f ∘⟨ C ⟩ (_+_ (AbEnriched x y) g h) ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ g) (f ∘⟨ C ⟩ h)
-      -- f ∘ (g + h) ≡ (f ∘ g) + (f ∘ h)
-
-    distr : (x y z : ob C) → (f g : C [ y , z ]) → (h : C [ x , y ]) →
-      (_+_ (AbEnriched y z) f g) ∘⟨ C ⟩ h ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ h) (g ∘⟨ C ⟩ h)
-      -- (f + g) ∘ h ≡ (f ∘ h) + (g ∘ h)
+  -- Zero morphism
+  record isZero {x y : ob C} (f : C [ x , y ]) : Type (ℓ-max ℓ ℓ') where
+    field
+      const : {w : ob C} → (g h : C [ w , x ]) →
+        f ∘⟨ C ⟩ g ≡ f ∘⟨ C ⟩ h
+      coconst : {z : ob C} → (g h : C [ y , z ]) →
+        g ∘⟨ C ⟩ f ≡ h ∘⟨ C ⟩ f
 
 
--- Binary biproducts
-record isBiproduct {C : Precategory ℓ ℓ'} (x y : ob C) : Type where
+  -- Binary biproducts
+  record Biproduct (x y : ob C) : Type (ℓ-max ℓ ℓ') where
+    field
+      b : ob C
+      px : C [ b , x ]
+      py : C [ b , y ]
+      ix : C [ x , b ]
+      iy : C [ y , b ]
+
+      pxix : px ∘⟨ C ⟩ ix ≡ id C x
+      pxiy : isZero (px ∘⟨ C ⟩ iy)
+      pyix : isZero (py ∘⟨ C ⟩ ix)
+      pyiy : py ∘⟨ C ⟩ iy ≡ id C y
+
+      bProd : isProduct {C = C} b px py
+      bCopr : isCoproduct {C = C} b ix iy
 
 
--- Additive categories
-record isAdditive (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-  -- open AbGroupStr
-  -- open Precategory
-  -- open Preadditive
+  -- Additive categories
+  record isAdditive : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    -- open AbGroupStr
+    -- open Precategory
+    -- open Preadditive
 
-  field
-    -- C : Precategory ℓ ℓ'
-    C-Preadd : isPreadditive C
+    field
+      -- C : Precategory ℓ ℓ'
+      C-Preadd : isPreadditive
 
-    -- Zero object
-    z : ob C
-    zInit : isInitial C z
-    zFinal : isFinal C z
+      -- Zero object
+      z : ob C
+      zInit : isInitial C z
+      zFinal : isFinal C z
 
-    -- Binary biproducts
+      -- Binary biproducts
+      bp : (x y : ob C) → Biproduct x y

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -1,81 +1,158 @@
 -- Defines abelian categories
-{-# OPTIONS --safe -W ignore #-}
+{-# OPTIONS -safe #-}
 
 module Cubical.Categories.Abelian.Base where
 
-open import Agda.Primitive using (Level)
 open import Cubical.Algebra.AbGroup.Base using (AbGroupStr)
-open import Cubical.Categories.Category.Base using (Precategory; _[_,_]; comp')
-open import Cubical.Categories.Limits.Base using (isProduct; isCoproduct)
+open import Cubical.Categories.Category.Base using (Precategory; _^op)
+open import Cubical.Categories.Colimits.Coproduct using (isCoproduct)
+open import Cubical.Categories.Limits.Product using (isProduct)
 open import Cubical.Categories.Limits.Terminal using (isInitial; isFinal)
-open import Cubical.Foundations.Prelude using (Type; ℓ-suc; ℓ-max; _≡_)
+open import Cubical.Categories.Morphism using (isMonic; isEpic)
+open import Cubical.Data.Sigma.Base using (∃!-syntax; Σ-syntax)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-suc; ℓ-max; _≡_)
 
 private
   variable
     ℓ ℓ' : Level
 
-module _ (C : Precategory ℓ ℓ') where
-  open Precategory
+module _ {C : Precategory ℓ ℓ'} where
+  open Precategory C
 
-  -- Preadditive categories
-  record isPreadditive : Type (ℓ-max ℓ (ℓ-suc ℓ')) where --(ℓ-suc (ℓ-max ℓ ℓ')) where
-    open AbGroupStr
-    -- open Precategory
 
-    field
-  --    C : Precategory ℓ ℓ'
-      AbEnriched : (x y : ob C) → AbGroupStr (C [ x , y ])
-      
-      distl : (x y z : ob C) → (f : C [ y , z ]) → (g h : C [ x , y ]) →
-        f ∘⟨ C ⟩ (_+_ (AbEnriched x y) g h) ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ g) (f ∘⟨ C ⟩ h)
-        -- f ∘ (g + h) ≡ (f ∘ g) + (f ∘ h)
-
-      distr : (x y z : ob C) → (f g : C [ y , z ]) → (h : C [ x , y ]) →
-        (_+_ (AbEnriched y z) f g) ∘⟨ C ⟩ h ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ h) (g ∘⟨ C ⟩ h)
-        -- (f + g) ∘ h ≡ (f ∘ h) + (g ∘ h)
-
+  -- MORPHISM / OBJECT DEFINITIONS
 
   -- Zero morphism
-  record isZero {x y : ob C} (f : C [ x , y ]) : Type (ℓ-max ℓ ℓ') where
+  record isZero {x y : ob} (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
     field
-      const : {w : ob C} → (g h : C [ w , x ]) →
-        f ∘⟨ C ⟩ g ≡ f ∘⟨ C ⟩ h
-      coconst : {z : ob C} → (g h : C [ y , z ]) →
-        g ∘⟨ C ⟩ f ≡ h ∘⟨ C ⟩ f
+      const : {w : ob} → (g h : Hom[ w , x ]) →
+        f ∘ g ≡ f ∘ h
+      coconst : {z : ob} → (g h : Hom[ y , z ]) →
+        g ∘ f ≡ h ∘ f
 
 
   -- Binary biproducts
-  record Biproduct (x y : ob C) : Type (ℓ-max ℓ ℓ') where
+  record Biproduct (x y : ob) : Type (ℓ-max ℓ ℓ') where
     field
-      b : ob C
-      px : C [ b , x ]
-      py : C [ b , y ]
-      ix : C [ x , b ]
-      iy : C [ y , b ]
+      b : ob
+      px : Hom[ b , x ]
+      py : Hom[ b , y ]
+      ix : Hom[ x , b ]
+      iy : Hom[ y , b ]
 
-      pxix : px ∘⟨ C ⟩ ix ≡ id C x
-      pxiy : isZero (px ∘⟨ C ⟩ iy)
-      pyix : isZero (py ∘⟨ C ⟩ ix)
-      pyiy : py ∘⟨ C ⟩ iy ≡ id C y
+      pxix : px ∘ ix ≡ id x
+      pxiy : isZero (px ∘ iy)
+      pyix : isZero (py ∘ ix)
+      pyiy : py ∘ iy ≡ id y
 
-      bProd : isProduct {C = C} b px py
-      bCopr : isCoproduct {C = C} b ix iy
+      bProd : isProduct {C = C} px py
+      bCopr : isCoproduct {C = C} ix iy
+
+
+  -- Kernels and cokernels
+  module _ {x y : ob} where
+    module _ (f : Hom[ x , y ]) where
+
+      record PreZeroer : Type (ℓ-max ℓ ℓ') where
+        constructor prezeroer
+        field
+          w : ob
+          k : Hom[ w , x ]
+          H : isZero (f ∘ k)
+
+      record isKernel (Z : PreZeroer) : Type (ℓ-max ℓ ℓ') where
+        open PreZeroer Z
+        field
+          univProp : (Y : PreZeroer) →
+            let open PreZeroer Y renaming (w to w'; k to k') in
+            ∃![ u ∈ Hom[ w' , w ] ]  k ∘ u ≡ k'
+
+
+      record PostZeroer : Type (ℓ-max ℓ ℓ') where
+        constructor postzeroer
+        field
+          z : ob
+          c : Hom[ y , z ]
+          H : isZero (c ∘ f)
+
+      record isCokernel (Z : PostZeroer) : Type (ℓ-max ℓ ℓ') where
+        open PostZeroer Z
+        field
+          univProp : (Y : PostZeroer) →
+            let open PostZeroer Y renaming (z to z'; c to c') in
+            ∃![ u ∈ Hom[ z , z' ] ]  u ∘ c ≡ c'
+
+
+    record _=ker_ {w : ob} (kerf : Hom[ w , x ]) (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        isEq : Σ[ H ∈ isZero (f ∘ kerf) ] isKernel f (prezeroer w kerf H)
+
+    record Kernel (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        w : ob
+        ker : Hom[ w , x ]
+        isKer : ker =ker f
+
+
+    record _=coker_ {z : ob} (cokerf : Hom[ y , z ]) (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        isCoeq : Σ[ H ∈ isZero (cokerf ∘ f) ] isCokernel f (postzeroer z cokerf H)
+    
+    record Cokernel (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        z : ob
+        coker : Hom[ y , z ]
+        isCoker : coker =coker f
+
+
+
+  -- ABELIAN HIERARCHY OF CATEGORIES
+
+  -- Preadditive categories
+  record isPreadditive : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      AbEnriched : (x y : ob) → AbGroupStr (Hom[ x , y ])
+      
+      distl : (x y z : ob) → (f : Hom[ y , z ]) → (g h : Hom[ x , y ]) →
+        let open AbGroupStr (AbEnriched x y) in
+        let open AbGroupStr (AbEnriched x z) renaming (_+_ to _+'_) in
+          f ∘ (g + h) ≡ (f ∘ g) +' (f ∘ h)
+
+      distr : (x y z : ob) → (f g : Hom[ y , z ]) → (h : Hom[ x , y ]) →
+        let open AbGroupStr (AbEnriched y z) in
+        let open AbGroupStr (AbEnriched x z) renaming (_+_ to _+'_) in
+          (f + g) ∘ h ≡ (f ∘ h) +' (g ∘ h)
 
 
   -- Additive categories
   record isAdditive : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-    -- open AbGroupStr
-    -- open Precategory
-    -- open Preadditive
-
     field
-      -- C : Precategory ℓ ℓ'
       C-Preadd : isPreadditive
 
       -- Zero object
-      z : ob C
+      z : ob
       zInit : isInitial C z
       zFinal : isFinal C z
 
       -- Binary biproducts
-      bp : (x y : ob C) → Biproduct x y
+      bp : (x y : ob) → Biproduct x y
+  
+
+  -- Preabelian categories
+  record isPreabelian : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      C-Addit : isAdditive
+      hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel f
+      hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel f
+  
+
+  -- Abelian categories
+  record isAbelian : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      C-Preab : isPreabelian
+      
+      monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic {C = C} m
+        → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (m =ker f)
+
+      epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic {C = C} e
+        → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (e =coker f) 

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -1,0 +1,57 @@
+-- Defines abelian categories
+{-# OPTIONS --safe -W ignore #-}
+
+module Cubical.Categories.Abelian.Base where
+
+open import Agda.Primitive using (Level)
+open import Cubical.Algebra.AbGroup.Base using (AbGroupStr)
+open import Cubical.Categories.Category.Base using (Precategory; _[_,_]; comp')
+open import Cubical.Categories.Limits.Terminal using (isInitial; isFinal)
+open import Cubical.Foundations.Prelude using (Type; ℓ-suc; ℓ-max; _≡_)
+
+
+private
+  variable
+    ℓ ℓ' : Level
+
+open Precategory
+
+
+-- Preadditive categories
+record isPreadditive (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ (ℓ-suc ℓ')) where --(ℓ-suc (ℓ-max ℓ ℓ')) where
+  open AbGroupStr
+  -- open Precategory
+
+  field
+--    C : Precategory ℓ ℓ'
+    AbEnriched : (x y : ob C) → AbGroupStr (C [ x , y ])
+    
+    distl : (x y z : ob C) → (f : C [ y , z ]) → (g h : C [ x , y ]) →
+      f ∘⟨ C ⟩ (_+_ (AbEnriched x y) g h) ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ g) (f ∘⟨ C ⟩ h)
+      -- f ∘ (g + h) ≡ (f ∘ g) + (f ∘ h)
+
+    distr : (x y z : ob C) → (f g : C [ y , z ]) → (h : C [ x , y ]) →
+      (_+_ (AbEnriched y z) f g) ∘⟨ C ⟩ h ≡ _+_ (AbEnriched x z) (f ∘⟨ C ⟩ h) (g ∘⟨ C ⟩ h)
+      -- (f + g) ∘ h ≡ (f ∘ h) + (g ∘ h)
+
+
+-- Binary biproducts
+record isBiproduct {C : Precategory ℓ ℓ'} (x y : ob C) : Type where
+
+
+-- Additive categories
+record isAdditive (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+  -- open AbGroupStr
+  -- open Precategory
+  -- open Preadditive
+
+  field
+    -- C : Precategory ℓ ℓ'
+    C-Preadd : isPreadditive C
+
+    -- Zero object
+    z : ob C
+    zInit : isInitial C z
+    zFinal : isFinal C z
+
+    -- Binary biproducts

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -1,5 +1,5 @@
 -- Defines abelian categories
-{-# OPTIONS -safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Abelian.Base where
 

--- a/Cubical/Categories/Colimits/Coequaliser.agda
+++ b/Cubical/Categories/Colimits/Coequaliser.agda
@@ -1,0 +1,20 @@
+-- Coequalisers
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Colimits.Coequaliser where
+
+open import Cubical.Categories.Category.Base using (Precategory; _^op)
+open import Cubical.Categories.Limits.Equaliser using (isEqualiser)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-max)
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ {C : Precategory ℓ ℓ'} where
+  open Precategory C
+
+  module _ {x y : ob} where
+    module _ {z : ob} where
+      isCoequaliser : Hom[ y , z ] → (f g : Hom[ x , y ]) → Type (ℓ-max ℓ ℓ')
+      isCoequaliser = isEqualiser {C = C ^op}

--- a/Cubical/Categories/Colimits/Coproduct.agda
+++ b/Cubical/Categories/Colimits/Coproduct.agda
@@ -1,0 +1,19 @@
+-- Binary coproducts
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Colimits.Coproduct where
+
+open import Cubical.Categories.Category.Base using (Precategory; _^op)
+open import Cubical.Categories.Limits.Product using (isProduct)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-max)
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ {C : Precategory ℓ ℓ'} where
+  open Precategory C
+
+  module _ {x y : ob} where
+    isCoproduct : {x+y : ob} (i₁ : Hom[ x , x+y ]) (i₂ : Hom[ y , x+y ]) → Type (ℓ-max ℓ ℓ')
+    isCoproduct = isProduct {C = C ^op}

--- a/Cubical/Categories/Instances/Discrete.agda
+++ b/Cubical/Categories/Instances/Discrete.agda
@@ -4,9 +4,8 @@
 module Cubical.Categories.Instances.Discrete where
 
 open import Cubical.Categories.Category.Base using (Precategory)
-open import Cubical.Data.Empty using (⊥)
 open import Cubical.Foundations.GroupoidLaws using (lUnit; rUnit; assoc)
-open import Cubical.Foundations.Prelude using (Level; Type; ℓ-zero; _≡_; refl; _∙_; sym)
+open import Cubical.Foundations.Prelude using (Level; Type; _≡_; refl; _∙_; sym)
 
 private
   variable
@@ -22,3 +21,22 @@ Discrete A ._⋆_ = _∙_
 Discrete A .⋆IdL f = sym (lUnit f)
 Discrete A .⋆IdR f = sym (rUnit f)
 Discrete A .⋆Assoc f g h = sym (assoc f g h)
+
+
+-- TODO: define functors out of discrete categories
+-- Should be equivalent to defining a function A → ob C
+-- However I ran into serious unification problems when trying to prove
+--   this preserves associativity
+
+
+-- module _ {A : Type ℓ}
+--          {C : Precategory ℓC ℓC'} where
+--   open Functor
+
+--   -- Functions f: A → ob C give functors F: Discrete A → C
+--   DiscFunc : (A → ob C) → Functor (Discrete A) C
+--   DiscFunc f .F-ob = f
+--   DiscFunc f .F-hom {x} p = subst (λ z → C [ f x , f z ]) p (id C (f x))
+--   DiscFunc f .F-id {x} = substRefl {B = λ z → C [ f x , f z ]} (id C (f x))
+--   DiscFunc f .F-seq = {!   !}
+--     -- substComposite (λ z → C [ f x , f z ]) p q (id C (f x))      Not right

--- a/Cubical/Categories/Instances/Discrete.agda
+++ b/Cubical/Categories/Instances/Discrete.agda
@@ -1,0 +1,24 @@
+-- Discrete category over a type
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Instances.Discrete where
+
+open import Cubical.Categories.Category.Base using (Precategory)
+open import Cubical.Data.Empty using (⊥)
+open import Cubical.Foundations.GroupoidLaws using (lUnit; rUnit; assoc)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-zero; _≡_; refl; _∙_; sym)
+
+private
+  variable
+    ℓ : Level
+
+open Precategory
+
+Discrete : Type ℓ → Precategory ℓ ℓ
+Discrete A .ob = A
+Discrete A .Hom[_,_] a a' = a ≡ a'
+Discrete A .id a = refl
+Discrete A ._⋆_ = _∙_
+Discrete A .⋆IdL f = sym (lUnit f)
+Discrete A .⋆IdR f = sym (rUnit f)
+Discrete A .⋆Assoc f g h = sym (assoc f g h)

--- a/Cubical/Categories/Limits/Equaliser.agda
+++ b/Cubical/Categories/Limits/Equaliser.agda
@@ -1,0 +1,45 @@
+-- Equalisers
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Limits.Equaliser where
+
+open import Cubical.Categories.Category.Base using (Precategory)
+open import Cubical.Data.Sigma.Base using (∃!-syntax; Σ-syntax)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-max; _≡_)
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ {C : Precategory ℓ ℓ'} where
+  open Precategory C
+
+  module _ {x y : ob} where
+    module _ (f g : Hom[ x , y ]) where
+
+      record Equalises : Type (ℓ-max ℓ ℓ') where
+        constructor equ
+        field
+          w : ob
+          m : Hom[ w , x ]
+          H : f ∘ m ≡ g ∘ m
+
+      record isEqualiser' (E : Equalises) : Type (ℓ-max ℓ ℓ') where
+        open Equalises E renaming (w to e; m to eq)
+
+        field
+          univProp : (Q : Equalises) →
+            let open Equalises Q in
+            ∃![ u ∈ Hom[ w , e ] ]  eq ∘ u ≡ m
+  
+  
+    module _ {w : ob} where
+
+      isEqualiser : Hom[ w , x ] → (f g : Hom[ x , y ]) → Type (ℓ-max ℓ ℓ')
+      isEqualiser k f g =
+        Σ[ H ∈ f ∘ k ≡ g ∘ k ]
+        isEqualiser' f g (equ w k H)
+
+
+-- TODO: define equalisers using isLimit from Cubical.Categories.Limits.Base
+--   and show this gives the same thing

--- a/Cubical/Categories/Limits/Product.agda
+++ b/Cubical/Categories/Limits/Product.agda
@@ -1,0 +1,40 @@
+-- Binary products
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Limits.Product where
+
+open import Cubical.Categories.Category.Base using (Precategory)
+open import Cubical.Data.Sigma.Base using (∃!-syntax) renaming (_×_ to _∧_)
+open import Cubical.Foundations.Prelude using (Level; Type; ℓ-max; _≡_)
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ {C : Precategory ℓ ℓ'} where
+  open Precategory C
+
+  module _ {x y : ob} where
+
+    record Span : Type (ℓ-max ℓ ℓ') where
+      constructor span
+      field
+        z : ob
+        f₁ : Hom[ z , x ]
+        f₂ : Hom[ z , y ]
+
+    record isProduct' (P : Span) : Type (ℓ-max ℓ ℓ') where
+      open Span P renaming (z to x×y; f₁ to π₁; f₂ to π₂)
+
+      field
+        univProp : (Q : Span) →
+          let open Span Q in
+          ∃![ f ∈ Hom[ z , x×y ] ]
+            (π₁ ∘ f ≡ f₁) ∧ (π₂ ∘ f ≡ f₂)
+    
+    isProduct : {x×y : ob} (π₁ : Hom[ x×y , x ]) (π₂ : Hom[ x×y , y ]) → Type (ℓ-max ℓ ℓ')
+    isProduct {x×y} π₁ π₂ = isProduct' (span x×y π₁ π₂)
+
+
+-- TODO: define products using isLimit from Cubical.Categories.Limits.Base
+--   and show this gives the same thing


### PR DESCRIPTION
This PR defines abelian categories in the file `Categories.Abelian.Base`.
The definition depends on (co)products, which I have defined in `Categories.Limits.Product` and `Categories.Colimits.Coproduct`.

I also defined:
- (co)equalisers in `Categories.Limits.Equaliser` and `Categories.Colimits.Coequaliser`
- discrete categories in `Categories.Instances.Discrete`

but didn't end up using these for `Abelian`. I could potentially move these into a separate pull request.

**Don't merge yet** - I still have some things to tidy up, but feedback and contributions are welcome.

### To do:
- [ ] Fix module issues - I'm running into problems having the `Precategory C` as an implicit argument, then it can't work out what `C` should be, so I have to give it explicitly anyway. (Lots of `{C = C}` in the code).
  - [ ] Can cokernels be defined as kernels in `C ^op`? (Don't repeat yourself)
- [ ] Make it easier to work with - I'm currently trying to define an example (Ab) of an abelian category, but it is quite messy. Some refactoring might make this nicer.
- [ ] Add a file `Categories/Abelian.agda`
- [ ] Clean up following style guide / [CONTRIBUTING.md](https://github.com/agda/cubical/blob/master/CONTRIBUTING.md)