### PR TITLE
Delooping of Group as HIT

### DIFF
--- a/Cubical/Algebra/Group/Instances/SetsAutomorphism.agda
+++ b/Cubical/Algebra/Group/Instances/SetsAutomorphism.agda
@@ -1,0 +1,71 @@
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.Group.Instances.SetsAutomorphism where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Algebra.Group.Base
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Properties
+
+
+module _ {ℓ} (A : Type ℓ) (isSet-A : isSet A) where
+
+  open GroupStr
+
+
+  SetAut≡ = SetsIso≡  isSet-A isSet-A
+  SetAut≡-ext = SetsIso≡-ext  isSet-A isSet-A
+
+
+  SetAut : Group ℓ
+  fst SetAut = Iso A A
+  1g (snd SetAut) = idIso
+  _·_ (snd SetAut) = compIso
+  inv (snd SetAut) = invIso
+  isGroup (snd SetAut) = isGroupSetAut 
+     where
+     abstract
+       isGroupSetAut : IsGroup {G = Iso A A} idIso compIso invIso
+       isGroupSetAut =
+          makeIsGroup
+            (isSet-SetsIso isSet-A isSet-A)
+            (λ _ _ _ → SetAut≡ refl refl)
+            (λ _ → SetAut≡ refl refl)
+            (λ _ → SetAut≡ refl refl)
+            (λ x → SetAut≡-ext (Iso.leftInv x) (Iso.leftInv x))
+            λ x → SetAut≡-ext (Iso.rightInv x) (Iso.rightInv x)
+
+
+-- action of group on its carrier
+G→SetAut⟨G⟩ : ∀ {ℓ} (G : Group ℓ) → GroupHom G (SetAut _ (isSetGroup G) )
+G→SetAut⟨G⟩ G'@(G , G-struct) = f , f-isHom
+  where
+    open GroupStr G-struct
+
+    open GroupTheory G'
+
+    isSet-G = (isSetGroup G')
+
+    GAut≡ = SetAut≡ _ isSet-G
+    GAut≡-ext = SetAut≡-ext _ isSet-G
+
+
+    f : G → Iso G G
+    Iso.fun (f x) = _· x  
+    Iso.inv (f x) =  _· (inv x)
+    Iso.rightInv (f x) b = sym (assoc _ _ _) ∙ cong (b ·_) (invl _) ∙ rid _
+    Iso.leftInv (f x) b = sym (assoc _ _ _) ∙ cong (b ·_) (invr _) ∙ rid _
+
+    f-isHom : IsGroupHom G-struct f _
+    IsGroupHom.pres· f-isHom x y =
+      GAut≡ (funExt λ _ → assoc _ _ _)
+            (funExt λ _ →  cong (_ ·_) (invDistr _ _) ∙ assoc _ _ _) 
+    IsGroupHom.pres1 f-isHom =
+      GAut≡ (funExt rid)
+            (funExt λ _ → cong (_ ·_) inv1g ∙ rid _)
+    IsGroupHom.presinv f-isHom x =
+      GAut≡ refl (funExt λ _ → cong (_ ·_) (invInv _))
+    

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -81,9 +81,18 @@ rCancel' p j k = rCancel-filler' p i0 j k
 lCancel : (p : x ≡ y) → p ⁻¹ ∙ p ≡ refl
 lCancel p = rCancel (p ⁻¹)
 
+
 assoc : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w) →
   p ∙ q ∙ r ≡ (p ∙ q) ∙ r
 assoc p q r k = (compPath-filler p q k) ∙ compPath-filler' q r (~ k)
+
+lemma-r : (p : x ≡ y) (q : y ≡ z) (r : x ≡ z) → p ∙ q ≡ r → p ≡ r ∙ (sym q)
+lemma-r p q r s = 
+  (rUnit _ ∙ cong (p ∙_) (sym (rCancel _)))
+   ∙ assoc _ _ _ ∙ cong (_∙ (sym q)) s  
+
+lemma-r' : (p : x ≡ y) (q : y ≡ z) (r : x ≡ z) → p ≡ r ∙ (sym q) → p ∙ q ≡ r
+lemma-r' p q r s = cong (_∙ q) s ∙ sym (assoc _ _ _) ∙ sym (rUnit _ ∙ cong (r ∙_) (sym (rCancel (sym q))))
 
 
 -- heterogeneous groupoid laws

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -30,7 +30,7 @@ HLevel = ℕ
 private
   variable
     ℓ ℓ' ℓ'' ℓ''' ℓ'''' ℓ''''' : Level
