### PR TITLE
Issue #396: enforce import rules

### DIFF
--- a/Cubical/Algebra/AbGroup/Base.agda
+++ b/Cubical/Algebra/AbGroup/Base.agda
@@ -9,12 +9,17 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.SIP
+
 open import Cubical.Data.Sigma
 open import Cubical.Data.Unit
+
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
 open import Cubical.Algebra.CommMonoid
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.DirProd
 
 open import Cubical.Displayed.Base
 open import Cubical.Displayed.Auto

--- a/Cubical/Algebra/AbGroup/TensorProduct.agda
+++ b/Cubical/Algebra/AbGroup/TensorProduct.agda
@@ -21,7 +21,7 @@ open import Cubical.Data.Sum hiding (map)
 open import Cubical.HITs.PropositionalTruncation
   renaming (map to pMap ; rec to pRec ; elim to pElim ; elim2 to pElim2)
 
-open import Cubical.Algebra.Group hiding (ℤ)
+open import Cubical.Algebra.Group
 open import Cubical.Algebra.Group.Morphisms
 open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Monoid

--- a/Cubical/Algebra/Algebra/Base.agda
+++ b/Cubical/Algebra/Algebra/Base.agda
@@ -22,6 +22,8 @@ open import Cubical.Algebra.Module
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Monoid
 
 open Iso

--- a/Cubical/Algebra/Group.agda
+++ b/Cubical/Algebra/Group.agda
@@ -3,15 +3,3 @@ module Cubical.Algebra.Group where
 
 open import Cubical.Algebra.Group.Base public
 open import Cubical.Algebra.Group.Properties public
-{-
-open import Cubical.Algebra.Group.GroupPath public
-open import Cubical.Algebra.Group.DirProd public
-open import Cubical.Algebra.Group.Morphisms public
-open import Cubical.Algebra.Group.MorphismProperties public
-open import Cubical.Algebra.Group.Subgroup public
-open import Cubical.Algebra.Group.QuotientGroup public
-open import Cubical.Algebra.Group.IsomorphismTheorems public
-open import Cubical.Algebra.Group.Instances.Unit public
-open import Cubical.Algebra.Group.Instances.Bool public
-open import Cubical.Algebra.Group.Instances.Int public
--}

--- a/Cubical/Algebra/Group.agda
+++ b/Cubical/Algebra/Group.agda
@@ -3,6 +3,7 @@ module Cubical.Algebra.Group where
 
 open import Cubical.Algebra.Group.Base public
 open import Cubical.Algebra.Group.Properties public
+{-
 open import Cubical.Algebra.Group.GroupPath public
 open import Cubical.Algebra.Group.DirProd public
 open import Cubical.Algebra.Group.Morphisms public
@@ -13,3 +14,4 @@ open import Cubical.Algebra.Group.IsomorphismTheorems public
 open import Cubical.Algebra.Group.Instances.Unit public
 open import Cubical.Algebra.Group.Instances.Bool public
 open import Cubical.Algebra.Group.Instances.Int public
+-}

--- a/Cubical/Algebra/Polynomials/Multivariate/Equiv/Comp-Poly.agda
+++ b/Cubical/Algebra/Polynomials/Multivariate/Equiv/Comp-Poly.agda
@@ -6,6 +6,7 @@ open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Nat renaming (_+_ to _+n_; _·_ to _·n_)
 open import Cubical.Data.Vec
+open import Cubical.Data.Vec.OperationsNat
 open import Cubical.Data.Sigma
 
 open import Cubical.Algebra.Ring

--- a/Cubical/Algebra/Polynomials/Multivariate/Equiv/Induced-Poly.agda
+++ b/Cubical/Algebra/Polynomials/Multivariate/Equiv/Induced-Poly.agda
@@ -7,6 +7,7 @@ open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Nat renaming (_+_ to _+n_; _·_ to _·n_)
 open import Cubical.Data.Vec
+open import Cubical.Data.Vec.OperationsNat
 open import Cubical.Data.Sigma
 
 open import Cubical.Algebra.Ring

