### PR TITLE
[ re #703, #743 ] Remove `extend*Context`

### DIFF
--- a/Cubical/Reflection/Base.agda
+++ b/Cubical/Reflection/Base.agda
@@ -46,10 +46,6 @@ hlam str t = R.lam R.hidden (R.abs str t)
 
 newMeta = R.checkType R.unknown
 
-extend*Context : ∀ {ℓ} {A : Type ℓ} → List (R.Arg R.Type) → R.TC A → R.TC A
-extend*Context [] tac = tac
-extend*Context (a ∷ as) tac = R.extendContext a (extend*Context as tac)
-
 makeAuxiliaryDef : String → R.Type → R.Term → R.TC R.Term
 makeAuxiliaryDef s ty term =
   R.freshName s >>= λ name →


### PR DESCRIPTION
This is the only function incompatible with the development version 2.6.3 of Agda. It is not used elsewhere in the library.

Removing it makes the library compatible with Agda 2.6.3 again. 