### PR TITLE
Decouple Precategory from Category and use Category in the CT library

### DIFF
--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -132,7 +132,6 @@ makeRing 0r 1r _+_ _·_ -_ is-setR assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-
        (makeIsRing is-setR assoc +-rid +-rinv +-comm
                    ·-assoc ·-rid ·-lid ·-rdist-+ ·-ldist-+ )
 
--- TODO: why are the Ring structures split and organized like this?
 record IsRingHom {A : Type ℓ} {B : Type ℓ'} (R : RingStr A) (f : A → B) (S : RingStr B)
   : Type (ℓ-max ℓ ℓ')
   where

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -190,6 +190,9 @@ isPropIsRingHom R f S = isOfHLevelRetractFromIso 1 IsRingHomIsoΣ
                                   (isPropΠ2 λ _ _ → isSetRing (_ , S) _ _)
                                   (isPropΠ λ _ → isSetRing (_ , S) _ _))
 
+isSetRingHom : (R : Ring ℓ) (S : Ring ℓ') → isSet (RingHom R S)
+isSetRingHom R S = isSetΣSndProp (isSetΠ (λ _ → isSetRing S)) (λ f → isPropIsRingHom (snd R) f (snd S))
+
 RingHomPathP : (R S T : Ring ℓ) (p : S ≡ T) (φ : RingHom R S) (ψ : RingHom R T)
              → PathP (λ i → R .fst → p i .fst) (φ .fst) (ψ .fst)
              → PathP (λ i → RingHom R (p i)) φ ψ

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -132,6 +132,7 @@ makeRing 0r 1r _+_ _·_ -_ is-setR assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-
        (makeIsRing is-setR assoc +-rid +-rinv +-comm
                    ·-assoc ·-rid ·-lid ·-rdist-+ ·-ldist-+ )
 
+-- TODO: why are the Ring structures split and organized like this?
 record IsRingHom {A : Type ℓ} {B : Type ℓ'} (R : RingStr A) (f : A → B) (S : RingStr B)
   : Type (ℓ-max ℓ ℓ')
   where

--- a/Cubical/Categories/Adjoint.agda
+++ b/Cubical/Categories/Adjoint.agda
@@ -12,7 +12,7 @@ open import Cubical.Foundations.Isomorphism
 open Functor
 
 open Iso
-open Precategory
+open Category
 
 {-
 ==============================================
@@ -43,7 +43,7 @@ definition.
 module UnitCounit where
 
   -- Adjoint def 1: unit-counit
-  record _⊣_ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor C D) (G : Functor D C)
+  record _⊣_ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (G : Functor D C)
                   : Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
     field
       -- unit
@@ -64,8 +64,7 @@ module UnitCounit where
   -}
 
   module _ {ℓC ℓC' ℓD ℓD'}
-    {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} {F : Functor C D} {G : Functor D C}
-    ⦃ isCatC : isCategory C ⦄ ⦃ isCatD : isCategory D ⦄
+    {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F : Functor C D} {G : Functor D C}
     (η : 𝟙⟨ C ⟩ ⇒ (funcComp G F))
     (ε : (funcComp F G) ⇒ 𝟙⟨ D ⟩)
     (Δ₁ : ∀ c → F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧ ≡ D .id)
@@ -84,7 +83,7 @@ module UnitCounit where
 
 module NaturalBijection where
   -- Adjoint def 2: natural bijection
-  record _⊣_ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor C D) (G : Functor D C) : Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
+  record _⊣_ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (G : Functor D C) : Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
     field
       adjIso : ∀ {c d} → Iso (D [ F ⟅ c ⟆ , d ]) (C [ c , G ⟅ d ⟆ ])
 
@@ -115,7 +114,7 @@ definition to the first.
 The second unnamed module does the reverse.
 -}
 
-module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor C D) (G : Functor D C) where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (G : Functor D C) where
   open UnitCounit
   open NaturalBijection renaming (_⊣_ to _⊣²_)
   module _ (adj : F ⊣² G) where
@@ -159,7 +158,7 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor 
 
     -- note : had to make this record syntax because termination checker was complaining
     -- due to referencing η and ε from the definitions of Δs
-    adj'→adj : ⦃ isCatC : isCategory C ⦄ ⦃ isCatD : isCategory D ⦄ → F ⊣ G
+    adj'→adj : F ⊣ G
     adj'→adj = record
       { η = η'
       ; ε = ε'
@@ -282,11 +281,11 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor 
       ≡⟨ sym (C .⋆Assoc _ _ _) ⟩
         η ⟦ c ⟧ ⋆⟨ C ⟩ G ⟪ F ⟪ g ⟫ ⟫ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫
       -- apply naturality
-      ≡⟨ rPrecatWhisker {C = C} _ _ _ natu ⟩
+      ≡⟨ rCatWhisker {C = C} _ _ _ natu ⟩
         (g ⋆⟨ C ⟩ η ⟦ G ⟅ d ⟆ ⟧) ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫
       ≡⟨ C .⋆Assoc _ _ _ ⟩
         g ⋆⟨ C ⟩ (η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫)
-      ≡⟨ lPrecatWhisker {C = C} _ _ _ δ₂ ⟩
+      ≡⟨ lCatWhisker {C = C} _ _ _ δ₂ ⟩
         g ⋆⟨ C ⟩ C .id
       ≡⟨ C .⋆IdR _ ⟩
         g
@@ -301,12 +300,12 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} (F : Functor 
       ≡⟨ D .⋆Assoc _ _ _ ⟩
         F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ (F ⟪ G ⟪ f ⟫ ⟫ ⋆⟨ D ⟩ ε ⟦ d ⟧)
       -- apply naturality
-      ≡⟨ lPrecatWhisker {C = D} _ _ _ natu ⟩
+      ≡⟨ lCatWhisker {C = D} _ _ _ natu ⟩
         F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ (ε ⟦ F ⟅ c ⟆ ⟧ ⋆⟨ D ⟩ f)
       ≡⟨ sym (D .⋆Assoc _ _ _) ⟩
         F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧ ⋆⟨ D ⟩ f
       -- apply triangle identity
-      ≡⟨ rPrecatWhisker {C = D} _ _ _ δ₁ ⟩
+      ≡⟨ rCatWhisker {C = D} _ _ _ δ₁ ⟩
         D .id ⋆⟨ D ⟩ f
       ≡⟨ D .⋆IdL _ ⟩
         f

--- a/Cubical/Categories/Category.agda
+++ b/Cubical/Categories/Category.agda
@@ -9,9 +9,9 @@
   Category             Type   Set    No
   Univalent Category   Type   Set    Yes
 
-  This file also contains
-    - pathToIso : Turns a path between two objects into an isomorphism between them
-    - opposite categories
+  The most useful notion is Category and the library is hence based on
+  them. If one needs precategories then they can be found in
+  Cubical.Categories.Category.Precategory
 
 -}
 {-# OPTIONS --safe #-}

--- a/Cubical/Categories/Category/Base.agda
+++ b/Cubical/Categories/Category/Base.agda
@@ -9,8 +9,8 @@ private
   variable
     ℓ ℓ' : Level
 
--- Precategories
-record Precategory ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+-- Categories with hom-sets
+record Category ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   -- no-eta-equality ; NOTE: need eta equality for `opop`
   field
     ob : Type ℓ
@@ -19,42 +19,36 @@ record Precategory ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
     _⋆_  : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ]) → Hom[ x , z ]
     ⋆IdL : ∀ {x y} (f : Hom[ x , y ]) → id ⋆ f ≡ f
     ⋆IdR : ∀ {x y} (f : Hom[ x , y ]) → f ⋆ id ≡ f
-    ⋆Assoc : ∀ {u v w x} (f : Hom[ u , v ]) (g : Hom[ v , w ]) (h : Hom[ w , x ]) → (f ⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+    ⋆Assoc : ∀ {x y z w} (f : Hom[ x , y ]) (g : Hom[ y , z ]) (h : Hom[ z , w ])
+           → (f ⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+    isSetHom : ∀ {x y} → isSet Hom[ x , y ]
 
   -- composition: alternative to diagramatic order
   _∘_ : ∀ {x y z} (g : Hom[ y , z ]) (f : Hom[ x , y ]) → Hom[ x , z ]
   g ∘ f = f ⋆ g
 
-open Precategory
-
+open Category
 
 -- Helpful syntax/notation
-_[_,_] : (C : Precategory ℓ ℓ') → (x y : C .ob) → Type ℓ'
+_[_,_] : (C : Category ℓ ℓ') → (x y : C .ob) → Type ℓ'
 _[_,_] = Hom[_,_]
 
 -- Needed to define this in order to be able to make the subsequence syntax declaration
-seq' : ∀ (C : Precategory ℓ ℓ') {x y z} (f : C [ x , y ]) (g : C [ y , z ]) → C [ x , z ]
+seq' : ∀ (C : Category ℓ ℓ') {x y z} (f : C [ x , y ]) (g : C [ y , z ]) → C [ x , z ]
 seq' = _⋆_
 
 infixl 15 seq'
 syntax seq' C f g = f ⋆⟨ C ⟩ g
 
 -- composition
-comp' : ∀ (C : Precategory ℓ ℓ') {x y z} (g : C [ y , z ]) (f : C [ x , y ]) → C [ x , z ]
+comp' : ∀ (C : Category ℓ ℓ') {x y z} (g : C [ y , z ]) (f : C [ x , y ]) → C [ x , z ]
 comp' = _∘_
 
 infixr 16 comp'
 syntax comp' C g f = g ∘⟨ C ⟩ f
 
