### PR TITLE
WIP: Coproduct of AbGroups

### DIFF
--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -17,7 +17,7 @@ module _ {X : Type ℓ} (A : X → Type ℓ') where
   infix 20 _⁻¹
 
 
-  data Coproduct : Type _ where
+  data Coproduct : Type (ℓ-max ℓ ℓ') where
     incl       : (x : X) → A x → Coproduct
     ε         : Coproduct
     _·_       : Coproduct → Coproduct → Coproduct

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -4,6 +4,7 @@ module Cubical.Algebra.AbGroup.Coproduct where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Structure
 
 open import Cubical.Algebra.AbGroup
 
@@ -11,14 +12,13 @@ private variable
   ℓ ℓ' : Level
   A : Type ℓ
 
-module _ {X : Type ℓ} (A : X → Type ℓ') where
+module _ {X : Type ℓ} (A : X → AbGroup ℓ') where
 
   infixl 7 _·_
   infix 20 _⁻¹
 
-
   data Coproduct : Type (ℓ-max ℓ ℓ') where
-    incl       : (x : X) → A x → Coproduct
+    incl       : (x : X) → ⟨ A x ⟩ → Coproduct
     ε         : Coproduct
     _·_       : Coproduct → Coproduct → Coproduct
     _⁻¹       : Coproduct → Coproduct
@@ -29,7 +29,7 @@ module _ {X : Type ℓ} (A : X → Type ℓ') where
     trunc     : isSet Coproduct
 
   module Elim {B : Coproduct → Type ℓ'}
-    (incl*       : (x : X) (a : A x) → B (incl x a))
+    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
     (ε*         : B ε)
     (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
     (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹))
@@ -57,7 +57,7 @@ module _ {X : Type ℓ} (A : X → Type ℓ') where
 
   module ElimProp {B : Coproduct → Type ℓ'}
     (BProp : {xs : Coproduct} → isProp (B xs))
-    (incl*       : (x : X) (a : A x) → B (incl x a))
+    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
     (ε*         : B ε)
     (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
     (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹)) where
@@ -71,7 +71,7 @@ module _ {X : Type ℓ} (A : X → Type ℓ') where
       (λ _ → (isProp→isSet BProp))
 
   module Rec {B : Type ℓ'} (BType : isSet B)
-    (incl*       : (x : X) (a : A x) → B)
+    (incl*       : (x : X) (a : ⟨ A x ⟩) → B)
     (ε*         : B)
     (_·*_       : B → B → B)
     (_⁻¹*       : B → B)

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -39,12 +39,12 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     trunc     : isSet Coproduct
 
   module _ {B : Coproduct → Type ℓ'}
-    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
+    (incl*       : {x : X} (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
     (⊖*_       : ∀ {x}     → B x → B (⊖ x))
     (inclPres+* : {x : X} → (a b : ⟨ A x ⟩)
-      → PathP (λ i → B (inclPres+ a b i)) (incl* _ (a + b)) (incl* _ a ⊕* incl* _ b))
+      → PathP (λ i → B (inclPres+ a b i)) (incl* (a + b)) (incl* a ⊕* incl* b))
     (assoc*     : ∀ {x y z} → (xs : B x) (ys : B y) (zs : B z)
       → PathP (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs)) ((xs ⊕* ys) ⊕* zs))
     (comm*      : ∀ {x y}   → (xs : B x) (ys : B y)
@@ -56,7 +56,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     (trunc*     : ∀ xs → isSet (B xs)) where
 
     elim : (x : Coproduct) → B x
-    elim (incl a) = incl* _ a
+    elim (incl a) = incl* a
     elim ε = ε*
     elim (x ⊕ y) = elim x ⊕* elim y
     elim (⊖ x) = ⊖* (elim x)
@@ -70,14 +70,14 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
   module _ {B : Coproduct → Type ℓ'}
     (BProp : {xs : Coproduct} → isProp (B xs))
-    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
+    (incl*       : {x : X} (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
     (_⊖*       : ∀ {x}     → B x → B (⊖ x)) where
 
     elimProp : (xs : Coproduct) → B xs
     elimProp = elim incl* ε* _⊕*_ _⊖*
-      (λ {x} a b → toPathP (BProp (transport (λ i → B (inclPres+ a b i)) (incl* _ (a + b))) (incl* _ a ⊕* incl* _ b)))
+      (λ {x} a b → toPathP (BProp (transport (λ i → B (inclPres+ a b i)) (incl* (a + b))) (incl* a ⊕* incl* b)))
       (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs))) ((xs ⊕* ys) ⊕* zs)))
       (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ⊕* ys)) (ys ⊕* xs)))
       (λ {x} xs → toPathP (BProp (transport (λ i → B (identityᵣ x i)) (xs ⊕* ε*)) xs))
@@ -98,18 +98,18 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     elimProp2 : (x y : Coproduct) → B x y
     elimProp2 =
       elimProp
-        (λ {_} → isPropΠ (λ _ → BProp))
-        (λ x a → elimProp BProp (λ y a' → incl* a a') ε*R ⊕*R ⊖*R)
+        (isPropΠ (λ _ → BProp))
+        (λ a → elimProp BProp (λ a' → incl* a a') ε*R ⊕*R ⊖*R)
         (λ _ → ε*L)
         (λ b b' x → ⊕*L (b x) (b' x))
         λ b x → ⊖*L (b x)
 
   module _ {B : Type ℓ'} (BType : isSet B)
-    (incl*       : (x : X) (a : ⟨ A x ⟩) → B)
+    (incl*       : {x : X} (a : ⟨ A x ⟩) → B)
     (ε*         : B)
     (_⊕*_       : B → B → B)
     (⊖*_       : B → B)
-    (inclPres+* : {x : X} → (a b : ⟨ A x ⟩) → incl* _ (a + b) ≡ incl* _ a ⊕* incl* _ b)
+    (inclPres+* : {x : X} → (a b : ⟨ A x ⟩) → incl* (a + b) ≡ incl* a ⊕* incl* b)
     (assoc*     : (x y z : B) → x ⊕* (y ⊕* z) ≡ (x ⊕* y) ⊕* z)
     (comm*      : (x y : B)   → x ⊕* y        ≡ y ⊕* x)
     (identityᵣ* : (x : B)     → x ⊕* ε*       ≡ x)
@@ -118,6 +118,10 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
     rec : Coproduct → B
     rec = elim incl* ε* _⊕*_ ⊖*_ inclPres+* assoc* comm* identityᵣ* invᵣ* (const BType)
+
+    recIncl : {x : X} (a : ⟨ A x ⟩)
+              → rec (incl a) ≡ incl* a
+    recIncl a = {!!}
 
   AsAbGroup : AbGroup ℓ
   AsAbGroup = makeAbGroup {G = Coproduct} ε _⊕_ ⊖_ trunc assoc identityᵣ invᵣ comm
@@ -135,12 +139,20 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
         inclInstance {x} = snd (incl* x)
       instance
         _ = snd B
+        _ = snd AsAbGroup
 
     inducedMap : Coproduct → ⟨ B ⟩
     inducedMap =
-      rec (isSetAbGroup B) (λ x a → fst (incl* x) a)
+      rec (isSetAbGroup B) (λ a → fst (incl* _) a)
           0g _+_ -_
           pres+ someGroup's.assoc someGroup's.comm someGroup's.rid someGroup's.invr
 
     inducedHom : AbGroupHom AsAbGroup B
-    inducedHom = inducedMap , makeIsGroupHom {!elimProp!}
+    inducedHom =
+      let ϕ = inducedMap
+      in ϕ ,
+         makeIsGroupHom
+           (elimProp2
+             (isSetAbGroup B _ _)
+             (λ a a' → ϕ (incl a + incl a') ≡⟨ {!!} ⟩ ϕ (incl a) + ϕ (incl a') ∎ )
+             {!!} {!!} {!!} {!!} {!!} {!!})

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -20,6 +20,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
   infix 20 ⊖_
 
   open AbGroupStr ⦃...⦄ using (_+_; -_; 0g)
+
   private
     instance
       givenAbGroupStr : {x : X} → AbGroupStr _
@@ -106,12 +107,17 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
   module UniversalProperty (B : AbGroup ℓ') (incl* : (x : X) → AbGroupHom (A x) B)
          where
-
+    open IsGroupHom ⦃...⦄ using () renaming (pres· to pres+)
+    module someGroup's = AbGroupStr ⦃...⦄
     private
+      instance
+        inclInstance : {x : X} → IsGroupHom _ _ _
+        inclInstance {x} = snd (incl* x)
       instance
         _ = snd B
 
     inducedMap : Coproduct → ⟨ B ⟩
-    inducedMap x =
-      rec (isSetAbGroup B) (λ x a → fst (incl* x) a) 0g _+_ -_ {!!} {!!} {!!} {!!}
-        {!!} {!!}
+    inducedMap =
+      rec (isSetAbGroup B) (λ x a → fst (incl* x) a)
+          0g _+_ -_
+          pres+ someGroup's.assoc someGroup's.comm someGroup's.rid someGroup's.invr

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -121,7 +121,11 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
     recIncl : {x : X} (a : ⟨ A x ⟩)
               → rec (incl a) ≡ incl* a
-    recIncl a = {!!}
+    recIncl a = refl
+
+    rec⊕ : (a a' : Coproduct)
+              → rec (a ⊕ a') ≡ rec a ⊕* rec a'
+    rec⊕ a a' = refl
 
   AsAbGroup : AbGroup ℓ
   AsAbGroup = makeAbGroup {G = Coproduct} ε _⊕_ ⊖_ trunc assoc identityᵣ invᵣ comm
@@ -154,5 +158,9 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
          makeIsGroupHom
            (elimProp2
              (isSetAbGroup B _ _)
-             (λ a a' → ϕ (incl a + incl a') ≡⟨ {!!} ⟩ ϕ (incl a) + ϕ (incl a') ∎ )
-             {!!} {!!} {!!} {!!} {!!} {!!})
+             (λ _ _ → refl)
+             refl refl
+             (λ _ _ → refl)
+             (λ _ _ → refl)
+             (λ _ → refl)
+             λ _ → refl)

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -7,6 +7,7 @@ open import Cubical.Foundations.Function
 open import Cubical.Foundations.Structure
 
 open import Cubical.Algebra.AbGroup
+open import Cubical.Algebra.Group.MorphismProperties using (makeIsGroupHom)
 
 private variable
   ℓ ℓ' : Level
@@ -17,11 +18,18 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
   infixl 7 _⊕_
   infix 20 ⊖_
 
+  open AbGroupStr ⦃...⦄ using (_+_)
+  private
+    instance
+      givenAbGroupStr : {x : X} → AbGroupStr _
+      givenAbGroupStr {x} = snd (A x)
+
   data Coproduct : Type ℓ where
-    incl       : (x : X) → ⟨ A x ⟩ → Coproduct
+    incl       : {x : X} → ⟨ A x ⟩ → Coproduct
     ε         : Coproduct
     _⊕_       : Coproduct → Coproduct → Coproduct
     ⊖_       : Coproduct → Coproduct
+    inclPres+ : {x : X} → (a b : ⟨ A x ⟩) → incl (a + b) ≡ (incl a) ⊕ (incl b)
     assoc     : ∀ x y z → x ⊕ (y ⊕ z) ≡ (x ⊕ y) ⊕ z
     comm      : ∀ x y   → x ⊕ y       ≡ y ⊕ x
     identityᵣ : ∀ x     → x ⊕ ε       ≡ x
@@ -29,10 +37,12 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     trunc     : isSet Coproduct
 
   module Elim {B : Coproduct → Type ℓ'}
-    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
+    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
     (⊖*_       : ∀ {x}     → B x → B (⊖ x))
+    (inclPres+* : {x : X} → (a b : ⟨ A x ⟩)
+      → PathP (λ i → B (inclPres+ a b i)) (incl* _ (a + b)) (incl* _ a ⊕* incl* _ b))
     (assoc*     : ∀ {x y z} → (xs : B x) (ys : B y) (zs : B z)
       → PathP (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs)) ((xs ⊕* ys) ⊕* zs))
     (comm*      : ∀ {x y}   → (xs : B x) (ys : B y)
@@ -43,27 +53,29 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
       → PathP (λ i → B (invᵣ x i)) (xs ⊕* (⊖* xs)) ε*)
     (trunc*     : ∀ xs → isSet (B xs)) where
 
-    f : (xs : Coproduct) → B xs
-    f (incl x a) = incl* x a
+    f : (x : Coproduct) → B x
+    f (incl a) = incl* _ a
     f ε = ε*
-    f (xs ⊕ ys) = f xs ⊕* f ys
-    f (⊖ xs) = ⊖* (f xs)
-    f (assoc xs ys zs i) = assoc* (f xs) (f ys) (f zs) i
-    f (comm xs ys i) = comm* (f xs) (f ys) i
-    f (identityᵣ xs i) = identityᵣ* (f xs) i
-    f (invᵣ xs i) = invᵣ* (f xs) i
-    f (trunc xs ys p q i j) = isOfHLevel→isOfHLevelDep 2 trunc*  (f xs) (f ys)
-      (cong f p) (cong f q) (trunc xs ys p q) i j
+    f (x ⊕ y) = f x ⊕* f y
+    f (⊖ x) = ⊖* (f x)
+    f (inclPres+ a b i) = {!!}
+    f (assoc x y z i) = assoc* (f x) (f y) (f z) i
+    f (comm x y i) = comm* (f x) (f y) i
+    f (identityᵣ x i) = identityᵣ* (f x) i
+    f (invᵣ x i) = invᵣ* (f x) i
+    f (trunc x y p q i j) = isOfHLevel→isOfHLevelDep 2 trunc*  (f x) (f y)
+      (cong f p) (cong f q) (trunc x y p q) i j
 
   module ElimProp {B : Coproduct → Type ℓ'}
     (BProp : {xs : Coproduct} → isProp (B xs))
-    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
+    (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
     (_⊖*       : ∀ {x}     → B x → B (⊖ x)) where
 
     f : (xs : Coproduct) → B xs
     f = Elim.f incl* ε* _⊕*_ _⊖*
+      (λ {x} a b → toPathP (BProp (transport (λ i → B (inclPres+ a b i)) (incl* _ (a + b))) (incl* _ a ⊕* incl* _ b)))
       (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs))) ((xs ⊕* ys) ⊕* zs)))
       (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ⊕* ys)) (ys ⊕* xs)))
       (λ {x} xs → toPathP (BProp (transport (λ i → B (identityᵣ x i)) (xs ⊕* ε*)) xs))
@@ -75,6 +87,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     (ε*         : B)
     (_⊕*_       : B → B → B)
     (⊖*_       : B → B)
+    (inclPres+* : {x : X} → (a b : ⟨ A x ⟩) → incl* _ (a + b) ≡ incl* _ a ⊕* incl* _ b)
     (assoc*     : (x y z : B) → x ⊕* (y ⊕* z) ≡ (x ⊕* y) ⊕* z)
     (comm*      : (x y : B)   → x ⊕* y        ≡ y ⊕* x)
     (identityᵣ* : (x : B)     → x ⊕* ε*       ≡ x)
@@ -82,13 +95,13 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     where
 
     f : Coproduct → B
-    f = Elim.f incl* ε* _⊕*_ ⊖*_ assoc* comm* identityᵣ* invᵣ* (const BType)
+    f = Elim.f incl* ε* _⊕*_ ⊖*_ inclPres+* assoc* comm* identityᵣ* invᵣ* (const BType)
 
   AsAbGroup : AbGroup ℓ
   AsAbGroup = makeAbGroup {G = Coproduct} ε _⊕_ ⊖_ trunc assoc identityᵣ invᵣ comm
 
   inclHom : (x : X) → AbGroupHom (A x) AsAbGroup
-  inclHom x = {!!}
+  inclHom x = (incl {x = x}) , (makeIsGroupHom inclPres+)
 
   module UniversalProperty (B : AbGroup ℓ') (incl* : (x : X) → AbGroupHom (A x) B)
          where

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -12,42 +12,42 @@ private variable
   ℓ ℓ' : Level
   A : Type ℓ
 
-module _ {X : Type ℓ} (A : X → AbGroup ℓ') where
+module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
-  infixl 7 _·_
-  infix 20 _⁻¹
+  infixl 7 _⊕_
+  infix 20 ⊖_
 
-  data Coproduct : Type (ℓ-max ℓ ℓ') where
+  data Coproduct : Type ℓ where
     incl       : (x : X) → ⟨ A x ⟩ → Coproduct
     ε         : Coproduct
-    _·_       : Coproduct → Coproduct → Coproduct
-    _⁻¹       : Coproduct → Coproduct
-    assoc     : ∀ x y z → x · (y · z) ≡ (x · y) · z
-    comm      : ∀ x y   → x · y       ≡ y · x
-    identityᵣ : ∀ x     → x · ε       ≡ x
-    invᵣ      : ∀ x     → x · x ⁻¹    ≡ ε
+    _⊕_       : Coproduct → Coproduct → Coproduct
+    ⊖_       : Coproduct → Coproduct
+    assoc     : ∀ x y z → x ⊕ (y ⊕ z) ≡ (x ⊕ y) ⊕ z
+    comm      : ∀ x y   → x ⊕ y       ≡ y ⊕ x
+    identityᵣ : ∀ x     → x ⊕ ε       ≡ x
+    invᵣ      : ∀ x     → x ⊕ (⊖ x)   ≡ ε
     trunc     : isSet Coproduct
 
   module Elim {B : Coproduct → Type ℓ'}
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
     (ε*         : B ε)
-    (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
-    (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹))
+    (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
+    (⊖*_       : ∀ {x}     → B x → B (⊖ x))
     (assoc*     : ∀ {x y z} → (xs : B x) (ys : B y) (zs : B z)
-      → PathP (λ i → B (assoc x y z i)) (xs ·* (ys ·* zs)) ((xs ·* ys) ·* zs))
+      → PathP (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs)) ((xs ⊕* ys) ⊕* zs))
     (comm*      : ∀ {x y}   → (xs : B x) (ys : B y)
-      → PathP (λ i → B (comm x y i)) (xs ·* ys) (ys ·* xs))
+      → PathP (λ i → B (comm x y i)) (xs ⊕* ys) (ys ⊕* xs))
     (identityᵣ* : ∀ {x}     → (xs : B x)
-      → PathP (λ i → B (identityᵣ x i)) (xs ·* ε*) xs)
+      → PathP (λ i → B (identityᵣ x i)) (xs ⊕* ε*) xs)
     (invᵣ* : ∀ {x} → (xs : B x)
-      → PathP (λ i → B (invᵣ x i)) (xs ·* (xs ⁻¹*)) ε*)
+      → PathP (λ i → B (invᵣ x i)) (xs ⊕* (⊖* xs)) ε*)
     (trunc*     : ∀ xs → isSet (B xs)) where
 
     f : (xs : Coproduct) → B xs
     f (incl x a) = incl* x a
     f ε = ε*
-    f (xs · ys) = f xs ·* f ys
-    f (xs ⁻¹) = f xs ⁻¹*
+    f (xs ⊕ ys) = f xs ⊕* f ys
+    f (⊖ xs) = ⊖* (f xs)
     f (assoc xs ys zs i) = assoc* (f xs) (f ys) (f zs) i
     f (comm xs ys i) = comm* (f xs) (f ys) i
     f (identityᵣ xs i) = identityᵣ* (f xs) i
@@ -59,36 +59,36 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ') where
     (BProp : {xs : Coproduct} → isProp (B xs))
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl x a))
     (ε*         : B ε)
-    (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
-    (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹)) where
+    (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
+    (_⊖*       : ∀ {x}     → B x → B (⊖ x)) where
 
     f : (xs : Coproduct) → B xs
-    f = Elim.f incl* ε* _·*_ _⁻¹*
-      (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ·* (ys ·* zs))) ((xs ·* ys) ·* zs)))
-      (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ·* ys)) (ys ·* xs)))
-      (λ {x} xs → toPathP (BProp (transport (λ i → B (identityᵣ x i)) (xs ·* ε*)) xs))
-      (λ {x} xs → toPathP (BProp (transport (λ i → B (invᵣ x i)) (xs ·* (xs ⁻¹*))) ε*))
+    f = Elim.f incl* ε* _⊕*_ _⊖*
+      (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs))) ((xs ⊕* ys) ⊕* zs)))
+      (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ⊕* ys)) (ys ⊕* xs)))
+      (λ {x} xs → toPathP (BProp (transport (λ i → B (identityᵣ x i)) (xs ⊕* ε*)) xs))
+      (λ {x} xs → toPathP (BProp (transport (λ i → B (invᵣ x i)) (xs ⊕* (xs ⊖*))) ε*))
       (λ _ → (isProp→isSet BProp))
 
   module Rec {B : Type ℓ'} (BType : isSet B)
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B)
     (ε*         : B)