--- a/Cubical/Algebra/Polynomials/Multivariate/Equiv/Poly1-Poly.agda
+++ b/Cubical/Algebra/Polynomials/Multivariate/Equiv/Poly1-Poly.agda
@@ -6,6 +6,7 @@ open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Nat renaming (_+_ to _+n_; _·_ to _·n_)
 open import Cubical.Data.Vec renaming ( [] to <> ; _∷_ to _::_)
+open import Cubical.Data.Vec.OperationsNat
 
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing

--- a/Cubical/Algebra/Polynomials/Multivariate/Properties.agda
+++ b/Cubical/Algebra/Polynomials/Multivariate/Properties.agda
@@ -5,6 +5,7 @@ open import Cubical.Foundations.Prelude
 
 open import Cubical.Data.Nat renaming(_+_ to _+n_; _·_ to _·n_)
 open import Cubical.Data.Vec
+open import Cubical.Data.Vec.OperationsNat
 
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing

--- a/Cubical/Algebra/Polynomials/Univariate/Base.agda
+++ b/Cubical/Algebra/Polynomials/Univariate/Base.agda
@@ -18,7 +18,7 @@ open import Cubical.Data.Nat.Order
 open import Cubical.Data.Empty.Base renaming (rec to ⊥rec )
 open import Cubical.Data.Bool hiding (_≤_)
 
-open import Cubical.Algebra.Group hiding (Bool)
+open import Cubical.Algebra.Group
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing
 

--- a/Cubical/Algebra/Polynomials/Univariate/Properties.agda
+++ b/Cubical/Algebra/Polynomials/Univariate/Properties.agda
@@ -18,7 +18,7 @@ open import Cubical.Data.Nat.Order
 open import Cubical.Data.Empty.Base renaming (rec to ⊥rec )
 open import Cubical.Data.Bool
 
-open import Cubical.Algebra.Group hiding (Bool)
+open import Cubical.Algebra.Group
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing
 

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -16,6 +16,8 @@ open import Cubical.Data.Sigma
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.AbGroup
 
 open import Cubical.Displayed.Base

--- a/Cubical/Data/Nat.agda
+++ b/Cubical/Data/Nat.agda
@@ -2,5 +2,4 @@
 module Cubical.Data.Nat where
 
 open import Cubical.Data.Nat.Base public
-
 open import Cubical.Data.Nat.Properties public

--- a/Cubical/Data/NatMinusOne.agda
+++ b/Cubical/Data/NatMinusOne.agda
@@ -2,5 +2,4 @@
 module Cubical.Data.NatMinusOne where
 
 open import Cubical.Data.NatMinusOne.Base public
-
 open import Cubical.Data.NatMinusOne.Properties public

--- a/Cubical/Data/Vec.agda
+++ b/Cubical/Data/Vec.agda
@@ -3,5 +3,3 @@ module Cubical.Data.Vec where
 
 open import Cubical.Data.Vec.Base public
 open import Cubical.Data.Vec.Properties public
-open import Cubical.Data.Vec.NAry public
-open import Cubical.Data.Vec.OperationsNat public

--- a/Cubical/Experiments/ZCohomology/Benchmarks.agda
+++ b/Cubical/Experiments/ZCohomology/Benchmarks.agda
@@ -27,8 +27,23 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Data.Nat
 open import Cubical.Data.Bool
 open import Cubical.Data.Int
+open import Cubical.Data.Sigma
+
 open import Cubical.HITs.Sn
