### PR TITLE
Clean the summary file for pi_4(S^3) = Z/2Z and prove two small general lemmas that were left as holes

### DIFF
--- a/Cubical/Algebra/Group/Morphisms.agda
+++ b/Cubical/Algebra/Group/Morphisms.agda
@@ -62,6 +62,9 @@ IsGroupEquiv M e N = IsGroupHom M (e .fst) N
 GroupEquiv : (G : Group ℓ) (H : Group ℓ') → Type (ℓ-max ℓ ℓ')
 GroupEquiv G H = Σ[ e ∈ (G .fst ≃ H .fst) ] IsGroupEquiv (G .snd) e (H .snd)
 
+groupEquivFun : {G : Group ℓ} {H : Group ℓ'} → GroupEquiv G H → G .fst → H .fst
+groupEquivFun e = e .fst .fst
+
 -- Image, kernel, surjective, injective, and bijections
 
 open IsGroupHom

--- a/Cubical/Algebra/Group/ZAction.agda
+++ b/Cubical/Algebra/Group/ZAction.agda
@@ -189,10 +189,9 @@ snd (Iso-pres-gen₂ G H g₁ g₂ genG is h) =
           (homPresℤ· (_ , snd is) g₂ (snd (fst (genG (inv (fst is) h))))))
 
 
-private
-  intLem₁ : (n m : ℕ) → Σ[ a ∈ ℕ ] (negsuc n * pos (suc m)) ≡ negsuc a
-  intLem₁ n zero = n , ·Comm  (negsuc n) (pos 1)
-  intLem₁ n (suc m) = lem _ _ .fst ,
+intLem₁ : (n m : ℕ) → Σ[ a ∈ ℕ ] (negsuc n * pos (suc m)) ≡ negsuc a
+intLem₁ n zero = n , ·Comm  (negsuc n) (pos 1)
+intLem₁ n (suc m) = lem _ _ .fst ,
        (·Comm (negsuc n) (pos (suc (suc m)))
     ∙∙ cong (negsuc n +ℤ_) (·Comm (pos (suc m)) (negsuc n) ∙ (intLem₁ n m .snd))
     ∙∙ lem _ _ .snd)
@@ -205,10 +204,10 @@ private
        (lem (suc (suc x)) y .fst)
      , (predℤ+negsuc y (negsuc (suc x)) ∙ snd ((lem (suc (suc x))) y))
 
-  intLem₂ : (n x : ℕ)
-    → Σ[ a ∈ ℕ ] ((pos (suc x)) * pos (suc (suc n)) ≡ pos (suc (suc a)))
-  intLem₂ n zero = n , refl
-  intLem₂ n (suc x) = lem _ _ (intLem₂ n x)
+intLem₂ : (n x : ℕ)
+  → Σ[ a ∈ ℕ ] ((pos (suc x)) * pos (suc (suc n)) ≡ pos (suc (suc a)))
+intLem₂ n zero = n , refl
+intLem₂ n (suc x) = lem _ _ (intLem₂ n x)
     where
     lem : (x : ℤ) (n : ℕ) → Σ[ a ∈ ℕ ] (x ≡ pos (suc (suc a)))
                   → Σ[ a ∈ ℕ ] pos n +ℤ x ≡ pos (suc (suc a))
@@ -216,11 +215,11 @@ private
       , cong (pos n +ℤ_) p ∙ cong sucℤ (sucℤ+pos a (pos n))
          ∙ sucℤ+pos a (pos (suc n)) ∙ (sym (pos+ (suc (suc n)) a))
 
-  ¬1=x·suc-suc : (n : ℕ) (x : ℤ) → ¬ pos 1 ≡ x * pos (suc (suc n))
-  ¬1=x·suc-suc n (pos zero) p = snotz (injPos p)
-  ¬1=x·suc-suc n (pos (suc n₁)) p =
-    snotz (injPos (sym (cong predℤ (snd (intLem₂ n n₁))) ∙ sym (cong predℤ p)))
-  ¬1=x·suc-suc n (negsuc n₁) p = posNotnegsuc _ _ (p ∙ intLem₁ _ _ .snd)
+¬1=x·suc-suc : (n : ℕ) (x : ℤ) → ¬ pos 1 ≡ x * pos (suc (suc n))
+¬1=x·suc-suc n (pos zero) p = snotz (injPos p)
+¬1=x·suc-suc n (pos (suc n₁)) p =
+  snotz (injPos (sym (cong predℤ (snd (intLem₂ n n₁))) ∙ sym (cong predℤ p)))
+¬1=x·suc-suc n (negsuc n₁) p = posNotnegsuc _ _ (p ∙ intLem₁ _ _ .snd)
 
 GroupEquivℤ-pres1 : (e : GroupEquiv ℤGroup ℤGroup) (x : ℤ)
   → (fst (fst e) 1) ≡ x → abs (fst (fst e) 1) ≡ 1

--- a/Cubical/Algebra/Group/ZAction.agda
+++ b/Cubical/Algebra/Group/ZAction.agda
@@ -434,5 +434,3 @@ GroupEquivℤ-isEquiv {G = G} =
    ⊎-rec (λ h₂ → subst isEquiv (sym (ℤHom1- ϕ (sym (cong (fst ϕ) h₂) ∙ h₁))) isEquiv-)
          (λ h₂ → subst isEquiv (sym (ℤHomId- ϕ (sym (cong (fst ϕ) h₂) ∙ h₁))) (idIsEquiv _))
          (gen₁ℤGroup-⊎ g gen)
-
-

--- a/Cubical/Algebra/Group/ZAction.agda
+++ b/Cubical/Algebra/Group/ZAction.agda
@@ -161,7 +161,7 @@ GroupHomℤ→ℤPres· e a b =
 -- Todo : generalise
 gen₁-by : (G : Group ℓ) → (g : fst G) → Type _
 gen₁-by G g = (h : fst G)
