### PR TITLE
Remove some unused imports

### DIFF
--- a/Cubical/Algebra/RingSolver/RawAlgebra.agda
+++ b/Cubical/Algebra/RingSolver/RawAlgebra.agda
@@ -2,7 +2,6 @@
 module Cubical.Algebra.RingSolver.RawAlgebra where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Data.Sigma
 open import Cubical.Data.Nat using (ℕ)
 open import Cubical.Data.Int renaming (_+_ to _+ℤ_ ; _·_ to _·ℤ_ ; -_ to -ℤ_ ; _-_ to _-ℤ_ ; +Assoc to +ℤAssoc ; +Comm to +ℤComm ; -DistL· to -ℤDistL·ℤ)
 

--- a/Cubical/Algebra/RingSolver/RawRing.agda
+++ b/Cubical/Algebra/RingSolver/RawRing.agda
@@ -2,8 +2,6 @@
 module Cubical.Algebra.RingSolver.RawRing where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Data.Sigma
-open import Cubical.Data.Nat using (ℕ)
 
 private
   variable

--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -1,8 +1,6 @@
 {-# OPTIONS --safe #-}
 module Cubical.Data.Bool.Base where
 
-open import Cubical.Core.Everything
-
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Empty
@@ -10,7 +8,6 @@ open import Cubical.Data.Sum.Base
 open import Cubical.Data.Unit.Base
 
 open import Cubical.Relation.Nullary.Base
-open import Cubical.Relation.Nullary.DecidableEq
 
 -- Obtain the booleans
 open import Agda.Builtin.Bool public

--- a/Cubical/Data/Empty/Base.agda
+++ b/Cubical/Data/Empty/Base.agda
@@ -1,7 +1,6 @@
 {-# OPTIONS --safe #-}
 module Cubical.Data.Empty.Base where
 
-open import Cubical.Core.Everything
 open import Cubical.Foundations.Prelude
 
 private

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -20,7 +20,6 @@ module Cubical.Foundations.Equiv where
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.GroupoidLaws
 
 open import Cubical.Foundations.Equiv.Base public
 open import Cubical.Data.Sigma.Base

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -16,8 +16,6 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv.Base
 
-open import Cubical.Foundations.Function
-
 private
   variable
     ℓ ℓ' : Level

--- a/Cubical/Functions/Morphism.agda
+++ b/Cubical/Functions/Morphism.agda
@@ -6,7 +6,6 @@ module Cubical.Functions.Morphism where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Function
 
 open Iso
 module ax {ℓ : Level} (A : Type ℓ) (_+A_ : A → A → A) (a₀ : A) where


### PR DESCRIPTION
This PR just removes some unused imports in various files.

Most of them were found by applying [agda-unused](https://github.com/msuperdock/agda-unused) to individual files (because it aborts with an error whenever it hits stuff like "record module instance applications"). I did not remove any `open import ... public`.