-open import Cubical.Algebra.Group hiding (ℤ ; Bool)
+open import Cubical.HITs.KleinBottle
+open import Cubical.HITs.RPn.Base
+open import Cubical.HITs.SetTruncation
+open import Cubical.HITs.Pushout
+open import Cubical.Homotopy.Hopf
+open S¹Hopf
+open import Cubical.HITs.Truncation
+open import Cubical.HITs.Susp
+open import Cubical.HITs.S1 hiding (rec ; elim ; ind)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+
 open import Cubical.ZCohomology.Base
 open import Cubical.ZCohomology.Properties
 open import Cubical.ZCohomology.GroupStructure hiding (_+ₕ_) renaming (_+'ₕ_ to _+ₕ_)
@@ -42,17 +57,6 @@ open import Cubical.ZCohomology.Groups.KleinBottle
 open import Cubical.ZCohomology.Groups.WedgeOfSpheres
 open import Cubical.ZCohomology.Groups.RP2
 open import Cubical.ZCohomology.Groups.CP2
-open import Cubical.Data.Sigma
-
-open import Cubical.HITs.KleinBottle
-open import Cubical.HITs.RPn.Base
-open import Cubical.HITs.SetTruncation
-open import Cubical.HITs.Pushout
-open import Cubical.Homotopy.Hopf
-open S¹Hopf
-open import Cubical.HITs.Truncation
-open import Cubical.HITs.Susp
-open import Cubical.HITs.S1 hiding (rec ; elim ; ind)
 
 open IsGroupHom
 open Iso

--- a/Cubical/Experiments/ZCohomologyOld/Properties.agda
+++ b/Cubical/Experiments/ZCohomologyOld/Properties.agda
@@ -1,9 +1,6 @@
 {-# OPTIONS --safe #-}
 module Cubical.Experiments.ZCohomologyOld.Properties where
 
-open import Cubical.ZCohomology.Base
-open import Cubical.HITs.S1
-open import Cubical.HITs.Sn
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
@@ -13,6 +10,8 @@ open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Equiv.HalfAdjoint
+
 open import Cubical.Data.Empty
 open import Cubical.Data.Sigma hiding (_×_)
 open import Cubical.HITs.Susp
@@ -24,13 +23,20 @@ open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; re
 open import Cubical.Homotopy.Loopspace
 open import Cubical.Homotopy.Connected
 open import Cubical.Homotopy.Freudenthal
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
-open import Cubical.Foundations.Equiv.HalfAdjoint
+
 open import Cubical.Data.NatMinusOne
 
 open import Cubical.HITs.Pushout
+open import Cubical.ZCohomology.Base
+open import Cubical.HITs.S1
+open import Cubical.HITs.Sn
 open import Cubical.Data.Sum.Base
 
 open import Cubical.Experiments.ZCohomologyOld.KcompPrelims

--- a/Cubical/HITs/FreeGroup/Properties.agda
+++ b/Cubical/HITs/FreeGroup/Properties.agda
@@ -23,6 +23,8 @@ open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.BiInvertible
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Monoid.Base
 open import Cubical.Algebra.Semigroup.Base
 

--- a/Cubical/HITs/FreeGroupoid/Properties.agda
+++ b/Cubical/HITs/FreeGroupoid/Properties.agda
@@ -22,6 +22,8 @@ open import Cubical.Foundations.Univalence using (ua)
 open import Cubical.HITs.SetTruncation renaming (rec to recTrunc)
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Monoid.Base
 open import Cubical.Algebra.Semigroup.Base
 

--- a/Cubical/Homotopy/EilenbergSteenrod.agda
+++ b/Cubical/Homotopy/EilenbergSteenrod.agda
@@ -27,7 +27,9 @@ open import Cubical.Data.Bool
 open import Cubical.Data.Sigma
 open import Cubical.Data.Int
 
-open import Cubical.Algebra.Group hiding (ℤ ; Bool)
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.AbGroup
 
 record coHomTheory {ℓ ℓ' : Level} (H : (n : ℤ) → Pointed ℓ → AbGroup ℓ') : Type (ℓ-suc (ℓ-max ℓ ℓ'))

--- a/Cubical/Homotopy/Group/Base.agda
+++ b/Cubical/Homotopy/Group/Base.agda
@@ -34,6 +34,9 @@ open import Cubical.Data.Bool
 open import Cubical.Data.Unit
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.GroupPath
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
 

--- a/Cubical/Homotopy/Group/LES.agda
+++ b/Cubical/Homotopy/Group/LES.agda
@@ -33,6 +33,9 @@ open import Cubical.Data.Sigma
 open import Cubical.Data.Nat
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.GroupPath
 
 -- We will need an explicitly defined equivalence
 -- (PathP (λ i → p i ≡ y) q q) ≃ (sym q ∙∙ p ∙∙ q ≡ refl)

--- a/Cubical/Homotopy/Group/Pi3S2.agda
+++ b/Cubical/Homotopy/Group/Pi3S2.agda
@@ -35,6 +35,10 @@ open import Cubical.Data.Int hiding (ℤ)
 open import Cubical.Algebra.Group
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Exact
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Unit
+open import Cubical.Algebra.Group.Instances.Int
 
 TotalHopf→∙S² : (Σ (S₊ 2) S¹Hopf , north , base) →∙ S₊∙ 2
 fst TotalHopf→∙S² = fst

--- a/Cubical/Homotopy/Group/Pi4S3/BrunerieNumber.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/BrunerieNumber.agda
@@ -53,6 +53,10 @@ open import Cubical.Algebra.Group
 open import Cubical.Algebra.Group.Exact
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Instances.IntMod
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Unit
+open import Cubical.Algebra.Group.GroupPath
 
 open Iso
 open Exact4

--- a/Cubical/Homotopy/Group/Pi4S3/QuickProof.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/QuickProof.agda
@@ -77,6 +77,10 @@ open import Cubical.Algebra.Group
 open import Cubical.Algebra.Group.Exact
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Instances.IntMod
+open import Cubical.Algebra.Group.GroupPath
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int
 
 open S¹Hopf
 open Iso

--- a/Cubical/Homotopy/Group/Pi4S3/S3PushoutIso2.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/S3PushoutIso2.agda
@@ -13,6 +13,9 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Data.Nat
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.GroupPath
 
 open import Cubical.HITs.Sn
 open import Cubical.HITs.Susp renaming (toSusp to σ)

--- a/Cubical/Homotopy/Group/PinSn.agda
+++ b/Cubical/Homotopy/Group/PinSn.agda
@@ -37,6 +37,8 @@ open import Cubical.ZCohomology.Properties
 open import Cubical.Algebra.Group
 open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.Group.ZAction
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 
 open Iso
 

--- a/Cubical/Homotopy/Group/SuspensionMap.agda
+++ b/Cubical/Homotopy/Group/SuspensionMap.agda
@@ -29,6 +29,8 @@ open import Cubical.Data.Nat
 open import Cubical.Data.Nat.Order
 
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
 

--- a/Cubical/Homotopy/HopfInvariant/Base.agda
+++ b/Cubical/Homotopy/HopfInvariant/Base.agda
@@ -34,9 +34,12 @@ open import Cubical.Data.Nat renaming (_+_ to _+ℕ_ ; _·_ to _·ℕ_)
 open import Cubical.Data.Unit
 
 open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Exact
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
 
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Sn

--- a/Cubical/Homotopy/HopfInvariant/Brunerie.agda
+++ b/Cubical/Homotopy/HopfInvariant/Brunerie.agda
@@ -51,10 +51,12 @@ open import Cubical.HITs.PropositionalTruncation
   renaming (map to pMap ; rec to pRec)
 
 open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Exact
-
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
 
 open Iso
 open IsGroupHom

--- a/Cubical/Homotopy/HopfInvariant/Homomorphism.agda
+++ b/Cubical/Homotopy/HopfInvariant/Homomorphism.agda
@@ -32,9 +32,13 @@ open import Cubical.Data.Nat renaming (_+_ to _+ℕ_ ; _·_ to _·ℕ_)
 open import Cubical.Data.Unit
 
 open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.DirProd
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Exact
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.GroupPath
 
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Sn

--- a/Cubical/Homotopy/HopfInvariant/HopfMap.agda
+++ b/Cubical/Homotopy/HopfInvariant/HopfMap.agda
@@ -37,9 +37,12 @@ open import Cubical.Data.Nat renaming (_+_ to _+ℕ_ ; _·_ to _·ℕ_)
 open import Cubical.Data.Unit
 
 open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.Group.ZAction
 open import Cubical.Algebra.Group.Exact
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.GroupPath
 
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Join

--- a/Cubical/ZCohomology/EilenbergSteenrodZ.agda
+++ b/Cubical/ZCohomology/EilenbergSteenrodZ.agda
@@ -39,9 +39,13 @@ open import Cubical.HITs.Wedge
 open import Cubical.HITs.Sn
 open import Cubical.HITs.S1
 
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.AbGroup.Instances.Unit
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
 
 open coHomTheory
 open Iso

--- a/Cubical/ZCohomology/GroupStructure.agda
+++ b/Cubical/ZCohomology/GroupStructure.agda
@@ -3,8 +3,6 @@ module Cubical.ZCohomology.GroupStructure where
 
 open import Cubical.ZCohomology.Base
 
-open import Cubical.HITs.S1 hiding (rec ; elim ; ind)
-open import Cubical.HITs.Sn
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
@@ -13,14 +11,24 @@ open import Cubical.Foundations.Pointed hiding (id)
 open import Cubical.Foundations.Path
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws renaming (assoc to assoc∙)
+
 open import Cubical.Data.Sigma
-open import Cubical.HITs.Susp
-open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2 ; isSetSetTrunc to §)
 open import Cubical.Data.Int renaming (_+_ to _ℤ+_ ; -_ to -ℤ_)
 open import Cubical.Data.Nat renaming (+-assoc to +-assocℕ ; +-comm to +-commℕ)
+
+open import Cubical.HITs.S1 hiding (rec ; elim ; ind)
+open import Cubical.HITs.Sn
+open import Cubical.HITs.Susp
+open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2 ; isSetSetTrunc to §)
 open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; rec to trRec ; elim3 to trElim3 ; map2 to trMap2)
+
 open import Cubical.Homotopy.Loopspace
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid

--- a/Cubical/ZCohomology/Groups/CP2.agda
+++ b/Cubical/ZCohomology/Groups/CP2.agda
@@ -25,7 +25,12 @@ open import Cubical.Data.Int
 open import Cubical.Data.Nat renaming (_+_ to _+ℕ_)
 open import Cubical.Data.Nat.Order
 open import Cubical.Data.Unit
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Unit
 
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.S1

--- a/Cubical/ZCohomology/Groups/Connected.agda
+++ b/Cubical/ZCohomology/Groups/Connected.agda
@@ -19,6 +19,9 @@ open import Cubical.Data.Int hiding (ℤ) renaming (_+_ to _+ℤ_; +Comm to +ℤ
 open import Cubical.Data.Nat
 open import Cubical.HITs.Truncation renaming (rec₊ to trRec)
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Instances.Int
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 
 open import Cubical.Homotopy.Connected
 open import Cubical.Foundations.Equiv

--- a/Cubical/ZCohomology/Groups/KleinBottle.agda
+++ b/Cubical/ZCohomology/Groups/KleinBottle.agda
@@ -13,7 +13,14 @@ open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to pRec2 ; e
 open import Cubical.HITs.PropositionalTruncation renaming (rec to pRec ; ∣_∣ to ∣_∣₁)
 open import Cubical.HITs.Truncation renaming (elim to trElim ; rec to trRec ; elim2 to trElim2)
 open import Cubical.Data.Nat hiding (isEven)
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup ; Bool to BoolGroup)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool renaming (Bool to BoolGroup)
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
 
 open import Cubical.Foundations.Equiv.HalfAdjoint
 open import Cubical.Foundations.Transport

--- a/Cubical/ZCohomology/Groups/RP2.agda
+++ b/Cubical/ZCohomology/Groups/RP2.agda
@@ -1,38 +1,43 @@
 {-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.RP2 where
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.GroupStructure
-open import Cubical.ZCohomology.Properties
-open import Cubical.ZCohomology.Groups.KleinBottle
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.GroupoidLaws
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.Equiv.HalfAdjoint
+open import Cubical.Foundations.Transport
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to pRec2 ; elim to sElim ; elim2 to sElim2 ; map to sMap)
 open import Cubical.HITs.PropositionalTruncation renaming (rec to pRec ; elim to pElim) hiding (map)
 open import Cubical.HITs.Truncation renaming (elim to trElim ; rec to trRec ; elim2 to trElim2)
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup ; Bool to BoolGroup)
-
-open import Cubical.Foundations.Equiv.HalfAdjoint
-open import Cubical.Foundations.Transport
-
-open import Cubical.ZCohomology.Groups.Connected
-
-open import Cubical.Data.Sigma
-
-open import Cubical.Foundations.Isomorphism
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
-open import Cubical.Foundations.Equiv
-open import Cubical.Homotopy.Connected
 open import Cubical.HITs.RPn.Base
 
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool renaming (Bool to BoolGroup)
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
+
+open import Cubical.Data.Sigma
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)
 open import Cubical.Data.Bool
 open import Cubical.Data.Int
 