-          → Σ[ a ∈ ℤ ] h ≡ (a ℤ[ G ]· g)
+            → Σ[ a ∈ ℤ ] h ≡ (a ℤ[ G ]· g)
 
 gen₂-by : ∀ {ℓ} (G : Group ℓ) → (g₁ g₂ : fst G) → Type _
 gen₂-by G g₁ g₂ =

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -84,6 +84,9 @@ isSetℤ = Discrete→isSet discreteℤ
 -Involutive (pos n)    = cong -_ (-pos n) ∙ -neg n
 -Involutive (negsuc n) = refl
 
+isEquiv- : isEquiv (-_)
+isEquiv- = isoToIsEquiv (iso -_ -_ -Involutive -Involutive)
+
 sucℤ+pos : ∀ n m → sucℤ (m +pos n) ≡ (sucℤ m) +pos n
 sucℤ+pos zero m = refl
 sucℤ+pos (suc n) m = cong sucℤ (sucℤ+pos n m)
@@ -443,6 +446,10 @@ private
 
 -DistR· : (b c : ℤ) → - (b · c) ≡ b · - c
 -DistR· b c = cong (-_) (·Comm b c) ∙∙ -DistL· c b ∙∙ ·Comm (- c) b
+
+ℤ·negsuc : (n : ℤ) (m : ℕ) → n · negsuc m ≡ - (n · pos (suc m))
+ℤ·negsuc (pos n) m = pos·negsuc n m
+ℤ·negsuc (negsuc n) m = negsuc·negsuc n m ∙ sym (-DistL· (negsuc n) (pos (suc m)))
 
 ·Assoc : (a b c : ℤ) → (a · (b · c)) ≡ ((a · b) · c)
 ·Assoc (pos zero) b c = refl

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -473,3 +473,8 @@ abs→⊎ x n = J (λ n _ → (x ≡ pos n) ⊎ (x ≡ - pos n)) (help x)
 ⊎→abs (negsuc n₁) n (inl x₁) = cong abs x₁
 ⊎→abs x zero (inr x₁) = cong abs x₁
 ⊎→abs x (suc n) (inr x₁) = cong abs x₁
+
+abs- : (x : ℤ) → abs x ≡ abs (- x)
+abs- (pos zero) = refl
+abs- (pos (suc n)) = refl
+abs- (negsuc n) = refl

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -474,7 +474,7 @@ abs→⊎ x n = J (λ n _ → (x ≡ pos n) ⊎ (x ≡ - pos n)) (help x)
 ⊎→abs x zero (inr x₁) = cong abs x₁
 ⊎→abs x (suc n) (inr x₁) = cong abs x₁
 
-abs- : (x : ℤ) → abs x ≡ abs (- x)
+abs- : (x : ℤ) → abs (- x) ≡ abs x
 abs- (pos zero) = refl
 abs- (pos (suc n)) = refl
 abs- (negsuc n) = refl

--- a/Cubical/Homotopy/Group/Pi4S3/Summary.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/Summary.agda
@@ -50,15 +50,15 @@ private
 [_]× (f , g) = [ f ∣ g ]π'
 
 -- Some type abbreviations (unproved results)