-    (_·*_       : B → B → B)
-    (_⁻¹*       : B → B)
-    (assoc*     : (x y z : B) → x ·* (y ·* z) ≡ (x ·* y) ·* z)
-    (comm*      : (x y : B)   → x ·* y        ≡ y ·* x)
-    (identityᵣ* : (x : B)     → x ·* ε*       ≡ x)
-    (invᵣ*      : (x : B)     → x ·* (x ⁻¹*)  ≡ ε*)
+    (_⊕*_       : B → B → B)
+    (⊖*_       : B → B)
+    (assoc*     : (x y z : B) → x ⊕* (y ⊕* z) ≡ (x ⊕* y) ⊕* z)
+    (comm*      : (x y : B)   → x ⊕* y        ≡ y ⊕* x)
+    (identityᵣ* : (x : B)     → x ⊕* ε*       ≡ x)
+    (invᵣ*      : (x : B)     → x ⊕* (⊖* x)  ≡ ε*)
     where
 
     f : Coproduct → B
-    f = Elim.f incl* ε* _·*_ _⁻¹* assoc* comm* identityᵣ* invᵣ* (const BType)
+    f = Elim.f incl* ε* _⊕*_ ⊖*_ assoc* comm* identityᵣ* invᵣ* (const BType)
 
-  AsAbGroup : AbGroup ℓ'
-  AsAbGroup = ?
+  AsAbGroup : AbGroup ℓ
+  AsAbGroup = makeAbGroup {G = Coproduct} ε _⊕_ ⊖_ trunc assoc identityᵣ invᵣ comm
 
   inclHom : (x : X) → AbGroupHom (A x) AsAbGroup