-open import Cubical.Foundations.Path
+open import Cubical.Homotopy.Connected
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.GroupStructure
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.Groups.KleinBottle
+open import Cubical.ZCohomology.Groups.Connected
 
 private
   variable

--- a/Cubical/ZCohomology/Groups/Sn.agda
+++ b/Cubical/ZCohomology/Groups/Sn.agda
@@ -37,7 +37,12 @@ open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; re
 
 open import Cubical.Homotopy.Connected
 
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup) hiding (Bool)
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Unit
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 
 infixr 31 _□_
 _□_ : _

--- a/Cubical/ZCohomology/Groups/SphereProduct.agda
+++ b/Cubical/ZCohomology/Groups/SphereProduct.agda
@@ -23,12 +23,6 @@ open import Cubical.Foundations.Pointed
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.GroupStructure
-open import Cubical.ZCohomology.Properties
-open import Cubical.ZCohomology.Groups.Sn
-open import Cubical.ZCohomology.RingStructure.CupProduct
-
 open import Cubical.Data.Sigma
 open import Cubical.Data.Nat
 open import Cubical.Data.Unit
@@ -42,11 +36,26 @@ open import Cubical.HITs.SetTruncation
 open import Cubical.HITs.PropositionalTruncation
   renaming (map to pMap ; rec to pRec)
 
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.GroupStructure
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.Groups.Sn
+open import Cubical.ZCohomology.RingStructure.CupProduct
+
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int
 
 open import Cubical.Relation.Nullary
 
 open import Cubical.Homotopy.Loopspace
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.GroupStructure
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.Groups.Sn
+open import Cubical.ZCohomology.RingStructure.CupProduct
 
 open Iso
 

