### PR TITLE
Free abelian categories

### DIFF
--- a/Cubical/Categories/Abelian.agda
+++ b/Cubical/Categories/Abelian.agda
@@ -1,0 +1,5 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Abelian where
+
+open import Cubical.Categories.Abelian.Base public

--- a/Cubical/Categories/Abelian.agda
+++ b/Cubical/Categories/Abelian.agda
@@ -2,4 +2,5 @@
 
 module Cubical.Categories.Abelian where
 
+open import Cubical.Categories.Abelian.Adelman public
 open import Cubical.Categories.Abelian.Base public

--- a/Cubical/Categories/Abelian/Adelman.agda
+++ b/Cubical/Categories/Abelian/Adelman.agda
@@ -1,0 +1,607 @@
+-- Adelman's construction of the free abelian category
+-- over an additive category
+--   see https://arxiv.org/pdf/2103.08379.pdf
+-- Notation is derived from the paper
+
+{-# OPTIONS #-}
+
+module Cubical.Categories.Abelian.Adelman where
+
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Categories.Abelian.Base
+open import Cubical.Categories.Additive
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Constructions.Quotient
+open import Cubical.Categories.Limits.Initial
+open import Cubical.Categories.Limits.Terminal
+open import Cubical.Data.Sigma
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Prelude
+open import Cubical.HITs.SetQuotients renaming ([_] to ⟦_⟧)
+open import Cubical.Reflection.RecordEquiv
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (A : AdditiveCategory ℓ ℓ') where
+  open AdditiveCategory A
+  open PreaddCategoryTheory preaddcat
+
+  {-
+      Following the paper, we:
+        1. Define an additive category A^Δ
+        2. Define a congruence relation ~ on A^Δ
+        3. Take the quotient  A^Δ / ~  =:  Adel(A)
+        4. Define abelian structure on Adel(A)
+  -}
+
+
+  ---------------------------------------
+  --  1a. CATEGORY STRUCTURE OF A^Δ
+  ---------------------------------------
+
+  -- Objects are composable pairs
+  --    r ───ρ───► a ───γ───► c
+  record CompPair : Type (ℓ-max ℓ ℓ') where
+    constructor cpair
+    field
+      r : ob
+      a : ob
+      c : ob
+      ρ : Hom[ r , a ]
+      γ : Hom[ a , c ]
+
+  open CompPair
+
+
+  -- Morphisms between composable pairs
+  {-  
+        X         rX ───ρX───► aX ───γX───► cX
+        │         │            │            │
+        f         ωf           αf           ψf
+        │         │            │            │
+        ▼         ▼            ▼            ▼ 
+        Y         rY ───ρY───► aY ───γY───► cY
+  -}
+  record _⇒_ (X Y : CompPair) : Type (ℓ-max ℓ ℓ') where
+    constructor cphom
+    field
+      ω : Hom[ r X , r Y ]
+      α : Hom[ a X , a Y ]
+      ψ : Hom[ c X , c Y ]
+      comm-ρ : ρ X ⋆ α ≡ ω ⋆ ρ Y
+      comm-γ : γ X ⋆ ψ ≡ α ⋆ γ Y
+
+  open _⇒_
+
+  -- _⇒_ isomorphic to a Σ-type
+  unquoteDecl ⇒IsoΣ = declareRecordIsoΣ ⇒IsoΣ (quote _⇒_)
+
+
+  -- Identity morphism - each component is identity
+  idₐ : {X : CompPair} → X ⇒ X
+  idₐ {X} = cphom id id id
+      (⋆IdR _ ∙ sym (⋆IdL _)) (⋆IdR _ ∙ sym (⋆IdL _))
+
+
+  -- Composition - pointwise
+  module _ {X Y Z : CompPair}
+           (f : X ⇒ Y)
+           (g : Y ⇒ Z) where
+
+    _⋆ₐ_ : X ⇒ Z
+    _⋆ₐ_ .ω = ω f ⋆ ω g
+    _⋆ₐ_ .α = α f ⋆ α g
+    _⋆ₐ_ .ψ = ψ f ⋆ ψ g
+
+    _⋆ₐ_ .comm-ρ =
+        ρ X ⋆ (α f ⋆ α g)       ≡⟨ sym (⋆Assoc _ _ _) ⟩
+        (ρ X ⋆ α f) ⋆ α g       ≡⟨ cong (_⋆ α g) (f .comm-ρ) ⟩
+        (ω f ⋆ ρ Y) ⋆ α g       ≡⟨ ⋆Assoc _ _ _ ⟩
+        ω f ⋆ (ρ Y ⋆ α g)       ≡⟨ cong (ω f ⋆_) (g .comm-ρ) ⟩
+        ω f ⋆ (ω g ⋆ ρ Z)       ≡⟨ sym (⋆Assoc _ _ _) ⟩
+        (ω f ⋆ ω g) ⋆ ρ Z       ∎
+
+    _⋆ₐ_ .comm-γ =
+        γ X ⋆ (ψ f ⋆ ψ g)       ≡⟨ sym (⋆Assoc _ _ _) ⟩
+        (γ X ⋆ ψ f) ⋆ ψ g       ≡⟨ cong (_⋆ ψ g) (f .comm-γ) ⟩
+        (α f ⋆ γ Y) ⋆ ψ g       ≡⟨ ⋆Assoc _ _ _ ⟩
+        α f ⋆ (γ Y ⋆ ψ g)       ≡⟨ cong (α f ⋆_) (g .comm-γ) ⟩
+        α f ⋆ (α g ⋆ γ Z)       ≡⟨ sym (⋆Assoc _ _ _) ⟩
+        (α f ⋆ α g) ⋆ γ Z       ∎
+
+    infixr 9 _⋆ₐ_
+
+
+  -- Equality of `f g : X ⇒ Y` is pointwise
+  private
+    eqLift : {X Y : CompPair} {f g : X ⇒ Y}
+          → (ω f ≡ ω g) → (α f ≡ α g) → (ψ f ≡ ψ g)
+          → f ≡ g
+    eqLift eqω eqα eqψ = isoFunInjective ⇒IsoΣ _ _
+        (ΣPathP (eqω , ΣPathP (eqα , ΣPathP (eqψ , ΣPathP
+        (toPathP (isSetHom _ _ _ _) , toPathP (isSetHom _ _ _ _))))))
+
+
+  -- Left identity
+  ⋆ₐIdL : {X Y : CompPair} (f : X ⇒ Y) →
+      idₐ ⋆ₐ f ≡ f
+  ⋆ₐIdL f = eqLift (⋆IdL _) (⋆IdL _) (⋆IdL _)
+
+  -- Right identity
+  ⋆ₐIdR : {X Y : CompPair} (f : X ⇒ Y) →
+      f ⋆ₐ idₐ ≡ f
+  ⋆ₐIdR f = eqLift (⋆IdR _) (⋆IdR _) (⋆IdR _)
+
+  -- Associativity
+  ⋆ₐAssoc : {X Y Z W : CompPair}
+    (f : X ⇒ Y) (g : Y ⇒ Z) (h : Z ⇒ W) →
+      (f ⋆ₐ g) ⋆ₐ h  ≡  f ⋆ₐ (g ⋆ₐ h)
+  ⋆ₐAssoc f g h = eqLift (⋆Assoc _ _ _) (⋆Assoc _ _ _) (⋆Assoc _ _ _)
+
+  -- `⇒` is a set
+  isSet⇒ : ∀ {X Y} → isSet (X ⇒ Y)
+  isSet⇒ = isOfHLevelRetractFromIso 2 ⇒IsoΣ
+    (isSetΣ isSetHom λ ω →   isSetΣ isSetHom λ α →   isSetΣ isSetHom λ ψ →
+          isProp→isSet (isPropΣ (isSetHom _ _) (λ comm-ρ → isSetHom _ _)))
+
+
+  A^Δ : Category (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  A^Δ .Category.ob = CompPair
+  A^Δ .Category.Hom[_,_] = _⇒_
+  A^Δ .Category.id = idₐ
+  A^Δ .Category._⋆_ = _⋆ₐ_
+  A^Δ .Category.⋆IdL = ⋆ₐIdL
+  A^Δ .Category.⋆IdR = ⋆ₐIdR
+  A^Δ .Category.⋆Assoc = ⋆ₐAssoc
+  A^Δ .Category.isSetHom = isSet⇒
+
+
+  ---------------------------------------
+  --  1b. PREADDITIVE STRUCTURE ON A^Δ
+  ---------------------------------------
+
+  -- Abelian group structure
+  module _ {X Y : CompPair} where
+  
+    0ₐ : X ⇒ Y
+    0ₐ = cphom 0h 0h 0h ((⋆0hr _) ∙ (sym (⋆0hl _)))
+                        ((⋆0hr _) ∙ (sym (⋆0hl _)))
+
+    _+ₐ_ : (f g : X ⇒ Y) → (X ⇒ Y)
+    f +ₐ g = cphom (ω f + ω g) (α f + α g) (ψ f + ψ g)
+      (
+        ρ X ⋆ (α f + α g)           ≡⟨ ⋆distl+ _ _ _ ⟩
+        ρ X ⋆ α f  +  ρ X ⋆ α g     ≡⟨ cong₂ _+_ (comm-ρ f) (comm-ρ g) ⟩
+        ω f ⋆ ρ Y  +  ω g ⋆ ρ Y     ≡⟨ sym (⋆distr+ _ _ _) ⟩
+        (ω f + ω g) ⋆ ρ Y           ∎
+      )(
+        γ X ⋆ (ψ f + ψ g)           ≡⟨ ⋆distl+ _ _ _ ⟩
+        γ X ⋆ ψ f  +  γ X ⋆ ψ g     ≡⟨ cong₂ _+_ (comm-γ f) (comm-γ g) ⟩
+        α f ⋆ γ Y  +  α g ⋆ γ Y     ≡⟨ sym (⋆distr+ _ _ _) ⟩
+        (α f + α g) ⋆ γ Y           ∎
+      )
+
+    infixr 7 _+ₐ_
+
+    -ₐ : X ⇒ Y → X ⇒ Y
+    -ₐ f = cphom (- ω f) (- α f) (- ψ f)
+      (
+        ρ X ⋆ (- α f)     ≡⟨ -distr⋆ _ _ ⟩
+        - ρ X ⋆ α f       ≡⟨ cong -_ (comm-ρ f) ⟩
+        - ω f ⋆ ρ Y       ≡⟨ sym (-distl⋆ _ _) ⟩
+        (- ω f) ⋆ ρ Y     ∎
+      )(
+        γ X ⋆ (- ψ f)     ≡⟨ -distr⋆ _ _ ⟩
+        - γ X ⋆ ψ f       ≡⟨ cong -_ (comm-γ f) ⟩
+        - α f ⋆ γ Y       ≡⟨ sym (-distl⋆ _ _) ⟩
+        (- α f) ⋆ γ Y     ∎
+      )
+
+
+    -- Abelian group axioms
+    +ₐassoc : (f g h : X ⇒ Y) →
+      f +ₐ (g +ₐ h) ≡ (f +ₐ g) +ₐ h
+    +ₐassoc f g h = eqLift (+assoc _ _ _) (+assoc _ _ _) (+assoc _ _ _)
+
+    +ₐidr : (f : X ⇒ Y) → f +ₐ 0ₐ ≡ f
+    +ₐidr f = eqLift (+idr _) (+idr _) (+idr _)
+
+    +ₐinvr : (f : X ⇒ Y) → f +ₐ (-ₐ f) ≡ 0ₐ
+    +ₐinvr f = eqLift (+invr _) (+invr _) (+invr _)
+
+    +ₐcomm : (f g : X ⇒ Y) → f +ₐ g ≡ g +ₐ f
+    +ₐcomm f g = eqLift (+comm _ _) (+comm _ _) (+comm _ _)
+
+
+  -- habstrₐ : HomAbStr A^Δ
+  -- habstrₐ = homabstr (λ _ _ →
+  --     abgroupstr (0ₐ) (_+ₐ_) (-ₐ)
+  --     (makeIsAbGroup  isSet⇒  +ₐassoc  +ₐidr  +ₐinvr  +ₐcomm))
+
+
+  -- Distributivity
+  module _ {X Y Z : CompPair} where
+
+    ⋆distl+ₐ : (f : X ⇒ Y) (g g' : Y ⇒ Z) →
+        f ⋆ₐ (g +ₐ g')  ≡  (f ⋆ₐ g) +ₐ (f ⋆ₐ g')
+    ⋆distl+ₐ f g g' = eqLift (⋆distl+ _ _ _) (⋆distl+ _ _ _) (⋆distl+ _ _ _)
+
+    ⋆distr+ₐ : (f f' : X ⇒ Y) (g : Y ⇒ Z) →
+        (f +ₐ f') ⋆ₐ g  ≡  (f ⋆ₐ g) +ₐ (f' ⋆ₐ g)
+    ⋆distr+ₐ f g g' = eqLift (⋆distr+ _ _ _) (⋆distr+ _ _ _) (⋆distr+ _ _ _)
+
+
+  A^Δ-preadd : PreaddCategory (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  A^Δ-preadd .PreaddCategory.cat = A^Δ
+  A^Δ-preadd .PreaddCategory.preadd .PreaddCategoryStr.homAbStr X Y =
+    abgroupstr (0ₐ) (_+ₐ_) (-ₐ)
+      (makeIsAbGroup  isSet⇒  +ₐassoc  +ₐidr  +ₐinvr  +ₐcomm)
+  A^Δ-preadd .PreaddCategory.preadd .PreaddCategoryStr.⋆distl+ = ⋆distl+ₐ
+  A^Δ-preadd .PreaddCategory.preadd .PreaddCategoryStr.⋆distr+ = ⋆distr+ₐ
+  
+
+  ---------------------------------------
+  --  1c. ADDITIVE STRUCTURE ON A^Δ
+  ---------------------------------------
+
+  -- Zero object
+  private
+    open ZeroObject zero renaming (z to zA)
+
+    zA→ : {x : ob} → Hom[ zA , x ]
+    zA→ {x} = zInit x .fst
+
+    →zA : {x : ob} → Hom[ x , zA ]
+    →zA {x} = zTerm x .fst
+
+  zₐ : CompPair
+  zₐ = cpair zA zA zA id id
+
+  zₐInit : isInitial A^Δ zₐ
+  zₐInit X = (cphom zA→ zA→ zA→ (isContr→isProp (zInit _) _ _)
+      (isContr→isProp (zInit _) _ _)) ,
+      λ f → eqLift (zInit _ .snd _) (zInit _ .snd _) (zInit _ .snd _)
+
+  zₐTerm : isTerminal A^Δ zₐ
+  zₐTerm X = (cphom →zA →zA →zA (isContr→isProp (zTerm _) _ _)
+      (isContr→isProp (zTerm _) _ _)) ,
+      λ f → eqLift (zTerm _ .snd _) (zTerm _ .snd _) (zTerm _ .snd _)
+
+  
+  -- Biproducts
+  open MatrixNotation A
+
+  module _ (X Y : CompPair) where
+    biprodₐ : Biproduct A^Δ-preadd X Y
+    biprodₐ .Biproduct.x⊕y =
+      cpair (r X ⊕ r Y) (a X ⊕ a Y) (c X ⊕ c Y)
+            (ρ X ` 0h ∣ 0h ` ρ Y) (γ X ` 0h ∣ 0h ` γ Y)
+
+    -- Everything else follows pointwise
+    biprodₐ .Biproduct.i₁ = cphom i₁ i₁ i₁ (sym (i₁⋆diag _ _)) (sym (i₁⋆diag _ _))
+    biprodₐ .Biproduct.i₂ = cphom i₂ i₂ i₂ (sym (i₂⋆diag _ _)) (sym (i₂⋆diag _ _))
+    biprodₐ .Biproduct.π₁ = cphom π₁ π₁ π₁      (diag⋆π₁ _ _)       (diag⋆π₁ _ _)
+    biprodₐ .Biproduct.π₂ = cphom π₂ π₂ π₂      (diag⋆π₂ _ _)       (diag⋆π₂ _ _)
+
+    biprodₐ .Biproduct.isBipr .IsBiproduct.i₁⋆π₁ = eqLift i₁⋆π₁ i₁⋆π₁ i₁⋆π₁
+    biprodₐ .Biproduct.isBipr .IsBiproduct.i₁⋆π₂ = eqLift i₁⋆π₂ i₁⋆π₂ i₁⋆π₂
+    biprodₐ .Biproduct.isBipr .IsBiproduct.i₂⋆π₁ = eqLift i₂⋆π₁ i₂⋆π₁ i₂⋆π₁
+    biprodₐ .Biproduct.isBipr .IsBiproduct.i₂⋆π₂ = eqLift i₂⋆π₂ i₂⋆π₂ i₂⋆π₂
+    biprodₐ .Biproduct.isBipr .IsBiproduct.∑π⋆i  = eqLift ∑π⋆i  ∑π⋆i  ∑π⋆i
+
+
+  ---------------------------------------
+  --  2. CONGRUENCE RELATION ~ ON A^Δ
+  ---------------------------------------
+  
+  {-  Given two parallel morphisms
+
+          X           rX ───ρX───► aX ───γX───► cX
+          ││          ││           ││           ││
+         f││g       ωf││ωg       αf││αg       ψf││ψg
+          ││          ││           ││           ││
+          ▼▼          ▼▼           ▼▼           ▼▼ 
+          Y           rY ───ρY───► aY ───γY───► cY
+
+      we say f ~ g if there exist
+
+               ╭────────── aX ───γX───► cX
+               │           ││            │
+             ∃ σ₁        αf││αg        ∃ σ₂
+               │           ││            │
+               ▼           ▼▼            │
+              rY ───ρY───► aY ◄──────────╯
+
+      such that  αf ─ αg  ≡  σ₁ ⋆ ρY  +  γX ⋆ σ₂.
+  -}
+  record _~_ {X Y : CompPair} (f g : X ⇒ Y) : Type (ℓ-max ℓ ℓ') where
+    field
+      σ₁ : Hom[ a X , r Y ]
+      σ₂ : Hom[ c X , a Y ]
+      eq :  α f ─ α g  ≡  σ₁ ⋆ ρ Y  +  γ X ⋆ σ₂
+
+  infix 5 _~_
+  open _~_
+
+
+  -- Reflexivity
+  ~refl : {X Y : CompPair} (f : X ⇒ Y) → f ~ f
+  ~refl f .σ₁ = 0h
+  ~refl f .σ₂ = 0h
+  ~refl {X} {Y} f .eq =
+      α f ─ α f                   ≡⟨ +invr _ ⟩
+      0h                          ≡⟨ sym (+idr _) ⟩
+      0h + 0h                     ≡⟨ cong (_+ 0h) (sym (⋆0hl _)) ⟩
+      (0h ⋆ ρ Y) + 0h             ≡⟨ cong ((0h ⋆ ρ Y) +_) (sym (⋆0hr _)) ⟩
+      (0h ⋆ ρ Y) + (γ X ⋆ 0h)     ∎
+
+
+  module _ {X Y : CompPair} where
+    -- Congruent with addition
+    ~cong+ : (f f' g g' : X ⇒ Y) →
+        f ~ f' → g ~ g' → (f +ₐ g) ~ (f' +ₐ g')
+    ~cong+ f f' g g' f~f' g~g' = λ where
+      .σ₁ →  σ₁ f~f' + σ₁ g~g'
+      .σ₂ →  σ₂ f~f' + σ₂ g~g'
+      .eq → 
+        (α f + α g) ─ (α f' + α g')
+                ≡⟨ cong ((α f + α g) +_) (-dist+ _ _) ⟩
+        (α f + α g) + (- α f' ─ α g')
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (α f ─ α f') + (α g ─ α g')
+                ≡⟨ cong₂ _+_ (f~f' .eq) (g~g' .eq) ⟩
+        (σ₁ f~f' ⋆ ρ Y  +  γ X ⋆ σ₂ f~f')  +  (σ₁ g~g' ⋆ ρ Y  +  γ X ⋆ σ₂ g~g')
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (σ₁ f~f' ⋆ ρ Y  +  σ₁ g~g' ⋆ ρ Y)  +  (γ X ⋆ σ₂ f~f'  +  γ X ⋆ σ₂ g~g')
+                ≡⟨ sym (cong₂ _+_ (⋆distr+ _ _ _) (⋆distl+ _ _ _)) ⟩
+        (σ₁ f~f' + σ₁ g~g') ⋆ ρ Y  +  γ X ⋆ (σ₂ f~f' + σ₂ g~g')
+                ∎
+
+    -- Congruent with negation
+    ~cong- : (f g : X ⇒ Y) →
+        f ~ g → (-ₐ f) ~ (-ₐ g)
+    ~cong- f g f~g = λ where
+      .σ₁ →  - σ₁ f~g
+      .σ₂ →  - σ₂ f~g
+      .eq →
+        - α f ─ (- α g)                           ≡⟨ sym (-dist+ _ _) ⟩
+        - (α f ─ α g)                             ≡⟨ cong -_ (f~g .eq) ⟩
+        - (σ₁ f~g ⋆ ρ Y  +  γ X ⋆ σ₂ f~g)         ≡⟨ -dist+ _ _ ⟩
+        - (σ₁ f~g ⋆ ρ Y)  +  - (γ X ⋆ σ₂ f~g)     ≡⟨ cong (_─ _ ⋆ _) (sym (-distl⋆ _ _)) ⟩
+        (- σ₁ f~g) ⋆ ρ Y  +  - (γ X ⋆ σ₂ f~g)     ≡⟨ cong (_ ⋆ _ +_) (sym (-distr⋆ _ _)) ⟩
+        (- σ₁ f~g) ⋆ ρ Y  +  γ X ⋆ (- σ₂ f~g)     ∎
+
+
+  -- Congruent with composition
+  ~cong⋆ : {X Y Z : CompPair}
+          (f f' : X ⇒ Y) → f ~ f' →
+          (g g' : Y ⇒ Z) → g ~ g'
+        → (f ⋆ₐ g) ~ (f' ⋆ₐ g')
+
+  ~cong⋆ {X} {Y} {Z} f f' f~f' g g' g~g' = λ where
+    .σ₁ → (σ₁ f~f') ⋆ ω g  +  α f' ⋆ (σ₁ g~g')
+    .σ₂ → (σ₂ f~f') ⋆ α g  +  ψ f' ⋆ (σ₂ g~g')
+    .eq →
+      let σ₁f⋆ωg⋆ρZ   = (σ₁ f~f' ⋆ ω g) ⋆ ρ Z;    γX⋆σ₂f⋆αg  = γ X ⋆ (σ₂ f~f' ⋆ α g);
+           αf'⋆σ₁g⋆ρZ = (α f' ⋆ σ₁ g~g') ⋆ ρ Z;   γX⋆ψf'⋆σ₂g = γ X ⋆ (ψ f' ⋆ σ₂ g~g') in
+      α f ⋆ α g  ─  α f' ⋆ α g'
+              ≡⟨ cong (_ +_) (sym (+idl _)) ⟩
+      α f ⋆ α g  +  0h  ─  α f' ⋆ α g'
+              ≡⟨ cong (λ u → _ + u ─ _) (sym (+invl _)) ⟩
+      α f ⋆ α g  +  (- α f' ⋆ α g  +  α f' ⋆ α g)  ─  α f' ⋆ α g'
+              ≡⟨ sym (+4assoc _ _ _ _) ⟩
+      (α f ⋆ α g  ─  α f' ⋆ α g)  +  (α f' ⋆ α g  ─  α f' ⋆ α g')
+              ≡⟨ cong₂ _+_ eq1 eq2 ⟩
+      (σ₁f⋆ωg⋆ρZ  +  γX⋆σ₂f⋆αg)  +  (αf'⋆σ₁g⋆ρZ  +  γX⋆ψf'⋆σ₂g)
+              ≡⟨ +4comm _ _ _ _ ⟩
+      (σ₁f⋆ωg⋆ρZ  +  αf'⋆σ₁g⋆ρZ)  +  (γX⋆σ₂f⋆αg  +  γX⋆ψf'⋆σ₂g)
+              ≡⟨ cong₂ _+_ (sym (⋆distr+ _ _ _)) (sym (⋆distl+ _ _ _)) ⟩
+      (σ₁ f~f' ⋆ ω g + α f' ⋆ σ₁ g~g') ⋆ ρ Z + γ X ⋆ (σ₂ f~f' ⋆ α g + ψ f' ⋆ σ₂ g~g')
+              ∎
+      where
+          eq1 =
+            α f ⋆ α g  ─  α f' ⋆ α g
+                    ≡⟨ cong (α f ⋆ α g +_) (sym (-distl⋆ _ _)) ⟩
+            α f ⋆ α g  +  (- α f') ⋆ α g
+                    ≡⟨ sym (⋆distr+ _ _ _) ⟩
+            (α f ─ α f') ⋆ α g
+                    ≡⟨ cong (_⋆ α g) (eq f~f') ⟩
+            (σ₁ f~f' ⋆ ρ Y  +  γ X ⋆ σ₂ f~f') ⋆ α g
+                    ≡⟨ ⋆distr+ _ _ _ ⟩
+            (σ₁ f~f' ⋆ ρ Y) ⋆ α g  +  (γ X ⋆ σ₂ f~f') ⋆ α g
+                    ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
+            σ₁ f~f' ⋆ (ρ Y ⋆ α g)  +  γ X ⋆ (σ₂ f~f' ⋆ α g)
+                    ≡⟨ cong (λ u → _ ⋆ u + _ ⋆ (σ₂ f~f' ⋆ _)) (g .comm-ρ) ⟩
+            σ₁ f~f' ⋆ (ω g ⋆ ρ Z)  +  γ X ⋆ (σ₂ f~f' ⋆ α g)
+                    ≡⟨ cong (_+ _ ⋆ (σ₂ f~f' ⋆ _)) (sym (⋆Assoc _ _ _)) ⟩
+            (σ₁ f~f' ⋆ ω g) ⋆ ρ Z  +  γ X ⋆ (σ₂ f~f' ⋆ α g)
+                    ∎
+          eq2 =
+            α f' ⋆ α g  ─  α f' ⋆ α g'
+                    ≡⟨ cong (_ +_) (sym (-distr⋆ _ _)) ⟩
+            α f' ⋆ α g  +  α f' ⋆ (- α g')
+                    ≡⟨ sym (⋆distl+ _ _ _) ⟩
+            α f' ⋆ (α g  ─  α g')
+                    ≡⟨ cong (_ ⋆_) (eq g~g') ⟩
+            α f' ⋆ (σ₁ g~g' ⋆ ρ Z  +  γ Y ⋆ σ₂ g~g')
+                    ≡⟨ ⋆distl+ _ _ _ ⟩
+            α f' ⋆ (σ₁ g~g' ⋆ ρ Z)  +  α f' ⋆ (γ Y ⋆ σ₂ g~g')
+                    ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
+            (α f' ⋆ σ₁ g~g') ⋆ ρ Z  +  (α f' ⋆ γ Y) ⋆ σ₂ g~g'
+                    ≡⟨ cong (λ u → (_ ⋆ σ₁ g~g') ⋆ _ + u ⋆ _) (sym (f' .comm-γ)) ⟩
+            (α f' ⋆ σ₁ g~g') ⋆ ρ Z  +  (γ X ⋆ ψ f') ⋆ σ₂ g~g'
+                    ≡⟨ cong (((α f' ⋆ σ₁ g~g') ⋆ ρ Z) +_) (⋆Assoc _ _ _) ⟩
+            (α f' ⋆ σ₁ g~g') ⋆ ρ Z  +  γ X ⋆ (ψ f' ⋆ σ₂ g~g')
+                    ∎
+
+
+  ---------------------------------------
+  --  3.  Adel(A)  :=  A^Δ / ~
+  ---------------------------------------
+
+  AdelAddCat : AdditiveCategory (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  AdelAddCat = AdditiveQuotient
+    record {
+      preaddcat = A^Δ-preadd;
+      addit = record {
+        zero = record { z = zₐ ; zInit = zₐInit ; zTerm = zₐTerm };
+        biprod = biprodₐ } }
+    _~_ ~refl ~cong⋆ ~cong+ ~cong-
+
+
+  ---------------------------------------
+  --  4. ABELIAN STRUCTURE ON Adel(A)
+  ---------------------------------------
+
+  private
+    A^Δ/~      = AdelAddCat .AdditiveCategory.preaddcat
+    Hom[_,_]/~ = AdelAddCat .AdditiveCategory.Hom[_,_]
+  
+  module _ {X Y : CompPair} (f : X ⇒ Y) where
+
+    AdelKerObj = cpair (r X ⊕ r Y) (a X ⊕ r Y) (c X ⊕ a Y)
+          (ρ X ` 0h ∣ 0h ` id) (γ X ` 0h ∣ α f ` ρ Y)
+
+    AdelKer : AdelKerObj ⇒ X
+    AdelKer = cphom (id ` 0h) (id ` 0h) (id ` 0h) {!   !} {!   !}
+
+    ker⋆f : AdelKer ⋆ₐ f ~ 0ₐ
+    ker⋆f = record {
+      σ₁ = (0h ` - id);
+      σ₂ = (0h ` id);
+      eq =
+          (id ` 0h) ⋆ α f  ─  0h
+                  ≡⟨ {!   !} ⟩
+          (id ` 0h) ⋆ α f
+                  ≡⟨ {!   !} ⟩
+          (π₁ ⋆ id  +  π₂ ⋆ 0h) ⋆ α f
+                  ≡⟨ {!   !} ⟩
+          (π₁  +  0h) ⋆ α f
+                  ≡⟨ {!   !} ⟩
+          π₁ ⋆ α f
+                  ≡⟨ {!   !} ⟩
+          (0h ` - id) ⋆ ρ Y  +  (γ X ` 0h ∣ α f ` ρ Y) ⋆ (0h ` id)
+                  ∎
+      }
+
+
+    module _ (W : CompPair) (t : W ⇒ X) (t⋆f~0 : t ⋆ₐ f ~ 0ₐ) where
+
+      u : W ⇒ AdelKerObj
+      u = cphom (ω t ∣ - ρ W ⋆ (σ₁ t⋆f~0))
+                (α t ∣ - σ₁ t⋆f~0)
+                (ψ t ∣ σ₂ t⋆f~0)
+                {!   !} {!   !}
+
+      u-comm : u ⋆ₐ AdelKer ~ t
+      u-comm = record {
+        σ₁ = 0h ;
+        σ₂ = 0h ;
+        eq =
+          α u ⋆ α AdelKer  ─  α t
+                  ≡⟨ refl ⟩
+          (α t ∣ - σ₁ t⋆f~0) ⋆ (id ` 0h)  ─  α t
+                  ≡⟨ cong (_─ _) (innerProd _ _ _ _) ⟩
+          (α t ⋆ id  +  (- σ₁ t⋆f~0) ⋆ 0h)  ─  α t
+                  ≡⟨ cong₂ (λ u₁ v → (u₁ + v) ─ _) (⋆IdR _) (⋆0hr _) ⟩
+          (α t  +  0h)  ─  α t
+                  ≡⟨ cong (_─ _) (+idr _) ⟩
+          α t  ─  α t
+                  ≡⟨ +invr _ ⟩
+          0h
+                  ≡⟨ sym (+idr _) ⟩
+          0h  +  0h
+                  ≡⟨ sym (cong₂ _+_ (⋆0hl _) (⋆0hr _)) ⟩
+          0h ⋆ ρ X  +  γ W ⋆ 0h
+                  ∎
+        }
+
+
+      u-unq : (v : W ⇒ AdelKerObj) → (v ⋆ₐ AdelKer ~ t) → v ~ u
+      u-unq v v⋆k~t = record {
+        σ₁ = (σ₁₁ ∣ σ₁₂);
+        σ₂ = (σ₂₁ ∣ σ₂₂);
+        eq =
+          α v ─ (α t ∣ - σ₁ t⋆f~0)
+                  ≡⟨ {!   !} ⟩
+          (α v ⋆ π₁ ∣ α v ⋆ π₂) ─ (α t ∣ - σ₁ t⋆f~0)
+                  ≡⟨ {!   !} ⟩
+          (α v ⋆ π₁ ─ α t  ∣  α v ⋆ π₂ + σ₁ t⋆f~0)
+                  ≡⟨ {!   !} ⟩
+          (σ₁₁ ⋆ ρ X  +  γ W ⋆ σ₂₁  ∣   σ₁₂  +  γ W ⋆ σ₂₂)
+                  ≡⟨ {!   !} ⟩
+          (σ₁₁ ⋆ ρ X  ∣  σ₁₁ ⋆ 0h)  +  (σ₁₂ ⋆ 0h  ∣  σ₁₂ ⋆ id)  +  (γ W ⋆ σ₂₁  ∣  γ W ⋆ σ₂₂)
+                  ≡⟨ {!   !} ⟩
+          (σ₁₁ ⋆ (ρ X ∣ 0h)  +  σ₁₂ ⋆ (0h ∣ id))  +  (γ W ⋆ σ₂₁  ∣  γ W ⋆ σ₂₂)
+                  ≡⟨ {!   !} ⟩
+          (σ₁₁ ∣ σ₁₂) ⋆ ((ρ X ∣ 0h) ` (0h ∣ id))  +  (γ W ⋆ σ₂₁  ∣  γ W ⋆ σ₂₂)
+                  ≡⟨ {!   !} ⟩
+          (σ₁₁ ∣ σ₁₂) ⋆ (ρ X ` 0h ∣ 0h ` id)  +  γ W ⋆ (σ₂₁ ∣ σ₂₂)
+                  ∎
+        }
+        where
+          σ₁₁ : Hom[ a W , r X ]
+          σ₁₁ = σ₁ v⋆k~t
+
+          σ₁₂ : Hom[ a W , r Y ]
+          σ₁₂ = {!   !}
+
+          σ₂₁ : Hom[ c W , a X ]
+          σ₂₁ = σ₂ v⋆k~t
+
+          σ₂₂ : Hom[ c W , r Y ]
+          σ₂₂ = {!   !}
+
+          eq1 :  α v ⋆ π₁ ─ α t  ≡  σ₁₁ ⋆ ρ X  +  γ W ⋆ σ₂₁
+          eq1 = {!  v⋆k~t .eq  !}
+
+          eq2 :  α v ⋆ π₂ + σ₁ t⋆f~0  ≡  σ₁₂  +  γ W ⋆ σ₂₂
+          eq2 = {!  t⋆f~0 .eq !}
+
+      -- v⋆k~t : v ⋆ₐ AdelKer ~ t
+      --    σ₁ : Hom[ a W , r X ]
+      --    σ₂ : Hom[ c W , a X ]
+      --    eq :  α v ⋆ (id ` 0h)  ─  α t  ≡  σ₁ v⋆k~t ⋆ ρ X  +  γ W ⋆ σ₂ v⋆k~t
+      --          α v ⋆ π₁  ─  α t  ≡  σ₁ v⋆k~t ⋆ ρ X  +  γ W ⋆ σ₂ v⋆k~t
+
+      -- t⋆f~0 : t ⋆ₐ f ~ 0ₐ
+      --    σ₁ : Hom[ a W , r Y ]
+      --    σ₂ : Hom[ c W , a Y ]
+      --    eq :  α t ⋆ α f  ─  α 0ₐ  ≡  σ₁ t⋆f~0 ⋆ ρ Y  +  γ W ⋆ σ₂ t⋆f~0
+      --          α t ⋆ α f  ≡  σ₁ t⋆f~0 ⋆ ρ Y  +  γ W ⋆ σ₂ t⋆f~0
+
+
+    -- univKer : ∀ (W : CompPair) (t : W ⇒ X)
+    --       → (t ⋆ₐ f) ~ 0ₐ →
+    --       ∃![ u ∈ (W ⇒ AdelKerObj) ] ((u ⋆ₐ AdelKer) ~ t)
+    -- univKer W t t⋆f~0 = ({!   !} ,
+    --                      {!   !}) ,
+    --                      {!   !}
+
+
+
+  module _ {X Y : CompPair} (⟦f⟧ : Hom[ X , Y ]/~) where
+
+    -- Now define kernel on quotient
+    AdelKer/~ : Kernel A^Δ/~ ⟦f⟧
+    AdelKer/~ = record {
+      k = rec {!   !} AdelKerObj {!   !} ⟦f⟧ ;
+      ker = ⟦ rec {!   !} {! AdelKer !} {!   !} ⟦f⟧ ⟧ ;
+      isKer = {!   !} }
+    
+    -- record {
+    --   k = cpair (r X ⊕ r Y) (a X ⊕ r Y) (c X ⊕ a Y)
+    --         ( ρ X ` 0h ∣ 0h ` id ) (γ X ` {!   !} ∣ {!  α ⟦f⟧ !} ` {!   !}) ;
+    --   ker = {!   !} ;
+    --   isKer = {!   !} }
+
+    -- Cokernels
+    -- AdelCoker : (⟦f⟧ : Hom[ X , Y ]/~) → Cokernel A^Δ/~ ⟦f⟧
+    -- AdelCoker = {!   !}
+
+
+  Adel : AbelianCategory (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
+  Adel = {!   !}

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -13,34 +13,19 @@ private
   variable
     ℓ ℓ' : Level
 
-module _ (C : Category ℓ ℓ') (habstr : HomAbStr C) where
-  open Category C
-  open HomAbStr habstr using (0h)
 
-  -- Zero morphisms
-  record isZero {x y : ob} (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
-    field
-      const : ∀ {w} (g h : Hom[ w , x ]) → g ⋆ f ≡ h ⋆ f
-      coconst : ∀ {z} (g h : Hom[ y , z ]) → f ⋆ g ≡ f ⋆ h
-
+-- (Co)kernels
+module _ (C : PreaddCategory ℓ ℓ') where
+  open PreaddCategory C
 
   module _ {x y : ob} (f : Hom[ x , y ]) where
 
     -- Kernels
     record IsKernel {k : ob} (ker : Hom[ k , x ]) : Type (ℓ-max ℓ ℓ') where
       field
-        ker⋆f : isZero (ker ⋆ f)
+        ker⋆f : ker ⋆ f ≡ 0h
         univ : ∀ (w : ob) (t : Hom[ w , x ])
-          → isZero (t ⋆ f) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
-
-    makeIsKernel : {k : ob} (ker : Hom[ k , x ]) →
-      (ker ⋆ f) ≡ 0h
-      → (u : ∀ (w : ob) (t : Hom[ w , x ]) → (t ⋆ f ≡ 0h)  →  Hom[ w , k ])
-      → (    ∀ (w : ob) (t : Hom[ w , x ]) → (H : t ⋆ f ≡ 0h)  →  (u w t H) ⋆ ker ≡ t)
-      → (    ∀ (w : ob) (t : Hom[ w , x ]) → (H : t ⋆ f ≡ 0h)  →  ∀ v → (v ⋆ ker ≡ t) → (v ≡ (u w t H)))
-      → IsKernel ker
-
-    makeIsKernel = ?
+          → (t ⋆ f ≡ 0h) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
 
     record Kernel : Type (ℓ-max ℓ ℓ') where
       constructor kernel
@@ -49,15 +34,15 @@ module _ (C : Category ℓ ℓ') (habstr : HomAbStr C) where
         ker : Hom[ k , x ]
         isKer : IsKernel ker
 
-      open IsKernel isKer
+      open IsKernel isKer public
 
 
     -- Cokernels
     record IsCokernel {c : ob} (coker : Hom[ y , c ]) : Type (ℓ-max ℓ ℓ') where
       field
-        f⋆coker : isZero (f ⋆ coker)
+        f⋆coker : f ⋆ coker ≡ 0h
         univ : ∀ (w : ob) (t : Hom[ y , w ])
-          → isZero (f ⋆ t) → ∃![ u ∈ Hom[ c , w ] ] (coker ⋆ u ≡ t)
+          → (f ⋆ t ≡ 0h) → ∃![ u ∈ Hom[ c , w ] ] (coker ⋆ u ≡ t)
 
     record Cokernel : Type (ℓ-max ℓ ℓ') where
       field
@@ -65,173 +50,53 @@ module _ (C : Category ℓ ℓ') (habstr : HomAbStr C) where
         coker : Hom[ y , c ]
         isCoker : IsCokernel coker
 
-      open IsCokernel isCoker
+      open IsCokernel isCoker public
 
 
-  -- Preabelian categories
-  record PreabCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-    field
-      addit : AdditiveCategoryStr C
-      hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel f
-      hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel f
+-- Preabelian categories
+record PreabCategoryStr (C : AdditiveCategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
+  open AdditiveCategory C
+  field
+    hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel preaddcat f
+    hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel preaddcat f
 
-    open AdditiveCategoryStr addit public
-
-
-  -- Abelian categories
-  record AbelianCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-    field
-      preab : PreabCategoryStr
-
-    private
-      _=ker_ : ∀ {k x y} → Hom[ k , x ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
-      m =ker f = IsKernel f m
-
-      _=coker_ : ∀ {c x y} → Hom[ y , c ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
-      e =coker f = IsCokernel f e
-
-    field
-      monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic C m
-        → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (m =ker f)
-
-      epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic C e
-        → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (e =coker f)
-
-    open PreabCategoryStr preab public
+  -- Convenient ker/coker functions
+  ker = λ {x y} (f : Hom[ x , y ]) → hasKernels f .Kernel.ker
+  coker = λ {x y} (f : Hom[ x , y ]) → hasCokernels f .Cokernel.coker
 
 
 record PreabCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   field
-    cat : Category ℓ ℓ'
-    preab : PreabCategoryStr cat
+    additcat : AdditiveCategory ℓ ℓ'
+    preab : PreabCategoryStr additcat
 
-  open Category cat public
+  open AdditiveCategory additcat public
   open PreabCategoryStr preab public
 
 
-record AbelianCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+-- Abelian categories
+record AbelianCategoryStr (C : PreabCategory ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
+  open PreabCategory C
+
+  private
+    _=ker_ : ∀ {k x y} → Hom[ k , x ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
+    m =ker f = IsKernel preaddcat f m
+
+    _=coker_ : ∀ {c x y} → Hom[ y , c ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
+    e =coker f = IsCokernel preaddcat f e
+
   field
-    cat : Category ℓ ℓ'
-    abcatstr : AbelianCategoryStr cat
+    monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic cat m
+      → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (m =ker f)
 
-  open Category cat public
-  open AbelianCategoryStr abcatstr public
-
-
-module _ (A : AdditiveCategory ℓ ℓ') where
-  open AdditiveCategory A
-
-  AddCat→AbelCat :
-    (hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel cat f)
-    (hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel cat f)
-    (monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic cat m
-        → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (IsKernel cat f m))
-    (epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic cat e
-        → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (IsCokernel cat f e))
-    → AbelianCategory ℓ ℓ'
-
-  AddCat→AbelCat hk hc mn en = record {
-      cat = cat;
-      abcatstr = record {
-        preab = record {
-          addit = addit;
-          hasKernels = hk ;
-          hasCokernels = hc } ;
-        monNormal = mn ;
-        epiNormal = en } }
+    epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic cat e
+      → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (e =coker f)
 
 
+record AbelianCategory (ℓ ℓ' : Level): Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    preabcat : PreabCategory ℓ ℓ'
+    abeli : AbelianCategoryStr preabcat
 
-
--- Test making kernel
--- open import Cubical.Algebra.AbGroup.Base
--- open import Cubical.Algebra.Group.Base --hiding (Subgroup)
--- open import Cubical.Algebra.Group.Subgroup hiding (Subgroup)
--- open import Cubical.Categories.Instances.AbGroups renaming (AbGroupCategory to Ab)
-
--- module _ {A B : AbGroup ℓ} (f : AbGroupHom A B) where
-
---   kerf-SubgroupA : Subgroup A
---   kerf-SubgroupA = kerSubgroup f
-
---   kerf-Group : Group ℓ
---   kerf-Group = Subgroup→Group (AbGroup→Group A) kerf-SubgroupA
-
---   kerf : AbGroup ℓ
---   kerf = Group→AbGroup kerf-Group
---          λ (a , Ha) (a' , Ha') → {! ΣPathP !}
---   --Subgroup→Group (kerSubgroup f)
---   --(λ a → Σ[ b ∈ B .fst ] (f a ≡ b), {!   !}) , {!   !}
-
-
-
-open import Cubical.Algebra.Group.Base
-open import Cubical.Algebra.Group.Morphisms
-open import Cubical.Algebra.Group.MorphismProperties renaming (compGroupHom to _⋆_)
-open import Cubical.Algebra.Group.Properties
-open import Cubical.Algebra.Group.Subgroup
-open import Cubical.Categories.Instances.Groups renaming (GroupCategory to Grp)
-open import Cubical.Data.Sigma.Properties
-
-
-module _ {G H : Group ℓ} (f : GroupHom G H) where
-  open GroupStr (snd H) using () renaming (1g to 1H; rid to idrH)
-  open GroupTheory H using () renaming (inv1g to inv1H)
-
-  kerf : Group ℓ
-  kerf = Subgroup→Group G (kerSubgroup f)
-
-  kerf-incl : GroupHom kerf G
-  kerf-incl = SubgIncl G (kerSubgroup f)
-
-  zero : ∀ {J : Group ℓ} → GroupHom J H
-  zero = (λ _ → 1H) , record {
-      pres· = λ _ _ → sym (idrH _) ;
-      pres1 = refl ;
-      presinv = λ _ → sym inv1H }
-
-  zsub : ∀ {G} (x : GroupHom G H) → x ≡ zero → isZero Grp x
-  zsub = {!   !}
-
-  zsub⁻¹ : ∀ {G} (x : GroupHom G H) → isZero Grp x → x ≡ zero
-  zsub⁻¹ = {!   !}
-
-  kerf⋆f : kerf-incl ⋆ f ≡ zero
-  kerf⋆f = GroupHom≡ (funExt (λ (_ , P) → P))
-
-
-  -- ∀ (w : ob) (t : Hom[ w , x ])
-  --        → isZero (t ⋆ f) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
-
-  module _ (J : Group ℓ) (t : GroupHom J G)
-           (t⋆f : t ⋆ f ≡ zero)
-           where
-
-    u : GroupHom J kerf
-    u = (λ j → t .fst j ,
-          funExt⁻ (fst (PathPΣ t⋆f)) j
-        ) , record {
-          pres· = λ j j' → ΣPathP ({!   !} , {!   !}) ;
-          pres1 = {! refl ? !} ;
-          presinv = {!   !} }
-
-    u⋆kerf : u ⋆ kerf-incl ≡ t
-    u⋆kerf = {!   !}
-
-    u-unq : ∀ v → (v ⋆ kerf-incl ≡ t) → (v ≡ u)
-    u-unq v v⋆k = GroupHom≡ (funExt (λ j → {!   !}))
-
-
-  c = {! u  !}
-
-
-  gpKernel : Kernel Grp f
-  gpKernel = record {
-    k = kerf ;
-    ker = kerf-incl ;
-    isKer = record {
-      ker⋆f = zsub {!   !} kerf⋆f ;
-      univ = λ J t t⋆f →
-        ((u J t (zsub⁻¹ (t ⋆ f) t⋆f)) ,
-        (u⋆kerf J t (zsub⁻¹ (t ⋆ f) t⋆f))) ,
-        λ (v , Hv) → {! \  !} } }
+  open PreabCategory preabcat public
+  open AbelianCategoryStr abeli public

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -1,0 +1,237 @@
+-- (Pre)abelian categories
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Abelian.Base where
+
+open import Cubical.Categories.Additive.Base
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Morphism
+open import Cubical.Data.Sigma.Base
+open import Cubical.Foundations.Prelude
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (C : Category ℓ ℓ') (habstr : HomAbStr C) where
+  open Category C
+  open HomAbStr habstr using (0h)
+
+  -- Zero morphisms
+  record isZero {x y : ob} (f : Hom[ x , y ]) : Type (ℓ-max ℓ ℓ') where
+    field
+      const : ∀ {w} (g h : Hom[ w , x ]) → g ⋆ f ≡ h ⋆ f
+      coconst : ∀ {z} (g h : Hom[ y , z ]) → f ⋆ g ≡ f ⋆ h
+
+
+  module _ {x y : ob} (f : Hom[ x , y ]) where
+  
+    -- Kernels
+    record IsKernel {k : ob} (ker : Hom[ k , x ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        ker⋆f : isZero (ker ⋆ f)
+        univ : ∀ (w : ob) (t : Hom[ w , x ])
+          → isZero (t ⋆ f) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
+
+    makeIsKernel : {k : ob} (ker : Hom[ k , x ]) →
+      (ker ⋆ f) ≡ 0h
+      → (u : ∀ (w : ob) (t : Hom[ w , x ]) → (t ⋆ f ≡ 0h)  →  Hom[ w , k ])
+      → (    ∀ (w : ob) (t : Hom[ w , x ]) → (H : t ⋆ f ≡ 0h)  →  (u w t H) ⋆ ker ≡ t)
+      → (    ∀ (w : ob) (t : Hom[ w , x ]) → (H : t ⋆ f ≡ 0h)  →  ∀ v → (v ⋆ ker ≡ t) → (v ≡ (u w t H)))
+      → IsKernel ker
+
+    makeIsKernel = ?
+
+    record Kernel : Type (ℓ-max ℓ ℓ') where
+      constructor kernel
+      field
+        k : ob
+        ker : Hom[ k , x ]
+        isKer : IsKernel ker
+
+      open IsKernel isKer
+
+
+    -- Cokernels
+    record IsCokernel {c : ob} (coker : Hom[ y , c ]) : Type (ℓ-max ℓ ℓ') where
+      field
+        f⋆coker : isZero (f ⋆ coker)
+        univ : ∀ (w : ob) (t : Hom[ y , w ])
+          → isZero (f ⋆ t) → ∃![ u ∈ Hom[ c , w ] ] (coker ⋆ u ≡ t)
+
+    record Cokernel : Type (ℓ-max ℓ ℓ') where
+      field
+        c : ob
+        coker : Hom[ y , c ]
+        isCoker : IsCokernel coker
+
+      open IsCokernel isCoker
+
+
+  -- Preabelian categories
+  record PreabCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      addit : AdditiveCategoryStr C
+      hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel f
+      hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel f
+
+    open AdditiveCategoryStr addit public
+
+
+  -- Abelian categories
+  record AbelianCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      preab : PreabCategoryStr
+
+    private
+      _=ker_ : ∀ {k x y} → Hom[ k , x ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
+      m =ker f = IsKernel f m
+
+      _=coker_ : ∀ {c x y} → Hom[ y , c ] → Hom[ x , y ] → Type (ℓ-max ℓ ℓ')
+      e =coker f = IsCokernel f e
+
+    field
+      monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic C m
+        → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (m =ker f)
+
+      epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic C e
+        → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (e =coker f)
+
+    open PreabCategoryStr preab public
+
+
+record PreabCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cat : Category ℓ ℓ'
+    preab : PreabCategoryStr cat
+
+  open Category cat public
+  open PreabCategoryStr preab public
+
+
+record AbelianCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cat : Category ℓ ℓ'
+    abcatstr : AbelianCategoryStr cat
+
+  open Category cat public
+  open AbelianCategoryStr abcatstr public
+
+
+module _ (A : AdditiveCategory ℓ ℓ') where
+  open AdditiveCategory A
+  
+  AddCat→AbelCat :
+    (hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel cat f)
+    (hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel cat f)
+    (monNormal : {x y : ob} → (m : Hom[ x , y ]) → isMonic cat m
+        → Σ[ z ∈ ob ] Σ[ f ∈ Hom[ y , z ] ] (IsKernel cat f m))
+    (epiNormal : {x y : ob} → (e : Hom[ x , y ]) → isEpic cat e
+        → Σ[ w ∈ ob ] Σ[ f ∈ Hom[ w , x ] ] (IsCokernel cat f e))
+    → AbelianCategory ℓ ℓ'
+
+  AddCat→AbelCat hk hc mn en = record {
+      cat = cat;
+      abcatstr = record {
+        preab = record {
+          addit = addit;
+          hasKernels = hk ;
+          hasCokernels = hc } ;
+        monNormal = mn ;
+        epiNormal = en } }
+
+
+
+
+-- Test making kernel
+-- open import Cubical.Algebra.AbGroup.Base
+-- open import Cubical.Algebra.Group.Base --hiding (Subgroup)
+-- open import Cubical.Algebra.Group.Subgroup hiding (Subgroup)
+-- open import Cubical.Categories.Instances.AbGroups renaming (AbGroupCategory to Ab)
+
+-- module _ {A B : AbGroup ℓ} (f : AbGroupHom A B) where
+
+--   kerf-SubgroupA : Subgroup A
+--   kerf-SubgroupA = kerSubgroup f
+
+--   kerf-Group : Group ℓ
+--   kerf-Group = Subgroup→Group (AbGroup→Group A) kerf-SubgroupA
+
+--   kerf : AbGroup ℓ
+--   kerf = Group→AbGroup kerf-Group
+--          λ (a , Ha) (a' , Ha') → {! ΣPathP !}
+--   --Subgroup→Group (kerSubgroup f)
+--   --(λ a → Σ[ b ∈ B .fst ] (f a ≡ b), {!   !}) , {!   !}
+
+
+
+open import Cubical.Algebra.Group.Base
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties renaming (compGroupHom to _⋆_)
+open import Cubical.Algebra.Group.Properties
+open import Cubical.Algebra.Group.Subgroup
+open import Cubical.Categories.Instances.Groups renaming (GroupCategory to Grp)
+open import Cubical.Data.Sigma.Properties
+
+
+module _ {G H : Group ℓ} (f : GroupHom G H) where
+  open GroupStr (snd H) using () renaming (1g to 1H; rid to idrH)
+  open GroupTheory H using () renaming (inv1g to inv1H)
+
+  kerf : Group ℓ
+  kerf = Subgroup→Group G (kerSubgroup f)
+
+  kerf-incl : GroupHom kerf G
+  kerf-incl = SubgIncl G (kerSubgroup f)
+
+  zero : ∀ {J : Group ℓ} → GroupHom J H
+  zero = (λ _ → 1H) , record {
+      pres· = λ _ _ → sym (idrH _) ;
+      pres1 = refl ;
+      presinv = λ _ → sym inv1H }
+
+  zsub : ∀ {G} (x : GroupHom G H) → x ≡ zero → isZero Grp x
+  zsub = {!   !}
+
+  zsub⁻¹ : ∀ {G} (x : GroupHom G H) → isZero Grp x → x ≡ zero
+  zsub⁻¹ = {!   !}
+
+  kerf⋆f : kerf-incl ⋆ f ≡ zero
+  kerf⋆f = GroupHom≡ (funExt (λ (_ , P) → P))
+
+
+  -- ∀ (w : ob) (t : Hom[ w , x ])
+  --        → isZero (t ⋆ f) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
+  
+  module _ (J : Group ℓ) (t : GroupHom J G)
+           (t⋆f : t ⋆ f ≡ zero)
+           where
+
+    u : GroupHom J kerf
+    u = (λ j → t .fst j , 
+          funExt⁻ (fst (PathPΣ t⋆f)) j
+        ) , record {
+          pres· = λ j j' → ΣPathP ({!   !} , {!   !}) ;
+          pres1 = {! refl ? !} ;
+          presinv = {!   !} }
+
+    u⋆kerf : u ⋆ kerf-incl ≡ t
+    u⋆kerf = {!   !}
+
+    u-unq : ∀ v → (v ⋆ kerf-incl ≡ t) → (v ≡ u)
+    u-unq v v⋆k = GroupHom≡ (funExt (λ j → {!   !}))
+
+  
+  c = {! u  !}
+
+
+  gpKernel : Kernel Grp f
+  gpKernel = record {
+    k = kerf ;
+    ker = kerf-incl ;
+    isKer = record {
+      ker⋆f = zsub {!   !} kerf⋆f ;
+      univ = λ J t t⋆f →
+        ((u J t (zsub⁻¹ (t ⋆ f) t⋆f)) ,
+        (u⋆kerf J t (zsub⁻¹ (t ⋆ f) t⋆f))) ,
+        λ (v , Hv) → {! \  !} } }

--- a/Cubical/Categories/Abelian/Base.agda
+++ b/Cubical/Categories/Abelian/Base.agda
@@ -25,7 +25,7 @@ module _ (C : Category ℓ ℓ') (habstr : HomAbStr C) where
 
 
   module _ {x y : ob} (f : Hom[ x , y ]) where
-  
+
     -- Kernels
     record IsKernel {k : ob} (ker : Hom[ k , x ]) : Type (ℓ-max ℓ ℓ') where
       field
@@ -120,7 +120,7 @@ record AbelianCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) wh
 
 module _ (A : AdditiveCategory ℓ ℓ') where
   open AdditiveCategory A
-  
+
   AddCat→AbelCat :
     (hasKernels : {x y : ob} → (f : Hom[ x , y ]) → Kernel cat f)
     (hasCokernels : {x y : ob} → (f : Hom[ x , y ]) → Cokernel cat f)
@@ -202,13 +202,13 @@ module _ {G H : Group ℓ} (f : GroupHom G H) where
 
   -- ∀ (w : ob) (t : Hom[ w , x ])
   --        → isZero (t ⋆ f) → ∃![ u ∈ Hom[ w , k ] ] (u ⋆ ker ≡ t)
-  
+
   module _ (J : Group ℓ) (t : GroupHom J G)
            (t⋆f : t ⋆ f ≡ zero)
            where
 
     u : GroupHom J kerf
-    u = (λ j → t .fst j , 
+    u = (λ j → t .fst j ,
           funExt⁻ (fst (PathPΣ t⋆f)) j
         ) , record {
           pres· = λ j j' → ΣPathP ({!   !} , {!   !}) ;
@@ -221,7 +221,7 @@ module _ {G H : Group ℓ} (f : GroupHom G H) where
     u-unq : ∀ v → (v ⋆ kerf-incl ≡ t) → (v ≡ u)
     u-unq v v⋆k = GroupHom≡ (funExt (λ j → {!   !}))
 
-  
+
   c = {! u  !}
 
 

--- a/Cubical/Categories/Additive.agda
+++ b/Cubical/Categories/Additive.agda
@@ -3,4 +3,5 @@
 module Cubical.Categories.Additive where
 
 open import Cubical.Categories.Additive.Base public
+open import Cubical.Categories.Additive.Properties public
 open import Cubical.Categories.Additive.Quotient public

--- a/Cubical/Categories/Additive.agda
+++ b/Cubical/Categories/Additive.agda
@@ -1,0 +1,6 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Additive where
+
+open import Cubical.Categories.Additive.Base public
+open import Cubical.Categories.Additive.Quotient public

--- a/Cubical/Categories/Additive/Base.agda
+++ b/Cubical/Categories/Additive/Base.agda
@@ -4,9 +4,8 @@
 module Cubical.Categories.Additive.Base where
 
 open import Cubical.Algebra.AbGroup.Base
--- open import Cubical.Algebra.Group.Properties
 open import Cubical.Categories.Category.Base
--- open import Cubical.Categories.Limits.Terminal
+open import Cubical.Categories.Limits.Terminal
 open import Cubical.Foundations.Prelude
 
 private
@@ -60,8 +59,8 @@ module _ (C : PreaddCategory ℓ ℓ') where
   record ZeroObject : Type (ℓ-max ℓ ℓ') where
     field
       z : ob
-      zInit : isInitial C z
-      zFinal : isFinal C z
+      zInit : isInitial cat z
+      zFinal : isFinal cat z
 
 
   -- Biproducts
@@ -93,11 +92,6 @@ module _ (C : PreaddCategory ℓ ℓ') where
   -- Additive categories
   record AdditiveCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
     field
-      preadd : PreaddCategoryStr
-
-    open PreaddCategoryStr preadd public
-
-    field
       zero : ZeroObject
       biprod : ∀ x y → Biproduct x y
 
@@ -107,19 +101,10 @@ module _ (C : PreaddCategory ℓ ℓ') where
     infixr 6 _⊕_
 
 
-
-
 record AdditiveCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   field
-    cat : Category ℓ ℓ'
-    addit : AdditiveCategoryStr cat
+    preaddcat : PreaddCategory ℓ ℓ'
+    addit : AdditiveCategoryStr preaddcat
 
-  open Category cat public
+  open PreaddCategory preaddcat public
   open AdditiveCategoryStr addit public
-
-
-AddCat→PreaddCat : AdditiveCategory ℓ ℓ' → PreaddCategory ℓ ℓ'
-AddCat→PreaddCat A = record {
-    cat = A .AdditiveCategory.cat;
-    preadd = A .AdditiveCategory.addit .AdditiveCategoryStr.preadd
-  }

--- a/Cubical/Categories/Additive/Base.agda
+++ b/Cubical/Categories/Additive/Base.agda
@@ -5,6 +5,7 @@ module Cubical.Categories.Additive.Base where
 
 open import Cubical.Algebra.AbGroup.Base
 open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Limits.Initial
 open import Cubical.Categories.Limits.Terminal
 open import Cubical.Foundations.Prelude
 
@@ -60,7 +61,7 @@ module _ (C : PreaddCategory ℓ ℓ') where
     field
       z : ob
       zInit : isInitial cat z
-      zFinal : isFinal cat z
+      zTerm : isTerminal cat z
 
 
   -- Biproducts

--- a/Cubical/Categories/Additive/Base.agda
+++ b/Cubical/Categories/Additive/Base.agda
@@ -1,0 +1,466 @@
+-- (Pre)additive categories
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Additive.Base where
+
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Algebra.Group.Properties
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Limits.Terminal
+open import Cubical.Foundations.Prelude
+
+private
+  variable
+    ℓ ℓ' : Level
+
+module _ (C : Category ℓ ℓ') where
+
+  open Category C
+
+  -- Abelian group structure on homsets
+  record HomAbStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    constructor homabstr
+    field
+      homAbStr : (x y : ob) → AbGroupStr Hom[ x , y ]
+
+    -- Polymorphic abelian group operations
+    0h = λ {x} {y} → AbGroupStr.0g (homAbStr x y)
+    -_ = λ {x} {y} → AbGroupStr.-_ (homAbStr x y)
+    _+_ = λ {x} {y} → AbGroupStr._+_ (homAbStr x y)
+
+    _─_ : ∀ {x y} (f g : Hom[ x , y ]) → Hom[ x , y ]
+    f ─ g = f + (- g)
+
+    infixr 7   _+_
+    infixl 7.5 _─_
+    infix  8    -_
+
+    -- Group theory lemmas
+    idl = λ {x y} → AbGroupStr.lid (homAbStr x y)
+    idr = λ {x y} → AbGroupStr.rid (homAbStr x y)
+    invl = λ {x y} → AbGroupStr.invl (homAbStr x y)
+    invr = λ {x y} → AbGroupStr.invr (homAbStr x y)
+    +assoc = λ {x y} → AbGroupStr.assoc (homAbStr x y)
+    +comm = λ {x y} → AbGroupStr.comm (homAbStr x y)
+
+    -dist+ : {x y : ob} (f g : Hom[ x , y ]) →
+        - (f + g) ≡ (- f) + (- g)
+    -dist+ {x} {y} f g =
+      let open GroupTheory (AbGroup→Group (Hom[ x , y ] , homAbStr x y)) in
+        (invDistr _ _) ∙ (+comm _ _)
+
+    +4assoc : {x y : ob} (a b c d : Hom[ x , y ]) →
+        (a + b) + (c + d)  ≡  a + (b + c) + d
+    +4assoc a b c d = sym (+assoc _ _ _) ∙ cong (a +_) (+assoc _ _ _)
+
+    +4comm : {x y : ob} (a b c d : Hom[ x , y ]) →
+        (a + b) + (c + d)  ≡  (a + c) + (b + d)
+    +4comm a b c d = +4assoc _ _ _ _ ∙
+        cong (λ u → a + (u + d)) (+comm _ _) ∙ sym (+4assoc _ _ _ _)
+
+
+  -- Preadditive categories
+  record PreaddCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      habstr : HomAbStr
+
+    open HomAbStr habstr public
+
+    field
+      distl : {x y z : ob} → (f : Hom[ x , y ]) → (g g' : Hom[ y , z ]) →
+          f ⋆ (g + g') ≡ (f ⋆ g) + (f ⋆ g')
+
+      distr : {x y z : ob} → (f f' : Hom[ x , y ]) → (g : Hom[ y , z ]) →
+          (f + f') ⋆ g ≡ (f ⋆ g) + (f' ⋆ g)
+
+    -- Some useful lemmas
+    0h⋆ : ∀ {w x y} (f : Hom[ x , y ]) → 0h ⋆ f ≡ 0h {w}
+    0h⋆ f =
+        0h ⋆ f                              ≡⟨ sym (idr _) ⟩
+        0h ⋆ f  +  0h                       ≡⟨ cong (0h ⋆ f +_) (sym (invr _)) ⟩
+        0h ⋆ f  +  (0h ⋆ f  ─  0h ⋆ f)      ≡⟨ +assoc _ _ _ ⟩
+        (0h ⋆ f  +  0h ⋆ f)  ─  0h ⋆ f      ≡⟨ cong (_─ 0h ⋆ f) (sym (distr _ _ _)) ⟩
+        (0h + 0h) ⋆ f  ─  0h ⋆ f            ≡⟨ cong (λ a → a ⋆ f ─ 0h ⋆ f) (idr _) ⟩
+        0h ⋆ f  ─  0h ⋆ f                   ≡⟨ invr _ ⟩
+        0h                                  ∎
+
+    _⋆0h : ∀ {x y z} (f : Hom[ x , y ]) → f ⋆ 0h ≡ 0h {x} {z}
+    f ⋆0h =
+        f ⋆ 0h                              ≡⟨ sym (idr _) ⟩
+        f ⋆ 0h  +  0h                       ≡⟨ cong (f ⋆ 0h +_) (sym (invr _)) ⟩
+        f ⋆ 0h  +  (f ⋆ 0h  ─  f ⋆ 0h)      ≡⟨ +assoc _ _ _ ⟩
+        (f ⋆ 0h  +  f ⋆ 0h)  ─  f ⋆ 0h      ≡⟨ cong (_─ f ⋆ 0h) (sym (distl _ _ _)) ⟩
+        f ⋆ (0h + 0h)  ─  f ⋆ 0h            ≡⟨ cong (λ a → f ⋆ a ─ f ⋆ 0h) (idr _) ⟩
+        f ⋆ 0h  ─  f ⋆ 0h                   ≡⟨ invr _ ⟩
+        0h                                  ∎
+
+    -distl⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
+      → (- f) ⋆ g ≡ - (f ⋆ g)
+    -distl⋆ {x} {y} {z} f g =
+      let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
+      invUniqueR (
+        f ⋆ g + (- f) ⋆ g     ≡⟨ sym (distr _ _ _) ⟩
+        (f ─ f) ⋆ g           ≡⟨ cong (_⋆ g) (invr _) ⟩
+        0h ⋆ g                ≡⟨ 0h⋆ _ ⟩
+        0h                    ∎
+      )
+
+    -distr⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
+      → f ⋆ (- g) ≡ - (f ⋆ g)
+    -distr⋆ {x} {y} {z} f g =
+      let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
+      invUniqueR (
+        f ⋆ g + f ⋆ (- g)     ≡⟨ sym (distl _ _ _) ⟩
+        f ⋆ (g ─ g)           ≡⟨ cong (f ⋆_) (invr _) ⟩
+        f ⋆ 0h                ≡⟨ _ ⋆0h ⟩
+        0h                    ∎
+      )
+
+
+  -- Zero object
+  record ZeroObject : Type (ℓ-max ℓ ℓ') where
+    field
+      z : ob
+      zInit : isInitial C z
+      zFinal : isFinal C z
+
+
+  -- Biproducts
+  module _ (habstr : HomAbStr) where
+    open HomAbStr habstr
+
+    record isBiproduct {x y x⊕y : ob}
+        (i₁ : Hom[ x , x⊕y ]) (i₂ : Hom[ y , x⊕y ])
+        (π₁ : Hom[ x⊕y , x ]) (π₂ : Hom[ x⊕y , y ])
+            : Type (ℓ-max ℓ ℓ') where
+
+      field
+        i₁⋆π₁ : i₁ ⋆ π₁ ≡ id
+        i₁⋆π₂ : i₁ ⋆ π₂ ≡ 0h
+        i₂⋆π₁ : i₂ ⋆ π₁ ≡ 0h
+        i₂⋆π₂ : i₂ ⋆ π₂ ≡ id
+        ∑π⋆i : π₁ ⋆ i₁ + π₂ ⋆ i₂ ≡ id
+
+
+    record Biproduct (x y : ob) : Type (ℓ-max ℓ ℓ') where
+      field
+        x⊕y : ob
+        i₁ : Hom[ x , x⊕y ]
+        i₂ : Hom[ y , x⊕y ]
+        π₁ : Hom[ x⊕y , x ]
+        π₂ : Hom[ x⊕y , y ]
+        isBipr : isBiproduct i₁ i₂ π₁ π₂
+
+      open isBiproduct isBipr public
+
+
+
+  -- Additive categories
+  record AdditiveCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
+    field
+      preadd : PreaddCategoryStr
+
+    open PreaddCategoryStr preadd public
+
+    field
+      zero : ZeroObject
+      biprod : ∀ x y → Biproduct habstr x y
+
+    -- Biproduct notation
+    open Biproduct
+    _⊕_ = λ (x y : ob) → biprod x y .x⊕y
+    infixr 6 _⊕_
+
+
+record PreaddCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cat : Category ℓ ℓ'
+    preadd : PreaddCategoryStr cat
+
+  open Category cat public
+  open PreaddCategoryStr preadd public
+
+
+record AdditiveCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cat : Category ℓ ℓ'
+    addit : AdditiveCategoryStr cat
+
+  open Category cat public
+  open AdditiveCategoryStr addit public
+
+
+AddCat→PreaddCat : AdditiveCategory ℓ ℓ' → PreaddCategory ℓ ℓ'
+AddCat→PreaddCat A = record {
+    cat = A .AdditiveCategory.cat;
+    preadd = A .AdditiveCategory.addit .AdditiveCategoryStr.preadd
+  }
+
+
+-- Matrix notation for morphisms (x₁ ⊕ ⋯ ⊕ x­­ₙ) → (y₁ ⊕ ⋯ ⊕ yₘ)
+module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
+    open AdditiveCategory A
+
+    -- Polymorphic biproduct morphisms
+    i₁ = λ {x y} → Biproduct.i₁ (biprod x y)
+    i₂ = λ {x y} → Biproduct.i₂ (biprod x y)
+    π₁ = λ {x y} → Biproduct.π₁ (biprod x y)
+    π₂ = λ {x y} → Biproduct.π₂ (biprod x y)
+    -- and axioms
+    i₁⋆π₁ = λ {x y} → Biproduct.i₁⋆π₁ (biprod x y)
+    i₁⋆π₂ = λ {x y} → Biproduct.i₁⋆π₂ (biprod x y)
+    i₂⋆π₁ = λ {x y} → Biproduct.i₂⋆π₁ (biprod x y)
+    i₂⋆π₂ = λ {x y} → Biproduct.i₂⋆π₂ (biprod x y)
+    ∑π⋆i  = λ {x y} → Biproduct.∑π⋆i  (biprod x y)
+
+
+    _∣_ : ∀ {x y y'} → Hom[ x , y ] → Hom[ x , y' ] → Hom[ x , y ⊕ y' ]
+    f ∣ f' = (f ⋆ i₁) + (f' ⋆ i₂)
+    infixr 5 _∣_
+
+    _`_ : ∀ {y y' z} → Hom[ y , z ] → Hom[ y' , z ] → Hom[ y ⊕ y' , z ]
+    g ` g' = (π₁ ⋆ g) + (π₂ ⋆ g')
+    infixr 6 _`_
+
+
+    -- Use the matrix notation like this:
+    private module _ (x y : ob) (f : Hom[ x , y ]) where
+
+      h : Hom[ x ⊕ x ⊕ x , y ⊕ y ⊕ y ⊕ y ]
+
+      h =  f  ` - f `  0h   ∣
+           0h `  0h `  f    ∣
+           f  ` - f `  0h   ∣
+           0h `  f  ` f + f
+
+
+    -- ρ X ⋆ i₁ ≡ i₁ ⋆ (ρ X ` 0h ∣ 0h ` ρ Y)
+
+    -- i₁ ⋆ (a ` b ∣ c ` d)
+    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
+    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
+
+    -- i ⋆ (a ∣ c) ` (b ∣ d)
+
+
+    -- Exchange law
+    exchange : ∀ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y ])
+            (c : Hom[ x , y' ]) (d : Hom[ x' , y' ]) →
+        (a ` b ∣ c ` d)  ≡  (a ∣ c) ` (b ∣ d)
+
+    exchange a b c d =
+        (π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂
+                ≡⟨ cong₂ _+_ (distr _ _ _) (distr _ _ _) ⟩
+        ((π₁ ⋆ a) ⋆ i₁  +  (π₂ ⋆ b) ⋆ i₁)  +  ((π₁ ⋆ c) ⋆ i₂  +  (π₂ ⋆ d) ⋆ i₂)
+                ≡⟨ +4comm _ _ _ _ ⟩
+        ((π₁ ⋆ a) ⋆ i₁  +  (π₁ ⋆ c) ⋆ i₂)  +  ((π₂ ⋆ b) ⋆ i₁  +  (π₂ ⋆ d) ⋆ i₂)
+                ≡⟨ cong₂ _+_ (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _))
+                            (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _)) ⟩
+        (π₁ ⋆ (a ⋆ i₁)  +  π₁ ⋆ (c ⋆ i₂))  +  (π₂ ⋆ (b ⋆ i₁)  +  π₂ ⋆ (d ⋆ i₂))
+                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+        π₁ ⋆ (a ⋆ i₁  +  c ⋆ i₂)  +  π₂ ⋆ (b ⋆ i₁  +  d ⋆ i₂)
+                ∎
+
+
+    -- iₖ times a row
+    module _ {x x' y : ob} (a : Hom[ x , y ]) (b : Hom[ x' , y ]) where
+
+      i₁⋆row :  i₁ ⋆ (a ` b)  ≡  a
+      i₁⋆row =
+          i₁ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
+                  ≡⟨ distl _ _ _ ⟩
+          i₁ ⋆ (π₁ ⋆ a)  +  i₁ ⋆ (π₂ ⋆ b)
+                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
+          (i₁ ⋆ π₁) ⋆ a  +  (i₁ ⋆ π₂) ⋆ b
+                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₁⋆π₁ i₁⋆π₂ ⟩
+          id ⋆ a  +  0h ⋆ b             
+                  ≡⟨ cong₂ _+_ (⋆IdL _) (0h⋆ _) ⟩
+          a  +  0h                      
+                  ≡⟨ idr _ ⟩
+          a       ∎
+
+      i₂⋆row :  i₂ ⋆ (a ` b)  ≡  b
+      i₂⋆row =
+          i₂ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
+                  ≡⟨ distl _ _ _ ⟩
+          i₂ ⋆ (π₁ ⋆ a)  +  i₂ ⋆ (π₂ ⋆ b)
+                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
+          (i₂ ⋆ π₁) ⋆ a  +  (i₂ ⋆ π₂) ⋆ b
+                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₂⋆π₁ i₂⋆π₂ ⟩
+          0h ⋆ a  +  id ⋆ b             
+                  ≡⟨ cong₂ _+_ (0h⋆ _) (⋆IdL _) ⟩
+          0h  +  b                      
+                  ≡⟨ idl _ ⟩
+          b       ∎
+
+
+    -- A column times πₖ
+    module _ {x y y' : ob} (a : Hom[ x , y ]) (b : Hom[ x , y' ]) where
+
+      col⋆π₁ :  (a ∣ b) ⋆ π₁  ≡  a
+      col⋆π₁ =
+          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₁
+                  ≡⟨ distr _ _ _ ⟩
+          (a ⋆ i₁) ⋆ π₁  +  (b ⋆ i₂) ⋆ π₁
+                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
+          a ⋆ (i₁ ⋆ π₁)  +  b ⋆ (i₂ ⋆ π₁)
+                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₁ i₂⋆π₁ ⟩
+          a ⋆ id  +  b ⋆ 0h
+                  ≡⟨ cong₂ _+_ (⋆IdR _) (_ ⋆0h) ⟩
+          a  +  0h
+                  ≡⟨ idr _ ⟩
+          a       ∎
+
+      col⋆π₂ :  (a ∣ b) ⋆ π₂  ≡  b
+      col⋆π₂ =
+          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₂
+                  ≡⟨ distr _ _ _ ⟩
+          (a ⋆ i₁) ⋆ π₂  +  (b ⋆ i₂) ⋆ π₂
+                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
+          a ⋆ (i₁ ⋆ π₂)  +  b ⋆ (i₂ ⋆ π₂)
+                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₂ i₂⋆π₂ ⟩
+          a ⋆ 0h  +  b ⋆ id
+                  ≡⟨ cong₂ _+_ (_ ⋆0h) (⋆IdR _) ⟩
+          0h  +  b
+                  ≡⟨ idl _ ⟩
+          b       ∎
+
+    -- iₖ / πₖ times a diagonal matrix
+    module _ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y' ]) where
+    
+      i₁⋆diag :  i₁ ⋆ (a ` 0h ∣ 0h ` b)  ≡  a ⋆ i₁
+      i₁⋆diag =
+          i₁ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₁ ⋆_) (exchange _ _ _ _) ⟩
+          i₁ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₁⋆row _ _ ⟩
+          (a ∣ 0h)                        ≡⟨ cong (a ⋆ i₁ +_) (0h⋆ _) ⟩
+          a ⋆ i₁  +  0h                   ≡⟨ idr _ ⟩
+          a ⋆ i₁                          ∎
+    
+      i₂⋆diag :  i₂ ⋆ (a ` 0h ∣ 0h ` b)  ≡  b ⋆ i₂
+      i₂⋆diag =
+          i₂ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₂ ⋆_) (exchange _ _ _ _) ⟩
+          i₂ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₂⋆row _ _ ⟩
+          (0h ∣ b)                        ≡⟨ cong (_+ b ⋆ i₂) (0h⋆ _) ⟩
+          0h  +  b ⋆ i₂                   ≡⟨ idl _ ⟩
+          b ⋆ i₂                          ∎
+
+      diag⋆π₁ :  (a ` 0h ∣ 0h ` b) ⋆ π₁  ≡  π₁ ⋆ a
+      diag⋆π₁ =
+          (a ` 0h ∣ 0h ` b) ⋆ π₁      ≡⟨ col⋆π₁ _ _ ⟩
+          a ` 0h                      ≡⟨ cong (π₁ ⋆ a +_) (_ ⋆0h) ⟩
+          π₁ ⋆ a  +  0h               ≡⟨ idr _ ⟩
+          π₁ ⋆ a                      ∎
+
+      diag⋆π₂ :  (a ` 0h ∣ 0h ` b) ⋆ π₂  ≡  π₂ ⋆ b
+      diag⋆π₂ =
+          (a ` 0h ∣ 0h ` b) ⋆ π₂      ≡⟨ col⋆π₂ _ _ ⟩
+          0h ` b                      ≡⟨ cong (_+ π₂ ⋆ b) (_ ⋆0h) ⟩
+          0h  +  π₂ ⋆ b               ≡⟨ idl _ ⟩
+          π₂ ⋆ b                      ∎
+    
+
+    -- Matrix addition
+    addRow : ∀ {x y z}
+        (f f' : Hom[ x , z ]) (g g' : Hom[ y , z ]) →
+        (f ` g) + (f' ` g') ≡ (f + f') ` (g + g')
+
+    addRow f f' g g' =
+        (π₁ ⋆ f + π₂ ⋆ g) + (π₁ ⋆ f' + π₂ ⋆ g')
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (π₁ ⋆ f + π₁ ⋆ f') + (π₂ ⋆ g + π₂ ⋆ g')
+                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+        π₁ ⋆ (f + f') + π₂ ⋆ (g + g')
+                ∎
+
+    addCol : ∀ {x y z}
+        (f f' : Hom[ x , y ]) (g g' : Hom[ x , z ]) →
+        (f ∣ g) + (f' ∣ g') ≡ (f + f') ∣ (g + g')
+
+    addCol f f' g g' =
+        (f ⋆ i₁ + g ⋆ i₂) + (f' ⋆ i₁ + g' ⋆ i₂)
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (f ⋆ i₁ + f' ⋆ i₁) + (g ⋆ i₂ + g' ⋆ i₂)
+                ≡⟨ sym (cong₂ _+_ (distr _ _ _) (distr _ _ _)) ⟩
+        (f + f') ⋆ i₁ + (g + g') ⋆ i₂
+                ∎
+
+
+    private
+      ⋆4assoc : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
+              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
+          (a ⋆ b) ⋆ (c ⋆ d) ≡ a ⋆ (b ⋆ c) ⋆ d
+      ⋆4assoc a b c d = (⋆Assoc _ _ _) ∙ cong (a ⋆_) (sym (⋆Assoc _ _ _))
+
+      ⋆4assoc' : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
+              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
+          (a ⋆ b) ⋆ (c ⋆ d) ≡ (a ⋆ (b ⋆ c)) ⋆ d
+      ⋆4assoc' a b c d = sym (⋆Assoc _ _ _) ∙ cong (_⋆ d) (⋆Assoc _ _ _)
+
+
+    -- Matrix multiplication
+    innerProd : ∀ {x y₁ y₂ z} (f₁ : Hom[ x , y₁ ]) (g₁ : Hom[ y₁ , z ])
+                              (f₂ : Hom[ x , y₂ ]) (g₂ : Hom[ y₂ , z ]) →
+        (f₁ ∣ f₂) ⋆ (g₁ ` g₂) ≡ (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
+
+    innerProd f₁ g₁ f₂ g₂ =
+        (f₁ ⋆ i₁ + f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
+                ≡⟨ distr _ _ _ ⟩
+        (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)  +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
+                ≡⟨ cong₂ _+_ (distl _ _ _) (distl _ _ _) ⟩
+        ((f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)  +  (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂))
+            +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)  +  (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)
+                ≡⟨ cong₂ _+_ (cong₂ _+_ eq₁₁ eq₁₂) (cong₂ _+_ eq₂₁ eq₂₂) ⟩
+        (f₁ ⋆ g₁  +  0h)  +  0h  +  f₂ ⋆ g₂
+                ≡⟨ cong₂ _+_ (idr _) (idl _) ⟩
+        (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
+                ∎
+     where
+      eq₁₁ = (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₁ ⋆ (i₁ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₁ ⟩
+             f₁ ⋆ id ⋆ g₁               ≡⟨ cong (f₁ ⋆_) (⋆IdL _) ⟩
+             f₁ ⋆ g₁                    ∎
+
+      eq₁₂ = (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₁ ⋆ (i₁ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₂ ⟩
+             f₁ ⋆ 0h ⋆ g₂               ≡⟨ cong (f₁ ⋆_) (0h⋆ _) ⟩
+             f₁ ⋆ 0h                    ≡⟨ _ ⋆0h ⟩
+             0h                         ∎
+
+      eq₂₁ = (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₂ ⋆ (i₂ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₁ ⟩
+             f₂ ⋆ 0h ⋆ g₁               ≡⟨ cong (f₂ ⋆_) (0h⋆ _) ⟩
+             f₂ ⋆ 0h                    ≡⟨ _ ⋆0h ⟩
+             0h                         ∎
+
+      eq₂₂ = (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₂ ⋆ (i₂ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₂ ⟩
+             f₂ ⋆ id ⋆ g₂               ≡⟨ cong (f₂ ⋆_) (⋆IdL _) ⟩
+             f₂ ⋆ g₂                    ∎
+
+
+    outerProd : ∀ {x₁ x₂ y z₁ z₂} (f₁ : Hom[ x₁ , y ]) (g₁ : Hom[ y , z₁ ])
+                                  (f₂ : Hom[ x₂ , y ]) (g₂ : Hom[ y , z₂ ]) →
+
+        (f₁ ` f₂) ⋆ (g₁ ∣ g₂)  ≡  f₁ ⋆ g₁ ` f₂ ⋆ g₁ ∣
+                                  f₁ ⋆ g₂ ` f₂ ⋆ g₂
+
+    outerProd {y = y} f₁ g₁ f₂ g₂ =
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁  +  g₂ ⋆ i₂)
+                ≡⟨ distl _ _ _ ⟩
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁)  +  (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₂ ⋆ i₂)
+                ≡⟨ cong₂ _+_ (eq g₁ i₁) (eq g₂ i₂) ⟩
+           (π₁ ⋆ (f₁ ⋆ g₁)  +  π₂ ⋆ (f₂ ⋆ g₁)) ⋆ i₁
+        +  (π₁ ⋆ (f₁ ⋆ g₂)  +  π₂ ⋆ (f₂ ⋆ g₂)) ⋆ i₂
+                ∎
+     where
+      eq = λ {z w} (g : Hom[ y , z ]) (i : Hom[ z , w ]) →
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g ⋆ i)
+                ≡⟨ distr _ _ _ ⟩
+        (π₁ ⋆ f₁) ⋆ (g ⋆ i)  +  (π₂ ⋆ f₂) ⋆ (g ⋆ i)
+                ≡⟨ cong₂ _+_ (⋆4assoc' _ _ _ _) (⋆4assoc' _ _ _ _) ⟩
+        (π₁ ⋆ (f₁ ⋆ g)) ⋆ i  +  (π₂ ⋆ (f₂ ⋆ g)) ⋆ i
+                ≡⟨ sym (distr _ _ _) ⟩
+        (π₁ ⋆ (f₁ ⋆ g)  +  π₂ ⋆ (f₂ ⋆ g)) ⋆ i
+                    ∎
+
+    -- Can we multiply an m×n matrix with an n×k matrix?

--- a/Cubical/Categories/Additive/Base.agda
+++ b/Cubical/Categories/Additive/Base.agda
@@ -4,22 +4,21 @@
 module Cubical.Categories.Additive.Base where
 
 open import Cubical.Algebra.AbGroup.Base
-open import Cubical.Algebra.Group.Properties
+-- open import Cubical.Algebra.Group.Properties
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Limits.Terminal
+-- open import Cubical.Categories.Limits.Terminal
 open import Cubical.Foundations.Prelude
 
 private
   variable
     ℓ ℓ' : Level
 
-module _ (C : Category ℓ ℓ') where
 
+-- Preadditive categories
+module _ (C : Category ℓ ℓ') where
   open Category C
 
-  -- Abelian group structure on homsets
-  record HomAbStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-    constructor homabstr
+  record PreaddCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
     field
       homAbStr : (x y : ob) → AbGroupStr Hom[ x , y ]
 
@@ -35,37 +34,6 @@ module _ (C : Category ℓ ℓ') where
     infixl 7.5 _─_
     infix  8    -_
 
-    -- Group theory lemmas
-    idl = λ {x y} → AbGroupStr.lid (homAbStr x y)
-    idr = λ {x y} → AbGroupStr.rid (homAbStr x y)
-    invl = λ {x y} → AbGroupStr.invl (homAbStr x y)
-    invr = λ {x y} → AbGroupStr.invr (homAbStr x y)
-    +assoc = λ {x y} → AbGroupStr.assoc (homAbStr x y)
-    +comm = λ {x y} → AbGroupStr.comm (homAbStr x y)
-
-    -dist+ : {x y : ob} (f g : Hom[ x , y ]) →
-        - (f + g) ≡ (- f) + (- g)
-    -dist+ {x} {y} f g =
-      let open GroupTheory (AbGroup→Group (Hom[ x , y ] , homAbStr x y)) in
-        (invDistr _ _) ∙ (+comm _ _)
-
-    +4assoc : {x y : ob} (a b c d : Hom[ x , y ]) →
-        (a + b) + (c + d)  ≡  a + (b + c) + d
-    +4assoc a b c d = sym (+assoc _ _ _) ∙ cong (a +_) (+assoc _ _ _)
-
-    +4comm : {x y : ob} (a b c d : Hom[ x , y ]) →
-        (a + b) + (c + d)  ≡  (a + c) + (b + d)
-    +4comm a b c d = +4assoc _ _ _ _ ∙
-        cong (λ u → a + (u + d)) (+comm _ _) ∙ sym (+4assoc _ _ _ _)
-
-
-  -- Preadditive categories
-  record PreaddCategoryStr : Type (ℓ-max ℓ (ℓ-suc ℓ')) where
-    field
-      habstr : HomAbStr
-
-    open HomAbStr habstr public
-
     field
       distl : {x y z : ob} → (f : Hom[ x , y ]) → (g g' : Hom[ y , z ]) →
           f ⋆ (g + g') ≡ (f ⋆ g) + (f ⋆ g')
@@ -73,49 +41,20 @@ module _ (C : Category ℓ ℓ') where
       distr : {x y z : ob} → (f f' : Hom[ x , y ]) → (g : Hom[ y , z ]) →
           (f + f') ⋆ g ≡ (f ⋆ g) + (f' ⋆ g)
 
-    -- Some useful lemmas
-    0h⋆ : ∀ {w x y} (f : Hom[ x , y ]) → 0h ⋆ f ≡ 0h {w}
-    0h⋆ f =
-        0h ⋆ f                              ≡⟨ sym (idr _) ⟩
-        0h ⋆ f  +  0h                       ≡⟨ cong (0h ⋆ f +_) (sym (invr _)) ⟩
-        0h ⋆ f  +  (0h ⋆ f  ─  0h ⋆ f)      ≡⟨ +assoc _ _ _ ⟩
-        (0h ⋆ f  +  0h ⋆ f)  ─  0h ⋆ f      ≡⟨ cong (_─ 0h ⋆ f) (sym (distr _ _ _)) ⟩
-        (0h + 0h) ⋆ f  ─  0h ⋆ f            ≡⟨ cong (λ a → a ⋆ f ─ 0h ⋆ f) (idr _) ⟩
-        0h ⋆ f  ─  0h ⋆ f                   ≡⟨ invr _ ⟩
-        0h                                  ∎
 
-    _⋆0h : ∀ {x y z} (f : Hom[ x , y ]) → f ⋆ 0h ≡ 0h {x} {z}
-    f ⋆0h =
-        f ⋆ 0h                              ≡⟨ sym (idr _) ⟩
-        f ⋆ 0h  +  0h                       ≡⟨ cong (f ⋆ 0h +_) (sym (invr _)) ⟩
-        f ⋆ 0h  +  (f ⋆ 0h  ─  f ⋆ 0h)      ≡⟨ +assoc _ _ _ ⟩
-        (f ⋆ 0h  +  f ⋆ 0h)  ─  f ⋆ 0h      ≡⟨ cong (_─ f ⋆ 0h) (sym (distl _ _ _)) ⟩
-        f ⋆ (0h + 0h)  ─  f ⋆ 0h            ≡⟨ cong (λ a → f ⋆ a ─ f ⋆ 0h) (idr _) ⟩
-        f ⋆ 0h  ─  f ⋆ 0h                   ≡⟨ invr _ ⟩
-        0h                                  ∎
+record PreaddCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
+  field
+    cat : Category ℓ ℓ'
+    preadd : PreaddCategoryStr cat
 
-    -distl⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
-      → (- f) ⋆ g ≡ - (f ⋆ g)
-    -distl⋆ {x} {y} {z} f g =
-      let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
-      invUniqueR (
-        f ⋆ g + (- f) ⋆ g     ≡⟨ sym (distr _ _ _) ⟩
-        (f ─ f) ⋆ g           ≡⟨ cong (_⋆ g) (invr _) ⟩
-        0h ⋆ g                ≡⟨ 0h⋆ _ ⟩
-        0h                    ∎
-      )
+  open Category cat public
+  open PreaddCategoryStr preadd public
 
-    -distr⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
-      → f ⋆ (- g) ≡ - (f ⋆ g)
-    -distr⋆ {x} {y} {z} f g =
-      let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
-      invUniqueR (
-        f ⋆ g + f ⋆ (- g)     ≡⟨ sym (distl _ _ _) ⟩
-        f ⋆ (g ─ g)           ≡⟨ cong (f ⋆_) (invr _) ⟩
-        f ⋆ 0h                ≡⟨ _ ⋆0h ⟩
-        0h                    ∎
-      )
 
+
+-- Additive categories
+module _ (C : PreaddCategory ℓ ℓ') where
+  open PreaddCategory C
 
   -- Zero object
   record ZeroObject : Type (ℓ-max ℓ ℓ') where
@@ -126,33 +65,29 @@ module _ (C : Category ℓ ℓ') where
 
 
   -- Biproducts
-  module _ (habstr : HomAbStr) where
-    open HomAbStr habstr
+  record isBiproduct {x y x⊕y : ob}
+      (i₁ : Hom[ x , x⊕y ]) (i₂ : Hom[ y , x⊕y ])
+      (π₁ : Hom[ x⊕y , x ]) (π₂ : Hom[ x⊕y , y ])
+          : Type (ℓ-max ℓ ℓ') where
 
-    record isBiproduct {x y x⊕y : ob}
-        (i₁ : Hom[ x , x⊕y ]) (i₂ : Hom[ y , x⊕y ])
-        (π₁ : Hom[ x⊕y , x ]) (π₂ : Hom[ x⊕y , y ])
-            : Type (ℓ-max ℓ ℓ') where
-
-      field
-        i₁⋆π₁ : i₁ ⋆ π₁ ≡ id
-        i₁⋆π₂ : i₁ ⋆ π₂ ≡ 0h
-        i₂⋆π₁ : i₂ ⋆ π₁ ≡ 0h
-        i₂⋆π₂ : i₂ ⋆ π₂ ≡ id
-        ∑π⋆i : π₁ ⋆ i₁ + π₂ ⋆ i₂ ≡ id
+    field
+      i₁⋆π₁ : i₁ ⋆ π₁ ≡ id
+      i₁⋆π₂ : i₁ ⋆ π₂ ≡ 0h
+      i₂⋆π₁ : i₂ ⋆ π₁ ≡ 0h
+      i₂⋆π₂ : i₂ ⋆ π₂ ≡ id
+      ∑π⋆i : π₁ ⋆ i₁ + π₂ ⋆ i₂ ≡ id
 
 
-    record Biproduct (x y : ob) : Type (ℓ-max ℓ ℓ') where
-      field
-        x⊕y : ob
-        i₁ : Hom[ x , x⊕y ]
-        i₂ : Hom[ y , x⊕y ]
-        π₁ : Hom[ x⊕y , x ]
-        π₂ : Hom[ x⊕y , y ]
-        isBipr : isBiproduct i₁ i₂ π₁ π₂
+  record Biproduct (x y : ob) : Type (ℓ-max ℓ ℓ') where
+    field
+      x⊕y : ob
+      i₁ : Hom[ x , x⊕y ]
+      i₂ : Hom[ y , x⊕y ]
+      π₁ : Hom[ x⊕y , x ]
+      π₂ : Hom[ x⊕y , y ]
+      isBipr : isBiproduct i₁ i₂ π₁ π₂
 
-      open isBiproduct isBipr public
-
+    open isBiproduct isBipr public
 
 
   -- Additive categories
@@ -164,7 +99,7 @@ module _ (C : Category ℓ ℓ') where
 
     field
       zero : ZeroObject
-      biprod : ∀ x y → Biproduct habstr x y
+      biprod : ∀ x y → Biproduct x y
 
     -- Biproduct notation
     open Biproduct
@@ -172,13 +107,6 @@ module _ (C : Category ℓ ℓ') where
     infixr 6 _⊕_
 
 
-record PreaddCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
-  field
-    cat : Category ℓ ℓ'
-    preadd : PreaddCategoryStr cat
-
-  open Category cat public
-  open PreaddCategoryStr preadd public
 
 
 record AdditiveCategory (ℓ ℓ' : Level) : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
@@ -195,272 +123,3 @@ AddCat→PreaddCat A = record {
     cat = A .AdditiveCategory.cat;
     preadd = A .AdditiveCategory.addit .AdditiveCategoryStr.preadd
   }
-
-
--- Matrix notation for morphisms (x₁ ⊕ ⋯ ⊕ x­­ₙ) → (y₁ ⊕ ⋯ ⊕ yₘ)
-module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
-    open AdditiveCategory A
-
-    -- Polymorphic biproduct morphisms
-    i₁ = λ {x y} → Biproduct.i₁ (biprod x y)
-    i₂ = λ {x y} → Biproduct.i₂ (biprod x y)
-    π₁ = λ {x y} → Biproduct.π₁ (biprod x y)
-    π₂ = λ {x y} → Biproduct.π₂ (biprod x y)
-    -- and axioms
-    i₁⋆π₁ = λ {x y} → Biproduct.i₁⋆π₁ (biprod x y)
-    i₁⋆π₂ = λ {x y} → Biproduct.i₁⋆π₂ (biprod x y)
-    i₂⋆π₁ = λ {x y} → Biproduct.i₂⋆π₁ (biprod x y)
-    i₂⋆π₂ = λ {x y} → Biproduct.i₂⋆π₂ (biprod x y)
-    ∑π⋆i  = λ {x y} → Biproduct.∑π⋆i  (biprod x y)
-
-
-    _∣_ : ∀ {x y y'} → Hom[ x , y ] → Hom[ x , y' ] → Hom[ x , y ⊕ y' ]
-    f ∣ f' = (f ⋆ i₁) + (f' ⋆ i₂)
-    infixr 5 _∣_
-
-    _`_ : ∀ {y y' z} → Hom[ y , z ] → Hom[ y' , z ] → Hom[ y ⊕ y' , z ]
-    g ` g' = (π₁ ⋆ g) + (π₂ ⋆ g')
-    infixr 6 _`_
-
-
-    -- Use the matrix notation like this:
-    private module _ (x y : ob) (f : Hom[ x , y ]) where
-
-      h : Hom[ x ⊕ x ⊕ x , y ⊕ y ⊕ y ⊕ y ]
-
-      h =  f  ` - f `  0h   ∣
-           0h `  0h `  f    ∣
-           f  ` - f `  0h   ∣
-           0h `  f  ` f + f
-
-
-    -- ρ X ⋆ i₁ ≡ i₁ ⋆ (ρ X ` 0h ∣ 0h ` ρ Y)
-
-    -- i₁ ⋆ (a ` b ∣ c ` d)
-    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
-    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
-
-    -- i ⋆ (a ∣ c) ` (b ∣ d)
-
-
-    -- Exchange law
-    exchange : ∀ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y ])
-            (c : Hom[ x , y' ]) (d : Hom[ x' , y' ]) →
-        (a ` b ∣ c ` d)  ≡  (a ∣ c) ` (b ∣ d)
-
-    exchange a b c d =
-        (π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂
-                ≡⟨ cong₂ _+_ (distr _ _ _) (distr _ _ _) ⟩
-        ((π₁ ⋆ a) ⋆ i₁  +  (π₂ ⋆ b) ⋆ i₁)  +  ((π₁ ⋆ c) ⋆ i₂  +  (π₂ ⋆ d) ⋆ i₂)
-                ≡⟨ +4comm _ _ _ _ ⟩
-        ((π₁ ⋆ a) ⋆ i₁  +  (π₁ ⋆ c) ⋆ i₂)  +  ((π₂ ⋆ b) ⋆ i₁  +  (π₂ ⋆ d) ⋆ i₂)
-                ≡⟨ cong₂ _+_ (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _))
-                            (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _)) ⟩
-        (π₁ ⋆ (a ⋆ i₁)  +  π₁ ⋆ (c ⋆ i₂))  +  (π₂ ⋆ (b ⋆ i₁)  +  π₂ ⋆ (d ⋆ i₂))
-                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
-        π₁ ⋆ (a ⋆ i₁  +  c ⋆ i₂)  +  π₂ ⋆ (b ⋆ i₁  +  d ⋆ i₂)
-                ∎
-
-
-    -- iₖ times a row
-    module _ {x x' y : ob} (a : Hom[ x , y ]) (b : Hom[ x' , y ]) where
-
-      i₁⋆row :  i₁ ⋆ (a ` b)  ≡  a
-      i₁⋆row =
-          i₁ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
-                  ≡⟨ distl _ _ _ ⟩
-          i₁ ⋆ (π₁ ⋆ a)  +  i₁ ⋆ (π₂ ⋆ b)
-                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
-          (i₁ ⋆ π₁) ⋆ a  +  (i₁ ⋆ π₂) ⋆ b
-                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₁⋆π₁ i₁⋆π₂ ⟩
-          id ⋆ a  +  0h ⋆ b             
-                  ≡⟨ cong₂ _+_ (⋆IdL _) (0h⋆ _) ⟩
-          a  +  0h                      
-                  ≡⟨ idr _ ⟩
-          a       ∎
-
-      i₂⋆row :  i₂ ⋆ (a ` b)  ≡  b
-      i₂⋆row =
-          i₂ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
-                  ≡⟨ distl _ _ _ ⟩
-          i₂ ⋆ (π₁ ⋆ a)  +  i₂ ⋆ (π₂ ⋆ b)
-                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
-          (i₂ ⋆ π₁) ⋆ a  +  (i₂ ⋆ π₂) ⋆ b
-                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₂⋆π₁ i₂⋆π₂ ⟩
-          0h ⋆ a  +  id ⋆ b             
-                  ≡⟨ cong₂ _+_ (0h⋆ _) (⋆IdL _) ⟩
-          0h  +  b                      
-                  ≡⟨ idl _ ⟩
-          b       ∎
-
-
-    -- A column times πₖ
-    module _ {x y y' : ob} (a : Hom[ x , y ]) (b : Hom[ x , y' ]) where
-
-      col⋆π₁ :  (a ∣ b) ⋆ π₁  ≡  a
-      col⋆π₁ =
-          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₁
-                  ≡⟨ distr _ _ _ ⟩
-          (a ⋆ i₁) ⋆ π₁  +  (b ⋆ i₂) ⋆ π₁
-                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
-          a ⋆ (i₁ ⋆ π₁)  +  b ⋆ (i₂ ⋆ π₁)
-                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₁ i₂⋆π₁ ⟩
-          a ⋆ id  +  b ⋆ 0h
-                  ≡⟨ cong₂ _+_ (⋆IdR _) (_ ⋆0h) ⟩
-          a  +  0h
-                  ≡⟨ idr _ ⟩
-          a       ∎
-
-      col⋆π₂ :  (a ∣ b) ⋆ π₂  ≡  b
-      col⋆π₂ =
-          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₂
-                  ≡⟨ distr _ _ _ ⟩
-          (a ⋆ i₁) ⋆ π₂  +  (b ⋆ i₂) ⋆ π₂
-                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
-          a ⋆ (i₁ ⋆ π₂)  +  b ⋆ (i₂ ⋆ π₂)
-                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₂ i₂⋆π₂ ⟩
-          a ⋆ 0h  +  b ⋆ id
-                  ≡⟨ cong₂ _+_ (_ ⋆0h) (⋆IdR _) ⟩
-          0h  +  b
-                  ≡⟨ idl _ ⟩
-          b       ∎
-
-    -- iₖ / πₖ times a diagonal matrix
-    module _ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y' ]) where
-    
-      i₁⋆diag :  i₁ ⋆ (a ` 0h ∣ 0h ` b)  ≡  a ⋆ i₁
-      i₁⋆diag =
-          i₁ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₁ ⋆_) (exchange _ _ _ _) ⟩
-          i₁ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₁⋆row _ _ ⟩
-          (a ∣ 0h)                        ≡⟨ cong (a ⋆ i₁ +_) (0h⋆ _) ⟩
-          a ⋆ i₁  +  0h                   ≡⟨ idr _ ⟩
-          a ⋆ i₁                          ∎
-    
-      i₂⋆diag :  i₂ ⋆ (a ` 0h ∣ 0h ` b)  ≡  b ⋆ i₂
-      i₂⋆diag =
-          i₂ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₂ ⋆_) (exchange _ _ _ _) ⟩
-          i₂ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₂⋆row _ _ ⟩
-          (0h ∣ b)                        ≡⟨ cong (_+ b ⋆ i₂) (0h⋆ _) ⟩
-          0h  +  b ⋆ i₂                   ≡⟨ idl _ ⟩
-          b ⋆ i₂                          ∎
-
-      diag⋆π₁ :  (a ` 0h ∣ 0h ` b) ⋆ π₁  ≡  π₁ ⋆ a
-      diag⋆π₁ =
-          (a ` 0h ∣ 0h ` b) ⋆ π₁      ≡⟨ col⋆π₁ _ _ ⟩
-          a ` 0h                      ≡⟨ cong (π₁ ⋆ a +_) (_ ⋆0h) ⟩
-          π₁ ⋆ a  +  0h               ≡⟨ idr _ ⟩
-          π₁ ⋆ a                      ∎
-
-      diag⋆π₂ :  (a ` 0h ∣ 0h ` b) ⋆ π₂  ≡  π₂ ⋆ b
-      diag⋆π₂ =
-          (a ` 0h ∣ 0h ` b) ⋆ π₂      ≡⟨ col⋆π₂ _ _ ⟩
-          0h ` b                      ≡⟨ cong (_+ π₂ ⋆ b) (_ ⋆0h) ⟩
-          0h  +  π₂ ⋆ b               ≡⟨ idl _ ⟩
-          π₂ ⋆ b                      ∎
-    
-
-    -- Matrix addition
-    addRow : ∀ {x y z}
-        (f f' : Hom[ x , z ]) (g g' : Hom[ y , z ]) →
-        (f ` g) + (f' ` g') ≡ (f + f') ` (g + g')
-
-    addRow f f' g g' =
-        (π₁ ⋆ f + π₂ ⋆ g) + (π₁ ⋆ f' + π₂ ⋆ g')
-                ≡⟨ +4comm _ _ _ _ ⟩
-        (π₁ ⋆ f + π₁ ⋆ f') + (π₂ ⋆ g + π₂ ⋆ g')
-                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
-        π₁ ⋆ (f + f') + π₂ ⋆ (g + g')
-                ∎
-
-    addCol : ∀ {x y z}
-        (f f' : Hom[ x , y ]) (g g' : Hom[ x , z ]) →
-        (f ∣ g) + (f' ∣ g') ≡ (f + f') ∣ (g + g')
-
-    addCol f f' g g' =
-        (f ⋆ i₁ + g ⋆ i₂) + (f' ⋆ i₁ + g' ⋆ i₂)
-                ≡⟨ +4comm _ _ _ _ ⟩
-        (f ⋆ i₁ + f' ⋆ i₁) + (g ⋆ i₂ + g' ⋆ i₂)
-                ≡⟨ sym (cong₂ _+_ (distr _ _ _) (distr _ _ _)) ⟩
-        (f + f') ⋆ i₁ + (g + g') ⋆ i₂
-                ∎
-
-
-    private
-      ⋆4assoc : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
-              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
-          (a ⋆ b) ⋆ (c ⋆ d) ≡ a ⋆ (b ⋆ c) ⋆ d
-      ⋆4assoc a b c d = (⋆Assoc _ _ _) ∙ cong (a ⋆_) (sym (⋆Assoc _ _ _))
-
-      ⋆4assoc' : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
-              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
-          (a ⋆ b) ⋆ (c ⋆ d) ≡ (a ⋆ (b ⋆ c)) ⋆ d
-      ⋆4assoc' a b c d = sym (⋆Assoc _ _ _) ∙ cong (_⋆ d) (⋆Assoc _ _ _)
-
-
-    -- Matrix multiplication
-    innerProd : ∀ {x y₁ y₂ z} (f₁ : Hom[ x , y₁ ]) (g₁ : Hom[ y₁ , z ])
-                              (f₂ : Hom[ x , y₂ ]) (g₂ : Hom[ y₂ , z ]) →
-        (f₁ ∣ f₂) ⋆ (g₁ ` g₂) ≡ (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
-
-    innerProd f₁ g₁ f₂ g₂ =
-        (f₁ ⋆ i₁ + f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
-                ≡⟨ distr _ _ _ ⟩
-        (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)  +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
-                ≡⟨ cong₂ _+_ (distl _ _ _) (distl _ _ _) ⟩
-        ((f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)  +  (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂))
-            +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)  +  (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)
-                ≡⟨ cong₂ _+_ (cong₂ _+_ eq₁₁ eq₁₂) (cong₂ _+_ eq₂₁ eq₂₂) ⟩
-        (f₁ ⋆ g₁  +  0h)  +  0h  +  f₂ ⋆ g₂
-                ≡⟨ cong₂ _+_ (idr _) (idl _) ⟩
-        (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
-                ∎
-     where
-      eq₁₁ = (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
-             f₁ ⋆ (i₁ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₁ ⟩
-             f₁ ⋆ id ⋆ g₁               ≡⟨ cong (f₁ ⋆_) (⋆IdL _) ⟩
-             f₁ ⋆ g₁                    ∎
-
-      eq₁₂ = (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
-             f₁ ⋆ (i₁ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₂ ⟩
-             f₁ ⋆ 0h ⋆ g₂               ≡⟨ cong (f₁ ⋆_) (0h⋆ _) ⟩
-             f₁ ⋆ 0h                    ≡⟨ _ ⋆0h ⟩
-             0h                         ∎
-
-      eq₂₁ = (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
-             f₂ ⋆ (i₂ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₁ ⟩
-             f₂ ⋆ 0h ⋆ g₁               ≡⟨ cong (f₂ ⋆_) (0h⋆ _) ⟩
-             f₂ ⋆ 0h                    ≡⟨ _ ⋆0h ⟩
-             0h                         ∎
-
-      eq₂₂ = (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
-             f₂ ⋆ (i₂ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₂ ⟩
-             f₂ ⋆ id ⋆ g₂               ≡⟨ cong (f₂ ⋆_) (⋆IdL _) ⟩
-             f₂ ⋆ g₂                    ∎
-
-
-    outerProd : ∀ {x₁ x₂ y z₁ z₂} (f₁ : Hom[ x₁ , y ]) (g₁ : Hom[ y , z₁ ])
-                                  (f₂ : Hom[ x₂ , y ]) (g₂ : Hom[ y , z₂ ]) →
-
-        (f₁ ` f₂) ⋆ (g₁ ∣ g₂)  ≡  f₁ ⋆ g₁ ` f₂ ⋆ g₁ ∣
-                                  f₁ ⋆ g₂ ` f₂ ⋆ g₂
-
-    outerProd {y = y} f₁ g₁ f₂ g₂ =
-        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁  +  g₂ ⋆ i₂)
-                ≡⟨ distl _ _ _ ⟩
-        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁)  +  (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₂ ⋆ i₂)
-                ≡⟨ cong₂ _+_ (eq g₁ i₁) (eq g₂ i₂) ⟩
-           (π₁ ⋆ (f₁ ⋆ g₁)  +  π₂ ⋆ (f₂ ⋆ g₁)) ⋆ i₁
-        +  (π₁ ⋆ (f₁ ⋆ g₂)  +  π₂ ⋆ (f₂ ⋆ g₂)) ⋆ i₂
-                ∎
-     where
-      eq = λ {z w} (g : Hom[ y , z ]) (i : Hom[ z , w ]) →
-        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g ⋆ i)
-                ≡⟨ distr _ _ _ ⟩
-        (π₁ ⋆ f₁) ⋆ (g ⋆ i)  +  (π₂ ⋆ f₂) ⋆ (g ⋆ i)
-                ≡⟨ cong₂ _+_ (⋆4assoc' _ _ _ _) (⋆4assoc' _ _ _ _) ⟩
-        (π₁ ⋆ (f₁ ⋆ g)) ⋆ i  +  (π₂ ⋆ (f₂ ⋆ g)) ⋆ i
-                ≡⟨ sym (distr _ _ _) ⟩
-        (π₁ ⋆ (f₁ ⋆ g)  +  π₂ ⋆ (f₂ ⋆ g)) ⋆ i
-                    ∎
-
-    -- Can we multiply an m×n matrix with an n×k matrix?

--- a/Cubical/Categories/Additive/Base.agda
+++ b/Cubical/Categories/Additive/Base.agda
@@ -34,10 +34,10 @@ module _ (C : Category ℓ ℓ') where
     infix  8    -_
 
     field
-      distl : {x y z : ob} → (f : Hom[ x , y ]) → (g g' : Hom[ y , z ]) →
+      ⋆distl+ : {x y z : ob} → (f : Hom[ x , y ]) → (g g' : Hom[ y , z ]) →
           f ⋆ (g + g') ≡ (f ⋆ g) + (f ⋆ g')
 
-      distr : {x y z : ob} → (f f' : Hom[ x , y ]) → (g : Hom[ y , z ]) →
+      ⋆distr+ : {x y z : ob} → (f f' : Hom[ x , y ]) → (g : Hom[ y , z ]) →
           (f + f') ⋆ g ≡ (f ⋆ g) + (f' ⋆ g)
 
 
@@ -64,7 +64,7 @@ module _ (C : PreaddCategory ℓ ℓ') where
 
 
   -- Biproducts
-  record isBiproduct {x y x⊕y : ob}
+  record IsBiproduct {x y x⊕y : ob}
       (i₁ : Hom[ x , x⊕y ]) (i₂ : Hom[ y , x⊕y ])
       (π₁ : Hom[ x⊕y , x ]) (π₂ : Hom[ x⊕y , y ])
           : Type (ℓ-max ℓ ℓ') where
@@ -84,9 +84,9 @@ module _ (C : PreaddCategory ℓ ℓ') where
       i₂ : Hom[ y , x⊕y ]
       π₁ : Hom[ x⊕y , x ]
       π₂ : Hom[ x⊕y , y ]
-      isBipr : isBiproduct i₁ i₂ π₁ π₂
+      isBipr : IsBiproduct i₁ i₂ π₁ π₂
 
-    open isBiproduct isBipr public
+    open IsBiproduct isBipr public
 
 
   -- Additive categories

--- a/Cubical/Categories/Additive/Properties.agda
+++ b/Cubical/Categories/Additive/Properties.agda
@@ -16,7 +16,7 @@ private
 -- Some useful lemmas about preadditive categories
 module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
   open PreaddCategory C
-  
+
   -- Pure group theory lemmas
   +idl = λ {x y} → AbGroupStr.lid (homAbStr x y)
   +idr = λ {x y} → AbGroupStr.rid (homAbStr x y)
@@ -47,7 +47,7 @@ module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
       0h ⋆ f                              ≡⟨ sym (+idr _) ⟩
       0h ⋆ f  +  0h                       ≡⟨ cong (0h ⋆ f +_) (sym (+invr _)) ⟩
       0h ⋆ f  +  (0h ⋆ f  ─  0h ⋆ f)      ≡⟨ +assoc _ _ _ ⟩
-      (0h ⋆ f  +  0h ⋆ f)  ─  0h ⋆ f      ≡⟨ cong (_─ 0h ⋆ f) (sym (distr _ _ _)) ⟩
+      (0h ⋆ f  +  0h ⋆ f)  ─  0h ⋆ f      ≡⟨ cong (_─ 0h ⋆ f) (sym (⋆distr+ _ _ _)) ⟩
       (0h + 0h) ⋆ f  ─  0h ⋆ f            ≡⟨ cong (λ a → a ⋆ f ─ 0h ⋆ f) (+idr _) ⟩
       0h ⋆ f  ─  0h ⋆ f                   ≡⟨ +invr _ ⟩
       0h                                  ∎
@@ -57,7 +57,7 @@ module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
       f ⋆ 0h                              ≡⟨ sym (+idr _) ⟩
       f ⋆ 0h  +  0h                       ≡⟨ cong (f ⋆ 0h +_) (sym (+invr _)) ⟩
       f ⋆ 0h  +  (f ⋆ 0h  ─  f ⋆ 0h)      ≡⟨ +assoc _ _ _ ⟩
-      (f ⋆ 0h  +  f ⋆ 0h)  ─  f ⋆ 0h      ≡⟨ cong (_─ f ⋆ 0h) (sym (distl _ _ _)) ⟩
+      (f ⋆ 0h  +  f ⋆ 0h)  ─  f ⋆ 0h      ≡⟨ cong (_─ f ⋆ 0h) (sym (⋆distl+ _ _ _)) ⟩
       f ⋆ (0h + 0h)  ─  f ⋆ 0h            ≡⟨ cong (λ a → f ⋆ a ─ f ⋆ 0h) (+idr _) ⟩
       f ⋆ 0h  ─  f ⋆ 0h                   ≡⟨ +invr _ ⟩
       0h                                  ∎
@@ -67,7 +67,7 @@ module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
   -distl⋆ {x} {y} {z} f g =
     let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
     invUniqueR (
-      f ⋆ g + (- f) ⋆ g     ≡⟨ sym (distr _ _ _) ⟩
+      f ⋆ g + (- f) ⋆ g     ≡⟨ sym (⋆distr+ _ _ _) ⟩
       (f ─ f) ⋆ g           ≡⟨ cong (_⋆ g) (+invr _) ⟩
       0h ⋆ g                ≡⟨ ⋆0hl _ ⟩
       0h                    ∎
@@ -78,7 +78,7 @@ module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
   -distr⋆ {x} {y} {z} f g =
     let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
     invUniqueR (
-      f ⋆ g + f ⋆ (- g)     ≡⟨ sym (distl _ _ _) ⟩
+      f ⋆ g + f ⋆ (- g)     ≡⟨ sym (⋆distl+ _ _ _) ⟩
       f ⋆ (g ─ g)           ≡⟨ cong (f ⋆_) (+invr _) ⟩
       f ⋆ 0h                ≡⟨ ⋆0hr _ ⟩
       0h                    ∎
@@ -131,14 +131,14 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
 
     exchange a b c d =
         (π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂
-                ≡⟨ cong₂ _+_ (distr _ _ _) (distr _ _ _) ⟩
+                ≡⟨ cong₂ _+_ (⋆distr+ _ _ _) (⋆distr+ _ _ _) ⟩
         ((π₁ ⋆ a) ⋆ i₁  +  (π₂ ⋆ b) ⋆ i₁)  +  ((π₁ ⋆ c) ⋆ i₂  +  (π₂ ⋆ d) ⋆ i₂)
                 ≡⟨ +4comm _ _ _ _ ⟩
         ((π₁ ⋆ a) ⋆ i₁  +  (π₁ ⋆ c) ⋆ i₂)  +  ((π₂ ⋆ b) ⋆ i₁  +  (π₂ ⋆ d) ⋆ i₂)
                 ≡⟨ cong₂ _+_ (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _))
                             (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _)) ⟩
         (π₁ ⋆ (a ⋆ i₁)  +  π₁ ⋆ (c ⋆ i₂))  +  (π₂ ⋆ (b ⋆ i₁)  +  π₂ ⋆ (d ⋆ i₂))
-                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+                ≡⟨ sym (cong₂ _+_ (⋆distl+ _ _ _) (⋆distl+ _ _ _)) ⟩
         π₁ ⋆ (a ⋆ i₁  +  c ⋆ i₂)  +  π₂ ⋆ (b ⋆ i₁  +  d ⋆ i₂)
                 ∎
 
@@ -148,29 +148,29 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
 
       i₁⋆row :  i₁ ⋆ (a ` b)  ≡  a
       i₁⋆row =
-          i₁ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
-                  ≡⟨ distl _ _ _ ⟩
+          i₁ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)
+                  ≡⟨ ⋆distl+ _ _ _ ⟩
           i₁ ⋆ (π₁ ⋆ a)  +  i₁ ⋆ (π₂ ⋆ b)
                   ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
           (i₁ ⋆ π₁) ⋆ a  +  (i₁ ⋆ π₂) ⋆ b
                   ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₁⋆π₁ i₁⋆π₂ ⟩
-          id ⋆ a  +  0h ⋆ b             
+          id ⋆ a  +  0h ⋆ b
                   ≡⟨ cong₂ _+_ (⋆IdL _) (⋆0hl _) ⟩
-          a  +  0h                      
+          a  +  0h
                   ≡⟨ +idr _ ⟩
           a       ∎
 
       i₂⋆row :  i₂ ⋆ (a ` b)  ≡  b
       i₂⋆row =
-          i₂ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
-                  ≡⟨ distl _ _ _ ⟩
+          i₂ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)
+                  ≡⟨ ⋆distl+ _ _ _ ⟩
           i₂ ⋆ (π₁ ⋆ a)  +  i₂ ⋆ (π₂ ⋆ b)
                   ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
           (i₂ ⋆ π₁) ⋆ a  +  (i₂ ⋆ π₂) ⋆ b
                   ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₂⋆π₁ i₂⋆π₂ ⟩
-          0h ⋆ a  +  id ⋆ b             
+          0h ⋆ a  +  id ⋆ b
                   ≡⟨ cong₂ _+_ (⋆0hl _) (⋆IdL _) ⟩
-          0h  +  b                      
+          0h  +  b
                   ≡⟨ +idl _ ⟩
           b       ∎
 
@@ -181,7 +181,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
       col⋆π₁ :  (a ∣ b) ⋆ π₁  ≡  a
       col⋆π₁ =
           (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₁
-                  ≡⟨ distr _ _ _ ⟩
+                  ≡⟨ ⋆distr+ _ _ _ ⟩
           (a ⋆ i₁) ⋆ π₁  +  (b ⋆ i₂) ⋆ π₁
                   ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
           a ⋆ (i₁ ⋆ π₁)  +  b ⋆ (i₂ ⋆ π₁)
@@ -195,7 +195,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
       col⋆π₂ :  (a ∣ b) ⋆ π₂  ≡  b
       col⋆π₂ =
           (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₂
-                  ≡⟨ distr _ _ _ ⟩
+                  ≡⟨ ⋆distr+ _ _ _ ⟩
           (a ⋆ i₁) ⋆ π₂  +  (b ⋆ i₂) ⋆ π₂
                   ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
           a ⋆ (i₁ ⋆ π₂)  +  b ⋆ (i₂ ⋆ π₂)
@@ -208,7 +208,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
 
     -- iₖ / πₖ times a diagonal matrix
     module _ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y' ]) where
-    
+
       i₁⋆diag :  i₁ ⋆ (a ` 0h ∣ 0h ` b)  ≡  a ⋆ i₁
       i₁⋆diag =
           i₁ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₁ ⋆_) (exchange _ _ _ _) ⟩
@@ -216,7 +216,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
           (a ∣ 0h)                        ≡⟨ cong (a ⋆ i₁ +_) (⋆0hl _) ⟩
           a ⋆ i₁  +  0h                   ≡⟨ +idr _ ⟩
           a ⋆ i₁                          ∎
-    
+
       i₂⋆diag :  i₂ ⋆ (a ` 0h ∣ 0h ` b)  ≡  b ⋆ i₂
       i₂⋆diag =
           i₂ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₂ ⋆_) (exchange _ _ _ _) ⟩
@@ -238,7 +238,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
           0h ` b                      ≡⟨ cong (_+ π₂ ⋆ b) (⋆0hr _) ⟩
           0h  +  π₂ ⋆ b               ≡⟨ +idl _ ⟩
           π₂ ⋆ b                      ∎
-    
+
 
     -- Matrix addition
     addRow : ∀ {x y z}
@@ -249,7 +249,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
         (π₁ ⋆ f + π₂ ⋆ g) + (π₁ ⋆ f' + π₂ ⋆ g')
                 ≡⟨ +4comm _ _ _ _ ⟩
         (π₁ ⋆ f + π₁ ⋆ f') + (π₂ ⋆ g + π₂ ⋆ g')
-                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+                ≡⟨ sym (cong₂ _+_ (⋆distl+ _ _ _) (⋆distl+ _ _ _)) ⟩
         π₁ ⋆ (f + f') + π₂ ⋆ (g + g')
                 ∎
 
@@ -261,7 +261,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
         (f ⋆ i₁ + g ⋆ i₂) + (f' ⋆ i₁ + g' ⋆ i₂)
                 ≡⟨ +4comm _ _ _ _ ⟩
         (f ⋆ i₁ + f' ⋆ i₁) + (g ⋆ i₂ + g' ⋆ i₂)
-                ≡⟨ sym (cong₂ _+_ (distr _ _ _) (distr _ _ _)) ⟩
+                ≡⟨ sym (cong₂ _+_ (⋆distr+ _ _ _) (⋆distr+ _ _ _)) ⟩
         (f + f') ⋆ i₁ + (g + g') ⋆ i₂
                 ∎
 
@@ -285,9 +285,9 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
 
     innerProd f₁ g₁ f₂ g₂ =
         (f₁ ⋆ i₁ + f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
-                ≡⟨ distr _ _ _ ⟩
+                ≡⟨ ⋆distr+ _ _ _ ⟩
         (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)  +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
-                ≡⟨ cong₂ _+_ (distl _ _ _) (distl _ _ _) ⟩
+                ≡⟨ cong₂ _+_ (⋆distl+ _ _ _) (⋆distl+ _ _ _) ⟩
         ((f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)  +  (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂))
             +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)  +  (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)
                 ≡⟨ cong₂ _+_ (cong₂ _+_ eq₁₁ eq₁₂) (cong₂ _+_ eq₂₁ eq₂₂) ⟩
@@ -327,7 +327,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
 
     outerProd {y = y} f₁ g₁ f₂ g₂ =
         (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁  +  g₂ ⋆ i₂)
-                ≡⟨ distl _ _ _ ⟩
+                ≡⟨ ⋆distl+ _ _ _ ⟩
         (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁)  +  (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₂ ⋆ i₂)
                 ≡⟨ cong₂ _+_ (eq g₁ i₁) (eq g₂ i₂) ⟩
            (π₁ ⋆ (f₁ ⋆ g₁)  +  π₂ ⋆ (f₂ ⋆ g₁)) ⋆ i₁
@@ -336,11 +336,11 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
      where
       eq = λ {z w} (g : Hom[ y , z ]) (i : Hom[ z , w ]) →
         (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g ⋆ i)
-                ≡⟨ distr _ _ _ ⟩
+                ≡⟨ ⋆distr+ _ _ _ ⟩
         (π₁ ⋆ f₁) ⋆ (g ⋆ i)  +  (π₂ ⋆ f₂) ⋆ (g ⋆ i)
                 ≡⟨ cong₂ _+_ (⋆4assoc' _ _ _ _) (⋆4assoc' _ _ _ _) ⟩
         (π₁ ⋆ (f₁ ⋆ g)) ⋆ i  +  (π₂ ⋆ (f₂ ⋆ g)) ⋆ i
-                ≡⟨ sym (distr _ _ _) ⟩
+                ≡⟨ sym (⋆distr+ _ _ _) ⟩
         (π₁ ⋆ (f₁ ⋆ g)  +  π₂ ⋆ (f₂ ⋆ g)) ⋆ i
                     ∎
 

--- a/Cubical/Categories/Additive/Properties.agda
+++ b/Cubical/Categories/Additive/Properties.agda
@@ -1,0 +1,355 @@
+-- Properties of (pre)additive categories
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Additive.Properties where
+
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Algebra.Group.Properties
+open import Cubical.Categories.Additive.Base
+open import Cubical.Foundations.Prelude
+
+private
+  variable
+    ℓ ℓ' : Level
+
+
+-- Some useful lemmas about preadditive categories
+module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
+  open PreaddCategory C
+  
+  -- Pure group theory lemmas
+  +idl = λ {x y} → AbGroupStr.lid (homAbStr x y)
+  +idr = λ {x y} → AbGroupStr.rid (homAbStr x y)
+  +invl = λ {x y} → AbGroupStr.invl (homAbStr x y)
+  +invr = λ {x y} → AbGroupStr.invr (homAbStr x y)
+  +assoc = λ {x y} → AbGroupStr.assoc (homAbStr x y)
+  +comm = λ {x y} → AbGroupStr.comm (homAbStr x y)
+
+  -dist+ : {x y : ob} (f g : Hom[ x , y ]) →
+      - (f + g) ≡ (- f) + (- g)
+  -dist+ {x} {y} f g =
+    let open GroupTheory (AbGroup→Group (Hom[ x , y ] , homAbStr x y)) in
+      (invDistr _ _) ∙ (+comm _ _)
+
+  +4assoc : {x y : ob} (a b c d : Hom[ x , y ]) →
+      (a + b) + (c + d)  ≡  a + (b + c) + d
+  +4assoc a b c d = sym (+assoc _ _ _) ∙ cong (a +_) (+assoc _ _ _)
+
+  +4comm : {x y : ob} (a b c d : Hom[ x , y ]) →
+      (a + b) + (c + d)  ≡  (a + c) + (b + d)
+  +4comm a b c d = +4assoc _ _ _ _ ∙
+      cong (λ u → a + (u + d)) (+comm _ _) ∙ sym (+4assoc _ _ _ _)
+
+
+  -- Interaction of categorical & group structure
+  ⋆0hl : ∀ {w x y} (f : Hom[ x , y ]) → 0h ⋆ f ≡ 0h {w}
+  ⋆0hl f =
+      0h ⋆ f                              ≡⟨ sym (+idr _) ⟩
+      0h ⋆ f  +  0h                       ≡⟨ cong (0h ⋆ f +_) (sym (+invr _)) ⟩
+      0h ⋆ f  +  (0h ⋆ f  ─  0h ⋆ f)      ≡⟨ +assoc _ _ _ ⟩
+      (0h ⋆ f  +  0h ⋆ f)  ─  0h ⋆ f      ≡⟨ cong (_─ 0h ⋆ f) (sym (distr _ _ _)) ⟩
+      (0h + 0h) ⋆ f  ─  0h ⋆ f            ≡⟨ cong (λ a → a ⋆ f ─ 0h ⋆ f) (+idr _) ⟩
+      0h ⋆ f  ─  0h ⋆ f                   ≡⟨ +invr _ ⟩
+      0h                                  ∎
+
+  ⋆0hr : ∀ {x y z} (f : Hom[ x , y ]) → f ⋆ 0h ≡ 0h {x} {z}
+  ⋆0hr f =
+      f ⋆ 0h                              ≡⟨ sym (+idr _) ⟩
+      f ⋆ 0h  +  0h                       ≡⟨ cong (f ⋆ 0h +_) (sym (+invr _)) ⟩
+      f ⋆ 0h  +  (f ⋆ 0h  ─  f ⋆ 0h)      ≡⟨ +assoc _ _ _ ⟩
+      (f ⋆ 0h  +  f ⋆ 0h)  ─  f ⋆ 0h      ≡⟨ cong (_─ f ⋆ 0h) (sym (distl _ _ _)) ⟩
+      f ⋆ (0h + 0h)  ─  f ⋆ 0h            ≡⟨ cong (λ a → f ⋆ a ─ f ⋆ 0h) (+idr _) ⟩
+      f ⋆ 0h  ─  f ⋆ 0h                   ≡⟨ +invr _ ⟩
+      0h                                  ∎
+
+  -distl⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
+    → (- f) ⋆ g ≡ - (f ⋆ g)
+  -distl⋆ {x} {y} {z} f g =
+    let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
+    invUniqueR (
+      f ⋆ g + (- f) ⋆ g     ≡⟨ sym (distr _ _ _) ⟩
+      (f ─ f) ⋆ g           ≡⟨ cong (_⋆ g) (+invr _) ⟩
+      0h ⋆ g                ≡⟨ ⋆0hl _ ⟩
+      0h                    ∎
+    )
+
+  -distr⋆ : ∀ {x y z} (f : Hom[ x , y ]) (g : Hom[ y , z ])
+    → f ⋆ (- g) ≡ - (f ⋆ g)
+  -distr⋆ {x} {y} {z} f g =
+    let open GroupTheory (AbGroup→Group (Hom[ x , z ] , homAbStr x z)) in
+    invUniqueR (
+      f ⋆ g + f ⋆ (- g)     ≡⟨ sym (distl _ _ _) ⟩
+      f ⋆ (g ─ g)           ≡⟨ cong (f ⋆_) (+invr _) ⟩
+      f ⋆ 0h                ≡⟨ ⋆0hr _ ⟩
+      0h                    ∎
+    )
+
+
+-- Matrix notation for morphisms  (x₁ ⊕ ⋯ ⊕ x­­ₙ) → (y₁ ⊕ ⋯ ⊕ yₘ)
+-- in an additive category
+module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
+    open AdditiveCategory A
+
+    -- Polymorphic biproduct morphisms
+    i₁ = λ {x y} → Biproduct.i₁ (biprod x y)
+    i₂ = λ {x y} → Biproduct.i₂ (biprod x y)
+    π₁ = λ {x y} → Biproduct.π₁ (biprod x y)
+    π₂ = λ {x y} → Biproduct.π₂ (biprod x y)
+    -- and axioms
+    i₁⋆π₁ = λ {x y} → Biproduct.i₁⋆π₁ (biprod x y)
+    i₁⋆π₂ = λ {x y} → Biproduct.i₁⋆π₂ (biprod x y)
+    i₂⋆π₁ = λ {x y} → Biproduct.i₂⋆π₁ (biprod x y)
+    i₂⋆π₂ = λ {x y} → Biproduct.i₂⋆π₂ (biprod x y)
+    ∑π⋆i  = λ {x y} → Biproduct.∑π⋆i  (biprod x y)
+
+
+    _∣_ : ∀ {x y y'} → Hom[ x , y ] → Hom[ x , y' ] → Hom[ x , y ⊕ y' ]
+    f ∣ f' = (f ⋆ i₁) + (f' ⋆ i₂)
+    infixr 5 _∣_
+
+    _`_ : ∀ {y y' z} → Hom[ y , z ] → Hom[ y' , z ] → Hom[ y ⊕ y' , z ]
+    g ` g' = (π₁ ⋆ g) + (π₂ ⋆ g')
+    infixr 6 _`_
+
+
+    -- Use the matrix notation like this:
+    private module _ (x y : ob) (f : Hom[ x , y ]) where
+
+      h : Hom[ x ⊕ x ⊕ x , y ⊕ y ⊕ y ⊕ y ]
+
+      h =  f  ` - f `  0h   ∣
+           0h `  0h `  f    ∣
+           f  ` - f `  0h   ∣
+           0h `  f  ` f + f
+
+
+    -- ρ X ⋆ i₁ ≡ i₁ ⋆ (ρ X ` 0h ∣ 0h ` ρ Y)
+
+    -- i₁ ⋆ (a ` b ∣ c ` d)
+    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
+    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
+
+    -- i ⋆ (a ∣ c) ` (b ∣ d)
+
+
+    -- Exchange law
+    exchange : ∀ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y ])
+            (c : Hom[ x , y' ]) (d : Hom[ x' , y' ]) →
+        (a ` b ∣ c ` d)  ≡  (a ∣ c) ` (b ∣ d)
+
+    exchange a b c d =
+        (π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂
+                ≡⟨ cong₂ _+_ (distr _ _ _) (distr _ _ _) ⟩
+        ((π₁ ⋆ a) ⋆ i₁  +  (π₂ ⋆ b) ⋆ i₁)  +  ((π₁ ⋆ c) ⋆ i₂  +  (π₂ ⋆ d) ⋆ i₂)
+                ≡⟨ +4comm _ _ _ _ ⟩
+        ((π₁ ⋆ a) ⋆ i₁  +  (π₁ ⋆ c) ⋆ i₂)  +  ((π₂ ⋆ b) ⋆ i₁  +  (π₂ ⋆ d) ⋆ i₂)
+                ≡⟨ cong₂ _+_ (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _))
+                            (cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _)) ⟩
+        (π₁ ⋆ (a ⋆ i₁)  +  π₁ ⋆ (c ⋆ i₂))  +  (π₂ ⋆ (b ⋆ i₁)  +  π₂ ⋆ (d ⋆ i₂))
+                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+        π₁ ⋆ (a ⋆ i₁  +  c ⋆ i₂)  +  π₂ ⋆ (b ⋆ i₁  +  d ⋆ i₂)
+                ∎
+
+
+    -- iₖ times a row
+    module _ {x x' y : ob} (a : Hom[ x , y ]) (b : Hom[ x' , y ]) where
+
+      i₁⋆row :  i₁ ⋆ (a ` b)  ≡  a
+      i₁⋆row =
+          i₁ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
+                  ≡⟨ distl _ _ _ ⟩
+          i₁ ⋆ (π₁ ⋆ a)  +  i₁ ⋆ (π₂ ⋆ b)
+                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
+          (i₁ ⋆ π₁) ⋆ a  +  (i₁ ⋆ π₂) ⋆ b
+                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₁⋆π₁ i₁⋆π₂ ⟩
+          id ⋆ a  +  0h ⋆ b             
+                  ≡⟨ cong₂ _+_ (⋆IdL _) (⋆0hl _) ⟩
+          a  +  0h                      
+                  ≡⟨ +idr _ ⟩
+          a       ∎
+
+      i₂⋆row :  i₂ ⋆ (a ` b)  ≡  b
+      i₂⋆row =
+          i₂ ⋆ (π₁ ⋆ a  +  π₂ ⋆ b)      
+                  ≡⟨ distl _ _ _ ⟩
+          i₂ ⋆ (π₁ ⋆ a)  +  i₂ ⋆ (π₂ ⋆ b)
+                  ≡⟨ cong₂ _+_ (sym (⋆Assoc _ _ _)) (sym (⋆Assoc _ _ _)) ⟩
+          (i₂ ⋆ π₁) ⋆ a  +  (i₂ ⋆ π₂) ⋆ b
+                  ≡⟨ cong₂ (λ u v → u ⋆ a + v ⋆ b) i₂⋆π₁ i₂⋆π₂ ⟩
+          0h ⋆ a  +  id ⋆ b             
+                  ≡⟨ cong₂ _+_ (⋆0hl _) (⋆IdL _) ⟩
+          0h  +  b                      
+                  ≡⟨ idl _ ⟩
+          b       ∎
+
+
+    -- A column times πₖ
+    module _ {x y y' : ob} (a : Hom[ x , y ]) (b : Hom[ x , y' ]) where
+
+      col⋆π₁ :  (a ∣ b) ⋆ π₁  ≡  a
+      col⋆π₁ =
+          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₁
+                  ≡⟨ distr _ _ _ ⟩
+          (a ⋆ i₁) ⋆ π₁  +  (b ⋆ i₂) ⋆ π₁
+                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
+          a ⋆ (i₁ ⋆ π₁)  +  b ⋆ (i₂ ⋆ π₁)
+                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₁ i₂⋆π₁ ⟩
+          a ⋆ id  +  b ⋆ 0h
+                  ≡⟨ cong₂ _+_ (⋆IdR _) (⋆0hr _) ⟩
+          a  +  0h
+                  ≡⟨ +idr _ ⟩
+          a       ∎
+
+      col⋆π₂ :  (a ∣ b) ⋆ π₂  ≡  b
+      col⋆π₂ =
+          (a ⋆ i₁  +  b ⋆ i₂) ⋆ π₂
+                  ≡⟨ distr _ _ _ ⟩
+          (a ⋆ i₁) ⋆ π₂  +  (b ⋆ i₂) ⋆ π₂
+                  ≡⟨ cong₂ _+_ (⋆Assoc _ _ _) (⋆Assoc _ _ _) ⟩
+          a ⋆ (i₁ ⋆ π₂)  +  b ⋆ (i₂ ⋆ π₂)
+                  ≡⟨ cong₂ (λ u v → a ⋆ u + b ⋆ v) i₁⋆π₂ i₂⋆π₂ ⟩
+          a ⋆ 0h  +  b ⋆ id
+                  ≡⟨ cong₂ _+_ (⋆0hr _) (⋆IdR _) ⟩
+          0h  +  b
+                  ≡⟨ idl _ ⟩
+          b       ∎
+
+    -- iₖ / πₖ times a diagonal matrix
+    module _ {x x' y y'} (a : Hom[ x , y ]) (b : Hom[ x' , y' ]) where
+    
+      i₁⋆diag :  i₁ ⋆ (a ` 0h ∣ 0h ` b)  ≡  a ⋆ i₁
+      i₁⋆diag =
+          i₁ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₁ ⋆_) (exchange _ _ _ _) ⟩
+          i₁ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₁⋆row _ _ ⟩
+          (a ∣ 0h)                        ≡⟨ cong (a ⋆ i₁ +_) (⋆0hl _) ⟩
+          a ⋆ i₁  +  0h                   ≡⟨ +idr _ ⟩
+          a ⋆ i₁                          ∎
+    
+      i₂⋆diag :  i₂ ⋆ (a ` 0h ∣ 0h ` b)  ≡  b ⋆ i₂
+      i₂⋆diag =
+          i₂ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₂ ⋆_) (exchange _ _ _ _) ⟩
+          i₂ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₂⋆row _ _ ⟩
+          (0h ∣ b)                        ≡⟨ cong (_+ b ⋆ i₂) (⋆0hl _) ⟩
+          0h  +  b ⋆ i₂                   ≡⟨ idl _ ⟩
+          b ⋆ i₂                          ∎
+
+      diag⋆π₁ :  (a ` 0h ∣ 0h ` b) ⋆ π₁  ≡  π₁ ⋆ a
+      diag⋆π₁ =
+          (a ` 0h ∣ 0h ` b) ⋆ π₁      ≡⟨ col⋆π₁ _ _ ⟩
+          a ` 0h                      ≡⟨ cong (π₁ ⋆ a +_) (⋆0hr _) ⟩
+          π₁ ⋆ a  +  0h               ≡⟨ +idr _ ⟩
+          π₁ ⋆ a                      ∎
+
+      diag⋆π₂ :  (a ` 0h ∣ 0h ` b) ⋆ π₂  ≡  π₂ ⋆ b
+      diag⋆π₂ =
+          (a ` 0h ∣ 0h ` b) ⋆ π₂      ≡⟨ col⋆π₂ _ _ ⟩
+          0h ` b                      ≡⟨ cong (_+ π₂ ⋆ b) (⋆0hr _) ⟩
+          0h  +  π₂ ⋆ b               ≡⟨ idl _ ⟩
+          π₂ ⋆ b                      ∎
+    
+
+    -- Matrix addition
+    addRow : ∀ {x y z}
+        (f f' : Hom[ x , z ]) (g g' : Hom[ y , z ]) →
+        (f ` g) + (f' ` g') ≡ (f + f') ` (g + g')
+
+    addRow f f' g g' =
+        (π₁ ⋆ f + π₂ ⋆ g) + (π₁ ⋆ f' + π₂ ⋆ g')
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (π₁ ⋆ f + π₁ ⋆ f') + (π₂ ⋆ g + π₂ ⋆ g')
+                ≡⟨ sym (cong₂ _+_ (distl _ _ _) (distl _ _ _)) ⟩
+        π₁ ⋆ (f + f') + π₂ ⋆ (g + g')
+                ∎
+
+    addCol : ∀ {x y z}
+        (f f' : Hom[ x , y ]) (g g' : Hom[ x , z ]) →
+        (f ∣ g) + (f' ∣ g') ≡ (f + f') ∣ (g + g')
+
+    addCol f f' g g' =
+        (f ⋆ i₁ + g ⋆ i₂) + (f' ⋆ i₁ + g' ⋆ i₂)
+                ≡⟨ +4comm _ _ _ _ ⟩
+        (f ⋆ i₁ + f' ⋆ i₁) + (g ⋆ i₂ + g' ⋆ i₂)
+                ≡⟨ sym (cong₂ _+_ (distr _ _ _) (distr _ _ _)) ⟩
+        (f + f') ⋆ i₁ + (g + g') ⋆ i₂
+                ∎
+
+
+    private
+      ⋆4assoc : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
+              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
+          (a ⋆ b) ⋆ (c ⋆ d) ≡ a ⋆ (b ⋆ c) ⋆ d
+      ⋆4assoc a b c d = (⋆Assoc _ _ _) ∙ cong (a ⋆_) (sym (⋆Assoc _ _ _))
+
+      ⋆4assoc' : ∀ {x y z w v} (a : Hom[ x , y ]) (b : Hom[ y , z ])
+              (c : Hom[ z , w ]) (d : Hom[ w , v ]) →
+          (a ⋆ b) ⋆ (c ⋆ d) ≡ (a ⋆ (b ⋆ c)) ⋆ d
+      ⋆4assoc' a b c d = sym (⋆Assoc _ _ _) ∙ cong (_⋆ d) (⋆Assoc _ _ _)
+
+
+    -- Matrix multiplication
+    innerProd : ∀ {x y₁ y₂ z} (f₁ : Hom[ x , y₁ ]) (g₁ : Hom[ y₁ , z ])
+                              (f₂ : Hom[ x , y₂ ]) (g₂ : Hom[ y₂ , z ]) →
+        (f₁ ∣ f₂) ⋆ (g₁ ` g₂) ≡ (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
+
+    innerProd f₁ g₁ f₂ g₂ =
+        (f₁ ⋆ i₁ + f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
+                ≡⟨ distr _ _ _ ⟩
+        (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)  +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁ + π₂ ⋆ g₂)
+                ≡⟨ cong₂ _+_ (distl _ _ _) (distl _ _ _) ⟩
+        ((f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)  +  (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂))
+            +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)  +  (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)
+                ≡⟨ cong₂ _+_ (cong₂ _+_ eq₁₁ eq₁₂) (cong₂ _+_ eq₂₁ eq₂₂) ⟩
+        (f₁ ⋆ g₁  +  0h)  +  0h  +  f₂ ⋆ g₂
+                ≡⟨ cong₂ _+_ (+idr _) (idl _) ⟩
+        (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
+                ∎
+     where
+      eq₁₁ = (f₁ ⋆ i₁) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₁ ⋆ (i₁ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₁ ⟩
+             f₁ ⋆ id ⋆ g₁               ≡⟨ cong (f₁ ⋆_) (⋆IdL _) ⟩
+             f₁ ⋆ g₁                    ∎
+
+      eq₁₂ = (f₁ ⋆ i₁) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₁ ⋆ (i₁ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₁⋆π₂ ⟩
+             f₁ ⋆ 0h ⋆ g₂               ≡⟨ cong (f₁ ⋆_) (⋆0hl _) ⟩
+             f₁ ⋆ 0h                    ≡⟨ ⋆0hr _ ⟩
+             0h                         ∎
+
+      eq₂₁ = (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₂ ⋆ (i₂ ⋆ π₁) ⋆ g₁        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₁ ⟩
+             f₂ ⋆ 0h ⋆ g₁               ≡⟨ cong (f₂ ⋆_) (⋆0hl _) ⟩
+             f₂ ⋆ 0h                    ≡⟨ ⋆0hr _ ⟩
+             0h                         ∎
+
+      eq₂₂ = (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)      ≡⟨ ⋆4assoc _ _ _ _ ⟩
+             f₂ ⋆ (i₂ ⋆ π₂) ⋆ g₂        ≡⟨ cong (λ u → _ ⋆ u ⋆ _) i₂⋆π₂ ⟩
+             f₂ ⋆ id ⋆ g₂               ≡⟨ cong (f₂ ⋆_) (⋆IdL _) ⟩
+             f₂ ⋆ g₂                    ∎
+
+
+    outerProd : ∀ {x₁ x₂ y z₁ z₂} (f₁ : Hom[ x₁ , y ]) (g₁ : Hom[ y , z₁ ])
+                                  (f₂ : Hom[ x₂ , y ]) (g₂ : Hom[ y , z₂ ]) →
+
+        (f₁ ` f₂) ⋆ (g₁ ∣ g₂)  ≡  f₁ ⋆ g₁ ` f₂ ⋆ g₁ ∣
+                                  f₁ ⋆ g₂ ` f₂ ⋆ g₂
+
+    outerProd {y = y} f₁ g₁ f₂ g₂ =
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁  +  g₂ ⋆ i₂)
+                ≡⟨ distl _ _ _ ⟩
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₁ ⋆ i₁)  +  (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g₂ ⋆ i₂)
+                ≡⟨ cong₂ _+_ (eq g₁ i₁) (eq g₂ i₂) ⟩
+           (π₁ ⋆ (f₁ ⋆ g₁)  +  π₂ ⋆ (f₂ ⋆ g₁)) ⋆ i₁
+        +  (π₁ ⋆ (f₁ ⋆ g₂)  +  π₂ ⋆ (f₂ ⋆ g₂)) ⋆ i₂
+                ∎
+     where
+      eq = λ {z w} (g : Hom[ y , z ]) (i : Hom[ z , w ]) →
+        (π₁ ⋆ f₁  +  π₂ ⋆ f₂) ⋆ (g ⋆ i)
+                ≡⟨ distr _ _ _ ⟩
+        (π₁ ⋆ f₁) ⋆ (g ⋆ i)  +  (π₂ ⋆ f₂) ⋆ (g ⋆ i)
+                ≡⟨ cong₂ _+_ (⋆4assoc' _ _ _ _) (⋆4assoc' _ _ _ _) ⟩
+        (π₁ ⋆ (f₁ ⋆ g)) ⋆ i  +  (π₂ ⋆ (f₂ ⋆ g)) ⋆ i
+                ≡⟨ sym (distr _ _ _) ⟩
+        (π₁ ⋆ (f₁ ⋆ g)  +  π₂ ⋆ (f₂ ⋆ g)) ⋆ i
+                    ∎
+
+    -- Can we multiply an m×n matrix with an n×k matrix?

--- a/Cubical/Categories/Additive/Properties.agda
+++ b/Cubical/Categories/Additive/Properties.agda
@@ -89,6 +89,7 @@ module PreaddCategoryTheory (C : PreaddCategory ℓ ℓ') where
 -- in an additive category
 module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
     open AdditiveCategory A
+    open PreaddCategoryTheory preaddcat
 
     -- Polymorphic biproduct morphisms
     i₁ = λ {x y} → Biproduct.i₁ (biprod x y)
@@ -121,15 +122,6 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
            0h `  0h `  f    ∣
            f  ` - f `  0h   ∣
            0h `  f  ` f + f
-
-
-    -- ρ X ⋆ i₁ ≡ i₁ ⋆ (ρ X ` 0h ∣ 0h ` ρ Y)
-
-    -- i₁ ⋆ (a ` b ∣ c ` d)
-    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
-    -- i₁ ⋆ ((π₁ ⋆ a  +  π₂ ⋆ b) ⋆ i₁  +  (π₁ ⋆ c  +  π₂ ⋆ d) ⋆ i₂)
-
-    -- i ⋆ (a ∣ c) ` (b ∣ d)
 
 
     -- Exchange law
@@ -179,7 +171,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
           0h ⋆ a  +  id ⋆ b             
                   ≡⟨ cong₂ _+_ (⋆0hl _) (⋆IdL _) ⟩
           0h  +  b                      
-                  ≡⟨ idl _ ⟩
+                  ≡⟨ +idl _ ⟩
           b       ∎
 
 
@@ -211,7 +203,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
           a ⋆ 0h  +  b ⋆ id
                   ≡⟨ cong₂ _+_ (⋆0hr _) (⋆IdR _) ⟩
           0h  +  b
-                  ≡⟨ idl _ ⟩
+                  ≡⟨ +idl _ ⟩
           b       ∎
 
     -- iₖ / πₖ times a diagonal matrix
@@ -230,7 +222,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
           i₂ ⋆ (a ` 0h ∣ 0h ` b)          ≡⟨ cong (i₂ ⋆_) (exchange _ _ _ _) ⟩
           i₂ ⋆ ((a ∣ 0h) ` (0h ∣ b))      ≡⟨ i₂⋆row _ _ ⟩
           (0h ∣ b)                        ≡⟨ cong (_+ b ⋆ i₂) (⋆0hl _) ⟩
-          0h  +  b ⋆ i₂                   ≡⟨ idl _ ⟩
+          0h  +  b ⋆ i₂                   ≡⟨ +idl _ ⟩
           b ⋆ i₂                          ∎
 
       diag⋆π₁ :  (a ` 0h ∣ 0h ` b) ⋆ π₁  ≡  π₁ ⋆ a
@@ -244,7 +236,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
       diag⋆π₂ =
           (a ` 0h ∣ 0h ` b) ⋆ π₂      ≡⟨ col⋆π₂ _ _ ⟩
           0h ` b                      ≡⟨ cong (_+ π₂ ⋆ b) (⋆0hr _) ⟩
-          0h  +  π₂ ⋆ b               ≡⟨ idl _ ⟩
+          0h  +  π₂ ⋆ b               ≡⟨ +idl _ ⟩
           π₂ ⋆ b                      ∎
     
 
@@ -300,7 +292,7 @@ module MatrixNotation (A : AdditiveCategory ℓ ℓ') where
             +  (f₂ ⋆ i₂) ⋆ (π₁ ⋆ g₁)  +  (f₂ ⋆ i₂) ⋆ (π₂ ⋆ g₂)
                 ≡⟨ cong₂ _+_ (cong₂ _+_ eq₁₁ eq₁₂) (cong₂ _+_ eq₂₁ eq₂₂) ⟩
         (f₁ ⋆ g₁  +  0h)  +  0h  +  f₂ ⋆ g₂
-                ≡⟨ cong₂ _+_ (+idr _) (idl _) ⟩
+                ≡⟨ cong₂ _+_ (+idr _) (+idl _) ⟩
         (f₁ ⋆ g₁) + (f₂ ⋆ g₂)
                 ∎
      where

--- a/Cubical/Categories/Additive/Quotient.agda
+++ b/Cubical/Categories/Additive/Quotient.agda
@@ -1,0 +1,157 @@
+-- Quotients of additive categories
+{-# OPTIONS --safe #-}
+
+module Cubical.Categories.Additive.Quotient where
+
+open import Cubical.Algebra.AbGroup.Base renaming (_/_ to _/G_)
+open import Cubical.Categories.Additive.Base
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Constructions.Quotient
+open import Cubical.Categories.Limits.Terminal
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Prelude
+open import Cubical.HITs.SetQuotients renaming (_/_ to _/s_; [_] to ⟦_⟧)
+
+private
+  variable
+    ℓ ℓ' ℓq : Level
+
+-- Quotients of preadditive categories
+module _ (C : PreaddCategory ℓ ℓ') where
+  open PreaddCategory C
+
+  module _ (_~_ : {x y : ob} (f g : Hom[ x , y ] ) → Type ℓq)
+           (~refl : {x y : ob} (f : Hom[ x , y ] ) → f ~ f)
+           (~cong⋆ : {x y z : ob}
+                     (f f' : Hom[ x , y ]) → f ~ f'
+                   → (g g' : Hom[ y , z ]) → g ~ g'
+                   → (f ⋆ g) ~ (f' ⋆ g'))
+           (~cong+ : {x y : ob} (f f' g g' : Hom[ x , y ])
+                   → f ~ f' → g ~ g' → (f + g) ~ (f' + g'))
+           (~cong- : {x y : ob} (f f' : Hom[ x , y ])
+                   → f ~ f' → (- f) ~ (- f'))           where
+
+    private
+      C/~ = QuotientCategory cat _~_ ~refl ~cong⋆
+      Hom[_,_]/~ = λ (x y : ob) → (Hom[ x , y ]) /s _~_
+      _⋆/~_ = C/~ .Category._⋆_
+
+      _+/~_ : {x y : ob} (f g : Hom[ x , y ]/~) → Hom[ x , y ]/~
+      _+/~_ = setQuotBinOp ~refl _+_ ~cong+
+
+    -- Quotient group structure on homsets
+    private
+      habstr/~ : HomAbStr C/~ --(x y : ob) → AbGroupStr Hom[ x , y ]/~
+      habstr/~ = homabstr
+        λ x y → abgroupstr
+          ⟦ 0h ⟧
+          _+/~_
+          (setQuotUnaryOp -_ ~cong-)
+          (makeIsAbGroup
+            squash/
+            (elimProp3 (λ _ _ _ → squash/ _ _)
+              λ _ _ _ → cong ⟦_⟧ (+assoc _ _ _))
+            (elimProp (λ _ → squash/ _ _)
+              λ _ → cong ⟦_⟧ (idr _))
+            (elimProp (λ _ → squash/ _ _)
+              λ _ → cong ⟦_⟧ (invr _))
+            (elimProp2 (λ _ _ → squash/ _ _)
+              λ _ _ → cong ⟦_⟧ (+comm _ _))
+          )
+
+    -- Distributivity
+    distl/~ : {x y z : ob} → (f : Hom[ x , y ]/~) → (g g' : Hom[ y , z ]/~) →
+        f  ⋆/~  (g  +/~  g')  ≡  (f  ⋆/~  g)  +/~  (f  ⋆/~  g')
+    distl/~ = elimProp (λ _ → isPropΠ2 (λ _ _ → squash/ _ _))
+              λ _ → elimProp2 (λ _ _ → squash/ _ _)
+                  (λ _ _ → cong ⟦_⟧ (distl _ _ _))
+
+    distr/~ : {x y z : ob} → (f f' : Hom[ x , y ]/~) → (g : Hom[ y , z ]/~) →
+        (f  +/~  f')  ⋆/~  g  ≡  (f  ⋆/~  g)  +/~  (f'  ⋆/~  g)
+    distr/~ = elimProp2 (λ _ _ → isPropΠ (λ _ → squash/ _ _))
+              λ _ _ → elimProp (λ _ → squash/ _ _)
+                  (λ _ → cong ⟦_⟧ (distr _ _ _))
+
+
+    -- Quotient of preadditive category
+    PreaddQuotient : PreaddCategory ℓ (ℓ-max ℓ' ℓq)
+    PreaddQuotient = record {
+        cat = C/~;
+        preadd = record {
+          habstr = habstr/~;
+          distl = distl/~;
+          distr = distr/~
+        }
+      }
+
+
+-- Quotients of additive categories
+module _ (A : AdditiveCategory ℓ ℓ') where
+  open AdditiveCategory A
+
+  module _ (_~_ : {x y : ob} (f g : Hom[ x , y ] ) → Type ℓq)
+           (~refl : {x y : ob} (f : Hom[ x , y ] ) → f ~ f)
+           (~cong⋆ : {x y z : ob}
+                     (f f' : Hom[ x , y ]) → f ~ f'
+                   → (g g' : Hom[ y , z ]) → g ~ g'
+                   → (f ⋆ g) ~ (f' ⋆ g'))
+           (~cong+ : {x y : ob} (f f' g g' : Hom[ x , y ])
+                   → f ~ f' → g ~ g' → (f + g) ~ (f' + g'))
+           (~cong- : {x y : ob} (f f' : Hom[ x , y ])
+                   → f ~ f' → (- f) ~ (- f'))           where
+
+    private
+      preaddquo = PreaddQuotient (AddCat→PreaddCat A)
+          _~_ ~refl ~cong⋆ ~cong+ ~cong-
+      A/~ = preaddquo .PreaddCategory.cat
+      habstr/~ = preaddquo .PreaddCategory.habstr
+    
+    -- Zero object
+    open ZeroObject zero
+    z/~ = z
+
+    z/~Init : isInitial A/~ z/~
+    z/~Init = isInitial/~ cat _~_ ~refl ~cong⋆ zInit
+
+    z/~Final : isFinal A/~ z/~
+    z/~Final = isFinal/~ cat _~_ ~refl ~cong⋆ zFinal
+
+    -- Biproducts
+    module _ (x y : ob) where
+      open Biproduct (biprod x y)
+
+      isBiprod/~ : isBiproduct A/~ habstr/~ ⟦ i₁ ⟧ ⟦ i₂ ⟧ ⟦ π₁ ⟧ ⟦ π₂ ⟧
+      isBiprod/~ = record {
+          i₁⋆π₁ = cong ⟦_⟧ i₁⋆π₁;
+          i₁⋆π₂ = cong ⟦_⟧ i₁⋆π₂;
+          i₂⋆π₁ = cong ⟦_⟧ i₂⋆π₁;
+          i₂⋆π₂ = cong ⟦_⟧ i₂⋆π₂;
+          ∑π⋆i  = cong ⟦_⟧ ∑π⋆i
+        }
+      
+      biprod/~ : Biproduct A/~ habstr/~ x y
+      biprod/~ = record {
+          x⊕y = x⊕y;
+          i₁ = ⟦ i₁ ⟧;
+          i₂ = ⟦ i₂ ⟧;
+          π₁ = ⟦ π₁ ⟧;
+          π₂ = ⟦ π₂ ⟧;
+          isBipr = isBiprod/~
+        }
+
+    open PreaddCategory
+    AdditiveQuotient : AdditiveCategory ℓ (ℓ-max ℓ' ℓq)
+    AdditiveQuotient = record {
+        cat = A/~;
+        addit = record {
+          preadd = preadd (PreaddQuotient
+              (AddCat→PreaddCat A) _~_
+              ~refl ~cong⋆ ~cong+ ~cong-);
+          zero = record {
+            z = z/~;
+            zInit = z/~Init;
+            zFinal = z/~Final
+          } ;
+          biprod = biprod/~
+        }
+      }

--- a/Cubical/Categories/Additive/Quotient.agda
+++ b/Cubical/Categories/Additive/Quotient.agda
@@ -3,14 +3,14 @@
 
 module Cubical.Categories.Additive.Quotient where
 
-open import Cubical.Algebra.AbGroup.Base renaming (_/_ to _/G_)
+open import Cubical.Algebra.AbGroup.Base
 open import Cubical.Categories.Additive.Base
+open import Cubical.Categories.Additive.Properties
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Constructions.Quotient
 open import Cubical.Categories.Limits.Terminal
-open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Prelude
-open import Cubical.HITs.SetQuotients renaming (_/_ to _/s_; [_] to ⟦_⟧)
+open import Cubical.HITs.SetQuotients renaming ([_] to ⟦_⟧)
 
 private
   variable
@@ -19,6 +19,7 @@ private
 -- Quotients of preadditive categories
 module _ (C : PreaddCategory ℓ ℓ') where
   open PreaddCategory C
+  open PreaddCategoryTheory C
 
   module _ (_~_ : {x y : ob} (f g : Hom[ x , y ] ) → Type ℓq)
            (~refl : {x y : ob} (f : Hom[ x , y ] ) → f ~ f)
@@ -33,56 +34,43 @@ module _ (C : PreaddCategory ℓ ℓ') where
 
     private
       C/~ = QuotientCategory cat _~_ ~refl ~cong⋆
-      Hom[_,_]/~ = λ (x y : ob) → (Hom[ x , y ]) /s _~_
+      Hom[_,_]/~ = λ (x y : ob) → (Hom[ x , y ]) / _~_
       _⋆/~_ = C/~ .Category._⋆_
 
       _+/~_ : {x y : ob} (f g : Hom[ x , y ]/~) → Hom[ x , y ]/~
-      _+/~_ = setQuotBinOp ~refl _+_ ~cong+
+      _+/~_ = setQuotBinOp ~refl ~refl _+_ ~cong+
 
     -- Quotient group structure on homsets
     private
-      habstr/~ : HomAbStr C/~ --(x y : ob) → AbGroupStr Hom[ x , y ]/~
-      habstr/~ = homabstr
-        λ x y → abgroupstr
-          ⟦ 0h ⟧
-          _+/~_
-          (setQuotUnaryOp -_ ~cong-)
-          (makeIsAbGroup
-            squash/
-            (elimProp3 (λ _ _ _ → squash/ _ _)
-              λ _ _ _ → cong ⟦_⟧ (+assoc _ _ _))
-            (elimProp (λ _ → squash/ _ _)
-              λ _ → cong ⟦_⟧ (idr _))
-            (elimProp (λ _ → squash/ _ _)
-              λ _ → cong ⟦_⟧ (invr _))
-            (elimProp2 (λ _ _ → squash/ _ _)
-              λ _ _ → cong ⟦_⟧ (+comm _ _))
-          )
+      open AbGroupStr renaming (_+_ to add; -_ to inv)
+      homAbStr/~ : (x y : ob) → AbGroupStr Hom[ x , y ]/~
+      homAbStr/~ x y .0g        = ⟦ 0h ⟧
+      homAbStr/~ x y .add       = _+/~_
+      homAbStr/~ x y .inv       = (setQuotUnaryOp -_ ~cong-)
+      homAbStr/~ x y .isAbGroup = makeIsAbGroup squash/
+          (elimProp3 (λ _ _ _ → squash/ _ _)  λ _ _ _ → cong ⟦_⟧ (+assoc _ _ _))
+          (elimProp  (λ _     → squash/ _ _)  λ _     → cong ⟦_⟧ (+idr _))
+          (elimProp  (λ _     → squash/ _ _)  λ _     → cong ⟦_⟧ (+invr _))
+          (elimProp2 (λ _ _   → squash/ _ _)  λ _ _   → cong ⟦_⟧ (+comm _ _))
 
     -- Distributivity
-    distl/~ : {x y z : ob} → (f : Hom[ x , y ]/~) → (g g' : Hom[ y , z ]/~) →
+    ⋆distl+/~ : {x y z : ob} → (f : Hom[ x , y ]/~) → (g g' : Hom[ y , z ]/~) →
         f  ⋆/~  (g  +/~  g')  ≡  (f  ⋆/~  g)  +/~  (f  ⋆/~  g')
-    distl/~ = elimProp (λ _ → isPropΠ2 (λ _ _ → squash/ _ _))
-              λ _ → elimProp2 (λ _ _ → squash/ _ _)
-                  (λ _ _ → cong ⟦_⟧ (distl _ _ _))
+    ⋆distl+/~ = elimProp3 (λ _ _ _ → squash/ _ _) λ _ _ _ → cong ⟦_⟧ (⋆distl+ _ _ _)
 
-    distr/~ : {x y z : ob} → (f f' : Hom[ x , y ]/~) → (g : Hom[ y , z ]/~) →
+    ⋆distr+/~ : {x y z : ob} → (f f' : Hom[ x , y ]/~) → (g : Hom[ y , z ]/~) →
         (f  +/~  f')  ⋆/~  g  ≡  (f  ⋆/~  g)  +/~  (f'  ⋆/~  g)
-    distr/~ = elimProp2 (λ _ _ → isPropΠ (λ _ → squash/ _ _))
-              λ _ _ → elimProp (λ _ → squash/ _ _)
-                  (λ _ → cong ⟦_⟧ (distr _ _ _))
+    ⋆distr+/~ = elimProp3 (λ _ _ _ → squash/ _ _) λ _ _ _ → cong ⟦_⟧ (⋆distr+ _ _ _)
 
 
     -- Quotient of preadditive category
+    open PreaddCategory
+    open PreaddCategoryStr
     PreaddQuotient : PreaddCategory ℓ (ℓ-max ℓ' ℓq)
-    PreaddQuotient = record {
-        cat = C/~;
-        preadd = record {
-          habstr = habstr/~;
-          distl = distl/~;
-          distr = distr/~
-        }
-      }
+    PreaddQuotient .cat = QuotientCategory (cat C) _~_ ~refl ~cong⋆
+    PreaddQuotient .preadd .homAbStr = homAbStr/~
+    PreaddQuotient .preadd .⋆distl+ = ⋆distl+/~
+    PreaddQuotient .preadd .⋆distr+ = ⋆distr+/~
 
 
 -- Quotients of additive categories
@@ -101,57 +89,35 @@ module _ (A : AdditiveCategory ℓ ℓ') where
                    → f ~ f' → (- f) ~ (- f'))           where
 
     private
-      preaddquo = PreaddQuotient (AddCat→PreaddCat A)
-          _~_ ~refl ~cong⋆ ~cong+ ~cong-
-      A/~ = preaddquo .PreaddCategory.cat
-      habstr/~ = preaddquo .PreaddCategory.habstr
-    
+      A/~ = PreaddQuotient preaddcat _~_ ~refl ~cong⋆ ~cong+ ~cong-
+
     -- Zero object
-    open ZeroObject zero
-    z/~ = z
-
-    z/~Init : isInitial A/~ z/~
-    z/~Init = isInitial/~ cat _~_ ~refl ~cong⋆ zInit
-
-    z/~Final : isFinal A/~ z/~
-    z/~Final = isFinal/~ cat _~_ ~refl ~cong⋆ zFinal
+    open ZeroObject
+    zero/~ : ZeroObject A/~
+    zero/~ .z = zero .z
+    zero/~ .zInit = isInitial/~ cat _~_ ~refl ~cong⋆ (zInit zero)
+    zero/~ .zFinal = isFinal/~ cat _~_ ~refl ~cong⋆ (zFinal zero)
 
     -- Biproducts
     module _ (x y : ob) where
-      open Biproduct (biprod x y)
+      open Biproduct
+      open IsBiproduct
 
-      isBiprod/~ : isBiproduct A/~ habstr/~ ⟦ i₁ ⟧ ⟦ i₂ ⟧ ⟦ π₁ ⟧ ⟦ π₂ ⟧
-      isBiprod/~ = record {
-          i₁⋆π₁ = cong ⟦_⟧ i₁⋆π₁;
-          i₁⋆π₂ = cong ⟦_⟧ i₁⋆π₂;
-          i₂⋆π₁ = cong ⟦_⟧ i₂⋆π₁;
-          i₂⋆π₂ = cong ⟦_⟧ i₂⋆π₂;
-          ∑π⋆i  = cong ⟦_⟧ ∑π⋆i
-        }
-      
-      biprod/~ : Biproduct A/~ habstr/~ x y
-      biprod/~ = record {
-          x⊕y = x⊕y;
-          i₁ = ⟦ i₁ ⟧;
-          i₂ = ⟦ i₂ ⟧;
-          π₁ = ⟦ π₁ ⟧;
-          π₂ = ⟦ π₂ ⟧;
-          isBipr = isBiprod/~
-        }
+      biprod/~ : Biproduct A/~ x y
+      biprod/~ .x⊕y = x ⊕ y
+      biprod/~ .i₁ = ⟦ i₁ (biprod x y) ⟧
+      biprod/~ .i₂ = ⟦ i₂ (biprod x y) ⟧
+      biprod/~ .π₁ = ⟦ π₁ (biprod x y) ⟧
+      biprod/~ .π₂ = ⟦ π₂ (biprod x y) ⟧
+      biprod/~ .isBipr .i₁⋆π₁ = cong ⟦_⟧ (i₁⋆π₁ (biprod x y))
+      biprod/~ .isBipr .i₁⋆π₂ = cong ⟦_⟧ (i₁⋆π₂ (biprod x y))
+      biprod/~ .isBipr .i₂⋆π₁ = cong ⟦_⟧ (i₂⋆π₁ (biprod x y))
+      biprod/~ .isBipr .i₂⋆π₂ = cong ⟦_⟧ (i₂⋆π₂ (biprod x y))
+      biprod/~ .isBipr .∑π⋆i  = cong ⟦_⟧ (∑π⋆i  (biprod x y))
 
-    open PreaddCategory
+
+    open AdditiveCategoryStr
     AdditiveQuotient : AdditiveCategory ℓ (ℓ-max ℓ' ℓq)
-    AdditiveQuotient = record {
-        cat = A/~;
-        addit = record {
-          preadd = preadd (PreaddQuotient
-              (AddCat→PreaddCat A) _~_
-              ~refl ~cong⋆ ~cong+ ~cong-);
-          zero = record {
-            z = z/~;
-            zInit = z/~Init;
-            zFinal = z/~Final
-          } ;
-          biprod = biprod/~
-        }
-      }
+    AdditiveQuotient .preaddcat = A/~
+    AdditiveQuotient .addit .zero = zero/~
+    AdditiveQuotient .addit .biprod = biprod/~

--- a/Cubical/Categories/Additive/Quotient.agda
+++ b/Cubical/Categories/Additive/Quotient.agda
@@ -96,7 +96,7 @@ module _ (A : AdditiveCategory ℓ ℓ') where
     zero/~ : ZeroObject A/~
     zero/~ .z = zero .z
     zero/~ .zInit = isInitial/~ cat _~_ ~refl ~cong⋆ (zInit zero)
-    zero/~ .zFinal = isFinal/~ cat _~_ ~refl ~cong⋆ (zFinal zero)
+    zero/~ .zTerm = isTerminal/~ cat _~_ ~refl ~cong⋆ (zTerm zero)
 
     -- Biproducts
     module _ (x y : ob) where

--- a/Cubical/Categories/Category/Base.agda
+++ b/Cubical/Categories/Category/Base.agda
@@ -27,6 +27,9 @@ record Category ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   _∘_ : ∀ {x y z} (g : Hom[ y , z ]) (f : Hom[ x , y ]) → Hom[ x , z ]
   g ∘ f = f ⋆ g
 
+  infixr 9 _⋆_
+  infixr 9 _∘_
+
 open Category
 
 -- Helpful syntax/notation


### PR DESCRIPTION
This is an (in-progress) formalisation of [arxiv:2103.08379](https://arxiv.org/abs/2103.08379). The work here builds on #672, so that will need to be merged first.

Given `A : AdditiveCategory ℓ ℓ'`, we define a free abelian category `Adel A` over `A`. With any luck, this will be a step towards defining an abelian category solver that can automatically do diagram chasing.

To do:
- [ ] Define (co)kernels on the quotient `AdelAddCat`
- [ ] Show monos are kernels, epis are cokernels
- [ ] Define `Adel A`
- [ ] Prove the universal property
- [ ] Possibly formalise other results from [arxiv:2103.08379](https://arxiv.org/abs/2103.08379), such as the proof of the snake lemma or five lemma.