-π₄S³≅ℤ/something : GroupEquiv (π 3 𝕊²) ℤ → Type₁
-π₄S³≅ℤ/something eq =
+π₄S³≡ℤ/something : GroupEquiv (π 3 𝕊²) ℤ → Type₁
+π₄S³≡ℤ/something eq =
   π 4 𝕊³ ≡ ℤ/ abs (eq .fst .fst [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×)
 
 -- Summary of the last steps of the proof
 module π₄S³
   (π₃S²≃ℤ           : GroupEquiv (π 3 𝕊²) ℤ)
   (gen-by-HopfMap   : gen₁-by (π 3 𝕊²) ∣ HopfMap ∣₂)
-  (π₄S³≅ℤ/whitehead : π₄S³≅ℤ/something π₃S²≃ℤ)
+  (π₄S³≡ℤ/whitehead : π₄S³≡ℤ/something π₃S²≃ℤ)
   (hopfWhitehead    : abs (HopfInvariant-π' 0 ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)) ≡ 2)
   where
 
@@ -84,4 +84,4 @@ module π₄S³
 
   -- The final result then follows
   π₄S³≡ℤ : π 4 𝕊³ ≡ ℤ/ 2
-  π₄S³≡ℤ = π₄S³≅ℤ/whitehead ∙ cong (ℤ/_) remAbs₂
+  π₄S³≡ℤ = π₄S³≡ℤ/whitehead ∙ cong (ℤ/_) remAbs₂

--- a/Cubical/Homotopy/Group/Pi4S3/Summary.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/Summary.agda
@@ -1,202 +1,87 @@
-{-# OPTIONS --safe --experimental-lossy-unification #-}
-module Cubical.Homotopy.Group.Pi4S3.Summary where
-
 {-
-This file contains a summary of what remains for π₄(S³) ≅ ℤ/2ℤ to be proved.
+
+This file contains a summary of what remains for π₄(S³) ≡ ℤ/2ℤ to be proved.
+
 See the module π₄S³ at the end of this file.
+
 -}
+
+{-# OPTIONS --safe #-}
+module Cubical.Homotopy.Group.Pi4S3.Summary where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Pointed
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Function
 
-open import Cubical.Data.Nat
-open import Cubical.Data.Sum renaming (rec to ⊎-rec)
-open import Cubical.Data.Empty renaming (rec to ⊥-rec)
-open import Cubical.Data.Sigma
-open import Cubical.Data.Int
-  renaming (_·_ to _·ℤ_ ; _+_ to _+ℤ_)
+open import Cubical.Data.Nat.Base
+open import Cubical.Data.Sigma.Base
+open import Cubical.Data.Int renaming (ℤ to Int) hiding (_+_)
+
+open import Cubical.HITs.Sn
+open import Cubical.HITs.SetTruncation
 
 open import Cubical.Homotopy.Group.Base hiding (π)
 open import Cubical.Homotopy.HopfInvariant.Base
 open import Cubical.Homotopy.HopfInvariant.Homomorphism
 open import Cubical.Homotopy.HopfInvariant.HopfMap
 open import Cubical.Homotopy.Whitehead
+
+open import Cubical.Algebra.Group.Base
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int
 open import Cubical.Algebra.Group.Instances.IntMod
-open import Cubical.Foundations.Isomorphism
-
-open import Cubical.HITs.Susp
-open import Cubical.HITs.Sn
-open import Cubical.HITs.PropositionalTruncation
-open import Cubical.HITs.SetTruncation
-
-open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup ; Bool to BoolGroup ; Unit to UnitGroup)
 open import Cubical.Algebra.Group.ZAction
 
--- TODO: this should not be off by one in the definition
-π : {ℓ : Level} → ℕ → Pointed ℓ → Group ℓ
+private
+  variable
+    ℓ : Level
+
+-- TODO: ideally this would not be off by one in the definition of π'Gr
+π : ℕ → Pointed ℓ → Group ℓ
 π n X = π'Gr (predℕ n) X
 
--- Nicer notation for spheres
+-- Nicer notation for the spheres (as pointed types)
+𝕊² 𝕊³ : Pointed₀
 𝕊² = S₊∙ 2
 𝕊³ = S₊∙ 3
 
-[_]× : ∀ {ℓ} {X : Pointed ℓ} {n m : ℕ}
-     → π' (suc n) X × π' (suc m) X → π' (suc (n + m)) X
+-- Whitehead product
+[_]× : {X : Pointed ℓ} {n m : ℕ} → π' (suc n) X × π' (suc m) X → π' (suc (n + m)) X
 [_]× (f , g) = [ f ∣ g ]π'
 
 -- Some type abbreviations (unproved results)
-π₃S²-gen : Type
-π₃S²-gen = gen₁-by (π 3 𝕊²) ∣ HopfMap ∣₂
-
-π₄S³≅ℤ/something : GroupEquiv (π 3 𝕊²) ℤGroup → Type₁
+π₄S³≅ℤ/something : GroupEquiv (π 3 𝕊²) ℤ → Type₁
 π₄S³≅ℤ/something eq =
   π 4 𝕊³ ≡ ℤ/ abs (eq .fst .fst [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×)
 
-asdf : (n : ℤ) (m : ℕ) → n ·ℤ negsuc m ≡ - (n ·ℤ pos (suc m))
-asdf (pos n) m = pos·negsuc n m
-asdf (negsuc n) m = negsuc·negsuc n m ∙ sym (-DistL· (negsuc n) (pos (suc m)))
-
-miniLem₁ : (g : ℤ) → gen₁-by ℤGroup g → (g ≡ 1) ⊎ (g ≡ -1)
-miniLem₁ (pos zero) h = ⊥-rec (negsucNotpos 0 0 (h (negsuc 0) .snd ∙ rUnitℤ· ℤGroup _))
-miniLem₁ (pos (suc zero)) h = inl refl
-miniLem₁ (pos (suc (suc n))) h = ⊥-rec (¬1=x·suc-suc n _ (rem (pos 1)))
-  where
-  rem : (x : ℤ) → x ≡ fst (h x) ·ℤ pos (suc (suc n))
-  rem x = h x .snd ∙ sym (ℤ·≡· (fst (h x)) (pos (suc (suc n))))
-miniLem₁ (negsuc zero) h = inr refl
-miniLem₁ (negsuc (suc n)) h = ⊥-rec (¬1=x·suc-suc n _ (rem (pos 1) ∙ asdf (fst (h (pos 1))) (suc n) ∙ -DistL· _ _))
-  where
-  rem : (x : ℤ) → x ≡ fst (h x) ·ℤ negsuc (suc n)
-  rem x = h x .snd ∙ sym (ℤ·≡· (fst (h x)) (negsuc (suc n)))
-
-lem : (ϕ : GroupHom ℤGroup ℤGroup) → fst ϕ (pos 1) ≡ pos 1 → fst ϕ ≡ idfun _
-lem ϕ p = funExt lem2
-    where
-    lem₁ : (x₁ : ℕ) → fst ϕ (pos x₁) ≡ idfun ℤ (pos x₁)
-    lem₁ zero = IsGroupHom.pres1 (snd ϕ)
-    lem₁ (suc zero) = p
-    lem₁ (suc (suc n)) =
-      IsGroupHom.pres· (snd ϕ) (pos (suc n)) 1
-                             ∙ cong₂ _+ℤ_ (lem₁ (suc n)) p
-
-    lem2 : (x₁ : ℤ) → fst ϕ x₁ ≡ idfun ℤ x₁
-    lem2 (pos n) = lem₁ n
-    lem2 (negsuc zero) =
-      IsGroupHom.presinv (snd ϕ) 1 ∙ cong (λ x → pos 0 - x) p
-    lem2 (negsuc (suc n)) =
-        (cong (fst ϕ) (sym (+Comm (pos 0) (negsuc (suc n))))
-      ∙ IsGroupHom.presinv (snd ϕ) (pos (suc (suc n))))
-      ∙∙ +Comm (pos 0) _
-      ∙∙ cong (-_) (lem₁ (suc (suc n)))
-
-lem₂ : (ϕ : GroupHom ℤGroup ℤGroup) → fst ϕ (negsuc 0) ≡ pos 1 → fst ϕ ≡ -_
-lem₂ ϕ p = funExt lem2
-    where
-    s = IsGroupHom.presinv (snd ϕ) (negsuc 0)
-     ∙∙ +Comm (pos 0) _
-     ∙∙ cong -_ p
-
-    lem2 : (n : ℤ) → fst ϕ n ≡ - n
-    lem2 (pos zero) = IsGroupHom.pres1 (snd ϕ)
-    lem2 (pos (suc zero)) = s
-    lem2 (pos (suc (suc n))) =
-         IsGroupHom.pres· (snd ϕ) (pos (suc n)) 1
-       ∙ cong₂ _+ℤ_ (lem2 (pos (suc n))) s
-    lem2 (negsuc zero) = p
-    lem2 (negsuc (suc n)) =
-         IsGroupHom.pres· (snd ϕ) (negsuc n) (negsuc 0)
-       ∙ cong₂ _+ℤ_ (lem2 (negsuc n)) p
-
-
-foo1 : (ϕ : GroupEquiv ℤGroup ℤGroup) → (fst (fst ϕ) (pos 1) ≡ pos 1) ⊎ (fst (fst ϕ) (pos 1) ≡ - (pos 1))
-foo1 ϕ =
-  groupEquivPresGen ℤGroup (compGroupEquiv ϕ (invGroupEquiv ϕ)) (pos 1) (inl (funExt⁻ (cong fst (invEquiv-is-rinv (ϕ .fst))) (pos 1))) ϕ
-
-foo : (ϕ : GroupEquiv ℤGroup ℤGroup) → (g : ℤ) → (fst (fst ϕ) g ≡ g) ⊎ (fst (fst ϕ) g ≡ - g)
-foo ϕ g = ⊎-rec (λ h → inl (funExt⁻ (lem (_ , ϕ .snd) h) g))
-                (λ h → inr (funExt⁻ (lem₂ (_ , ϕ .snd) (IsGroupHom.presinv (snd ϕ) (pos 1) ∙ sym (pos0+ (- fst (fst ϕ) (pos 1))) ∙ cong -_ h)) g)) (foo1 ϕ)
-
-miniLem₂ : (ϕ : GroupEquiv ℤGroup ℤGroup) (g : ℤ)
-         → (abs g ≡ abs (fst (fst ϕ) g))
-miniLem₂ ϕ g = ⊎-rec (λ h → sym (cong abs h)) (λ h → sym (abs- _) ∙ sym (cong abs h)) (foo ϕ g)
-
--- some minor group lemmas
-groupLem-help : (g : ℤ)
-              → gen₁-by ℤGroup g
-              → (ϕ : GroupHom ℤGroup ℤGroup)
-              → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
-              → isEquiv (fst ϕ)
-groupLem-help g gen ϕ = main (miniLem₁ g gen)
-  where
-  isEquiv- : isEquiv (-_)
-  isEquiv- = isoToIsEquiv (iso -_ -_ -Involutive -Involutive)
-
-  main : (g ≡ pos 1) ⊎ (g ≡ negsuc 0)
-      → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
-      → isEquiv (fst ϕ)
-  main (inl p) =
-    J (λ g p → (fst ϕ g ≡ pos 1)
-             ⊎ (fst ϕ g ≡ negsuc 0) → isEquiv (fst ϕ))
-      (λ { (inl x) → subst isEquiv (sym (lem ϕ x)) (snd (idEquiv _))
-         ; (inr x) → subst isEquiv
-                            (sym (lem₂ ϕ (IsGroupHom.presinv (snd ϕ) (pos 1)
-                          ∙ (cong (λ x → pos 0 - x) x))))
-                            isEquiv- })
-                 (sym p)
-  main (inr p) =
-    J (λ g p → (fst ϕ g ≡ pos 1)
-             ⊎ (fst ϕ g ≡ negsuc 0) → isEquiv (fst ϕ))
-      (λ { (inl x) → subst isEquiv (sym (lem₂ ϕ x)) isEquiv-
-         ; (inr x) → subst isEquiv
-                       (sym (lem ϕ (
-                       IsGroupHom.presinv (snd ϕ) (negsuc 0)
-                     ∙ cong (λ x → pos 0 - x) x)))
-                    (snd (idEquiv _))})
-      (sym p)
-
-groupLem : {G : Group₀}
-         → GroupEquiv ℤGroup G
-         → (g : fst G)
-         → gen₁-by G g
-         → (ϕ : GroupHom G ℤGroup)
-         → (fst ϕ g ≡ 1) ⊎ (fst ϕ g ≡ -1)
-         → isEquiv (fst ϕ)
-groupLem {G = G} =
-  GroupEquivJ
-    (λ G _ → (g : fst G)
-         → gen₁-by G g
-         → (ϕ : GroupHom G ℤGroup)
-         → (fst ϕ g ≡ 1) ⊎ (fst ϕ g ≡ -1)
-         → isEquiv (fst ϕ))
-    groupLem-help
-
-lemabs : ∀ {G : Group₀} (ϕ ψ : GroupEquiv ℤGroup G) (g : fst G)
-    → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g)
-lemabs =
-  GroupEquivJ
-    (λ G ϕ → (ψ : GroupEquiv ℤGroup G) (g : fst G)
-    → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g))
-    λ ψ → miniLem₂ (invGroupEquiv ψ)
-
--- summary
+-- Summary of the last steps of the proof
 module π₄S³
-  (ℤ≅π₃S² : GroupEquiv (π 3 𝕊²) ℤGroup)
-  (gen-by-HopfMap : π₃S²-gen)
-  (π₄S³≅ℤ/whitehead : π₄S³≅ℤ/something ℤ≅π₃S²)
-  (hopfWhitehead : abs (HopfInvariant-π' 0 ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)) ≡ 2)
+  (π₃S²≃ℤ           : GroupEquiv (π 3 𝕊²) ℤ)
+  (gen-by-HopfMap   : gen₁-by (π 3 𝕊²) ∣ HopfMap ∣₂)
+  (π₄S³≅ℤ/whitehead : π₄S³≅ℤ/something π₃S²≃ℤ)
+  (hopfWhitehead    : abs (HopfInvariant-π' 0 ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)) ≡ 2)
   where
-  hopfInvariantEquiv : GroupEquiv (π 3 𝕊²) ℤGroup
+
+  -- Package the Hopf invariant up into a group equivalence
+  hopfInvariantEquiv : GroupEquiv (π 3 𝕊²) ℤ
   fst (fst hopfInvariantEquiv) = HopfInvariant-π' 0
   snd (fst hopfInvariantEquiv) =
-    groupLem (invGroupEquiv ℤ≅π₃S²) ∣ HopfMap ∣₂
-             gen-by-HopfMap
-             (GroupHom-HopfInvariant-π' 0)
-             (abs→⊎ _ _ HopfInvariant-HopfMap)
+    GroupEquivℤ-isEquiv (invGroupEquiv π₃S²≃ℤ) ∣ HopfMap ∣₂
+                        gen-by-HopfMap (GroupHom-HopfInvariant-π' 0)
+                        (abs→⊎ _ _ HopfInvariant-HopfMap)
   snd hopfInvariantEquiv = snd (GroupHom-HopfInvariant-π' 0)
 
-  main : π 4 𝕊³ ≡ ℤ/ 2
-  main = π₄S³≅ℤ/whitehead
-       ∙ cong (ℤ/_) (lemabs (invGroupEquiv ℤ≅π₃S²) (invGroupEquiv hopfInvariantEquiv) _ ∙ hopfWhitehead)
+  -- The two equivalences map [ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]× to
+  -- the same number, modulo the sign
+  remAbs : abs (groupEquivFun π₃S²≃ℤ [ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)
+         ≡ abs (groupEquivFun hopfInvariantEquiv [ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)
+  remAbs = absGroupEquivℤGroup (invGroupEquiv π₃S²≃ℤ) (invGroupEquiv hopfInvariantEquiv) _
+
+  -- So the image of [ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]× under π₃S²≃ℤ
+  -- is 2 (modulo the sign)
+  remAbs₂ : abs (groupEquivFun π₃S²≃ℤ [ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×) ≡ 2
+  remAbs₂ = remAbs ∙ hopfWhitehead
+
+  -- The final result then follows
+  π₄S³≡ℤ : π 4 𝕊³ ≡ ℤ/ 2
+  π₄S³≡ℤ = π₄S³≅ℤ/whitehead ∙ cong (ℤ/_) remAbs₂

--- a/Cubical/Homotopy/Group/Pi4S3/Summary.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/Summary.agda
@@ -2,7 +2,7 @@
 module Cubical.Homotopy.Group.Pi4S3.Summary where
 
 {-
-This file contains a summary of what remains for π₄S³≅ℤ/2 to be proved.
+This file contains a summary of what remains for π₄(S³) ≅ ℤ/2ℤ to be proved.
 See the module π₄S³ at the end of this file.
 -}
 
@@ -17,7 +17,7 @@ open import Cubical.Data.Sigma
 open import Cubical.Data.Int
   renaming (_·_ to _·ℤ_ ; _+_ to _+ℤ_)
 
-open import Cubical.Homotopy.Group.Base
+open import Cubical.Homotopy.Group.Base hiding (π)
 open import Cubical.Homotopy.HopfInvariant.Base
 open import Cubical.Homotopy.HopfInvariant.Homomorphism
 open import Cubical.Homotopy.HopfInvariant.HopfMap
@@ -26,41 +26,48 @@ open import Cubical.Algebra.Group.Instances.IntMod
 open import Cubical.Foundations.Isomorphism
 
 open import Cubical.HITs.Sn
+open import Cubical.HITs.PropositionalTruncation
 open import Cubical.HITs.SetTruncation
 
 open import Cubical.Algebra.Group
   renaming (ℤ to ℤGroup ; Bool to BoolGroup ; Unit to UnitGroup)
 open import Cubical.Algebra.Group.ZAction
 
+-- TODO: this should not be off by one in the definition
+π : {ℓ : Level} → ℕ → Pointed ℓ → Group ℓ
+π n X = π'Gr (predℕ n) X
+
+-- Nicer notation for spheres
+𝕊² = S₊∙ 2
+𝕊³ = S₊∙ 3
 
 [_]× : ∀ {ℓ} {X : Pointed ℓ} {n m : ℕ}
-  → π' (suc n) X × π' (suc m) X → π' (suc (n + m)) X
+     → π' (suc n) X × π' (suc m) X → π' (suc (n + m)) X
 [_]× (f , g) = [ f ∣ g ]π'
 
 -- Some type abbreviations (unproved results)
 π₃S²-gen : Type
-π₃S²-gen = gen₁-by (π'Gr 2 (S₊∙ 2)) ∣ HopfMap ∣₂
+π₃S²-gen = gen₁-by (π 3 𝕊²) ∣ HopfMap ∣₂
 
-π₄S³≅ℤ/something : GroupEquiv ℤGroup (π'Gr 2 (S₊∙ 2))
-                 → Type
+π₄S³≅ℤ/something : GroupEquiv ℤGroup (π 3 𝕊²) → Type
 π₄S³≅ℤ/something eq =
-  GroupIso (π'Gr 3 (S₊∙ 3))
-           (ℤ/ abs (invEq (fst eq)
-             [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×))
+  GroupIso (π 4 𝕊³)
+           (ℤ/ abs (invEq (fst eq) [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×))
 
 miniLem₁ : Type
 miniLem₁ = (g : ℤ) → gen₁-by ℤGroup g → (g ≡ 1) ⊎ (g ≡ -1)
 
 miniLem₂ : Type
 miniLem₂ = (ϕ : GroupEquiv ℤGroup ℤGroup) (g : ℤ)
-      → (abs g ≡ abs (fst (fst ϕ) g))
+         → (abs g ≡ abs (fst (fst ϕ) g))
 
 -- some minor group lemmas
-groupLem-help : miniLem₁ → (g : ℤ) →
-      gen₁-by ℤGroup g →
-      (ϕ : GroupHom ℤGroup ℤGroup) →
-      (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
-    → isEquiv (fst ϕ)
+groupLem-help : miniLem₁
+              → (g : ℤ)
+              → gen₁-by ℤGroup g
+              → (ϕ : GroupHom ℤGroup ℤGroup)
+              → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
+              → isEquiv (fst ϕ)
 groupLem-help grlem1 g gen ϕ = main (grlem1 g gen)
   where
   isEquiv- : isEquiv (-_)
@@ -136,6 +143,13 @@ groupLem : {G : Group₀}
          → (fst ϕ g ≡ 1) ⊎ (fst ϕ g ≡ -1)
          → isEquiv (fst ϕ)
 groupLem {G = G} s =
+
+-- snd (fst (BijectionIsoToGroupEquiv {G = G} {H = ℤGroup}
+--   (bijIso ϕ
+--   (isMono→isInjective ϕ (λ {x} {y} hxy → {!sym (cong (ϕ .fst) (hg x .snd)) ∙ hxy ∙ cong (ϕ .fst) (hg y .snd)!}))
+--   λ x → ∣ e .fst .fst x , {!hg (e .fst .fst x)!} ∣))) -- let boo : (a b : fst G) → invEq (e .fst) a ≡ invEq (e .fst) b → a ≡ b
+--            --     boo = {!!}
+--            -- in hg x .snd ∙ boo _ _ {!!}) {!!})))
   GroupEquivJ
     (λ G _ → (g : fst G)
          → gen₁-by G g
@@ -148,23 +162,18 @@ groupLem {G = G} s =
 module π₄S³
   (mini-lem₁ : miniLem₁)
   (mini-lem₂ : miniLem₂)
-  (ℤ≅π₃S² : GroupEquiv ℤGroup (π'Gr 2 (S₊∙ 2)))
+  (ℤ≅π₃S² : GroupEquiv ℤGroup (π 3 𝕊²))
   (gen-by-HopfMap : π₃S²-gen)
   (π₄S³≅ℤ/whitehead : π₄S³≅ℤ/something ℤ≅π₃S²)
-  (hopfWhitehead :
-       abs (HopfInvariant-π' 0
-             ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×))
-     ≡ 2)
+  (hopfWhitehead : abs (HopfInvariant-π' 0 ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)) ≡ 2)
   where
-  π₄S³ = π'Gr 3 (S₊∙ 3)
-
-  hopfInvariantEquiv : GroupEquiv (π'Gr 2 (S₊∙ 2)) ℤGroup
+  hopfInvariantEquiv : GroupEquiv (π 3 𝕊²) ℤGroup
   fst (fst hopfInvariantEquiv) = HopfInvariant-π' 0
-  snd (fst hopfInvariantEquiv) =
-    groupLem mini-lem₁ ℤ≅π₃S² ∣ HopfMap ∣₂
-             gen-by-HopfMap
-             (GroupHom-HopfInvariant-π' 0)
-             (abs→⊎ _ _ HopfInvariant-HopfMap)
+  snd (fst hopfInvariantEquiv) = {!HopfInvariant-π' 0!}
+    -- groupLem mini-lem₁ ℤ≅π₃S² ∣ HopfMap ∣₂
+    --          gen-by-HopfMap
+    --          (GroupHom-HopfInvariant-π' 0)
+    --          (abs→⊎ _ _ HopfInvariant-HopfMap)
   snd hopfInvariantEquiv = snd (GroupHom-HopfInvariant-π' 0)
 
   lem : ∀ {G : Group₀} (ϕ ψ : GroupEquiv ℤGroup G) (g : fst G)
@@ -175,8 +184,7 @@ module π₄S³
       → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g))
       λ ψ → mini-lem₂ (invGroupEquiv ψ)
 
-  main : GroupIso π₄S³ (ℤ/ 2)
-  main = subst (GroupIso π₄S³)
-               (cong (ℤ/_) (lem ℤ≅π₃S² (invGroupEquiv (hopfInvariantEquiv)) _
-                               ∙ hopfWhitehead))
+  main : GroupIso (π 4 𝕊³) (ℤ/ 2)
+  main = subst (GroupIso (π 4 𝕊³))
+               (cong (ℤ/_) (lem ℤ≅π₃S² (invGroupEquiv (hopfInvariantEquiv)) _ ∙ hopfWhitehead))
                π₄S³≅ℤ/whitehead

--- a/Cubical/Homotopy/Group/Pi4S3/Summary.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/Summary.agda
@@ -121,7 +121,7 @@ foo ϕ g = ⊎-rec (λ h → inl (funExt⁻ (lem (_ , ϕ .snd) h) g))
 
 miniLem₂ : (ϕ : GroupEquiv ℤGroup ℤGroup) (g : ℤ)
          → (abs g ≡ abs (fst (fst ϕ) g))
-miniLem₂ ϕ g = ⊎-rec (λ h → sym (cong abs h)) (λ h → abs- _ ∙ sym (cong abs h)) (foo ϕ g)
+miniLem₂ ϕ g = ⊎-rec (λ h → sym (cong abs h)) (λ h → sym (abs- _) ∙ sym (cong abs h)) (foo ϕ g)
 
 -- some minor group lemmas
 groupLem-help : (g : ℤ)

--- a/Cubical/Homotopy/Group/Pi4S3/Summary.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/Summary.agda
@@ -12,7 +12,8 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Function
 
 open import Cubical.Data.Nat
-open import Cubical.Data.Sum
+open import Cubical.Data.Sum renaming (rec to ⊎-rec)
+open import Cubical.Data.Empty renaming (rec to ⊥-rec)
 open import Cubical.Data.Sigma
 open import Cubical.Data.Int
   renaming (_·_ to _·ℤ_ ; _+_ to _+ℤ_)
@@ -25,6 +26,7 @@ open import Cubical.Homotopy.Whitehead
 open import Cubical.Algebra.Group.Instances.IntMod
 open import Cubical.Foundations.Isomorphism
 
+open import Cubical.HITs.Susp
 open import Cubical.HITs.Sn
 open import Cubical.HITs.PropositionalTruncation
 open import Cubical.HITs.SetTruncation
@@ -49,32 +51,29 @@ open import Cubical.Algebra.Group.ZAction
 π₃S²-gen : Type
 π₃S²-gen = gen₁-by (π 3 𝕊²) ∣ HopfMap ∣₂
 
-π₄S³≅ℤ/something : GroupEquiv ℤGroup (π 3 𝕊²) → Type
+π₄S³≅ℤ/something : GroupEquiv (π 3 𝕊²) ℤGroup → Type₁
 π₄S³≅ℤ/something eq =
-  GroupIso (π 4 𝕊³)
-           (ℤ/ abs (invEq (fst eq) [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×))
+  π 4 𝕊³ ≡ ℤ/ abs (eq .fst .fst [ ∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂ ]×)
 
-miniLem₁ : Type
-miniLem₁ = (g : ℤ) → gen₁-by ℤGroup g → (g ≡ 1) ⊎ (g ≡ -1)
+asdf : (n : ℤ) (m : ℕ) → n ·ℤ negsuc m ≡ - (n ·ℤ pos (suc m))
+asdf (pos n) m = pos·negsuc n m
+asdf (negsuc n) m = negsuc·negsuc n m ∙ sym (-DistL· (negsuc n) (pos (suc m)))
 
-miniLem₂ : Type
-miniLem₂ = (ϕ : GroupEquiv ℤGroup ℤGroup) (g : ℤ)
-         → (abs g ≡ abs (fst (fst ϕ) g))
-
--- some minor group lemmas
-groupLem-help : miniLem₁
-              → (g : ℤ)
-              → gen₁-by ℤGroup g
-              → (ϕ : GroupHom ℤGroup ℤGroup)
-              → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
-              → isEquiv (fst ϕ)
-groupLem-help grlem1 g gen ϕ = main (grlem1 g gen)
+miniLem₁ : (g : ℤ) → gen₁-by ℤGroup g → (g ≡ 1) ⊎ (g ≡ -1)
+miniLem₁ (pos zero) h = ⊥-rec (negsucNotpos 0 0 (h (negsuc 0) .snd ∙ rUnitℤ· ℤGroup _))
+miniLem₁ (pos (suc zero)) h = inl refl
+miniLem₁ (pos (suc (suc n))) h = ⊥-rec (¬1=x·suc-suc n _ (rem (pos 1)))
   where
-  isEquiv- : isEquiv (-_)
-  isEquiv- = isoToIsEquiv (iso -_ -_ -Involutive -Involutive)
+  rem : (x : ℤ) → x ≡ fst (h x) ·ℤ pos (suc (suc n))
+  rem x = h x .snd ∙ sym (ℤ·≡· (fst (h x)) (pos (suc (suc n))))
+miniLem₁ (negsuc zero) h = inr refl
+miniLem₁ (negsuc (suc n)) h = ⊥-rec (¬1=x·suc-suc n _ (rem (pos 1) ∙ asdf (fst (h (pos 1))) (suc n) ∙ -DistL· _ _))
+  where
+  rem : (x : ℤ) → x ≡ fst (h x) ·ℤ negsuc (suc n)
+  rem x = h x .snd ∙ sym (ℤ·≡· (fst (h x)) (negsuc (suc n)))
 
-  lem : fst ϕ (pos 1) ≡ pos 1 → fst ϕ ≡ idfun _
-  lem p = funExt lem2
+lem : (ϕ : GroupHom ℤGroup ℤGroup) → fst ϕ (pos 1) ≡ pos 1 → fst ϕ ≡ idfun _
+lem ϕ p = funExt lem2
     where
     lem₁ : (x₁ : ℕ) → fst ϕ (pos x₁) ≡ idfun ℤ (pos x₁)
     lem₁ zero = IsGroupHom.pres1 (snd ϕ)
@@ -93,8 +92,8 @@ groupLem-help grlem1 g gen ϕ = main (grlem1 g gen)
       ∙∙ +Comm (pos 0) _
       ∙∙ cong (-_) (lem₁ (suc (suc n)))
 
-  lem₂ : fst ϕ (negsuc 0) ≡ pos 1 → fst ϕ ≡ -_
-  lem₂ p = funExt lem2
+lem₂ : (ϕ : GroupHom ℤGroup ℤGroup) → fst ϕ (negsuc 0) ≡ pos 1 → fst ϕ ≡ -_
+lem₂ ϕ p = funExt lem2
     where
     s = IsGroupHom.presinv (snd ϕ) (negsuc 0)
      ∙∙ +Comm (pos 0) _
@@ -111,80 +110,93 @@ groupLem-help grlem1 g gen ϕ = main (grlem1 g gen)
          IsGroupHom.pres· (snd ϕ) (negsuc n) (negsuc 0)
        ∙ cong₂ _+ℤ_ (lem2 (negsuc n)) p
 
+
+foo1 : (ϕ : GroupEquiv ℤGroup ℤGroup) → (fst (fst ϕ) (pos 1) ≡ pos 1) ⊎ (fst (fst ϕ) (pos 1) ≡ - (pos 1))
+foo1 ϕ =
+  groupEquivPresGen ℤGroup (compGroupEquiv ϕ (invGroupEquiv ϕ)) (pos 1) (inl (funExt⁻ (cong fst (invEquiv-is-rinv (ϕ .fst))) (pos 1))) ϕ
+
+foo : (ϕ : GroupEquiv ℤGroup ℤGroup) → (g : ℤ) → (fst (fst ϕ) g ≡ g) ⊎ (fst (fst ϕ) g ≡ - g)
+foo ϕ g = ⊎-rec (λ h → inl (funExt⁻ (lem (_ , ϕ .snd) h) g))
+                (λ h → inr (funExt⁻ (lem₂ (_ , ϕ .snd) (IsGroupHom.presinv (snd ϕ) (pos 1) ∙ sym (pos0+ (- fst (fst ϕ) (pos 1))) ∙ cong -_ h)) g)) (foo1 ϕ)
+
+miniLem₂ : (ϕ : GroupEquiv ℤGroup ℤGroup) (g : ℤ)
+         → (abs g ≡ abs (fst (fst ϕ) g))
+miniLem₂ ϕ g = ⊎-rec (λ h → sym (cong abs h)) (λ h → abs- _ ∙ sym (cong abs h)) (foo ϕ g)
+
+-- some minor group lemmas
+groupLem-help : (g : ℤ)
+              → gen₁-by ℤGroup g
+              → (ϕ : GroupHom ℤGroup ℤGroup)
+              → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
+              → isEquiv (fst ϕ)
+groupLem-help g gen ϕ = main (miniLem₁ g gen)
+  where
+  isEquiv- : isEquiv (-_)
+  isEquiv- = isoToIsEquiv (iso -_ -_ -Involutive -Involutive)
+
   main : (g ≡ pos 1) ⊎ (g ≡ negsuc 0)
       → (fst ϕ g ≡ pos 1) ⊎ (fst ϕ g ≡ negsuc 0)
       → isEquiv (fst ϕ)
   main (inl p) =
     J (λ g p → (fst ϕ g ≡ pos 1)
              ⊎ (fst ϕ g ≡ negsuc 0) → isEquiv (fst ϕ))
-      (λ { (inl x) → subst isEquiv (sym (lem x)) (snd (idEquiv _))
+      (λ { (inl x) → subst isEquiv (sym (lem ϕ x)) (snd (idEquiv _))
          ; (inr x) → subst isEquiv
-                            (sym (lem₂ (IsGroupHom.presinv (snd ϕ) (pos 1)
+                            (sym (lem₂ ϕ (IsGroupHom.presinv (snd ϕ) (pos 1)
                           ∙ (cong (λ x → pos 0 - x) x))))
                             isEquiv- })
                  (sym p)
   main (inr p) =
     J (λ g p → (fst ϕ g ≡ pos 1)
              ⊎ (fst ϕ g ≡ negsuc 0) → isEquiv (fst ϕ))
-      (λ { (inl x) → subst isEquiv (sym (lem₂ x)) isEquiv-
+      (λ { (inl x) → subst isEquiv (sym (lem₂ ϕ x)) isEquiv-
          ; (inr x) → subst isEquiv
-                       (sym (lem (
+                       (sym (lem ϕ (
                        IsGroupHom.presinv (snd ϕ) (negsuc 0)
                      ∙ cong (λ x → pos 0 - x) x)))
                     (snd (idEquiv _))})
       (sym p)
 
 groupLem : {G : Group₀}
-         → miniLem₁
          → GroupEquiv ℤGroup G
          → (g : fst G)
          → gen₁-by G g
          → (ϕ : GroupHom G ℤGroup)
          → (fst ϕ g ≡ 1) ⊎ (fst ϕ g ≡ -1)
          → isEquiv (fst ϕ)
-groupLem {G = G} s =
-
--- snd (fst (BijectionIsoToGroupEquiv {G = G} {H = ℤGroup}
---   (bijIso ϕ
---   (isMono→isInjective ϕ (λ {x} {y} hxy → {!sym (cong (ϕ .fst) (hg x .snd)) ∙ hxy ∙ cong (ϕ .fst) (hg y .snd)!}))
---   λ x → ∣ e .fst .fst x , {!hg (e .fst .fst x)!} ∣))) -- let boo : (a b : fst G) → invEq (e .fst) a ≡ invEq (e .fst) b → a ≡ b
---            --     boo = {!!}
---            -- in hg x .snd ∙ boo _ _ {!!}) {!!})))
+groupLem {G = G} =
   GroupEquivJ
     (λ G _ → (g : fst G)
          → gen₁-by G g
          → (ϕ : GroupHom G ℤGroup)
          → (fst ϕ g ≡ 1) ⊎ (fst ϕ g ≡ -1)
          → isEquiv (fst ϕ))
-    (groupLem-help s)
+    groupLem-help
+
+lemabs : ∀ {G : Group₀} (ϕ ψ : GroupEquiv ℤGroup G) (g : fst G)
+    → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g)
+lemabs =
+  GroupEquivJ
+    (λ G ϕ → (ψ : GroupEquiv ℤGroup G) (g : fst G)
+    → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g))
+    λ ψ → miniLem₂ (invGroupEquiv ψ)
 
 -- summary
 module π₄S³
-  (mini-lem₁ : miniLem₁)
-  (mini-lem₂ : miniLem₂)
-  (ℤ≅π₃S² : GroupEquiv ℤGroup (π 3 𝕊²))
+  (ℤ≅π₃S² : GroupEquiv (π 3 𝕊²) ℤGroup)
   (gen-by-HopfMap : π₃S²-gen)
   (π₄S³≅ℤ/whitehead : π₄S³≅ℤ/something ℤ≅π₃S²)
   (hopfWhitehead : abs (HopfInvariant-π' 0 ([ (∣ idfun∙ _ ∣₂ , ∣ idfun∙ _ ∣₂) ]×)) ≡ 2)
   where
   hopfInvariantEquiv : GroupEquiv (π 3 𝕊²) ℤGroup
   fst (fst hopfInvariantEquiv) = HopfInvariant-π' 0
-  snd (fst hopfInvariantEquiv) = {!HopfInvariant-π' 0!}
-    -- groupLem mini-lem₁ ℤ≅π₃S² ∣ HopfMap ∣₂
-    --          gen-by-HopfMap
-    --          (GroupHom-HopfInvariant-π' 0)
-    --          (abs→⊎ _ _ HopfInvariant-HopfMap)
+  snd (fst hopfInvariantEquiv) =
+    groupLem (invGroupEquiv ℤ≅π₃S²) ∣ HopfMap ∣₂
+             gen-by-HopfMap
+             (GroupHom-HopfInvariant-π' 0)
+             (abs→⊎ _ _ HopfInvariant-HopfMap)
   snd hopfInvariantEquiv = snd (GroupHom-HopfInvariant-π' 0)
 
-  lem : ∀ {G : Group₀} (ϕ ψ : GroupEquiv ℤGroup G) (g : fst G)
-      → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g)
-  lem =
-    GroupEquivJ
-      (λ G ϕ → (ψ : GroupEquiv ℤGroup G) (g : fst G)
-      → abs (invEq (fst ϕ) g) ≡ abs (invEq (fst ψ) g))
-      λ ψ → mini-lem₂ (invGroupEquiv ψ)
-
-  main : GroupIso (π 4 𝕊³) (ℤ/ 2)
-  main = subst (GroupIso (π 4 𝕊³))
-               (cong (ℤ/_) (lem ℤ≅π₃S² (invGroupEquiv (hopfInvariantEquiv)) _ ∙ hopfWhitehead))
-               π₄S³≅ℤ/whitehead
+  main : π 4 𝕊³ ≡ ℤ/ 2
+  main = π₄S³≅ℤ/whitehead
+       ∙ cong (ℤ/_) (lemabs (invGroupEquiv ℤ≅π₃S²) (invGroupEquiv hopfInvariantEquiv) _ ∙ hopfWhitehead)


### PR DESCRIPTION
Proving the "mini lemmas" required me to prove some lemmas that I think could be done nicer with some of the theory of https://github.com/agda/cubical/pull/705. Also a lot of the results I proved ended up in ZActions, but should probably be moved and better integrated with the new theory about divisibility for Z. Maybe @kangrongji would be up for doing this?

@aljungstrom : This will cause some conflicts in the Summary file with https://github.com/agda/cubical/pull/698. I think it would be easier to merge this PR first and then just fix the conflicts in this one file of your bigger PR, what do you think?

It could also be nice to keep the summary module with its arguments and just instantiate the main result afterwards. This way the summary file could be used as a connection between the formalization and the main results in Guillaume's thesis. What do you think?