--- a/Cubical/ZCohomology/Groups/Torus.agda
+++ b/Cubical/ZCohomology/Groups/Torus.agda
@@ -24,7 +24,13 @@ open import Cubical.Data.Sigma
 open import Cubical.Data.Int renaming (_+_ to _+ℤ_; +Comm to +ℤ-comm ; +Assoc to +ℤ-assoc)
 open import Cubical.Data.Nat
 open import Cubical.Data.Unit
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup ; Bool to BoolGroup)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool renaming (Bool to BoolGroup)
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.S1

--- a/Cubical/ZCohomology/Groups/Unit.agda
+++ b/Cubical/ZCohomology/Groups/Unit.agda
@@ -10,7 +10,6 @@ open import Cubical.ZCohomology.Properties
 open import Cubical.ZCohomology.GroupStructure
 
 open import Cubical.HITs.Sn
-
 open import Cubical.HITs.Susp
 open import Cubical.HITs.Truncation
 open import Cubical.HITs.SetTruncation
@@ -21,11 +20,16 @@ open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Data.Int hiding (ℤ ; _+_ ; +Comm)
 open import Cubical.Data.Nat
 open import Cubical.Data.Unit
+open import Cubical.Data.Sigma
 
 open import Cubical.Homotopy.Connected
 