-
--- Categories
-record isCategory (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
-  field
-    isSetHom : ∀ {x y} → isSet (C [ x , y ])
-
--- Isomorphisms and paths in precategories
-
-record CatIso {C : Precategory ℓ ℓ'} (x y : C .ob) : Type ℓ' where
+-- Isomorphisms and paths in categories
+record CatIso {C : Category ℓ ℓ'} (x y : C .ob) : Type ℓ' where
   constructor catiso
   field
     mor : C [ x , y ]
@@ -62,15 +56,13 @@ record CatIso {C : Precategory ℓ ℓ'} (x y : C .ob) : Type ℓ' where
     sec : inv ⋆⟨ C ⟩ mor ≡ C .id
     ret : mor ⋆⟨ C ⟩ inv ≡ C .id
 
-
-pathToIso : {C : Precategory ℓ ℓ'} {x y : C .ob} (p : x ≡ y) → CatIso {C = C} x y
-pathToIso {C = C} p = J (λ z _ → CatIso _ z) (catiso (C .id) idx (C .⋆IdL idx) (C .⋆IdL idx)) p
+pathToIso : {C : Category ℓ ℓ'} {x y : C .ob} (p : x ≡ y) → CatIso {C = C} x y
+pathToIso {C = C} p = J (λ z _ → CatIso _ z) (catiso idx idx (C .⋆IdL idx) (C .⋆IdL idx)) p
   where
     idx = C .id
 
 -- Univalent Categories
-
-record isUnivalent (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
+record isUnivalent (C : Category ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
   field
     univ : (x y : C .ob) → isEquiv (pathToIso {C = C} {x = x} {y = y})
 
@@ -84,11 +76,12 @@ record isUnivalent (C : Precategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
     equivFun (invEquiv (univEquiv x y)) p
 
 -- Opposite category
-_^op : Precategory ℓ ℓ' → Precategory ℓ ℓ'
-(C ^op) .ob = C .ob
-(C ^op) .Hom[_,_] x y = C .Hom[_,_] y x
-(C ^op) .id = C .id
-(C ^op) ._⋆_ f g = C ._⋆_ g f
-(C ^op) .⋆IdL = C .⋆IdR
-(C ^op) .⋆IdR = C .⋆IdL
-(C ^op) .⋆Assoc f g h = sym (C .⋆Assoc _ _ _)
+_^op : Category ℓ ℓ' → Category ℓ ℓ'
+ob (C ^op)           = ob C
+Hom[_,_] (C ^op) x y = C [ y , x ]
+id (C ^op)           = id C
+_⋆_ (C ^op) f g      = g ⋆⟨ C ⟩ f
+⋆IdL (C ^op)         = C .⋆IdR
+⋆IdR (C ^op)         = C .⋆IdL
+⋆Assoc (C ^op) f g h = sym (C .⋆Assoc _ _ _)
+isSetHom (C ^op)     = C .isSetHom

--- a/Cubical/Categories/Category/Precategory.agda
+++ b/Cubical/Categories/Category/Precategory.agda
@@ -1,0 +1,54 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Category.Precategory where
+
+open import Cubical.Foundations.Prelude
+
+private
+  variable
+    ℓ ℓ' : Level
+
+-- Precategories
+record Precategory ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  -- no-eta-equality ; NOTE: need eta equality for `opop`
+  field
+    ob : Type ℓ
+    Hom[_,_] : ob → ob → Type ℓ'
+    id   : ∀ {x} → Hom[ x , x ]
+    _⋆_  : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ]) → Hom[ x , z ]
+    ⋆IdL : ∀ {x y} (f : Hom[ x , y ]) → id ⋆ f ≡ f
+    ⋆IdR : ∀ {x y} (f : Hom[ x , y ]) → f ⋆ id ≡ f
+    ⋆Assoc : ∀ {u v w x} (f : Hom[ u , v ]) (g : Hom[ v , w ]) (h : Hom[ w , x ]) → (f ⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+
+  -- composition: alternative to diagramatic order
+  _∘_ : ∀ {x y z} (g : Hom[ y , z ]) (f : Hom[ x , y ]) → Hom[ x , z ]
+  g ∘ f = f ⋆ g
+
+open Precategory
+
+-- Helpful syntax/notation
+_[_,_] : (C : Precategory ℓ ℓ') → (x y : C .ob) → Type ℓ'
+_[_,_] = Hom[_,_]
+
+-- Needed to define this in order to be able to make the subsequence syntax declaration
+seq' : ∀ (C : Precategory ℓ ℓ') {x y z} (f : C [ x , y ]) (g : C [ y , z ]) → C [ x , z ]
+seq' = _⋆_
+
+infixl 15 seq'
+syntax seq' C f g = f ⋆⟨ C ⟩ g
+
+-- composition
+comp' : ∀ (C : Precategory ℓ ℓ') {x y z} (g : C [ y , z ]) (f : C [ x , y ]) → C [ x , z ]
+comp' = _∘_
+
+infixr 16 comp'
+syntax comp' C g f = g ∘⟨ C ⟩ f
+
+-- Opposite precategory
+_^op : Precategory ℓ ℓ' → Precategory ℓ ℓ'
+(C ^op) .ob = C .ob
+(C ^op) .Hom[_,_] x y = C .Hom[_,_] y x
+(C ^op) .id = C .id
+(C ^op) ._⋆_ f g = C ._⋆_ g f
+(C ^op) .⋆IdL = C .⋆IdR
+(C ^op) .⋆IdR = C .⋆IdL
+(C ^op) .⋆Assoc f g h = sym (C .⋆Assoc _ _ _)

--- a/Cubical/Categories/Category/Properties.agda
+++ b/Cubical/Categories/Category/Properties.agda
@@ -6,45 +6,45 @@ open import Cubical.Foundations.HLevels
 
 open import Cubical.Categories.Category.Base
 
-open Precategory
+open Category
 
 private
   variable
     ℓ ℓ' : Level
 
-module _ {C : Precategory ℓ ℓ'} ⦃ isC : isCategory C ⦄ where
-  open isCategory isC
+module _ {C : Category ℓ ℓ'} where
+
   -- isSet where your allowed to compare paths where one side is only
   -- equal up to path. Is there a generalization of this?
   isSetHomP1 : ∀ {x y : C .ob} {n : C [ x , y ]}
               → isOfHLevelDep 1 (λ m → m ≡ n)
-  isSetHomP1 {x = x} {y} {n} = isOfHLevel→isOfHLevelDep 1 (λ m → isSetHom m n)
+  isSetHomP1 {x = x} {y} {n} = isOfHLevel→isOfHLevelDep 1 (λ m → isSetHom C m n)
 
   -- isSet where the arrows can be between non-definitionally equal obs
   isSetHomP2l : ∀ {y : C .ob}
               → isOfHLevelDep 2 (λ x → C [ x , y ])
-  isSetHomP2l = isOfHLevel→isOfHLevelDep 2 (λ a → isSetHom {x = a})
+  isSetHomP2l = isOfHLevel→isOfHLevelDep 2 (λ a → isSetHom C {x = a})
 
   isSetHomP2r : ∀ {x : C .ob}
               → isOfHLevelDep 2 (λ y → C [ x , y ])
-  isSetHomP2r = isOfHLevel→isOfHLevelDep 2 (λ a → isSetHom {y = a})
+  isSetHomP2r = isOfHLevel→isOfHLevelDep 2 (λ a → isSetHom C {y = a})
 
 
 -- opposite of opposite is definitionally equal to itself
-involutiveOp : ∀ {C : Precategory ℓ ℓ'} → C ^op ^op ≡ C
+involutiveOp : ∀ {C : Category ℓ ℓ'} → C ^op ^op ≡ C
 involutiveOp = refl
 
-module _ {C : Precategory ℓ ℓ'} where
+module _ {C : Category ℓ ℓ'} where
   -- Other useful operations on categories
 
   -- whisker the parallel morphisms g and g' with f
-  lPrecatWhisker : {x y z : C .ob} (f : C [ x , y ]) (g g' : C [ y , z ]) (p : g ≡ g')
+  lCatWhisker : {x y z : C .ob} (f : C [ x , y ]) (g g' : C [ y , z ]) (p : g ≡ g')
                  → f ⋆⟨ C ⟩ g ≡ f ⋆⟨ C ⟩ g'
-  lPrecatWhisker f _ _ p = cong (_⋆_ C f) p
+  lCatWhisker f _ _ p = cong (_⋆_ C f) p
 
-  rPrecatWhisker : {x y z : C .ob} (f f' : C [ x , y ]) (g : C [ y , z ]) (p : f ≡ f')
+  rCatWhisker : {x y z : C .ob} (f f' : C [ x , y ]) (g : C [ y , z ]) (p : f ≡ f')
                  → f ⋆⟨ C ⟩ g ≡ f' ⋆⟨ C ⟩ g
-  rPrecatWhisker _ _ g p = cong (λ v → v ⋆⟨ C ⟩ g) p
+  rCatWhisker _ _ g p = cong (λ v → v ⋆⟨ C ⟩ g) p
 
   -- working with equal objects
   idP : ∀ {x x'} {p : x ≡ x'} → C [ x , x' ]
@@ -79,14 +79,14 @@ module _ {C : Precategory ℓ ℓ'} where
 
 
   -- whiskering with heterogenous seq -- (maybe should let z be heterogeneous too)
-  lPrecatWhiskerP : {x y z y' : C .ob} {p : y ≡ y'}
+  lCatWhiskerP : {x y z y' : C .ob} {p : y ≡ y'}
                   → (f : C [ x , y ]) (g : C [ y , z ]) (g' : C [ y' , z ])
                   → (r : PathP (λ i → C [ p i , z ]) g g')
                   → f ⋆⟨ C ⟩ g ≡ seqP {p = p} f g'
-  lPrecatWhiskerP f g g' r = cong (λ v → f ⋆⟨ C ⟩ v) (sym (fromPathP (symP r)))
+  lCatWhiskerP f g g' r = cong (λ v → f ⋆⟨ C ⟩ v) (sym (fromPathP (symP r)))
 
-  rPrecatWhiskerP : {x y' y z : C .ob} {p : y' ≡ y}
+  rCatWhiskerP : {x y' y z : C .ob} {p : y' ≡ y}
                   → (f' : C [ x , y' ]) (f : C [ x , y ]) (g : C [ y , z ])
                   → (r : PathP (λ i → C [ x , p i ]) f' f)
                   → f ⋆⟨ C ⟩ g ≡ seqP' {p = p} f' g
-  rPrecatWhiskerP f' f g r = cong (λ v → v ⋆⟨ C ⟩ g) (sym (fromPathP r))
+  rCatWhiskerP f' f g r = cong (λ v → v ⋆⟨ C ⟩ g) (sym (fromPathP r))

--- a/Cubical/Categories/Commutativity.agda
+++ b/Cubical/Categories/Commutativity.agda
@@ -9,8 +9,8 @@ private
   variable
     ℓ ℓ' : Level
 
-module _ {C : Precategory ℓ ℓ'} where
-  open Precategory C
+module _ {C : Category ℓ ℓ'} where
+  open Category C
 
   compSq : ∀ {x y z w u v} {f : C [ x , y ]} {g h} {k : C [ z , w ]} {l} {m} {n : C [ u , v ]}
        -- square 1

--- a/Cubical/Categories/Constructions/Elements.agda
+++ b/Cubical/Categories/Constructions/Elements.agda
@@ -4,7 +4,7 @@
 
 open import Cubical.Categories.Category
 
-module Cubical.Categories.Constructions.Elements {ℓ ℓ'} {C : Precategory ℓ ℓ'} where
+module Cubical.Categories.Constructions.Elements {ℓ ℓ'} {C : Category ℓ ℓ'} where
 
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Functor
@@ -17,16 +17,16 @@ import Cubical.Categories.Constructions.Slice as Slice
 
 -- some issues
 -- * always need to specify objects during composition because can't infer isSet
-open Precategory
+open Category
 open Functor
 
 
-getIsSet : ∀ {ℓS} {C : Precategory ℓ ℓ'} (F : Functor C (SET ℓS)) → (c : C .ob) → isSet (fst (F ⟅ c ⟆))
+getIsSet : ∀ {ℓS} {C : Category ℓ ℓ'} (F : Functor C (SET ℓS)) → (c : C .ob) → isSet (fst (F ⟅ c ⟆))
 getIsSet F c = snd (F ⟅ c ⟆)
 
 
 infix 50 ∫_
-∫_ : ∀ {ℓS} → Functor C (SET ℓS) → Precategory (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
+∫_ : ∀ {ℓS} → Functor C (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
 -- objects are (c , x) pairs where c ∈ C and x ∈ F c
 (∫ F) .ob = Σ[ c ∈ C .ob ] fst (F ⟅ c ⟆)
 -- morphisms are f : c → c' which take x to x'
@@ -70,10 +70,10 @@ infix 50 ∫_
 
       p2 : x₃ ≡ (F ⟪ f ⋆⟨ C ⟩ (g ⋆⟨ C ⟩ h) ⟫) x
       p2 = snd ((∫ F) ._⋆_ f' ((∫ F) ._⋆_ {o1} {o2} {o3} g' h'))
-
+(∫ F) .isSetHom {x} {y} = isSetΣSndProp (C .isSetHom) λ _ → (F ⟅ fst y ⟆) .snd _ _
 
 -- same thing but for presheaves
-∫ᴾ_ : ∀ {ℓS} → Functor (C ^op) (SET ℓS) → Precategory (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
+∫ᴾ_ : ∀ {ℓS} → Functor (C ^op) (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
 -- objects are (c , x) pairs where c ∈ C and x ∈ F c
 (∫ᴾ F) .ob = Σ[ c ∈ C .ob ] fst (F ⟅ c ⟆)
 -- morphisms are f : c → c' which take x to x'
@@ -117,6 +117,7 @@ infix 50 ∫_
 
       p2 : x ≡ (F ⟪ f ⋆⟨ C ⟩ (g ⋆⟨ C ⟩ h) ⟫) x₃
       p2 = snd ((∫ᴾ F) ._⋆_ f' ((∫ᴾ F) ._⋆_ {o1} {o2} {o3} g' h'))
+(∫ᴾ F) .isSetHom {x} = isSetΣSndProp (C .isSetHom) (λ _ → (F ⟅ fst x ⟆) .snd _ _)
 
 -- helpful results
 

--- a/Cubical/Categories/Constructions/Slice.agda
+++ b/Cubical/Categories/Constructions/Slice.agda
@@ -12,12 +12,11 @@ open import Cubical.Categories.Morphism renaming (isIso to isIsoC)
 
 open import Cubical.Data.Sigma
 
-open Precategory
-open isCategory
+open Category
 open isUnivalent
 open Iso
 
-module Cubical.Categories.Constructions.Slice {ℓ ℓ' : Level} (C : Precategory ℓ ℓ') (c : C .ob) {{isC : isCategory C}} where
+module Cubical.Categories.Constructions.Slice {ℓ ℓ' : Level} (C : Category ℓ ℓ') (c : C .ob) where
 
 -- just a helper to prevent redundency
 TypeC : Type (ℓ-suc (ℓ-max ℓ ℓ'))
@@ -89,7 +88,7 @@ SliceHom-≡-intro' : ∀ {a b} {f g : C [ a .S-ob , b .S-ob ]} {c₁} {c₂}
 SliceHom-≡-intro' {a} {b} {f} {g} {c₁} {c₂} p i = slicehom (p i) (c₁≡c₂ i)
   where
     c₁≡c₂ : PathP (λ i → (p i) ⋆⟨ C ⟩ (b .S-arr) ≡ a .S-arr) c₁ c₂
-    c₁≡c₂ = isOfHLevel→isOfHLevelDep 1 (λ _ → isC .isSetHom _ _) c₁ c₂ p
+    c₁≡c₂ = isOfHLevel→isOfHLevelDep 1 (λ _ → C .isSetHom _ _) c₁ c₂ p
 
 -- SliceHom is isomorphic to the Sigma type with the same components
 SliceHom-Σ-Iso : ∀ {a b}
@@ -100,13 +99,13 @@ SliceHom-Σ-Iso .rightInv = λ x → refl
 SliceHom-Σ-Iso .leftInv = λ x → refl
 
 
--- Precategory definition
+-- Category definition
 
-SliceCat : Precategory _ _
-SliceCat .ob = SliceOb
-SliceCat .Hom[_,_] = SliceHom
-SliceCat .id = slicehom (C .id) (C .⋆IdL _)
-SliceCat ._⋆_ {sliceob j} {sliceob k} {sliceob l} (slicehom f p) (slicehom g p') =
+SliceCat : Category (ℓ-max ℓ ℓ') ℓ'
+ob SliceCat = SliceOb
+Hom[_,_] SliceCat = SliceHom
+id SliceCat = slicehom (C .id) (C .⋆IdL _)
+_⋆_ SliceCat {sliceob j} {sliceob k} {sliceob l} (slicehom f p) (slicehom g p') =
   slicehom
     (f ⋆⟨ C ⟩ g)
     ( f ⋆⟨ C ⟩ g ⋆⟨ C ⟩ l
@@ -117,19 +116,13 @@ SliceCat ._⋆_ {sliceob j} {sliceob k} {sliceob l} (slicehom f p) (slicehom g p
     ≡⟨ p ⟩
       j
     ∎)
-SliceCat .⋆IdL (slicehom S-hom S-comm) =
-  SliceHom-≡-intro (⋆IdL C _) (toPathP (isC .isSetHom _ _ _ _))
-SliceCat .⋆IdR (slicehom S-hom S-comm) =
-  SliceHom-≡-intro (⋆IdR C _) (toPathP (isC .isSetHom _ _ _ _))
-SliceCat .⋆Assoc f g h =
-  SliceHom-≡-intro (⋆Assoc C _ _ _) (toPathP (isC .isSetHom _ _ _ _))
-
-
--- SliceCat is a Category
-
-instance
-  isCatSlice : isCategory SliceCat
-  isCatSlice .isSetHom {a} {b} (slicehom f c₁) (slicehom g c₂) p q = cong isoP p'≡q'
+⋆IdL SliceCat (slicehom S-hom S-comm) =
+  SliceHom-≡-intro (⋆IdL C _) (toPathP (C .isSetHom _ _ _ _))
+⋆IdR SliceCat (slicehom S-hom S-comm) =
+  SliceHom-≡-intro (⋆IdR C _) (toPathP (C .isSetHom _ _ _ _))
+⋆Assoc SliceCat f g h =
+  SliceHom-≡-intro (⋆Assoc C _ _ _) (toPathP (C .isSetHom _ _ _ _))
+isSetHom SliceCat {a} {b} (slicehom f c₁) (slicehom g c₂) p q = cong isoP p'≡q'
     where
       -- paths between SliceHoms are equivalent to the projection paths
       p' : Σ[ p ∈ f ≡ g ] PathP (λ i → (p i) ⋆⟨ C ⟩ (S-arr b) ≡ S-arr a) c₁ c₂
@@ -142,11 +135,11 @@ instance
 
       -- need the groupoidness for dependent paths
       isGroupoidDepHom : isOfHLevelDep 2 B
-      isGroupoidDepHom = isOfHLevel→isOfHLevelDep 2 (λ v x y → isSet→isGroupoid (isC .isSetHom) _ _ x y)
+      isGroupoidDepHom = isOfHLevel→isOfHLevelDep 2 (λ v x y → isSet→isGroupoid (C .isSetHom) _ _ x y)
 
       -- we first prove that the projected paths are equal
       p'≡q' : p' ≡ q'
-      p'≡q' = ΣPathP ((isC .isSetHom _ _ _ _) , toPathP (isGroupoidDepHom _ _ _ _ _))
+      p'≡q' = ΣPathP (C .isSetHom _ _ _ _ , toPathP (isGroupoidDepHom _ _ _ _ _))
 
       -- and then we can use equivalence to lift these paths up
       -- to actual SliceHom paths
@@ -256,8 +249,7 @@ module _ ⦃ isU : isUnivalent C ⦄ where
             k'≡k i = (pToIIso .rightInv extractIso) i .mor
 
             kcom'≡kcom : PathP (λ j → (k'≡k j) ⋆⟨ C ⟩ g ≡ f) (kc' .S-comm) (kc .S-comm)
-            kcom'≡kcom = isSetHomP1 _ _ λ i → (k'≡k i) ⋆⟨ C ⟩ g
-
+            kcom'≡kcom = isSetHomP1 {C = C} _ _ λ i → (k'≡k i) ⋆⟨ C ⟩ g
             kc'≡kc : kc' ≡ kc
             kc'≡kc i = slicehom (k'≡k i) (kcom'≡kcom i)
 
@@ -267,7 +259,7 @@ module _ ⦃ isU : isUnivalent C ⦄ where
             l'≡l i = (pToIIso .rightInv extractIso) i .inv
 
             lcom'≡lcom : PathP (λ j → (l'≡l j) ⋆⟨ C ⟩ f ≡ g) (lc' .S-comm) (lc .S-comm)
-            lcom'≡lcom = isSetHomP1 _ _ λ i → (l'≡l i) ⋆⟨ C ⟩ f
+            lcom'≡lcom = isSetHomP1 {C = C} _ _ λ i → (l'≡l i) ⋆⟨ C ⟩ f
 
             lc'≡lc : lc' ≡ lc
             lc'≡lc i = slicehom (l'≡l i) (lcom'≡lcom i)
@@ -276,13 +268,13 @@ module _ ⦃ isU : isUnivalent C ⦄ where
 
             s' = (sIso .fun) (sIso .inv is) .sec
             s'≡s : PathP (λ i → lc'≡lc i ⋆⟨ SliceCat ⟩ kc'≡kc i ≡ SliceCat .id) s' s
-            s'≡s = isSetHomP1 _ _ λ i → lc'≡lc i ⋆⟨ SliceCat ⟩ kc'≡kc i
+            s'≡s = isSetHomP1 {C = SliceCat} _ _ λ i → lc'≡lc i ⋆⟨ SliceCat ⟩ kc'≡kc i
 
             -- ret
 
             r' = (sIso .fun) (sIso .inv is) .ret
             r'≡r : PathP (λ i → kc'≡kc i ⋆⟨ SliceCat ⟩ lc'≡lc i ≡ SliceCat .id) r' r
-            r'≡r = isSetHomP1 _ _ λ i → kc'≡kc i ⋆⟨ SliceCat ⟩ lc'≡lc i
+            r'≡r = isSetHomP1 {C = SliceCat} _ _ λ i → kc'≡kc i ⋆⟨ SliceCat ⟩ lc'≡lc i
 
         sIso .leftInv p = p'≡p
           -- to show that the round trip is equivalent to the identity
@@ -332,7 +324,7 @@ module _ ⦃ isU : isUnivalent C ⦄ where
 
             -- isSetHom gives us the second component, path between morphisms
             p'Mor≡pMor : PathP (λ j → PathP (λ i → C [ (p'Ob≡pOb j) i , c ]) f g) p'Mor pMor
-            p'Mor≡pMor = isSetHomP2l _ _ p'Mor pMor p'Ob≡pOb
+            p'Mor≡pMor = isSetHomP2l {C = C} _ _ p'Mor pMor p'Ob≡pOb
 
             -- we can use the above paths to show that p' ≡ p
             p'≡p : p' ≡ p

--- a/Cubical/Categories/Equivalence/Base.agda
+++ b/Cubical/Categories/Equivalence/Base.agda
@@ -1,22 +1,20 @@
 {-# OPTIONS --safe #-}
-
 module Cubical.Categories.Equivalence.Base where
 
 open import Cubical.Foundations.Prelude
+
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.NaturalTransformation
 
-open Precategory
+open Category
 open Functor
 
 private
   variable
     ℓC ℓC' ℓD ℓD' : Level
 
--- Definition
-
-record isEquivalence {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'}
+record isEquivalence {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
                      (func : Functor C D) : Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
   field
     invFunc : Functor D C
@@ -24,7 +22,8 @@ record isEquivalence {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'}
     η : 𝟙⟨ C ⟩ ≅ᶜ invFunc ∘F func
     ε : func ∘F invFunc ≅ᶜ 𝟙⟨ D ⟩
 
-record _≃ᶜ_ (C : Precategory ℓC ℓC') (D : Precategory ℓD ℓD') : Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
+record _≃ᶜ_ (C : Category ℓC ℓC') (D : Category ℓD ℓD') :
+               Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
   field
     func : Functor C D
     isEquiv : isEquivalence func

--- a/Cubical/Categories/Equivalence/Properties.agda
+++ b/Cubical/Categories/Equivalence/Properties.agda
@@ -11,7 +11,7 @@ open import Cubical.Categories.Morphism
 open import Cubical.Categories.Equivalence.Base
 open import Cubical.HITs.PropositionalTruncation.Base
 
-open Precategory
+open Category
 open Functor
 open NatIso
 open CatIso
@@ -24,7 +24,7 @@ private
 
 -- Equivalence implies Full, Faithul, and Essentially Surjective
 
-module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   symEquiv : ∀ {F : Functor C D} → (e : isEquivalence F) → isEquivalence (e .invFunc)
   symEquiv {F} record { invFunc = G ; η = η ; ε = ε } = record { invFunc = F ; η = symNatIso ε ; ε = symNatIso η }
 
@@ -47,7 +47,7 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
       -- isomorphism between c' and GFc'
       c'Iso = isIso→CatIso (η .nIso c')
 
-module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   isEquiv→Full : ∀ {F : Functor C D} → isEquivalence F → isFull F
   isEquiv→Full {F} eq@record { invFunc = G
                              ; η = η

--- a/Cubical/Categories/Functor/Base.agda
+++ b/Cubical/Categories/Functor/Base.agda
@@ -11,11 +11,11 @@ private
   variable
     ℓC ℓC' ℓD ℓD' : Level
 
-record Functor (C : Precategory ℓC ℓC') (D : Precategory ℓD ℓD') :
+record Functor (C : Category ℓC ℓC') (D : Category ℓD ℓD') :
          Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) where
   no-eta-equality
 
-  open Precategory
+  open Category
 
   field
     F-ob  : C .ob → D .ob
@@ -31,9 +31,9 @@ record Functor (C : Precategory ℓC ℓC') (D : Precategory ℓD ℓD') :
 private
   variable
     ℓ ℓ' : Level
-    C D E : Precategory ℓ ℓ'
+    C D E : Category ℓ ℓ'
 
-open Precategory
+open Category
 open Functor
 
 -- Helpful notation
@@ -56,10 +56,10 @@ _⟪_⟫ = F-hom
 
 -- Functor constructions
 
-𝟙⟨_⟩ : ∀ (C : Precategory ℓ ℓ') → Functor C C
-𝟙⟨ C ⟩ .F-ob x = x
-𝟙⟨ C ⟩ .F-hom f = f
-𝟙⟨ C ⟩ .F-id = refl
+𝟙⟨_⟩ : ∀ (C : Category ℓ ℓ') → Functor C C
+𝟙⟨ C ⟩ .F-ob x    = x
+𝟙⟨ C ⟩ .F-hom f   = f
+𝟙⟨ C ⟩ .F-id      = refl
 𝟙⟨ C ⟩ .F-seq _ _ = refl
 
 -- functor composition

--- a/Cubical/Categories/Functor/Compose.agda
+++ b/Cubical/Categories/Functor/Compose.agda
@@ -11,8 +11,7 @@ open import Cubical.Categories.NaturalTransformation.Base
 open import Cubical.Categories.Instances.Functors
 
 module _ {ℓC ℓC' ℓD ℓD' ℓE ℓE'}
-  {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'}
-  (E : Precategory ℓE ℓE') ⦃ isCatE : isCategory E ⦄
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (E : Category ℓE ℓE')
   (F : Functor C D)
   where
 
@@ -27,9 +26,7 @@ module _ {ℓC ℓC' ℓD ℓD' ℓE ℓE'}
   precomposeF .F-seq f g = refl
 
 module _ {ℓC ℓC' ℓD ℓD' ℓE ℓE'}
-  (C : Precategory ℓC ℓC')
-  {D : Precategory ℓD ℓD'} ⦃ isCatD : isCategory D ⦄
-  {E : Precategory ℓE ℓE'} ⦃ isCatE : isCategory E ⦄
+  (C : Category ℓC ℓC') {D : Category ℓD ℓD'} {E : Category ℓE ℓE'}
   (G : Functor D E)
   where
 

--- a/Cubical/Categories/Functor/Properties.agda
+++ b/Cubical/Categories/Functor/Properties.agda
@@ -11,9 +11,9 @@ open import Cubical.Categories.Functor.Base
 private
   variable
     ℓ ℓ' ℓ'' : Level
-    B C D E : Precategory ℓ ℓ'
+    B C D E : Category ℓ ℓ'
 
-open Precategory
+open Category
 open Functor
 
 {-

--- a/Cubical/Categories/Instances/CommRings.agda
+++ b/Cubical/Categories/Instances/CommRings.agda
@@ -4,18 +4,20 @@ module Cubical.Categories.Instances.CommRings where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 
+open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing
 
 open import Cubical.Categories.Category
 
-open Precategory
+open Category
 open CommRingHoms
 
-CommRingsPrecategory : ∀ {ℓ} → Precategory (ℓ-suc ℓ) ℓ
-ob CommRingsPrecategory                     = CommRing _
-Hom[_,_] CommRingsPrecategory               = CommRingHom
-id CommRingsPrecategory {R}                 = idCommRingHom R
-_⋆_ CommRingsPrecategory {R} {S} {T}        = compCommRingHom R S T
-⋆IdL CommRingsPrecategory {R} {S}           = compIdCommRingHom {R = R} {S}
-⋆IdR CommRingsPrecategory {R} {S}           = idCompCommRingHom {R = R} {S}
-⋆Assoc CommRingsPrecategory {R} {S} {T} {U} = compAssocCommRingHom {R = R} {S} {T} {U}
+CommRingsCategory : ∀ {ℓ} → Category (ℓ-suc ℓ) ℓ
+ob CommRingsCategory                     = CommRing _
+Hom[_,_] CommRingsCategory               = CommRingHom
+id CommRingsCategory {R}                 = idCommRingHom R
+_⋆_ CommRingsCategory {R} {S} {T}        = compCommRingHom R S T
+⋆IdL CommRingsCategory {R} {S}           = compIdCommRingHom {R = R} {S}
+⋆IdR CommRingsCategory {R} {S}           = idCompCommRingHom {R = R} {S}
+⋆Assoc CommRingsCategory {R} {S} {T} {U} = compAssocCommRingHom {R = R} {S} {T} {U}
+isSetHom CommRingsCategory               = isSetRingHom _ _

--- a/Cubical/Categories/Instances/Cospan.agda
+++ b/Cubical/Categories/Instances/Cospan.agda
@@ -23,7 +23,6 @@ CospanCat .Hom[_,_] ① ① = Unit
 CospanCat .Hom[_,_] ② ② = Unit
 CospanCat .Hom[_,_] _ _ = ⊥
 
-
 CospanCat ._⋆_ {x = ⓪} {⓪} {⓪} f g = tt
 CospanCat ._⋆_ {x = ①} {①} {①} f g = tt
 CospanCat ._⋆_ {x = ②} {②} {②} f g = tt
@@ -58,4 +57,8 @@ CospanCat .⋆Assoc {②} {②} {②} {①} _ _ _ = refl
 CospanCat .⋆Assoc {②} {②} {①} {①} _ _ _ = refl
 CospanCat .⋆Assoc {②} {①} {①} {①} _ _ _ = refl
 
-CospanCat .isSetHom = {!!}
+CospanCat .isSetHom {⓪} {⓪} = isSetUnit
+CospanCat .isSetHom {⓪} {①} = isSetUnit
+CospanCat .isSetHom {①} {①} = isSetUnit
+CospanCat .isSetHom {②} {①} = isSetUnit
+CospanCat .isSetHom {②} {②} = isSetUnit

--- a/Cubical/Categories/Instances/Cospan.agda
+++ b/Cubical/Categories/Instances/Cospan.agda
@@ -6,14 +6,14 @@ open import Cubical.Categories.Category
 open import Cubical.Data.Unit
 open import Cubical.Data.Empty
 
-open Precategory
+open Category
 
 data 𝟛 : Type ℓ-zero where
   ⓪ : 𝟛
   ① : 𝟛
   ② : 𝟛
 
-CospanCat : Precategory ℓ-zero ℓ-zero
+CospanCat : Category ℓ-zero ℓ-zero
 CospanCat .ob = 𝟛
 
 CospanCat .Hom[_,_] ⓪ ① = Unit
@@ -57,3 +57,5 @@ CospanCat .⋆Assoc {②} {②} {②} {②} _ _ _ = refl
 CospanCat .⋆Assoc {②} {②} {②} {①} _ _ _ = refl
 CospanCat .⋆Assoc {②} {②} {①} {①} _ _ _ = refl
 CospanCat .⋆Assoc {②} {①} {①} {①} _ _ _ = refl
+
+CospanCat .isSetHom = {!!}

--- a/Cubical/Categories/Instances/Functors.agda
+++ b/Cubical/Categories/Instances/Functors.agda
@@ -13,26 +13,23 @@ private
   variable
     ℓC ℓC' ℓD ℓD' : Level
 
-module _ (C : Precategory ℓC ℓC') (D : Precategory ℓD ℓD') ⦃ isCatD : isCategory D ⦄ where
-  open Precategory
-  open isCategory
+module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
+  open Category
   open NatTrans
   open Functor
 
-  FUNCTOR : Precategory (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) (ℓ-max (ℓ-max ℓC ℓC') ℓD')
-  FUNCTOR .ob = Functor C D
-  FUNCTOR .Hom[_,_] = NatTrans
-  FUNCTOR .id {F} = idTrans F
-  FUNCTOR ._⋆_ = seqTrans
-  FUNCTOR .⋆IdL α = makeNatTransPath λ i x → D .⋆IdL (α .N-ob x) i
-  FUNCTOR .⋆IdR α = makeNatTransPath λ i x → D .⋆IdR (α .N-ob x) i
-  FUNCTOR .⋆Assoc α β γ = makeNatTransPath λ i x → D .⋆Assoc (α .N-ob x) (β .N-ob x) (γ .N-ob x) i
-
-  isCatFUNCTOR : isCategory FUNCTOR
-  isCatFUNCTOR .isSetHom = isSetNat
+  FUNCTOR : Category (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD')) (ℓ-max (ℓ-max ℓC ℓC') ℓD')
+  ob FUNCTOR           = Functor C D
+  Hom[_,_] FUNCTOR     = NatTrans
+  id FUNCTOR {F}       = idTrans F
+  _⋆_ FUNCTOR          = seqTrans
+  ⋆IdL FUNCTOR α       = makeNatTransPath λ i x → D .⋆IdL (α .N-ob x) i
+  ⋆IdR FUNCTOR α       = makeNatTransPath λ i x → D .⋆IdR (α .N-ob x) i
+  ⋆Assoc FUNCTOR α β γ = makeNatTransPath λ i x → D .⋆Assoc (α .N-ob x) (β .N-ob x) (γ .N-ob x) i
+  isSetHom FUNCTOR     = isSetNat
 
   open isIsoC renaming (inv to invC)
-  -- component wise iso is an iso in Functor
+  -- componentwise iso is an iso in Functor
   FUNCTORIso : ∀ {F G : Functor C D} (α : F ⇒ G)
              → (∀ (c : C .ob) → isIsoC {C = D} (α ⟦ c ⟧))
              → isIsoC {C = FUNCTOR} α
@@ -53,8 +50,3 @@ module _ (C : Precategory ℓC ℓC') (D : Precategory ℓD ℓD') ⦃ isCatD : 
       areInv-αd = isIso→areInv (is d)
   FUNCTORIso α is .sec = makeNatTransPath (funExt (λ c → (is c) .sec))
   FUNCTORIso α is .ret = makeNatTransPath (funExt (λ c → (is c) .ret))
-
-instance
-  ⦃isCatFUNCTOR⦄ : {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} ⦃ isCatD : isCategory D ⦄
-    → isCategory (FUNCTOR C D)
-  ⦃isCatFUNCTOR⦄ {C = C} {D} = isCatFUNCTOR C D

--- a/Cubical/Categories/Instances/Rings.agda
+++ b/Cubical/Categories/Instances/Rings.agda
@@ -8,14 +8,15 @@ open import Cubical.Algebra.Ring
 
 open import Cubical.Categories.Category
 
-open Precategory
+open Category
 open RingHoms
 
-RingsPrecategory : ∀ {ℓ} → Precategory (ℓ-suc ℓ) ℓ
-ob RingsPrecategory       = Ring _
-Hom[_,_] RingsPrecategory = RingHom
-id RingsPrecategory {R}   = idRingHom R
-_⋆_ RingsPrecategory      = compRingHom
-⋆IdL RingsPrecategory     = compIdRingHom
-⋆IdR RingsPrecategory     = idCompRingHom
-⋆Assoc RingsPrecategory   = compAssocRingHom
+RingsCategory : ∀ {ℓ} → Category (ℓ-suc ℓ) ℓ
+ob RingsCategory       = Ring _
+Hom[_,_] RingsCategory = RingHom
+id RingsCategory {R}   = idRingHom R
+_⋆_ RingsCategory      = compRingHom
+⋆IdL RingsCategory     = compIdRingHom
+⋆IdR RingsCategory     = idCompRingHom
+⋆Assoc RingsCategory   = compAssocRingHom
+isSetHom RingsCategory = isSetRingHom _ _

--- a/Cubical/Categories/Instances/Sets.agda
+++ b/Cubical/Categories/Instances/Sets.agda
@@ -15,7 +15,7 @@ module _ ℓ where
   SET : Category (ℓ-suc ℓ) ℓ
   ob SET = hSet ℓ
   Hom[_,_] SET (A , _) (B , _) = A → B
-  id SET x = x 
+  id SET x = x
   _⋆_ SET f g x = g (f x)
   ⋆IdL SET f = refl
   ⋆IdR SET f = refl

--- a/Cubical/Categories/Instances/Sets.agda
+++ b/Cubical/Categories/Instances/Sets.agda
@@ -9,40 +9,18 @@ open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.NaturalTransformation
 
-open Precategory
-open isCategory
+open Category
 
 module _ ℓ where
-  SET : Precategory (ℓ-suc ℓ) ℓ
-  SET .ob                       = Σ (Type ℓ) isSet
-  SET .Hom[_,_] (A , _) (B , _) = A → B
-  SET .id                       = λ x → x
-  SET ._⋆_ f g                  = λ x → g (f x)
-  SET .⋆IdL f                   = refl
-  SET .⋆IdR f                   = refl
-  SET .⋆Assoc f g h             = refl
-
-module _ {ℓ} where
-  isSetExpIdeal : {A B : Type ℓ} → isSet B → isSet (A → B)
-  isSetExpIdeal B/set = isSetΠ λ _ → B/set
-
-  isSetLift : {A : Type ℓ} → isSet A → isSet (Lift {ℓ} {ℓ-suc ℓ} A)
-  isSetLift = isOfHLevelLift 2
-
-  module _ {A B : SET ℓ .ob} where
-    -- monic/surjectiveness
-    open import Cubical.Categories.Morphism
-    isSurjSET : (f : SET ℓ [ A , B ]) → Type _
-    isSurjSET f = ∀ (b : fst B) → Σ[ a ∈ fst A ] f a ≡ b
-
-    -- isMonic→isSurjSET : {f : SET ℓ [ A , B ]}
-    --                   → isEpic {C = SET ℓ} {x = A} {y = B} f
-    --                   → isSurjSET f
-    -- isMonic→isSurjSET ism b = {!!} , {!!}
-
-  instance
-    SET-category : isCategory (SET ℓ)
-    SET-category .isSetHom {_} {B , B/set} = isSetExpIdeal B/set
+  SET : Category (ℓ-suc ℓ) ℓ
+  ob SET = hSet ℓ
+  Hom[_,_] SET (A , _) (B , _) = A → B
+  id SET x = x 
+  _⋆_ SET f g x = g (f x)
+  ⋆IdL SET f = refl
+  ⋆IdR SET f = refl
+  ⋆Assoc SET f g h = refl
+  isSetHom SET {A} {B} = isSetΠ (λ _ → snd B)
 
 private
   variable
@@ -51,19 +29,19 @@ private
 open Functor
 
 -- Hom functors
-_[-,_] : (C : Precategory ℓ ℓ') → (c : C .ob) → ⦃ isCat : isCategory C ⦄ → Functor (C ^op) (SET ℓ')
-(C [-, c ]) ⦃ isCat ⦄ .F-ob x = (C [ x , c ]) , isCat .isSetHom
-(C [-, c ])           .F-hom f k = f ⋆⟨ C ⟩ k
-(C [-, c ])           .F-id = funExt λ _ → C .⋆IdL _
-(C [-, c ])           .F-seq _ _ = funExt λ _ → C .⋆Assoc _ _ _
+_[-,_] : (C : Category ℓ ℓ') → (c : C .ob) → Functor (C ^op) (SET ℓ')
+(C [-, c ]) .F-ob x    = (C [ x , c ]) , C .isSetHom
+(C [-, c ]) .F-hom f k = f ⋆⟨ C ⟩ k
+(C [-, c ]) .F-id      = funExt λ _ → C .⋆IdL _
+(C [-, c ]) .F-seq _ _ = funExt λ _ → C .⋆Assoc _ _ _
 
-_[_,-] : (C : Precategory ℓ ℓ') → (c : C .ob) → ⦃ isCat : isCategory C ⦄ → Functor C (SET ℓ')
-(C [ c ,-]) ⦃ isCat ⦄ .F-ob x = (C [ c , x ]) , isCat .isSetHom
-(C [ c ,-])           .F-hom f k = k ⋆⟨ C ⟩ f
-(C [ c ,-])           .F-id = funExt λ _ → C .⋆IdR _
-(C [ c ,-])           .F-seq _ _ = funExt λ _ → sym (C .⋆Assoc _ _ _)
+_[_,-] : (C : Category ℓ ℓ') → (c : C .ob)→ Functor C (SET ℓ')
+(C [ c ,-]) .F-ob x    = (C [ c , x ]) , C .isSetHom
+(C [ c ,-]) .F-hom f k = k ⋆⟨ C ⟩ f
+(C [ c ,-]) .F-id      = funExt λ _ → C .⋆IdR _
+(C [ c ,-]) .F-seq _ _ = funExt λ _ → sym (C .⋆Assoc _ _ _)
 
-module _ {C : Precategory ℓ ℓ'} ⦃ _ : isCategory C ⦄ {F : Functor C (SET ℓ')} where
+module _ {C : Category ℓ ℓ'} {F : Functor C (SET ℓ')} where
   open NatTrans
 
   -- natural transformations by pre/post composition
@@ -92,16 +70,3 @@ Iso→CatIso is .mor = is .fun
 Iso→CatIso is .cInv = is .inv
 Iso→CatIso is .sec = funExt λ b → is .rightInv b -- is .rightInv
 Iso→CatIso is .ret = funExt λ b → is .leftInv b -- is .rightInv
-
-
--- TYPE category is has all types as objects
--- kind of useless
-module _ ℓ where
-  TYPE : Precategory (ℓ-suc ℓ) ℓ
-  TYPE .ob           = Type ℓ
-  TYPE .Hom[_,_] A B = A → B
-  TYPE .id           = λ x → x
-  TYPE ._⋆_ f g      = λ x → g (f x)
-  TYPE .⋆IdL f       = refl
-  TYPE .⋆IdR f       = refl
-  TYPE .⋆Assoc f g h = refl

--- a/Cubical/Categories/Instances/TypePrecategory.agda
+++ b/Cubical/Categories/Instances/TypePrecategory.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --safe #-}
+module Cubical.Categories.Instances.TypePrecategory where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Categories.Category.Precategory
+
+open Precategory
+
+-- TYPE precategory has types as objects
+module _ ℓ where
+  TYPE : Precategory (ℓ-suc ℓ) ℓ
+  TYPE .ob           = Type ℓ
+  TYPE .Hom[_,_] A B = A → B
+  TYPE .id           = λ x → x
+  TYPE ._⋆_ f g      = λ x → g (f x)
+  TYPE .⋆IdL f       = refl
+  TYPE .⋆IdR f       = refl
+  TYPE .⋆Assoc f g h = refl

--- a/Cubical/Categories/Limits/Base.agda
+++ b/Cubical/Categories/Limits/Base.agda
@@ -16,9 +16,9 @@ private
     ℓJ ℓJ' ℓC ℓC' : Level
     ℓ ℓ' ℓ'' : Level
 
-module _ {J : Precategory ℓJ ℓJ'}
-         {C : Precategory ℓC ℓC'} where
-  open Precategory
+module _ {J : Category ℓJ ℓJ'}
+         {C : Category ℓC ℓC'} where
+  open Category
   open Functor
   open NatTrans
 
@@ -80,15 +80,15 @@ module _ {J : Precategory ℓJ ℓJ'}
         islim : isLimit head
 
 -- a Category is complete if it has all limits
-complete' : {ℓJ ℓJ' : Level} (C : Precategory ℓC ℓC') → Type _
-complete' {ℓJ = ℓJ} {ℓJ'} C = (J : Precategory ℓJ ℓJ') (K : Functor J C) → Limit K
+complete' : {ℓJ ℓJ' : Level} (C : Category ℓC ℓC') → Type _
+complete' {ℓJ = ℓJ} {ℓJ'} C = (J : Category ℓJ ℓJ') (K : Functor J C) → Limit K
 
-complete : (C : Precategory ℓC ℓC') → Typeω
+complete : (C : Category ℓC ℓC') → Typeω
 complete C = ∀ {ℓJ ℓJ'} → complete' {ℓJ = ℓJ} {ℓJ'} C
 
 open Limit
 open NatTrans
-open Precategory
+open Category
 
 
 

--- a/Cubical/Categories/Limits/Pullback.agda
+++ b/Cubical/Categories/Limits/Pullback.agda
@@ -14,9 +14,9 @@ private
   variable
     ℓ ℓ' : Level
 
-module _ {C : Precategory ℓ ℓ'} where
+module _ {C : Category ℓ ℓ'} where
 
-  open Precategory C
+  open Category C
   open Functor
 
   record Cospan : Type (ℓ-max ℓ ℓ') where

--- a/Cubical/Categories/Limits/Terminal.agda
+++ b/Cubical/Categories/Limits/Terminal.agda
@@ -13,8 +13,8 @@ private
   variable
     ℓ ℓ' : Level
 
-module _ (C : Precategory ℓ ℓ') where
-  open Precategory C
+module _ (C : Category ℓ ℓ') where
+  open Category C
 
   isInitial : (x : ob) → Type (ℓ-max ℓ ℓ')
   isInitial x = ∀ (y : ob) → isContr (C [ x , y ])
@@ -48,7 +48,7 @@ module _ (C : Precategory ℓ ℓ') where
 
   open isUnivalent
 
-  -- The type of initial objects of a univalent precategory is a proposition,
+  -- The type of initial objects of a univalent category is a proposition,
   -- i.e. all initial objects are equal.
   isPropInitial : (hC : isUnivalent C) → isProp (hasInitialOb)
   isPropInitial hC x y =
@@ -77,11 +77,11 @@ module _ (C : Precategory ℓ ℓ') where
         y→x→y = isContr→isProp (hy y) _ _ -- similar.
     in catiso x→y y→x y→x→y x→y→x
 
-  -- The type of final objects of a univalent precategory is a proposition,
+  -- The type of final objects of a univalent category is a proposition,
   -- i.e. all final objects are equal.
   isPropFinal : (hC : isUnivalent C) → isProp (hasFinalOb)
   isPropFinal hC x y =
     -- Being final is a prop ∴ Suffices equal as objects in C.
-    Σ≡Prop (isPropIsFinal)
+    Σ≡Prop isPropIsFinal
     -- C is univalent ∴ Suffices isomorphic as objects in C.
     (CatIsoToPath hC (isFinalToIso (snd x) (snd y)))

--- a/Cubical/Categories/Morphism.agda
+++ b/Cubical/Categories/Morphism.agda
@@ -11,8 +11,8 @@ private
   variable
     ℓ ℓ' : Level
 
-module _ {C : Precategory ℓ ℓ'} where
-  open Precategory C
+module _ {C : Category ℓ ℓ'} where
+  open Category C
 
   private
     variable

--- a/Cubical/Categories/NaturalTransformation/Base.agda
+++ b/Cubical/Categories/NaturalTransformation/Base.agda
@@ -14,16 +14,16 @@ open import Cubical.Categories.Morphism renaming (isIso to isIsoC)
 
 private
   variable
-    ℓC ℓC' ℓD ℓD' : Level
+    ℓA ℓA' ℓB ℓB' ℓC ℓC' ℓD ℓD' : Level
 
-module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   -- syntax for sequencing in category D
   infixl 15 _⋆ᴰ_
   private
     _⋆ᴰ_ : ∀ {x y z} (f : D [ x , y ]) (g : D [ y , z ]) → D [ x , z ]
     f ⋆ᴰ g = f ⋆⟨ D ⟩ g
 
-  open Precategory
+  open Category
   open Functor
 
   -- type aliases because it gets tedious typing it out all the time
@@ -172,9 +172,8 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
                    (β .N-hom f i)
 
 
-  module _  ⦃ isCatD : isCategory D ⦄ {F G : Functor C D} {α β : NatTrans F G} where
-    open Precategory
-    open isCategory
+  module _ {F G : Functor C D} {α β : NatTrans F G} where
+    open Category
     open Functor
     open NatTrans
 
@@ -182,32 +181,26 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
     makeNatTransPath p i .N-ob = p i
     makeNatTransPath p i .N-hom f = rem i
       where
-        rem : PathP (λ i → (F .F-hom f) ⋆ᴰ (p i _) ≡ (p i _) ⋆ᴰ (G .F-hom f)) (α .N-hom f) (β .N-hom f)
-        rem = toPathP (isCatD .isSetHom _ _ _ _)
+        rem : PathP (λ i → (F .F-hom f) ⋆ᴰ (p i _) ≡ (p i _) ⋆ᴰ (G .F-hom f))
+                    (α .N-hom f) (β .N-hom f)
+        rem = toPathP (D .isSetHom _ _ _ _)
 
-  module _  ⦃ isCatD : isCategory D ⦄ {F F' G G' : Functor C D}
-            {α : NatTrans F G}
-            {β : NatTrans F' G'} where
-    open Precategory
-    open isCategory
+  module _  {F F' G G' : Functor C D} {α : NatTrans F G} {β : NatTrans F' G'} where
+    open Category
     open Functor
     open NatTrans
     makeNatTransPathP : ∀ (p : F ≡ F') (q : G ≡ G')
-                      → PathP (λ i → (x : C .ob) → D [ (p i) .F-ob x , (q i) .F-ob x ]) (α .N-ob) (β .N-ob)
+                      → PathP (λ i → (x : C .ob) → D [ (p i) .F-ob x , (q i) .F-ob x ])
+                              (α .N-ob) (β .N-ob)
                       → PathP (λ i → NatTrans (p i) (q i)) α β
     makeNatTransPathP p q P i .N-ob = P i
     makeNatTransPathP p q P i .N-hom f = rem i
       where
-        rem : PathP (λ i → ((p i) .F-hom f) ⋆ᴰ (P i _) ≡ (P i _) ⋆ᴰ ((q i) .F-hom f)) (α .N-hom f) (β .N-hom f)
-        rem = toPathP (isCatD .isSetHom _ _ _ _)
+        rem : PathP (λ i → ((p i) .F-hom f) ⋆ᴰ (P i _) ≡ (P i _) ⋆ᴰ ((q i) .F-hom f))
+                    (α .N-hom f) (β .N-hom f)
+        rem = toPathP (D .isSetHom _ _ _ _)
 
-
-
-private
-  variable
-    ℓA ℓA' ℓB ℓB' : Level
-
-module _ {B : Precategory ℓB ℓB'} {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
+module _ {B : Category ℓB ℓB'} {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   open NatTrans
   -- whiskering
   -- αF

--- a/Cubical/Categories/NaturalTransformation/Properties.agda
+++ b/Cubical/Categories/NaturalTransformation/Properties.agda
@@ -20,11 +20,10 @@ private
 open isIsoC
 open NatIso
 open NatTrans
-open Precategory
-open isCategory
+open Category
 open Functor
 
-module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   private
     _⋆ᴰ_ : ∀ {x y z} (f : D [ x , y ]) (g : D [ y , z ]) → D [ x , z ]
     f ⋆ᴰ g = f ⋆⟨ D ⟩ g
@@ -89,7 +88,7 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
 
       NTPath≡PathΣ = ua NTPath≃PathΣ
 
-  module _ ⦃ isCatD : isCategory D ⦄ where
+  module _ where
     open NatTransP
 
     -- if the target category has hom Sets, then any natural transformation is a set
@@ -125,11 +124,11 @@ module _ {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'} where
 
         -- the Ob function is a set
         isSetN-ob : isSet ((x : C .ob) → D [(F .F-ob x) , (G .F-ob x)])
-        isSetN-ob = isOfHLevelΠ 2 λ _ → isCatD .isSetHom
+        isSetN-ob = isOfHLevelΠ 2 λ _ → D .isSetHom
 
         -- the Hom function is a set
         isSetN-hom : (ϕ : typeN-ob) → isSet (typeN-hom ϕ)
-        isSetN-hom γ = isProp→isSet (isPropImplicitΠ λ x → isPropImplicitΠ λ y → isPropΠ λ f → isCatD .isSetHom _ _)
+        isSetN-hom γ = isProp→isSet (isPropImplicitΠ2 λ x y → isPropΠ λ f → D .isSetHom _ _)
 
         -- in fact it's a dependent Set, which we need because N-hom depends on N-ob
         isSetN-homP : isOfHLevelDep 2 (λ γ → {x y : C .ob} (f : C [ x , y ]) → (F .F-hom f) ⋆ᴰ (γ y) ≡ (γ x) ⋆ᴰ (G .F-hom f))

--- a/Cubical/Categories/Presheaf/Base.agda
+++ b/Cubical/Categories/Presheaf/Base.agda
@@ -1,25 +1,13 @@
-{-# OPTIONS --postfix-projections --safe #-}
-
+{-# OPTIONS --safe #-}
 module Cubical.Categories.Presheaf.Base where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Equiv
-open import Cubical.HITs.PropositionalTruncation
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Functor
-open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Functors
 
-module _ {ℓ ℓ'} where
-
-  PreShv : Precategory ℓ ℓ' → (ℓS : Level)
-         → Precategory (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS)) (ℓ-max (ℓ-max ℓ ℓ') ℓS)
-  PreShv C ℓS = FUNCTOR (C ^op) (SET ℓS)
-
-instance
-  isCatPreShv : ∀ {ℓ ℓ'} {C : Precategory ℓ ℓ'} {ℓS}
-    → isCategory (PreShv C ℓS)
-  isCatPreShv {C = C} {ℓS} = isCatFUNCTOR (C ^op) (SET ℓS)
+PreShv : ∀ {ℓ ℓ'} → Category ℓ ℓ' → (ℓS : Level)
+       → Category (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS))
+                  (ℓ-max (ℓ-max ℓ ℓ') ℓS)
+PreShv C ℓS = FUNCTOR (C ^op) (SET ℓS)

--- a/Cubical/Categories/Presheaf/KanExtension.agda
+++ b/Cubical/Categories/Presheaf/KanExtension.agda
@@ -27,7 +27,7 @@ open import Cubical.Categories.Instances.Sets
 -}
 
 module Lan {ℓC ℓC' ℓD ℓD'} ℓS
-  {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'}
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
   (F : Functor C D)
   where
 
@@ -35,8 +35,8 @@ module Lan {ℓC ℓC' ℓD ℓD'} ℓS
   open NatTrans
 
   private
-    module C = Precategory C
-    module D = Precategory D
+    module C = Category C
+    module D = Category D
 
     {-
       We want the category SET ℓ we're mapping into to be large enough that the coend will take presheaves
@@ -197,7 +197,7 @@ module Lan {ℓC ℓC' ℓD ℓD'} ℓS
 -}
 
 module Ran {ℓC ℓC' ℓD ℓD'} ℓS
-  {C : Precategory ℓC ℓC'} {D : Precategory ℓD ℓD'}
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
   (F : Functor C D)
   where
 
@@ -205,8 +205,8 @@ module Ran {ℓC ℓC' ℓD ℓD'} ℓS
   open NatTrans
 
   private
-    module C = Precategory C
-    module D = Precategory D
+    module C = Category C
+    module D = Category D
 
     {-
       We want the category SET ℓ we're mapping into to be large enough that the coend will take presheaves

--- a/Cubical/Categories/Presheaf/Properties.agda
+++ b/Cubical/Categories/Presheaf/Properties.agda
@@ -27,14 +27,14 @@ private
 
 
 -- (PreShv C) / F ≃ᶜ PreShv (∫ᴾ F)
-module _ {ℓS : Level} (C : Precategory ℓ ℓ') (F : Functor (C ^op) (SET ℓS)) where
-  open Precategory
+module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS)) where
+  open Category
   open Functor
   open _≃ᶜ_
   open isEquivalence
   open NatTrans
   open NatIso
-  open Slice (PreShv C ℓS) F ⦃ isCatPreShv {C = C} ⦄
+  open Slice (PreShv C ℓS) F
   open Elements {C = C}
 
   open Fibration.ForSets

--- a/Cubical/Categories/TypesOfCategories/TypeCategory.agda
+++ b/Cubical/Categories/TypesOfCategories/TypeCategory.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --postfix-projections --safe #-}
+{-# OPTIONS --safe #-}
 
 module Cubical.Categories.TypesOfCategories.TypeCategory where
 
@@ -18,9 +18,9 @@ open import Cubical.Categories.Instances.Sets
 
 open Fibration.ForSets
 
-record isTypeCategory {ℓ ℓ' ℓ''} (C : Precategory ℓ ℓ')
+record isTypeCategory {ℓ ℓ' ℓ''} (C : Category ℓ ℓ')
        : Type (ℓ-max ℓ (ℓ-max ℓ' (ℓ-suc ℓ''))) where
-  open Precategory C
+  open Category C
   open Cospan
   open PullbackLegs
   open isPullback
@@ -54,9 +54,9 @@ record isTypeCategory {ℓ ℓ' ℓ''} (C : Precategory ℓ ℓ')
                       (pblegs (π Γ' (reindex f A)) q⟨ f , A ⟩)
 
 -- presheaves are type contexts
-module _ {ℓ ℓ' ℓ'' : Level} (C : Precategory ℓ ℓ') where
+module _ {ℓ ℓ' ℓ'' : Level} (C : Category ℓ ℓ') where
   open isTypeCategory
-  open Precategory
+  open Category
   open Functor
   open NatTrans
   open isPullback

--- a/Cubical/Categories/TypesOfCategories/TypeCategory.agda
+++ b/Cubical/Categories/TypesOfCategories/TypeCategory.agda
@@ -62,12 +62,14 @@ module _ {ℓ ℓ' ℓ'' : Level} (C : Category ℓ ℓ') where
   open isPullback
 
   private
+    isSurjSET : ∀ {ℓ} {A B : SET ℓ .ob} → (f : SET ℓ [ A , B ]) → Type _
+    isSurjSET {A = A} {B} f = ∀ (b : fst B) → Σ[ a ∈ fst A ] f a ≡ b
+
     -- types over Γ are types with a "projection" (aka surjection) to Γ
     PSTy[_] : PreShv C ℓ'' .ob → Type _
     PSTy[ Γ ] = Σ[ ΓA ∈ PreShv C ℓ'' .ob ]
                    Σ[ π ∈ ΓA ⇒ Γ ]
-                     (∀ (c : C .ob)
-                     → isSurjSET {A = ΓA ⟅ c ⟆} {Γ ⟅ c ⟆} (π ⟦ c ⟧))
+                     (∀ (c : C .ob) → isSurjSET {A = ΓA ⟅ c ⟆} {Γ ⟅ c ⟆} (π ⟦ c ⟧))
 
     -- just directly use types from above as context extensions
     PSCext : (Γ : _) → PSTy[ Γ ] → Σ[ ΓA ∈ PreShv C ℓ'' .ob ] ΓA ⇒ Γ

--- a/Cubical/Categories/Yoneda.agda
+++ b/Cubical/Categories/Yoneda.agda
@@ -23,23 +23,13 @@ private
 
 -- THE YONEDA LEMMA
 
-open isCategory
 open NatTrans
 open NatTransP
 open Functor
 open Iso
 
-module _ (A B : Type ℓ) (f : A → B) where
-
-  isInj = ∀ (x y : A) → (f x ≡ f y) → x ≡ y
-  isSurj = ∀ (b : B) → Σ[ a ∈ A ] f a ≡ b
-
-  bijectionToIso : isInj × isSurj
-                 → isIso f
-  bijectionToIso (i , s) = (λ b → fst (s b)) , (λ b → snd (s b)) , λ a → i (fst (s (f a))) a (snd (s (f a)))
-
-module _ {C : Precategory ℓ ℓ'} ⦃ isCatC : isCategory C ⦄ where
-  open Precategory
+module _ {C : Category ℓ ℓ'} where
+  open Category
 
   yoneda : (F : Functor C (SET ℓ'))
          → (c : C .ob)
@@ -92,11 +82,8 @@ module _ {C : Precategory ℓ ℓ'} ⦃ isCatC : isCategory C ⦄ where
           αh≡βh : PathP (λ i → NHType (αo≡βo i)) αh βh -- αh βh
           αh≡βh = isPropHomP αh βh αo≡βo
             where
-              isProp-hom : ⦃ isCatSET : isCategory (SET ℓ') ⦄ → (ϕ : NOType) → isProp (NHType ϕ)
-              isProp-hom ⦃ isCatSET ⦄ γ = isPropImplicitΠ λ x
-                                        → isPropImplicitΠ λ y
-                                        → isPropΠ λ f
-                                        → isCatSET .isSetHom {x = (C [ c , x ]) , (isCatC .isSetHom)} {F ⟅ y ⟆} _ _
+              isProp-hom : (ϕ : NOType) → isProp (NHType ϕ)
+              isProp-hom γ = isPropImplicitΠ2 λ x y → isPropΠ λ f → isSetHom (SET _) {x = (C [ c , x ]) , C .isSetHom } {F ⟅ y ⟆} _ _
 
               isPropHomP : isOfHLevelDep 1 (λ ηo → NHType ηo)
               isPropHomP = isOfHLevel→isOfHLevelDep 1 λ a → isProp-hom a
@@ -135,14 +122,14 @@ module _ {C : Precategory ℓ ℓ'} ⦃ isCatC : isCategory C ⦄ where
 
 -- Yoneda embedding
 -- TODO: probably want to rename/refactor
-module _ {C : Precategory ℓ ℓ} ⦃ C-cat : isCategory C ⦄ where
+module _ {C : Category ℓ ℓ} where
   open Functor
   open NatTrans
-  open Precategory C
+  open Category C
 
   yo : ob → Functor (C ^op) (SET ℓ)
   yo x .F-ob y .fst = C [ y , x ]
-  yo x .F-ob y .snd = C-cat .isSetHom
+  yo x .F-ob y .snd = isSetHom
   yo x .F-hom f g = f ⋆⟨ C ⟩ g
   yo x .F-id i f = ⋆IdL f i
   yo x .F-seq f g i h = ⋆Assoc g f h i

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -15,6 +15,7 @@ private
     D : (a : A) (b : B a) → C a b → Type ℓ
     E : (x : A) → (y : B x) → (z : C x y) → (w : D x y z) → Type ℓ
     F : (x : A) → (y : B x) → (z : C x y) → (w : D x y z) → (u : E x y z w) → Type ℓ
+
 -- The identity function
 idfun : (A : Type ℓ) → A → A
 idfun _ x = x

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -341,6 +341,10 @@ isOfHLevelΣ {B = B} (suc (suc n)) h1 h2 x y =
 isSetΣ : isSet A → ((x : A) → isSet (B x)) → isSet (Σ A B)
 isSetΣ = isOfHLevelΣ 2
 
+-- Useful consequence
+isSetΣSndProp : isSet A → ((x : A) → isProp (B x)) → isSet (Σ A B)
+isSetΣSndProp h p = isSetΣ h (λ x → isProp→isSet (p x))
+
 isGroupoidΣ : isGroupoid A → ((x : A) → isGroupoid (B x)) → isGroupoid (Σ A B)
 isGroupoidΣ = isOfHLevelΣ 3
 


### PR DESCRIPTION
Precategories are now in a separate file and almost nothing relies on it (I think it's only the precategory of types that does at the moment). 

I did not yet fix cospans and limits. I might redefine the cospan category to rely on Fin instead to get a slicker definition

This PR fixes issue https://github.com/agda/cubical/issues/625