### PR TITLE
Congruence over dependent paths of functions with ua in their domain

### DIFF
--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -256,6 +256,16 @@ ua→ {e = e} {f₀ = f₀} {f₁} h i a =
   lem : ∀ a₁ → e .fst (transport (sym (ua e)) a₁) ≡ a₁
   lem a₁ = secEq e _ ∙ transportRefl _
 
+-- Congruence over dependent paths of functions with ua in their domain
+ua→cong : ∀ {ℓ ℓ' ℓ''} {A₀ A₁ : Type ℓ} {e : A₀ ≃ A₁}
+  {B : (i : I) → Type ℓ'}
+  {C : (i : I) → Type ℓ''}
+  {f₀ : A₀ → B i0} {f₁ : A₁ → B i1}
+  (F : {i : I} → B i → C i)
+  (p : PathP (λ i → ua e i → B i) f₀ f₁)
+  → PathP (λ i → ua e i → C i) (F {i0} ∘ f₀) (F {i1} ∘ f₁)
+ua→cong F p = λ i x → F (p i x)
+
 ua→⁻ : ∀ {ℓ ℓ'} {A₀ A₁ : Type ℓ} {e : A₀ ≃ A₁} {B : (i : I) → Type ℓ'}
   {f₀ : A₀ → B i0} {f₁ : A₁ → B i1}
   → PathP (λ i → ua e i → B i) f₀ f₁


### PR DESCRIPTION
Recently, I've been doing some work involving lots dependent paths over function types. I found the `ua→`-lemmata to quite helpful, but the library is still missing an equivalent of `cong` for such paths. I thought this would make a good first contribution.

Questions:
 - [ ] Is this a duplicate effort?
 - [ ] Is `ua→cong` a good name? (Or `cong-ua→`, `ua→∘`, ...?)
 - [ ] Should the interval argument to `F` be explicit?
 - [ ] What's the documentation supposed to look like?
 - [ ] Would you like to see some example usage?