-    A : Type ℓ
+    A A' : Type ℓ
     B : A → Type ℓ
     C : (x : A) → B x → Type ℓ
     D : (x : A) (y : B x) → C x y → Type ℓ
@@ -668,3 +668,61 @@ snd (ΣSquareSet {B = B} pB {p = p} {q = q} {r = r} {s = s} sq i j) = lem i j
   lem : SquareP (λ i j → B (sq i j))
           (cong snd p) (cong snd r) (cong snd s) (cong snd q)
   lem = toPathP (isOfHLevelPathP' 1 (pB _) _ _ _ _)
+
+isSet-SetsIso : isSet A → isSet A' → isSet (Iso A A')
+isSet-SetsIso {A = A} {A' = A'} isSet-A isSet-A' x y p₀ p₁ = h
+  where
+
+   module X = Iso x 
+   module Y = Iso y  
+
+   f-p : ∀ i₁ → (Iso.fun (p₀ i₁) , Iso.inv (p₀ i₁)) ≡
+               (Iso.fun (p₁ i₁) , Iso.inv (p₁ i₁))
+   fst (f-p i₁ i) a = isSet-A' (X.fun a) (Y.fun a) (cong _ p₀) (cong _ p₁) i i₁
+   snd (f-p i₁ i) a' = isSet-A (X.inv a') (Y.inv a') (cong _ p₀) (cong _ p₁) i i₁
+
+   s-p : ∀ b → _
+   s-p b =
+     isSet→SquareP (λ i j → isProp→isSet (isSet-A' _ _))
+       refl refl (λ i₁ → (Iso.rightInv (p₀ i₁) b)) (λ i₁ → (Iso.rightInv (p₁ i₁) b))
+
+   r-p : ∀ a → _
+   r-p a =
+     isSet→SquareP (λ i j → isProp→isSet (isSet-A _ _))
+       refl refl (λ i₁ → (Iso.leftInv (p₀ i₁) a)) (λ i₁ → (Iso.leftInv (p₁ i₁) a))
+
+
+   h : p₀ ≡ p₁
+   Iso.fun (h i i₁) = fst (f-p i₁ i) 
+   Iso.inv (h i i₁) = snd (f-p i₁ i)
+   Iso.rightInv (h i i₁) b = s-p b i₁ i 
+   Iso.leftInv (h i i₁) a = r-p a i₁ i 
+
+
+SetsIso≡-ext : isSet A → isSet A'
+          → ∀ {a b : Iso A A'}
+          → (∀ x → Iso.fun a x ≡ Iso.fun b x)
+          → (∀ x → Iso.inv a x ≡ Iso.inv b x)
+          → a ≡ b
+Iso.fun (SetsIso≡-ext isSet-A isSet-A' {a} {b} fun≡ inv≡ i) x = fun≡ x i
+Iso.inv (SetsIso≡-ext isSet-A isSet-A' {a} {b} fun≡ inv≡ i) x = inv≡ x i
+Iso.rightInv (SetsIso≡-ext isSet-A isSet-A' {a} {b} fun≡ inv≡ i) b₁ =
+   isSet→SquareP (λ _ _ → isSet-A')
+     (Iso.rightInv a b₁)
+     (Iso.rightInv b b₁)
+     (λ i → fun≡ (inv≡ b₁ i) i)
+     refl i
+Iso.leftInv (SetsIso≡-ext isSet-A isSet-A' {a} {b} fun≡ inv≡ i) a₁ =
+   isSet→SquareP (λ _ _ → isSet-A)
+     (Iso.leftInv a a₁)
+     (Iso.leftInv b a₁)
+     (λ i → inv≡ (fun≡ a₁ i) i )
+     refl i
+
+SetsIso≡ : isSet A → isSet A'
+          → ∀ {a b : Iso A A'}
+          → (Iso.fun a ≡ Iso.fun b)
+          → (Iso.inv a ≡ Iso.inv b)
+          → a ≡ b
+SetsIso≡ isSet-A isSet-A' p q =
+  SetsIso≡-ext isSet-A isSet-A' (funExt⁻ p) (funExt⁻ q)

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -183,3 +183,4 @@ codomainIso : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ'
            → Iso B C
            → Iso (A → B) (A → C)
 codomainIso z = codomainIsoDep λ _ → z
+

--- a/Cubical/HITs/Delooping/Group.agda
+++ b/Cubical/HITs/Delooping/Group.agda
@@ -1,0 +1,218 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.HITs.Delooping.Group where
+
+open import Cubical.Foundations.Everything
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Algebra.Group.Base
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Properties
+
+open import Cubical.Algebra.Group.Instances.SetsAutomorphism
+
+open import Cubical.Homotopy.Group.Base
+
+variable
+  ℓ : Level
+
+
+ΣPathPProp≡ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+           → ∀ {a}
+           → {u : (B a)}
+           → (q : (a : A) → isProp (B a))
+           → (ΣPathPProp  {A = λ x → A} {B = λ _ x → B x} {u = a , u} {v = a , u} q refl) ≡ refl
+fst (ΣPathPProp≡ {a = a} q i i₁) = a
+snd (ΣPathPProp≡ {B = B} {a = a} {u = u} q i i₁) =
+    hcomp (λ k →
+            λ { (i = i1) → u
+              ; (i₁ = i0) → u
+              ; (i₁ = i1) → q a (transp (λ i₂ → B a) i0 u) u (k ∨ i)
+              })
+           {!!}
+          -- (transportRefl u i)
+
+-- i = i0 ⊢ hcomp
+--          (λ { j (i₁ = i0) → u
+--             ; j (i₁ = i1) → q a (transp (λ i₂ → B a) i0 u) u j
+--             })
+--          (transp (λ j → B a) (~ i₁) u)
+-- i = i1 ⊢ u
+-- i₁ = i0 ⊢ u
+-- i₁ = i1 ⊢ u
+
+module _ (G : Group ℓ) where
+
+  open GroupStr (snd G) renaming (assoc to assocG)
+
+  open GroupTheory G
+
+  isSet-⟨G⟩ = (isSetGroup G)
+
+  data B[_] : Type ℓ where
+    base : B[_]
+    loop : ⟨ G ⟩ → base ≡ base
+    loop1 : loop 1g ≡ refl
+    loopInv : ∀ g → loop (inv g) ≡ sym (loop g)  
+    loop· : ∀ (g x : ⟨ G ⟩)
+        → PathP (λ i → base ≡ loop g i) (loop (x · (inv g))) (loop x)
+    trunc : isGroupoid B[_]
+
+  private
+    variable
+      ℓ' : Level
+      A : Type ℓ'
+
+
+  module Elim where
+    rec : (x : A)
+        → (p : ⟨ G ⟩ → x ≡ x)
+        → p 1g ≡ refl
+        → (∀ g → (p (inv g)) ≡ sym (p g))
+        → (sq : ∀ (g x' : ⟨ G ⟩)
+             → PathP (λ i → x ≡ p g i) (p (x' · (inv g))) (p x'))
+        → isGroupoid A
+        → B[_] → A
+    rec x p x₁ x₂ sq x₃ = go
+      where
+        go : _ → _
+        go base = x
+        go (loop x i) = p x i
+        go (loop1 i i₁) = x₁ i i₁
+        go (loopInv g i i₁) = x₂ g i i₁
+        go (loop· g₁ g₂ i i₁) = sq g₁ g₂ i i₁
+        go (trunc x x₁ x₂ y x₃' y₁ i i₁ x₄) =
+          x₃ (go x) (go x₁) (cong go x₂) (cong go y) (cong (cong go) x₃') (cong (cong go) y₁) i i₁ x₄
+
+    elim : ∀ {ℓ'} (P : B[_] → Type ℓ')
+         → (x : P base)
+         → (p : (g : ⟨ G ⟩) → PathP (λ i → P (loop g i)) x x)
+         → SquareP (λ i i₁ → P (loop1 i i₁)) (p 1g ) refl refl refl
+         → (∀ g → SquareP (λ i i₁ → P (loopInv g i i₁)) (p (inv g)) (λ i₁ → p g (~ i₁)) refl refl )
+         → (∀ g₁ g₂ → SquareP (λ i i₁ → P (loop· g₁ g₂ i i₁)) (p (g₂ · inv g₁)) (p g₂) refl (p g₁) )
+         → isOfHLevelDep 3 P
+         → (z : B[_]) → P z
+    elim P x p x₁ x₂ x₃ x₄ = go
+      where
+        go : ∀ z → _
+        go base = x
+        go (loop x i) = p x i
+        go (loop1 i i₁) = x₁ i i₁
+        go (loopInv g i i₁) = x₂ g i i₁
+        go (loop· g₁ g₂ i i₁) = x₃ g₁ g₂ i i₁
+        go (trunc x x₁ x₂ y x₃' y₁ i i₁ x₄') =
+          x₄ (go x) (go x₁) (cong go x₂) (cong go y) (cong (cong go) x₃') (cong (cong go) y₁)
+            (trunc x x₁ x₂ y x₃' y₁ )
+            i i₁ x₄'
+
+    elimSet : ∀ {ℓ'} (P : B[_] → Type ℓ')
+         → (x : P base)
+         → (p : (g : ⟨ G ⟩) → PathP (λ i → P (loop g i)) x x)
+         → isOfHLevelDep 2 P
+         → (z : B[_]) → P z
+    elimSet P x p Pset =
+      elim P x p
+        (toPathP (Pset _ _ _ _ _))
+        (λ _ → toPathP (Pset _ _ _ _ _))
+        (λ _ _ → toPathP (Pset _ _ _ _ _))
+        (isOfHLevelDepSuc 2 Pset)
+
+    Code : B[_] → hSet ℓ
+    Code =
+      rec (⟨ G ⟩ , isSet-⟨G⟩)
+          (λ g → w' (isoToPath (fst (G→SetAut⟨G⟩ G) g)))
+          p1
+          p2
+          p3
+          (isOfHLevelTypeOfHLevel 2)
+      where
+       w : _
+       w = invEq≡→equivFun≡ (Σ≡PropEquiv (λ _ → isPropIsSet))
+
+       w≡ : (a b : _≡_ {A = hSet ℓ} (fst G , isSet-⟨G⟩) (fst G , isSet-⟨G⟩))
+             → transport (cong fst a) ≡ transport (cong fst b)   
+             → a ≡ b
+       w≡ a b x =
+         let z = isInjectiveTransport x
+
+             zz : PathP (λ z₁ → _≡_ {A = hSet ℓ} (fst (a z₁) , snd (a z₁)) (fst (b z₁) , snd (b z₁))) _ _
+             zz = λ i → ΣPathPProp (λ _ → isPropIsSet) λ i₁ → z i₁ i
+
+             ppp0 : _
+             ppp0 = ΣPathPProp≡ (λ _ → isPropIsSet)
+
+             ppp1 : _
+             ppp1 = ΣPathPProp≡ (λ _ → isPropIsSet)
+
+         in transport (λ i → PathP (λ x₁ → ppp0 i x₁ ≡ ppp1 i x₁) a b)
+                      (λ i i₁ → ((fst (zz i₁ i)) , snd (zz i₁ i)))
+           
+         
+       w' : (fst G ≡ fst G) → ((fst G , isSet-⟨G⟩) ≡ (fst G , isSet-⟨G⟩))
+       w' = equivFun (Σ≡PropEquiv (λ z → isPropIsSet {A = z}) {fst G , isSet-⟨G⟩} {fst G , isSet-⟨G⟩})
+
+       p1 : _
+       p1 = w (isInjectiveTransport (funExt (cong (transport refl) ∘ sym ∘ rid)))
+
+       p2 : _
+       p2 g = w (isInjectiveTransport (funExt λ x → cong (_· _) (transportRefl _) ∙ sym (transportRefl _)))
+
+       p3 : _
+       p3 g x' = toPathP (fromPathP (compPath-filler _ _)
+         ∙ w≡ _ _
+            (funExt λ x → cong (transport refl)
+               (cong (_· g) (transportRefl _ ∙ cong (_· (x' · inv g)) (transportRefl x))
+                 ∙ sym (assocG _ _ _) ∙ cong (x ·_) (sym (assocG _ _ _) ∙ cong (x' ·_) (invl g) ∙ rid x'))))
+
+
+    El : B[_] → Type ℓ
+    El b = Code b .fst
+
+
+    encode : ∀ x → base ≡ x → El x
+    encode x p = transport (cong El p) 1g 
+
+    decodeSq : ∀ g → PathP (λ i → El (loop g i) → base ≡ loop g i) loop loop
+    decodeSq g i x j =
+      hcomp (λ k →
+                  λ { (i = i0) →
+                         let p' = sym (assocG x g (inv g)) ∙ cong (x ·_) (invr g) ∙ rid x
+                         in (cong loop p') k j
+                    ; (i = i1) → loop x j
+                    ; (j = i0) → base
+                    ; (j = i1) → loop g i})
+           (loop· g (unglue (i ∨ ~ i) x) i j)
+
+    decode : (x : B[_]) → El x → base ≡ x
+    decode = elimSet _
+      loop
+      decodeSq
+      (isOfHLevel→isOfHLevelDep 2
+       λ _ → isOfHLevelΠ 2 λ _ → trunc base _)
+      
+
+    ΩB[_]-Iso-⟨G⟩ : Iso ⟨ G ⟩ (base ≡ base) 
+    Iso.fun ΩB[_]-Iso-⟨G⟩ = loop
+    Iso.inv ΩB[_]-Iso-⟨G⟩ = encode base
+    Iso.rightInv ΩB[_]-Iso-⟨G⟩ =
+       J (λ y x →  decode y (encode y x) ≡ x) (cong loop (transportRefl _) ∙ loop1)
+    Iso.leftInv ΩB[_]-Iso-⟨G⟩ _ = transportRefl _ ∙ lid _
+
+    ΩB[_] : Group ℓ
+    ΩB[_] = (base ≡ base) , groupstr refl _∙_ sym
+       (makeIsGroup (trunc _ _) assoc  (λ x → sym (rUnit x)) (λ x → sym (lUnit x)) rCancel lCancel)
+
+    loop-isHom : GroupEquiv G ΩB[_] 
+    fst loop-isHom = loop , isoToIsEquiv ΩB[_]-Iso-⟨G⟩ 
+    IsGroupHom.pres· (snd loop-isHom) x y =
+             cong (loop ∘ (x ·_) )(sym (invInv y))
+           ∙ sym (fromPathP (symP (loop· (inv y) x)))
+           ∙ fromPathP (compPath-filler (loop x) (λ i → loop (inv y) (~ i)))
+           ∙ (λ j i →
+                   hcomp
+                     (doubleComp-faces (λ _ → base) (sym (loopInv y j)) i)
+                      (loop x i))
+    IsGroupHom.pres1 (snd loop-isHom) = loop1 
+    IsGroupHom.presinv (snd loop-isHom) = loopInv

--- a/Cubical/HITs/Delooping/Group.agda
+++ b/Cubical/HITs/Delooping/Group.agda
@@ -24,24 +24,10 @@ variable
            → {u : (B a)}
            → (q : (a : A) → isProp (B a))
            → (ΣPathPProp  {A = λ x → A} {B = λ _ x → B x} {u = a , u} {v = a , u} q refl) ≡ refl
-fst (ΣPathPProp≡ {a = a} q i i₁) = a
-snd (ΣPathPProp≡ {B = B} {a = a} {u = u} q i i₁) =
-    hcomp (λ k →
-            λ { (i = i1) → u
-              ; (i₁ = i0) → u
-              ; (i₁ = i1) → q a (transp (λ i₂ → B a) i0 u) u (k ∨ i)
-              })
-           {!!}
-          -- (transportRefl u i)
-
--- i = i0 ⊢ hcomp
---          (λ { j (i₁ = i0) → u
---             ; j (i₁ = i1) → q a (transp (λ i₂ → B a) i0 u) u j
---             })
---          (transp (λ j → B a) (~ i₁) u)
--- i = i1 ⊢ u
--- i₁ = i0 ⊢ u
--- i₁ = i1 ⊢ u
+fst (ΣPathPProp≡ _ _ _) = _
+snd (ΣPathPProp≡ {a = a} {u = u} q i i₁) = 
+  isSet→SquareP (λ i j → isProp→isSet (q a))
+    (sym (transportRefl u) ∙ q a (transport refl u) u) (refl {x = u}) (refl {x = u}) (refl {x = u}) i i₁
 
 module _ (G : Group ℓ) where
 


### PR DESCRIPTION
code type checks,
closely follows code-decode (Cubical.HITs.S1.Base) and existing delooping of Z_2 (Cubical.HITs.Delooping.Two)
todo : 
 - celanup
 - better naming
 - simplyfing Code definition
 - add abstract defitnions where possible
 - show equivalence with library definition of loopspace (existing eqivalence is to non-tuncated version of loopspace)