### PR TITLE
Build cubical with latest Agda master (2022-05-09)

### DIFF
--- a/Cubical/Data/FinData/Properties.agda
+++ b/Cubical/Data/FinData/Properties.agda
@@ -141,8 +141,8 @@ toℕ∘enum {n = ℕsuc n} (ℕsuc m) p i = ℕsuc (toℕ∘enum m (pred-≤-pr
 enumExt : {m m' : ℕ}(p : m < n)(p' : m' < n) → m ≡ m' → enum m p ≡ enum m' p'
 enumExt p p' q i = enum (q i) (isProp→PathP (λ i → isProp≤ {m = ℕsuc (q i)}) p p' i)
 
-enumInj : {p : m < k}{q : n < k} → enum m p ≡ enum n q → m ≡ n
-enumInj p = sym (toℕ∘enum _ _) ∙ cong toℕ p ∙ toℕ∘enum _ _
+enumInj : (p : m < k) (q : n < k) → enum m p ≡ enum n q → m ≡ n
+enumInj p q path = sym (toℕ∘enum _ p) ∙ cong toℕ path ∙ toℕ∘enum _ q
 
 enumIndStep :
     (P : Fin n → Type ℓ)

--- a/Cubical/Data/W/Indexed.agda
+++ b/Cubical/Data/W/Indexed.agda
@@ -21,8 +21,8 @@ private
     ℓX ℓS ℓP : Level
 
 module Types {X : Type ℓX} (S : X → Type ℓS) (P : ∀ x → S x → Type ℓP) (inX : ∀ x (s : S x) → P x s → X) where
-  data IW : (x : X) → Type (ℓ-max ℓX (ℓ-max ℓS ℓP)) where
-    node : ∀ {x} → (s : S x) → (subtree : (p : P x s) → IW (inX x s p)) → IW x
+  data IW (x : X) : Type (ℓ-max ℓX (ℓ-max ℓS ℓP)) where
+    node : (s : S x) → (subtree : (p : P x s) → IW (inX x s p)) → IW x
 
   Subtree : ∀ {x} → (s : S x) → Type (ℓ-max (ℓ-max ℓX ℓS) ℓP)
   Subtree {x} s = (p : P x s) → IW (inX x s p)


### PR DESCRIPTION
I noticed yesterday that the latest `cubical` does not build with the latest `agda`.  This PR should fix this.
- 2 hidden arguments that can no longer be inferred: fixed by providing these arguments
- a regression in the termination checker: fixed by turning the index of `IW` into a parameter

If you agree and merge this, the submodule pin for `cubical` in the `agda` repo can be moved forward.

On another note, it would be good if you would test `cubical` also with the latest `agda`, just to get alerted of breakages.  Maybe you can add such to your CI, using the deploys of Agda (https://github.com/agda/agda/actions/workflows/deploy.yml)