### PR TITLE
Generalize universal property of quotient rings

### DIFF
--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -162,7 +162,7 @@ IsRingEquiv M e N = IsRingHom M (e .fst) N
 RingEquiv : (R : Ring ℓ) (S : Ring ℓ') → Type (ℓ-max ℓ ℓ')
 RingEquiv R S = Σ[ e ∈ (⟨ R ⟩ ≃ ⟨ S ⟩) ] IsRingEquiv (R .snd) e (S .snd)
 
-_$_ : {R S : Ring ℓ} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
+_$_ : {R : Ring ℓ} {S : Ring ℓ'} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
 φ $ x = φ .fst x
 
 RingEquiv→RingHom : {A B : Ring ℓ} → RingEquiv A B → RingHom A B

--- a/Cubical/Algebra/Ring/Properties.agda
+++ b/Cubical/Algebra/Ring/Properties.agda
@@ -242,7 +242,7 @@ module RingEquivs where
   fst (invEquivRing e) = invEquiv (fst e)
   snd (invEquivRing e) = isRingHomInv e
 
-module RingHomTheory {R S : Ring ℓ} (φ : RingHom R S) where
+module RingHomTheory {R : Ring ℓ} {S : Ring ℓ'} (φ : RingHom R S) where
   open RingTheory ⦃...⦄
   open RingStr ⦃...⦄
   open IsRingHom (φ .snd)

--- a/Cubical/Algebra/Ring/QuotientRing.agda
+++ b/Cubical/Algebra/Ring/QuotientRing.agda
@@ -16,7 +16,7 @@ open import Cubical.Algebra.Ring.Kernel
 
 private
   variable
-    ℓ : Level
+    ℓ ℓ' : Level
 
 module _ (R' : Ring ℓ) (I : ⟨ R' ⟩  → hProp ℓ) (I-isIdeal : isIdeal R' I) where
   open RingStr (snd R')
@@ -196,7 +196,7 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
       _ = R
       _ = snd R
 
-  module _ {S : Ring ℓ} (φ : RingHom R S) where
+  module _ {S : Ring ℓ'} (φ : RingHom R S) where
     open IsRingHom
     open RingHomTheory φ
     private
@@ -206,8 +206,12 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
       f = fst φ
       module φ = IsRingHom (snd φ)
 
-
-    inducedHom : Iₛ ⊆ kernel φ → RingHom (R / I) S
+    {-
+      We do not use the kernel ideal, since it is *not* an ideal in R,
+      if S is from a different universe. Instead, the condition, that
+      Iₛ is contained in the kernel of φ is rephrased explicitly.
+    -}
+    inducedHom : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r) → RingHom (R / I) S
     fst (inducedHom Iₛ⊆kernel) =
       elim
         (λ _ → isSetRing S)
@@ -226,11 +230,11 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
     pres- (snd (inducedHom Iₛ⊆kernel)) =
       elimProp (λ _ → isSetRing S _ _) φ.pres-
 
-    solution : (p : Iₛ ⊆ kernel φ)
+    solution : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r))
                → (x : ⟨ R ⟩) → inducedHom p $ [ x ] ≡ φ $ x
     solution p x = refl
 
-    unique : (p : Iₛ ⊆ kernel φ)
+    unique : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r))
              → (ψ : RingHom (R / I) S) → (ψIsSolution : (x : ⟨ R ⟩) → ψ $ [ x ] ≡ φ $ x)
              → (x : ⟨ R ⟩) → ψ $ [ x ] ≡ inducedHom p $ [ x ]
     unique p ψ ψIsSolution x = ψIsSolution x


### PR DESCRIPTION
With this PR, the universal property of quotient rings quantifies over rings of all universe levels.