### PR TITLE
Don't claim cubical compiles with the latest agda development version

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,7 +12,7 @@ on:
 ########################################################################
 ## CONFIGURATION
 ##
-## See SETTINGS for the most important configuration variable: AGDA_COMMIT.
+## See SETTINGS for the most important configuration variable: AGDA_BRANCH.
 ## It has to be defined as a build step because it is potentially branch
 ## dependent.
 ##
@@ -45,9 +45,11 @@ jobs:
       ########################################################################
       ## SETTINGS
       ##
-      ## AGDA_COMMIT picks the version of Agda to use to build the library.
+      ## AGDA_BRANCH picks the version of Agda to use to build the library.
       ## It can either be a hash of a specific commit (to target a bugfix for
       ## instance) or a tag e.g. tags/v2.6.1.3 (to target a released version).
+      ## Please adjust README.md and INSTALL.md accordingly, if you change
+      ## AGDA_BRANCH.
       ########################################################################
 
       - name: Initialise variables

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,7 +12,7 @@ on:
 ########################################################################
 ## CONFIGURATION
 ##
-## See SETTINGS for the most important configuration variable: AGDA_BRANCH.
+## See SETTINGS for the most important configuration variable: AGDA_COMMIT.
 ## It has to be defined as a build step because it is potentially branch
 ## dependent.
 ##
@@ -45,11 +45,9 @@ jobs:
       ########################################################################
       ## SETTINGS
       ##
-      ## AGDA_BRANCH picks the version of Agda to use to build the library.
+      ## AGDA_COMMIT picks the version of Agda to use to build the library.
       ## It can either be a hash of a specific commit (to target a bugfix for
       ## instance) or a tag e.g. tags/v2.6.1.3 (to target a released version).
-      ## Please adjust README.md and INSTALL.md accordingly, if you change
-      ## AGDA_BRANCH.
       ########################################################################
 
       - name: Initialise variables

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 Installation of agda/cubical
 ============================
 
-The cubical library should compile with the latest official release version
+The cubical library should compile on the latest official release version
 of Agda:
 
 https://github.com/agda/agda

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,8 @@
 Installation of agda/cubical
 ============================
 
-The cubical library should compile on the latest development version
+The cubical library compiles with Agda 2.6.2.
+The cubical library might also compile on the latest development version
 of Agda:
 
 https://github.com/agda/agda

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,7 @@
 Installation of agda/cubical
 ============================
 
-The cubical library compiles with Agda 2.6.2.
-The cubical library might also compile on the latest development version
+The cubical library should compile with the latest official release version
 of Agda:
 
 https://github.com/agda/agda

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 Installation of agda/cubical
 ============================
 
-The cubical library should compile on the latest official release version
+The cubical library should compile on the latest official release
 of Agda:
 
 https://github.com/agda/agda

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A standard library for Cubical Agda
 ===================================
 
-This library compiles with the latest official release version of
+This library compiles with the latest official release of
 [Agda](https://github.com/agda/agda/). For detailed install
 instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 A standard library for Cubical Agda
 ===================================
 
-This library compiles with version 2.6.2 of [Agda](https://github.com/agda/agda/). For detailed install
-instructions see the
+This library compiles with the latest official release version of
+[Agda](https://github.com/agda/agda/).
+For detailed install instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)
 file.
 
 The source code has a glorious clickable [rendered version](https://agda.github.io/cubical/Cubical.README.html).
 
-If you want to use Agda 2.6.2, you
+If you want to use Agda 2.6.2 instead of the latest release version, you
 can check out the tag `v0.3` of this library.
 
-If you want to use Agda 2.6.1.3, you
+If you want to use Agda 2.6.1.3 instead of the latest release version, you
 can check out the tag `v0.2` of this library.
 
-If you want to use Agda 2.6.0.1, you
+If you want to use Agda 2.6.0.1 instead of the latest release version, you
 can check out the tag `v0.1` of this library.
 
 For some introductory lecture notes see the material for the Cubical Agda course

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ A standard library for Cubical Agda
 ===================================
 
 This library compiles with the latest official release version of
-[Agda](https://github.com/agda/agda/).
-For detailed install instructions see the
+[Agda](https://github.com/agda/agda/). For detailed install
+instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)
 file.
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 A standard library for Cubical Agda
 ===================================
 
-This library compiles with the master branch of the development
-version of [Agda](https://github.com/agda/agda/). For detailed install
+This library compiles with version 2.6.2 of [Agda](https://github.com/agda/agda/). For detailed install
 instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)
 file.
 
 The source code has a glorious clickable [rendered version](https://agda.github.io/cubical/Cubical.README.html).
 
-If you want to use Agda 2.6.2 instead of the latest development version, you
+If you want to use Agda 2.6.2, you
 can check out the tag `v0.3` of this library.
 
-If you want to use Agda 2.6.1.3 instead of the latest development version, you
+If you want to use Agda 2.6.1.3, you
 can check out the tag `v0.2` of this library.
 
-If you want to use Agda 2.6.0.1 instead of the latest development version, you
+If you want to use Agda 2.6.0.1, you
 can check out the tag `v0.1` of this library.
 
 For some introductory lecture notes see the material for the Cubical Agda course


### PR DESCRIPTION
The readme claims, that the library compiles with the latest version of agda. That is currently not true.
I made some quick changes to improve the situation.
What do you think @mortberg , @ecavallo ?