-  inclHom x = ?
+  inclHom x = {!!}
 
   module UniversalProperty (B : AbGroup ℓ') (incl* : (x : X) → AbGroupHom (A x) B)
          where

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -84,6 +84,26 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
       (λ {x} xs → toPathP (BProp (transport (λ i → B (invᵣ x i)) (xs ⊕* (xs ⊖*))) ε*))
       (λ _ → (isProp→isSet BProp))
 
+  module _ {B : (x y : Coproduct) → Type ℓ'}
+    (BProp : {x y : Coproduct} → isProp (B x y))
+    (incl*       : {x x' : X} (a : ⟨ A x ⟩) (a' : ⟨ A x' ⟩) → B (incl a) (incl a'))
+    (ε*L         : {x : Coproduct} → B ε x)
+    (ε*R         : {x : Coproduct} → B x ε)
+    (⊕*R       : ∀ {x y z}   → B x y → B x z → B x (y ⊕ z))
+    (⊕*L       : ∀ {x y z}   → B x y → B z y → B (x ⊕ z) y)
+    (⊖*R       : ∀ {x y}     → B x y → B x (⊖ y))
+    (⊖*L       : ∀ {x y}     → B x y → B (⊖ x) y)
+    where
+
+    elimProp2 : (x y : Coproduct) → B x y
+    elimProp2 =
+      elimProp
+        (λ {_} → isPropΠ (λ _ → BProp))
+        (λ x a → elimProp BProp (λ y a' → incl* a a') ε*R ⊕*R ⊖*R)
+        (λ _ → ε*L)
+        (λ b b' x → ⊕*L (b x) (b' x))
+        λ b x → ⊖*L (b x)
+
   module _ {B : Type ℓ'} (BType : isSet B)
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B)
     (ε*         : B)
@@ -121,3 +141,6 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
       rec (isSetAbGroup B) (λ x a → fst (incl* x) a)
           0g _+_ -_
           pres+ someGroup's.assoc someGroup's.comm someGroup's.rid someGroup's.invr
+
+    inducedHom : AbGroupHom AsAbGroup B
+    inducedHom = inducedMap , makeIsGroupHom {!elimProp!}

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -83,3 +83,12 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ') where
 
     f : Coproduct → B
     f = Elim.f incl* ε* _·*_ _⁻¹* assoc* comm* identityᵣ* invᵣ* (const BType)
+
+  AsAbGroup : AbGroup ℓ'
+  AsAbGroup = ?
+
+  inclHom : (x : X) → AbGroupHom (A x) AsAbGroup
+  inclHom x = ?
+
+  module UniversalProperty (B : AbGroup ℓ') (incl* : (x : X) → AbGroupHom (A x) B)
+         where

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -1,0 +1,85 @@
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.AbGroup.Coproduct where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+open import Cubical.Algebra.AbGroup
+
+private variable
+  ℓ ℓ' : Level
+  A : Type ℓ
+
+module _ {X : Type ℓ} (A : X → Type ℓ') where
+
+  infixl 7 _·_
+  infix 20 _⁻¹
+
+
+  data Coproduct : Type _ where
+    incl       : (x : X) → A x → Coproduct
+    ε         : Coproduct
+    _·_       : Coproduct → Coproduct → Coproduct
+    _⁻¹       : Coproduct → Coproduct
+    assoc     : ∀ x y z → x · (y · z) ≡ (x · y) · z
+    comm      : ∀ x y   → x · y       ≡ y · x
+    identityᵣ : ∀ x     → x · ε       ≡ x
+    invᵣ      : ∀ x     → x · x ⁻¹    ≡ ε
+    trunc     : isSet Coproduct
+
+  module Elim {B : Coproduct → Type ℓ'}
+    (incl*       : (x : X) (a : A x) → B (incl x a))
+    (ε*         : B ε)
+    (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
+    (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹))
+    (assoc*     : ∀ {x y z} → (xs : B x) (ys : B y) (zs : B z)
+      → PathP (λ i → B (assoc x y z i)) (xs ·* (ys ·* zs)) ((xs ·* ys) ·* zs))
+    (comm*      : ∀ {x y}   → (xs : B x) (ys : B y)
+      → PathP (λ i → B (comm x y i)) (xs ·* ys) (ys ·* xs))
+    (identityᵣ* : ∀ {x}     → (xs : B x)
+      → PathP (λ i → B (identityᵣ x i)) (xs ·* ε*) xs)
+    (invᵣ* : ∀ {x} → (xs : B x)
+      → PathP (λ i → B (invᵣ x i)) (xs ·* (xs ⁻¹*)) ε*)
+    (trunc*     : ∀ xs → isSet (B xs)) where
+
+    f : (xs : Coproduct) → B xs
+    f (incl x a) = incl* x a
+    f ε = ε*
+    f (xs · ys) = f xs ·* f ys
+    f (xs ⁻¹) = f xs ⁻¹*
+    f (assoc xs ys zs i) = assoc* (f xs) (f ys) (f zs) i
+    f (comm xs ys i) = comm* (f xs) (f ys) i
+    f (identityᵣ xs i) = identityᵣ* (f xs) i
+    f (invᵣ xs i) = invᵣ* (f xs) i
+    f (trunc xs ys p q i j) = isOfHLevel→isOfHLevelDep 2 trunc*  (f xs) (f ys)
+      (cong f p) (cong f q) (trunc xs ys p q) i j
+
+  module ElimProp {B : Coproduct → Type ℓ'}
+    (BProp : {xs : Coproduct} → isProp (B xs))
+    (incl*       : (x : X) (a : A x) → B (incl x a))
+    (ε*         : B ε)
+    (_·*_       : ∀ {x y}   → B x → B y → B (x · y))
+    (_⁻¹*       : ∀ {x}     → B x → B (x ⁻¹)) where
+
+    f : (xs : Coproduct) → B xs
+    f = Elim.f incl* ε* _·*_ _⁻¹*
+      (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ·* (ys ·* zs))) ((xs ·* ys) ·* zs)))
+      (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ·* ys)) (ys ·* xs)))
+      (λ {x} xs → toPathP (BProp (transport (λ i → B (identityᵣ x i)) (xs ·* ε*)) xs))
+      (λ {x} xs → toPathP (BProp (transport (λ i → B (invᵣ x i)) (xs ·* (xs ⁻¹*))) ε*))
+      (λ _ → (isProp→isSet BProp))
+
+  module Rec {B : Type ℓ'} (BType : isSet B)
+    (incl*       : (x : X) (a : A x) → B)
+    (ε*         : B)
+    (_·*_       : B → B → B)
+    (_⁻¹*       : B → B)
+    (assoc*     : (x y z : B) → x ·* (y ·* z) ≡ (x ·* y) ·* z)
+    (comm*      : (x y : B)   → x ·* y        ≡ y ·* x)
+    (identityᵣ* : (x : B)     → x ·* ε*       ≡ x)
+    (invᵣ*      : (x : B)     → x ·* (x ⁻¹*)  ≡ ε*)
+    where
+
+    f : Coproduct → B
+    f = Elim.f incl* ε* _·*_ _⁻¹* assoc* comm* identityᵣ* invᵣ* (const BType)

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -8,6 +8,7 @@ open import Cubical.Foundations.Structure
 
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.Group.MorphismProperties using (makeIsGroupHom)
+open import Cubical.Algebra.Group.Morphisms using (IsGroupHom)
 
 private variable
   ℓ ℓ' : Level
@@ -18,7 +19,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
   infixl 7 _⊕_
   infix 20 ⊖_
 
-  open AbGroupStr ⦃...⦄ using (_+_)
+  open AbGroupStr ⦃...⦄ using (_+_; -_; 0g)
   private
     instance
       givenAbGroupStr : {x : X} → AbGroupStr _
@@ -29,11 +30,11 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     ε         : Coproduct
     _⊕_       : Coproduct → Coproduct → Coproduct
     ⊖_       : Coproduct → Coproduct
-    inclPres+ : {x : X} → (a b : ⟨ A x ⟩) → incl (a + b) ≡ (incl a) ⊕ (incl b)
-    assoc     : ∀ x y z → x ⊕ (y ⊕ z) ≡ (x ⊕ y) ⊕ z
-    comm      : ∀ x y   → x ⊕ y       ≡ y ⊕ x
-    identityᵣ : ∀ x     → x ⊕ ε       ≡ x
-    invᵣ      : ∀ x     → x ⊕ (⊖ x)   ≡ ε
+    inclPres+ : {x : X} → (a a' : ⟨ A x ⟩) → incl (a + a') ≡ (incl a) ⊕ (incl a')
+    assoc     : ∀ a a' a'' → a ⊕ (a' ⊕ a'') ≡ (a ⊕ a') ⊕ a''
+    comm      : ∀ a a'   → a ⊕ a'       ≡ a' ⊕ a
+    identityᵣ : ∀ a     → a ⊕ ε       ≡ a
+    invᵣ      : ∀ a     → a ⊕ (⊖ a)   ≡ ε
     trunc     : isSet Coproduct
 
   module Elim {B : Coproduct → Type ℓ'}
@@ -58,7 +59,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     f ε = ε*
     f (x ⊕ y) = f x ⊕* f y
     f (⊖ x) = ⊖* (f x)
-    f (inclPres+ a b i) = {!!}
+    f (inclPres+ a a' i) = inclPres+* a a' i
     f (assoc x y z i) = assoc* (f x) (f y) (f z) i
     f (comm x y i) = comm* (f x) (f y) i
     f (identityᵣ x i) = identityᵣ* (f x) i
@@ -105,3 +106,12 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
   module UniversalProperty (B : AbGroup ℓ') (incl* : (x : X) → AbGroupHom (A x) B)
          where
+
+    private
+      instance
+        _ = snd B
+
+    inducedMap : Coproduct → ⟨ B ⟩
+    inducedMap x =
+      Rec.f (isSetAbGroup B) (λ x a → fst (incl* x) a) 0g _+_ -_ ? ? ? ?
+        ? ?

--- a/Cubical/Algebra/AbGroup/Coproduct.agda
+++ b/Cubical/Algebra/AbGroup/Coproduct.agda
@@ -37,7 +37,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     invᵣ      : ∀ a     → a ⊕ (⊖ a)   ≡ ε
     trunc     : isSet Coproduct
 
-  module Elim {B : Coproduct → Type ℓ'}
+  module _ {B : Coproduct → Type ℓ'}
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
@@ -54,28 +54,28 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
       → PathP (λ i → B (invᵣ x i)) (xs ⊕* (⊖* xs)) ε*)
     (trunc*     : ∀ xs → isSet (B xs)) where
 
-    f : (x : Coproduct) → B x
-    f (incl a) = incl* _ a
-    f ε = ε*
-    f (x ⊕ y) = f x ⊕* f y
-    f (⊖ x) = ⊖* (f x)
-    f (inclPres+ a a' i) = inclPres+* a a' i
-    f (assoc x y z i) = assoc* (f x) (f y) (f z) i
-    f (comm x y i) = comm* (f x) (f y) i
-    f (identityᵣ x i) = identityᵣ* (f x) i
-    f (invᵣ x i) = invᵣ* (f x) i
-    f (trunc x y p q i j) = isOfHLevel→isOfHLevelDep 2 trunc*  (f x) (f y)
-      (cong f p) (cong f q) (trunc x y p q) i j
+    elim : (x : Coproduct) → B x
+    elim (incl a) = incl* _ a
+    elim ε = ε*
+    elim (x ⊕ y) = elim x ⊕* elim y
+    elim (⊖ x) = ⊖* (elim x)
+    elim (inclPres+ a a' i) = inclPres+* a a' i
+    elim (assoc x y z i) = assoc* (elim x) (elim y) (elim z) i
+    elim (comm x y i) = comm* (elim x) (elim y) i
+    elim (identityᵣ x i) = identityᵣ* (elim x) i
+    elim (invᵣ x i) = invᵣ* (elim x) i
+    elim (trunc x y p q i j) = isOfHLevel→isOfHLevelDep 2 trunc*  (elim x) (elim y)
+      (cong elim p) (cong elim q) (trunc x y p q) i j
 
-  module ElimProp {B : Coproduct → Type ℓ'}
+  module _ {B : Coproduct → Type ℓ'}
     (BProp : {xs : Coproduct} → isProp (B xs))
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B (incl a))
     (ε*         : B ε)
     (_⊕*_       : ∀ {x y}   → B x → B y → B (x ⊕ y))
     (_⊖*       : ∀ {x}     → B x → B (⊖ x)) where
 
-    f : (xs : Coproduct) → B xs
-    f = Elim.f incl* ε* _⊕*_ _⊖*
+    elimProp : (xs : Coproduct) → B xs
+    elimProp = elim incl* ε* _⊕*_ _⊖*
       (λ {x} a b → toPathP (BProp (transport (λ i → B (inclPres+ a b i)) (incl* _ (a + b))) (incl* _ a ⊕* incl* _ b)))
       (λ {x y z} xs ys zs → toPathP (BProp (transport (λ i → B (assoc x y z i)) (xs ⊕* (ys ⊕* zs))) ((xs ⊕* ys) ⊕* zs)))
       (λ {x y} xs ys → toPathP (BProp (transport (λ i → B (comm x y i)) (xs ⊕* ys)) (ys ⊕* xs)))
@@ -83,7 +83,7 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
       (λ {x} xs → toPathP (BProp (transport (λ i → B (invᵣ x i)) (xs ⊕* (xs ⊖*))) ε*))
       (λ _ → (isProp→isSet BProp))
 
-  module Rec {B : Type ℓ'} (BType : isSet B)
+  module _ {B : Type ℓ'} (BType : isSet B)
     (incl*       : (x : X) (a : ⟨ A x ⟩) → B)
     (ε*         : B)
     (_⊕*_       : B → B → B)
@@ -95,8 +95,8 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
     (invᵣ*      : (x : B)     → x ⊕* (⊖* x)  ≡ ε*)
     where
 
-    f : Coproduct → B
-    f = Elim.f incl* ε* _⊕*_ ⊖*_ inclPres+* assoc* comm* identityᵣ* invᵣ* (const BType)
+    rec : Coproduct → B
+    rec = elim incl* ε* _⊕*_ ⊖*_ inclPres+* assoc* comm* identityᵣ* invᵣ* (const BType)
 
   AsAbGroup : AbGroup ℓ
   AsAbGroup = makeAbGroup {G = Coproduct} ε _⊕_ ⊖_ trunc assoc identityᵣ invᵣ comm
@@ -113,5 +113,5 @@ module _ {X : Type ℓ} (A : X → AbGroup ℓ) where
 
     inducedMap : Coproduct → ⟨ B ⟩
     inducedMap x =
-      Rec.f (isSetAbGroup B) (λ x a → fst (incl* x) a) 0g _+_ -_ ? ? ? ?
-        ? ?
+      rec (isSetAbGroup B) (λ x a → fst (incl* x) a) 0g _+_ -_ {!!} {!!} {!!} {!!}
+        {!!} {!!}


### PR DESCRIPTION
Defines the coproduct of a type-indexed family of abelian groups as a HIT. 
WIP: Show the universal property. 