### PR TITLE
Add transportComposite

### DIFF
--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -124,6 +124,11 @@ substComposite : ∀ {ℓ ℓ′} {A : Type ℓ} → (B : A → Type ℓ′)
 substComposite B p q Bx i =
   transport (cong B (compPath-filler' p q (~ i))) (transport-fillerExt (cong B p) i Bx)
 
+-- transporting along a composite path is equivalent to transporting twice
+transportComposite : ∀ {ℓ} {A B C : Type ℓ} (p : A ≡ B) (q : B ≡ C) (x : A)
+                 → transport (p ∙ q) x ≡ transport q (transport p x)
+transportComposite = substComposite (λ D → D)
+
 -- substitution commutes with morphisms in slices
 substCommSlice : ∀ {ℓ ℓ′} {A : Type ℓ}
                    → (B C : A → Type ℓ′)


### PR DESCRIPTION
This PR just adds the following definition to Transport.agda:

```agda
-- transporting along a composite path is equivalent to transporting twice
transportComposite : ∀ {ℓ} {A B C : Type ℓ} (p : A ≡ B) (q : B ≡ C) (x : A)
                 → transport (p ∙ q) x ≡ transport q (transport p x)
transportComposite = substComposite (λ D → D)
```

It's a fairly fundamental property, and whilst `substComposite` already exists that can be hard to find for newcomers looking for a result about `transport`.