-open import Cubical.Data.Sigma
 open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int
+open import Cubical.Algebra.Group.Instances.Unit
+
 
 -- H⁰(Unit)
 open IsGroupHom

--- a/Cubical/ZCohomology/Groups/Wedge.agda
+++ b/Cubical/ZCohomology/Groups/Wedge.agda
@@ -1,34 +1,41 @@
 {-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Groups.Wedge where
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.GroupStructure
-open import Cubical.ZCohomology.Properties
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Pointed
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.GroupoidLaws renaming (assoc to assoc∙)
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+
 open import Cubical.HITs.Wedge
-open import Cubical.Data.Int hiding (_+_)
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2 ; map to sMap)
 open import Cubical.HITs.PropositionalTruncation renaming (rec to pRec ; ∣_∣ to ∣_∣₁)
 open import Cubical.HITs.Truncation renaming (elim to trElim ; rec to trRec ; elim2 to trElim2)
-open import Cubical.Data.Nat
-open import Cubical.Algebra.Group
-
-open import Cubical.ZCohomology.Groups.Unit
-open import Cubical.ZCohomology.Groups.Sn
-
-open import Cubical.HITs.Pushout
-open import Cubical.Data.Sigma
-
-open import Cubical.Foundations.Isomorphism
-open import Cubical.Homotopy.Connected
 open import Cubical.HITs.Susp
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
-open import Cubical.Foundations.Equiv
+open import Cubical.HITs.Pushout
+open import Cubical.Data.Nat
+open import Cubical.Data.Sigma
+open import Cubical.Data.Int hiding (_+_)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+
+open import Cubical.Homotopy.Connected
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.GroupStructure
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.Groups.Unit
+open import Cubical.ZCohomology.Groups.Sn
+
+
+
 
 open IsGroupHom
 open Iso

--- a/Cubical/ZCohomology/Groups/WedgeOfSpheres.agda
+++ b/Cubical/ZCohomology/Groups/WedgeOfSpheres.agda
@@ -27,8 +27,13 @@ open import Cubical.HITs.Pushout
 open import Cubical.HITs.Truncation renaming (elim to trElim) hiding (map ; elim2)
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim)
 
-open import Cubical.Algebra.Group renaming (ℤ to ℤGroup ; Bool to BoolGroup)
-
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool renaming (Bool to BoolGroup)
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
 
 S¹⋁S¹ : Type₀
 S¹⋁S¹ = S₊∙ 1 ⋁ S₊∙ 1

--- a/Cubical/ZCohomology/Gysin.agda
+++ b/Cubical/ZCohomology/Gysin.agda
@@ -1,22 +1,6 @@
 {-# OPTIONS --safe --experimental-lossy-unification #-}
 module Cubical.ZCohomology.Gysin where
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.Groups.Connected
-open import Cubical.ZCohomology.GroupStructure
-open import Cubical.ZCohomology.Properties
-open import Cubical.ZCohomology.MayerVietorisUnreduced
-open import Cubical.ZCohomology.Groups.Unit
-open import Cubical.ZCohomology.Groups.Wedge
-open import Cubical.ZCohomology.Groups.Sn
-open import Cubical.ZCohomology.RingStructure.CupProduct
-open import Cubical.ZCohomology.RingStructure.RingLaws
-open import Cubical.ZCohomology.RingStructure.GradedCommutativity
-
-open import Cubical.Relation.Nullary
-
-open import Cubical.Functions.Embedding
-
 open import Cubical.Foundations.Path
 open import Cubical.Foundations.Equiv.HalfAdjoint
 open import Cubical.Foundations.HLevels
@@ -30,6 +14,10 @@ open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Pointed.Homogeneous
 
+open import Cubical.Functions.Embedding
+
+open import Cubical.Relation.Nullary
+
 open import Cubical.Data.Sum
 open import Cubical.Data.Fin
 open import Cubical.Data.Empty renaming (rec to ⊥-rec)
@@ -39,10 +27,13 @@ open import Cubical.Data.Nat renaming (_+_ to _+ℕ_ ; _·_ to _·ℕ_)
 open import Cubical.Data.Nat.Order
 open import Cubical.Data.Unit
 open import Cubical.Data.Bool
-open import Cubical.Algebra.Group
-  renaming (ℤ to ℤGroup) hiding (Bool)
-open import Cubical.Algebra.Group.ZAction
+
 open import Cubical.Algebra.AbGroup
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.ZAction
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
 
 open import Cubical.HITs.Pushout.Flattening
 open import Cubical.HITs.Pushout
@@ -61,6 +52,18 @@ open import Cubical.Homotopy.Connected
 open import Cubical.Homotopy.Hopf
 open import Cubical.Homotopy.Loopspace
 open import Cubical.Homotopy.Group.Base
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.Groups.Connected
+open import Cubical.ZCohomology.GroupStructure
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.MayerVietorisUnreduced
+open import Cubical.ZCohomology.Groups.Unit
+open import Cubical.ZCohomology.Groups.Wedge
+open import Cubical.ZCohomology.Groups.Sn
+open import Cubical.ZCohomology.RingStructure.CupProduct
+open import Cubical.ZCohomology.RingStructure.RingLaws
+open import Cubical.ZCohomology.RingStructure.GradedCommutativity
 
 -- There seems to be some problems with the termination checker.
 -- Spelling out integer induction with 3 base cases like this

--- a/Cubical/ZCohomology/MayerVietorisUnreduced.agda
+++ b/Cubical/ZCohomology/MayerVietorisUnreduced.agda
@@ -1,10 +1,6 @@
 {-# OPTIONS --safe #-}
 module Cubical.ZCohomology.MayerVietorisUnreduced where
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.Properties
-open import Cubical.ZCohomology.GroupStructure
-
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Prelude
@@ -19,9 +15,20 @@ open import Cubical.HITs.S1
 open import Cubical.HITs.Susp
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2)
 open import Cubical.HITs.PropositionalTruncation renaming (rec to pRec ; elim to pElim ; elim2 to pElim2 ; ∥_∥ to ∥_∥₁ ; ∣_∣ to ∣_∣₁)
-open import Cubical.Data.Nat
-open import Cubical.Algebra.Group
 open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; rec to trRec ; elim3 to trElim3)
+open import Cubical.Data.Nat
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.DirProd
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool renaming (Bool to BoolGroup)
+open import Cubical.Algebra.Group.Instances.Int renaming (ℤ to ℤGroup)
+open import Cubical.Algebra.Group.Instances.Unit
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.Properties
+open import Cubical.ZCohomology.GroupStructure
 
 open IsGroupHom
 

--- a/Cubical/ZCohomology/Properties.agda
+++ b/Cubical/ZCohomology/Properties.agda
@@ -15,11 +15,6 @@ This module contains:
 -}
 
 
-open import Cubical.ZCohomology.Base
-open import Cubical.ZCohomology.GroupStructure
-
-open import Cubical.HITs.S1 hiding (encode ; decode ; _·_)
-open import Cubical.HITs.Sn
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Function
@@ -30,21 +25,33 @@ open import Cubical.Foundations.Pointed.Homogeneous
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.GroupoidLaws renaming (assoc to assoc∙)
 open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Equiv.HalfAdjoint
+
+open import Cubical.Functions.Morphism
+
 open import Cubical.HITs.Susp
 open import Cubical.HITs.SetTruncation renaming (rec to sRec ; rec2 to sRec2 ; elim to sElim ; elim2 to sElim2 ; isSetSetTrunc to §)
+open import Cubical.HITs.S1 hiding (encode ; decode ; _·_)
+open import Cubical.HITs.Sn
+open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; map2 to trMap2; rec to trRec ; elim3 to trElim3)
+
+open import Cubical.Data.Sum.Base hiding (map)
 open import Cubical.Data.Int renaming (_+_ to _ℤ+_) hiding (-_)
 open import Cubical.Data.Nat
-open import Cubical.HITs.Truncation renaming (elim to trElim ; map to trMap ; map2 to trMap2; rec to trRec ; elim3 to trElim3)
+open import Cubical.Data.Sigma
+
 open import Cubical.Homotopy.Loopspace
 open import Cubical.Homotopy.Connected
-open import Cubical.Algebra.Group hiding (ℤ)
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
-open import Cubical.Foundations.Equiv.HalfAdjoint
-open import Cubical.Data.Sum.Base hiding (map)
-open import Cubical.Functions.Morphism
-open import Cubical.Data.Sigma
+
+open import Cubical.ZCohomology.Base
+open import Cubical.ZCohomology.GroupStructure
 
 open Iso renaming (inv to inv')
 


### PR DESCRIPTION
Enforce the rule that a re-exporting file Foo.agda should only re-export Foo/Base.agda and Foo/Properties.agda.