### PR TITLE
ℚ is a Field

### DIFF
--- a/Cubical/Algebra/CommRing/Instances/QuoInt.agda
+++ b/Cubical/Algebra/CommRing/Instances/QuoInt.agda
@@ -18,15 +18,15 @@ open CommRingStr
 
 -- The missing additive inversion
 
-+-lInv' : ∀ n s → signed (not s) n +ℤ signed s n ≡ signed s zero
-+-lInv' zero _ = refl
-+-lInv' (suc n) spos = predℤ-+ʳ (neg n) (pos (suc n)) ∙ (λ i → neg n +ℤ predSucℤ (pos n) i) ∙ +-lInv' n spos
-+-lInv' (suc n) sneg = sucℤ-+ʳ  (pos n) (neg (suc n)) ∙ (λ i → pos n +ℤ sucPredℤ (neg n) i) ∙ +-lInv' n sneg
++InvL' : ∀ n s → signed (not s) n +ℤ signed s n ≡ signed s zero
++InvL' zero _ = refl
++InvL' (suc n) spos = predℤ-+ʳ (neg n) (pos (suc n)) ∙ (λ i → neg n +ℤ predSucℤ (pos n) i) ∙ +InvL' n spos
++InvL' (suc n) sneg = sucℤ-+ʳ  (pos n) (neg (suc n)) ∙ (λ i → pos n +ℤ sucPredℤ (neg n) i) ∙ +InvL' n sneg
 
-+-lInv : (n : ℤType) → (-ℤ n) +ℤ n ≡ 0
-+-lInv (signed spos n) = +-lInv' n spos
-+-lInv (signed sneg n) = +-lInv' n sneg ∙ sym posneg
-+-lInv (posneg i) j =
++InvL : (n : ℤType) → (-ℤ n) +ℤ n ≡ 0
++InvL (signed spos n) = +InvL' n spos
++InvL (signed sneg n) = +InvL' n sneg ∙ sym posneg
++InvL (posneg i) j =
   hcomp (λ k → λ
     { (i = i0) → 0
     ; (i = i1) → compPath-filler refl (sym posneg) k j
@@ -34,22 +34,22 @@ open CommRingStr
     ; (j = i1) → posneg (i ∧ ~ k) })
   (posneg i)
 
-+-rInv : (n : ℤType) → n +ℤ (-ℤ n) ≡ 0
-+-rInv n = +-comm n (-ℤ n) ∙ +-lInv n
++InvR : (n : ℤType) → n +ℤ (-ℤ n) ≡ 0
++InvR n = +-comm n (-ℤ n) ∙ +InvL n
 
 
-ℤ : CommRing ℓ-zero
-fst ℤ = ℤType
-0r (snd ℤ) = 0
-1r (snd ℤ) = 1
-_+_ (snd ℤ) = _+ℤ_
-_·_ (snd ℤ) = _·ℤ_
-- snd ℤ = -ℤ_
-isCommRing (snd ℤ) = isCommRingℤ
+ℤCommRing : CommRing ℓ-zero
+ℤCommRing .fst = ℤType
+ℤCommRing .snd .0r = 0
+ℤCommRing .snd .1r = 1
+ℤCommRing .snd ._+_ = _+ℤ_
+ℤCommRing .snd ._·_ = _·ℤ_
+ℤCommRing .snd .-_ = -ℤ_
+ℤCommRing .snd .isCommRing = isCommRingℤ
   where
   abstract
     isCommRingℤ : IsCommRing 0 1 _+ℤ_ _·ℤ_ -ℤ_
     isCommRingℤ = makeIsCommRing
       isSetℤ +-assoc (+-zeroʳ _)
-      +-rInv +-comm ·-assoc
+      +InvR +-comm ·-assoc
       ·-identityʳ (λ x y z → sym (·-distribˡ x y z)) ·-comm

--- a/Cubical/Algebra/CommRing/Instances/QuoInt.agda
+++ b/Cubical/Algebra/CommRing/Instances/QuoInt.agda
@@ -1,0 +1,55 @@
+{-
+
+ℤ is a Commutative Ring (using QuoInt)
+
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.CommRing.Instances.QuoInt where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Data.Nat  using (ℕ ; zero ; suc)
+open import Cubical.Data.Bool using (not)
+open import Cubical.Data.Int.MoreInts.QuoInt
+  renaming ( ℤ to ℤType ; _+_ to _+ℤ_; _·_ to _·ℤ_; -_ to -ℤ_)
+
+open CommRingStr
+
+-- The missing additive inversion
+
++-lInv' : ∀ n s → signed (not s) n +ℤ signed s n ≡ signed s zero
++-lInv' zero _ = refl
++-lInv' (suc n) spos = predℤ-+ʳ (neg n) (pos (suc n)) ∙ (λ i → neg n +ℤ predSucℤ (pos n) i) ∙ +-lInv' n spos
++-lInv' (suc n) sneg = sucℤ-+ʳ  (pos n) (neg (suc n)) ∙ (λ i → pos n +ℤ sucPredℤ (neg n) i) ∙ +-lInv' n sneg
+
++-lInv : (n : ℤType) → (-ℤ n) +ℤ n ≡ 0
++-lInv (signed spos n) = +-lInv' n spos
++-lInv (signed sneg n) = +-lInv' n sneg ∙ sym posneg
++-lInv (posneg i) j =
+  hcomp (λ k → λ
+    { (i = i0) → 0
+    ; (i = i1) → compPath-filler refl (sym posneg) k j
+    ; (j = i0) → posneg i
+    ; (j = i1) → posneg (i ∧ ~ k) })
+  (posneg i)
+
++-rInv : (n : ℤType) → n +ℤ (-ℤ n) ≡ 0
++-rInv n = +-comm n (-ℤ n) ∙ +-lInv n
+
+
+ℤ : CommRing ℓ-zero
+fst ℤ = ℤType
+0r (snd ℤ) = 0
+1r (snd ℤ) = 1
+_+_ (snd ℤ) = _+ℤ_
+_·_ (snd ℤ) = _·ℤ_
+- snd ℤ = -ℤ_
+isCommRing (snd ℤ) = isCommRingℤ
+  where
+  abstract
+    isCommRingℤ : IsCommRing 0 1 _+ℤ_ _·ℤ_ -ℤ_
+    isCommRingℤ = makeIsCommRing
+      isSetℤ +-assoc (+-zeroʳ _)
+      +-rInv +-comm ·-assoc
+      ·-identityʳ (λ x y z → sym (·-distribˡ x y z)) ·-comm

--- a/Cubical/Algebra/CommRing/Instances/QuoInt.agda
+++ b/Cubical/Algebra/CommRing/Instances/QuoInt.agda
@@ -12,7 +12,7 @@ open import Cubical.Algebra.CommRing
 open import Cubical.Data.Nat  using (ℕ ; zero ; suc)
 open import Cubical.Data.Bool using (not)
 open import Cubical.Data.Int.MoreInts.QuoInt
-  renaming ( ℤ to ℤType ; _+_ to _+ℤ_; _·_ to _·ℤ_; -_ to -ℤ_)
+  renaming (ℤ to ℤType ; _+_ to _+ℤ_; _·_ to _·ℤ_; -_ to -ℤ_)
 
 open CommRingStr
 

--- a/Cubical/Algebra/CommRing/Instances/QuoQ.agda
+++ b/Cubical/Algebra/CommRing/Instances/QuoQ.agda
@@ -10,18 +10,19 @@ open import Cubical.Foundations.Prelude
 
 open import Cubical.Algebra.CommRing
 open import Cubical.HITs.Rationals.QuoQ
-  renaming ( ℚ to ℚType ; _+_ to _+ℚ_; _·_ to _·ℚ_; -_ to -ℚ_)
+  renaming (ℚ to ℚType ; _+_ to _+ℚ_; _·_ to _·ℚ_; -_ to -ℚ_)
 
 open CommRingStr
 
-ℚ : CommRing ℓ-zero
-fst ℚ = ℚType
-0r (snd ℚ) = 0
-1r (snd ℚ) = 1
-_+_ (snd ℚ) = _+ℚ_
-_·_ (snd ℚ) = _·ℚ_
-- snd ℚ = -ℚ_
-isCommRing (snd ℚ) = isCommRingℚ
+
+ℚCommRing : CommRing ℓ-zero
+ℚCommRing .fst = ℚType
+ℚCommRing .snd .0r = 0
+ℚCommRing .snd .1r = 1
+ℚCommRing .snd ._+_ = _+ℚ_
+ℚCommRing .snd ._·_ = _·ℚ_
+ℚCommRing .snd .-_ = -ℚ_
+ℚCommRing .snd .isCommRing = isCommRingℚ
   where
   abstract
     isCommRingℚ : IsCommRing 0 1 _+ℚ_ _·ℚ_ -ℚ_

--- a/Cubical/Algebra/CommRing/Instances/QuoQ.agda
+++ b/Cubical/Algebra/CommRing/Instances/QuoQ.agda
@@ -1,0 +1,31 @@
+{-
+
+ℚ is a Commutative Ring
+
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.CommRing.Instances.QuoQ where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Algebra.CommRing
+open import Cubical.HITs.Rationals.QuoQ
+  renaming ( ℚ to ℚType ; _+_ to _+ℚ_; _·_ to _·ℚ_; -_ to -ℚ_)
+
+open CommRingStr
+
+ℚ : CommRing ℓ-zero
+fst ℚ = ℚType
+0r (snd ℚ) = 0
+1r (snd ℚ) = 1
+_+_ (snd ℚ) = _+ℚ_
+_·_ (snd ℚ) = _·ℚ_
+- snd ℚ = -ℚ_
+isCommRing (snd ℚ) = isCommRingℚ
+  where
+  abstract
+    isCommRingℚ : IsCommRing 0 1 _+ℚ_ _·ℚ_ -ℚ_
+    isCommRingℚ = makeIsCommRing
+      isSetℚ +-assoc +-identityʳ
+      +-inverseʳ +-comm ·-assoc
+      ·-identityʳ (λ x y z → sym (·-distribˡ x y z)) ·-comm

--- a/Cubical/Algebra/Field/Base.agda
+++ b/Cubical/Algebra/Field/Base.agda
@@ -43,6 +43,12 @@ record IsField {R : Type ℓ}
     hasInverse : (x : R) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r
     0≢1        : ¬ 0r ≡ 1r
 
+  _[_]⁻¹ : (x : R) → ¬ x ≡ 0r → R
+  x [ ¬x≡0 ]⁻¹ = hasInverse x ¬x≡0 .fst
+
+  ·⁻¹≡1 : (x : R) (≢0 : ¬ x ≡ 0r) → x · (x [ ≢0 ]⁻¹) ≡ 1r
+  ·⁻¹≡1 x ¬x≡0 = hasInverse x ¬x≡0 .snd
+
   open IsCommRing isCommRing public
 
 record FieldStr (A : Type ℓ) : Type (ℓ-suc ℓ) where

--- a/Cubical/Algebra/Field/Base.agda
+++ b/Cubical/Algebra/Field/Base.agda
@@ -208,5 +208,5 @@ isPropIsField {R = R} 0r 1r _+_ _·_ -_ H@(isfield RR RC RD) (isfield SR SC SD) 
 FieldPath : (R S : Field ℓ) → FieldEquiv R S ≃ (R ≡ S)
 FieldPath = ∫ 𝒮ᴰ-Field .UARel.ua
 
-uaFieldRing : {A B : Field ℓ} → FieldEquiv A B → A ≡ B
-uaFieldRing {A = A} {B = B} = equivFun (FieldPath A B)
+uaField : {A B : Field ℓ} → FieldEquiv A B → A ≡ B
+uaField {A = A} {B = B} = equivFun (FieldPath A B)

--- a/Cubical/Algebra/Field/Base.agda
+++ b/Cubical/Algebra/Field/Base.agda
@@ -33,6 +33,7 @@ private
   variable
     ℓ ℓ' : Level
 
+
 record IsField {R : Type ℓ}
                   (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R) : Type ℓ where
 
@@ -43,13 +44,14 @@ record IsField {R : Type ℓ}
     hasInverse : (x : R) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r
     0≢1        : ¬ 0r ≡ 1r
 
+  open IsCommRing isCommRing public
+
   _[_]⁻¹ : (x : R) → ¬ x ≡ 0r → R
   x [ ¬x≡0 ]⁻¹ = hasInverse x ¬x≡0 .fst
 
   ·⁻¹≡1 : (x : R) (≢0 : ¬ x ≡ 0r) → x · (x [ ≢0 ]⁻¹) ≡ 1r
   ·⁻¹≡1 x ¬x≡0 = hasInverse x ¬x≡0 .snd
 
-  open IsCommRing isCommRing public
 
 record FieldStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
@@ -69,11 +71,13 @@ record FieldStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 
   open IsField isField public
 
+
 Field : ∀ ℓ → Type (ℓ-suc ℓ)
 Field ℓ = TypeWithStr ℓ FieldStr
 
 isSetField : (R : Field ℓ) → isSet ⟨ R ⟩
 isSetField R = R .snd .FieldStr.isField .IsField.·IsMonoid .IsMonoid.isSemigroup .IsSemigroup.is-set
+
 
 makeIsField : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R} { -_ : R → R}
                  {_[_]⁻¹ : (x : R) → ¬ (x ≡ 0r) → R}
@@ -112,11 +116,25 @@ makeField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
 makeField 0r 1r _+_ _·_ -_ _[_]⁻¹ is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1 =
   _ , fieldstr _ _ _ _ _ (makeIsField is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1)
 
+
+module _ (R : CommRing ℓ) where
+
+  open CommRingStr (R .snd)
+
+  makeFieldFromCommRing :
+    (hasInv : (x : R .fst) → ¬ x ≡ 0r → Σ[ y ∈ R .fst ] x · y ≡ 1r)
+    (0≢1 : ¬ 0r ≡ 1r)
+    → Field ℓ
+  makeFieldFromCommRing hasInv 0≢1 .fst = R .fst
+  makeFieldFromCommRing hasInv 0≢1 .snd = fieldstr _ _ _ _ _ (isfield isCommRing hasInv 0≢1)
+
+
 FieldStr→CommRingStr : {A : Type ℓ} → FieldStr A → CommRingStr A
 FieldStr→CommRingStr (fieldstr _ _ _ _ _ H) = commringstr _ _ _ _ _ (IsField.isCommRing H)
 
 Field→CommRing : Field ℓ → CommRing ℓ
 Field→CommRing (_ , fieldstr _ _ _ _ _ H) = _ , commringstr _ _ _ _ _ (IsField.isCommRing H)
+
 
 record IsFieldHom {A : Type ℓ} {B : Type ℓ'} (R : FieldStr A) (f : A → B) (S : FieldStr B)
   : Type (ℓ-max ℓ ℓ')
@@ -139,6 +157,7 @@ unquoteDecl IsFieldHomIsoΣ = declareRecordIsoΣ IsFieldHomIsoΣ (quote IsFieldH
 FieldHom : (R : Field ℓ) (S : Field ℓ') → Type (ℓ-max ℓ ℓ')
 FieldHom R S = Σ[ f ∈ (⟨ R ⟩ → ⟨ S ⟩) ] IsFieldHom (R .snd) f (S .snd)
 
+
 IsFieldEquiv : {A : Type ℓ} {B : Type ℓ'}
   (R : FieldStr A) (e : A ≃ B) (S : FieldStr B) → Type (ℓ-max ℓ ℓ')
 IsFieldEquiv R e S = IsFieldHom R (e .fst) S
@@ -146,11 +165,14 @@ IsFieldEquiv R e S = IsFieldHom R (e .fst) S
 FieldEquiv : (R : Field ℓ) (S : Field ℓ') → Type (ℓ-max ℓ ℓ')
 FieldEquiv R S = Σ[ e ∈ (R .fst ≃ S .fst) ] IsFieldEquiv (R .snd) e (S .snd)
 
+
 _$_ : {R S : Field ℓ} → (φ : FieldHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
 φ $ x = φ .fst x
 
+
 FieldEquiv→FieldHom : {A B : Field ℓ} → FieldEquiv A B → FieldHom A B
 FieldEquiv→FieldHom (e , eIsHom) = e .fst , eIsHom
+
 
 isPropIsField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
              → isProp (IsField 0r 1r _+_ _·_ -_)
@@ -163,6 +185,7 @@ isPropIsField {R = R} 0r 1r _+_ _·_ -_ H@(isfield RR RC RD) (isfield SR SC SD) 
 
   isPropInv : isProp ((x : _) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r)
   isPropInv = isPropΠ2 (λ x _ → Units.inverseUniqueness (Field→CommRing (_ , fieldstr _ _ _ _ _ H)) x)
+
 
 𝒮ᴰ-Field : DUARel (𝒮-Univ ℓ) FieldStr ℓ
 𝒮ᴰ-Field =

--- a/Cubical/Algebra/Field/Base.agda
+++ b/Cubical/Algebra/Field/Base.agda
@@ -34,15 +34,14 @@ private
     ℓ ℓ' : Level
 
 record IsField {R : Type ℓ}
-                  (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
-                  (_[_]⁻¹ : (x : R) → ¬ (x ≡ 0r) → R) : Type ℓ where
+                  (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R) : Type ℓ where
 
   constructor isfield
 
   field
     isCommRing : IsCommRing 0r 1r _+_ _·_ -_
-    ·⁻¹≡1      : (x : R) (≢0 : ¬ (x ≡ 0r)) → x · (x [ ≢0 ]⁻¹) ≡ 1r
-    0≢1        : ¬ (0r ≡ 1r)
+    hasInverse : (x : R) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r
+    0≢1        : ¬ 0r ≡ 1r
 
   open IsCommRing isCommRing public
 
@@ -56,8 +55,7 @@ record FieldStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
     _+_        : A → A → A
     _·_        : A → A → A
     -_         : A → A
-    _[_]⁻¹     : (x : A) → ¬ (x ≡ 0r) → A
-    isField    : IsField 0r 1r _+_ _·_ -_ _[_]⁻¹
+    isField    : IsField 0r 1r _+_ _·_ -_
 
   infix  8 -_
   infixl 7 _·_
@@ -84,9 +82,13 @@ makeIsField : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R} { -_ : R →
                  (·-comm : (x y : R) → x · y ≡ y · x)
                  (·⁻¹≡1 : (x : R) (≢0 : ¬ (x ≡ 0r)) → x · (x [ ≢0 ]⁻¹) ≡ 1r)
                  (0≢1 : ¬ (0r ≡ 1r))
-               → IsField 0r 1r _+_ _·_ -_ _[_]⁻¹
-makeIsField {_+_ = _+_} is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1 =
-  isfield (makeIsCommRing is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm) ·⁻¹≡1 0≢1
+               → IsField 0r 1r _+_ _·_ -_
+makeIsField {R = R} {0r = 0r} {1r = 1r} {_+_ = _+_} {_·_ = _·_} {_[_]⁻¹ = _[_]⁻¹}
+  is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1 =
+  isfield (makeIsCommRing is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm) ·-inv 0≢1
+    where
+    ·-inv : (x : R) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r
+    ·-inv x ¬x≡0 = x [ ¬x≡0 ]⁻¹ , ·⁻¹≡1 x ¬x≡0
 
 makeField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R) (_[_]⁻¹ : (x : R) → ¬ (x ≡ 0r) → R)
                  (is-setR : isSet R)
@@ -102,13 +104,13 @@ makeField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
                  (0≢1 : ¬ (0r ≡ 1r))
                → Field ℓ
 makeField 0r 1r _+_ _·_ -_ _[_]⁻¹ is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1 =
-  _ , fieldstr _ _ _ _ _ _ (makeIsField is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1)
+  _ , fieldstr _ _ _ _ _ (makeIsField is-setR +-assoc +-rid +-rinv +-comm ·-assoc ·-rid ·-rdist-+ ·-comm ·⁻¹≡1 0≢1)
 
 FieldStr→CommRingStr : {A : Type ℓ} → FieldStr A → CommRingStr A
-FieldStr→CommRingStr (fieldstr _ _ _ _ _ _ H) = commringstr _ _ _ _ _ (IsField.isCommRing H)
+FieldStr→CommRingStr (fieldstr _ _ _ _ _ H) = commringstr _ _ _ _ _ (IsField.isCommRing H)
 
 Field→CommRing : Field ℓ → CommRing ℓ
-Field→CommRing (_ , fieldstr _ _ _ _ _ _ H) = _ , commringstr _ _ _ _ _ (IsField.isCommRing H)
+Field→CommRing (_ , fieldstr _ _ _ _ _ H) = _ , commringstr _ _ _ _ _ (IsField.isCommRing H)
 
 record IsFieldHom {A : Type ℓ} {B : Type ℓ'} (R : FieldStr A) (f : A → B) (S : FieldStr B)
   : Type (ℓ-max ℓ ℓ')
@@ -125,7 +127,6 @@ record IsFieldHom {A : Type ℓ} {B : Type ℓ'} (R : FieldStr A) (f : A → B) 
     pres+  : (x y : A) → f (x R.+ y) ≡ f x S.+ f y
     pres·  : (x y : A) → f (x R.· y) ≡ f x S.· f y
     pres-  : (x : A) → f (R.- x) ≡ S.- (f x)
-    pres⁻¹ : (x : A) (≢0 : ¬ (x ≡ R.0r)) (f≢0 : ¬ (f x ≡ S.0r))  → f (x R.[ ≢0 ]⁻¹) ≡ ((f x) S.[ f≢0 ]⁻¹)
 
 unquoteDecl IsFieldHomIsoΣ = declareRecordIsoΣ IsFieldHomIsoΣ (quote IsFieldHom)
 
@@ -145,17 +146,38 @@ _$_ : {R S : Field ℓ} → (φ : FieldHom R S) → (x : ⟨ R ⟩) → ⟨ S �
 FieldEquiv→FieldHom : {A B : Field ℓ} → FieldEquiv A B → FieldHom A B
 FieldEquiv→FieldHom (e , eIsHom) = e .fst , eIsHom
 
-isPropIsField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R) (_[_]⁻¹ : (x : R) → ¬ (x ≡ 0r) → R)
-             → isProp (IsField 0r 1r _+_ _·_ -_ _[_]⁻¹)
-isPropIsField 0r 1r _+_ _·_ -_ _[_]⁻¹ (isfield RR RC RD) (isfield SR SC SD) =
+isPropIsField : {R : Type ℓ} (0r 1r : R) (_+_ _·_ : R → R → R) (-_ : R → R)
+             → isProp (IsField 0r 1r _+_ _·_ -_)
+isPropIsField {R = R} 0r 1r _+_ _·_ -_ H@(isfield RR RC RD) (isfield SR SC SD) =
   λ i → isfield (isPropIsCommRing _ _ _ _ _ RR SR i)
-                   (isPropInv RC SC i) (isProp→⊥ RD SD i)
+                   (isPropInv RC SC i) (isProp¬ _ RD SD i)
   where
   isSetR : isSet _
   isSetR =  RR .IsCommRing.·IsMonoid .IsMonoid.isSemigroup .IsSemigroup.is-set
 
-  isPropInv : isProp ((x : _) → (≢0 : ¬ (x ≡ 0r)) → x · (x [ ≢0 ]⁻¹) ≡ 1r)
-  isPropInv = isPropΠ2 λ _ _ → isSetR _ _
+  isPropInv : isProp ((x : _) → ¬ x ≡ 0r → Σ[ y ∈ R ] x · y ≡ 1r)
+  isPropInv = isPropΠ2 (λ x _ → Units.inverseUniqueness (Field→CommRing (_ , fieldstr _ _ _ _ _ H)) x)
 
-  isProp→⊥ : ∀ {A : Type ℓ} → isProp (A → ⊥)
-  isProp→⊥ = isPropΠ λ _ → isProp⊥
+𝒮ᴰ-Field : DUARel (𝒮-Univ ℓ) FieldStr ℓ
+𝒮ᴰ-Field =
+  𝒮ᴰ-Record (𝒮-Univ _) IsFieldEquiv
+    (fields:
+      data[ 0r ∣ null ∣ pres0 ]
+      data[ 1r ∣ null ∣ pres1 ]
+      data[ _+_ ∣ bin ∣ pres+ ]
+      data[ _·_ ∣ bin ∣ pres· ]
+      data[ -_ ∣ autoDUARel _ _ ∣ pres- ]
+      prop[ isField ∣ (λ _ _ → isPropIsField _ _ _ _ _) ])
+  where
+  open FieldStr
+  open IsFieldHom
+
+  -- faster with some sharing
+  null = autoDUARel (𝒮-Univ _) (λ A → A)
+  bin = autoDUARel (𝒮-Univ _) (λ A → A → A → A)
+
+FieldPath : (R S : Field ℓ) → FieldEquiv R S ≃ (R ≡ S)
+FieldPath = ∫ 𝒮ᴰ-Field .UARel.ua
+
+uaFieldRing : {A B : Field ℓ} → FieldEquiv A B → A ≡ B
+uaFieldRing {A = A} {B = B} = equivFun (FieldPath A B)

--- a/Cubical/Algebra/Field/Instances/QuoQ.agda
+++ b/Cubical/Algebra/Field/Instances/QuoQ.agda
@@ -15,13 +15,10 @@ open import Cubical.Data.Nat using (ℕ ; zero ; suc)
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Int.MoreInts.QuoInt
   using    (ℤ ; spos ; sneg ; pos ; neg ; signed ; posneg ; isSetℤ ; 0≢1-ℤ)
-  renaming (_·_ to _·ℤ_ ; _+_ to _+ℤ_ ; -_ to -ℤ_
+  renaming (_·_ to _·ℤ_ ; -_ to -ℤ_
            ; ·-zeroˡ to ·ℤ-zeroˡ
-           ; ·-zeroʳ to ·ℤ-zeroʳ
-           ; ·-identityʳ to ·ℤ-identityʳ
-           ; ·-comm  to ·ℤ-comm
-           ; ·-assoc to ·ℤ-assoc)
-open import Cubical.HITs.SetQuotients as SetQuot hiding (_/_)
+           ; ·-identityʳ to ·ℤ-identityʳ)
+open import Cubical.HITs.SetQuotients as SetQuot
 open import Cubical.HITs.Rationals.QuoQ
   using    (ℚ ; ℕ₊₁→ℤ ; isEquivRel∼)
 
@@ -29,9 +26,7 @@ open import Cubical.Algebra.Field
 open import Cubical.Algebra.CommRing
 open import Cubical.Algebra.CommRingSolver.Reflection
 open import Cubical.Algebra.CommRing.Instances.QuoInt
-  renaming (ℤ to ℤRing)
 open import Cubical.Algebra.CommRing.Instances.QuoQ
-  renaming (ℚ to ℚRing)
 
 open import Cubical.Relation.Nullary
 
@@ -64,10 +59,9 @@ a≡0→a/b≡0 (a , b) a≡0 = eq/ _ _ a·1≡0·b
 
 -- ℚ is a field
 
-open CommRingStr (ℚRing .snd)
-open Units        ℚRing
-
-open Helpers      ℤRing
+open CommRingStr (ℚCommRing .snd)
+open Units        ℚCommRing
+open Helpers      ℤCommRing
 
 
 hasInverseℚ : (q : ℚ) → ¬ q ≡ 0 → Σ[ p ∈ ℚ ] q · p ≡ 1
@@ -95,4 +89,4 @@ hasInverseℚ = SetQuot.elimProp (λ q → isPropΠ (λ _ → inverseUniqueness 
 -- The instance
 
 ℚField : Field ℓ-zero
-ℚField = makeFieldFromCommRing ℚRing hasInverseℚ 0≢1-ℚ
+ℚField = makeFieldFromCommRing ℚCommRing hasInverseℚ 0≢1-ℚ

--- a/Cubical/Algebra/Field/Instances/QuoQ.agda
+++ b/Cubical/Algebra/Field/Instances/QuoQ.agda
@@ -1,0 +1,98 @@
+{-
+
+ℚ is a Field
+
+-}
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.Field.Instances.QuoQ where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Empty as Empty
+open import Cubical.Data.Nat using (ℕ ; zero ; suc)
+open import Cubical.Data.NatPlusOne
+open import Cubical.Data.Int.MoreInts.QuoInt
+  using    (ℤ ; spos ; sneg ; pos ; neg ; signed ; posneg ; isSetℤ ; 0≢1-ℤ)
+  renaming (_·_ to _·ℤ_ ; _+_ to _+ℤ_ ; -_ to -ℤ_
+           ; ·-zeroˡ to ·ℤ-zeroˡ
+           ; ·-zeroʳ to ·ℤ-zeroʳ
+           ; ·-identityʳ to ·ℤ-identityʳ
+           ; ·-comm to ·ℤ-comm
+           ; ·-assoc to ·ℤ-assoc)
+open import Cubical.HITs.SetQuotients as SetQuot hiding (_/_)
+open import Cubical.HITs.Rationals.QuoQ
+  using    (ℚ ; ℕ₊₁→ℤ ; isEquivRel∼)
+
+open import Cubical.Algebra.Field
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRingSolver.Reflection
+open import Cubical.Algebra.CommRing.Instances.QuoInt
+  renaming (ℤ to ℤRing)
+open import Cubical.Algebra.CommRing.Instances.QuoQ
+  renaming (ℚ to ℚRing)
+
+open import Cubical.Relation.Nullary
+
+
+-- It seems there are bugs when applying ring solver to explicit ring.
+-- The following is a work-around.
+private
+  module Helpers {ℓ : Level}(𝓡 : CommRing ℓ) where
+    open CommRingStr (𝓡 .snd)
+
+    helper1 : (x y : 𝓡 .fst) → (x · y) · 1r ≡ 1r · (y · x)
+    helper1 = solve 𝓡
+
+    helper2 : (x y : 𝓡 .fst) → ((- x) · (- y)) · 1r ≡ 1r · (y · x)
+    helper2 = solve 𝓡
+
+
+-- A rational number is zero if and only if its numerator is zero
+
+a/b≡0→a≡0 : (x : ℤ × ℕ₊₁) → [ x ] ≡ 0 → x .fst ≡ 0
+a/b≡0→a≡0 (a , b) a/b≡0 = sym (·ℤ-identityʳ a) ∙ a·1≡0·b ∙ ·ℤ-zeroˡ (ℕ₊₁→ℤ b)
+  where a·1≡0·b : a ·ℤ 1 ≡ 0 ·ℤ (ℕ₊₁→ℤ b)
+        a·1≡0·b = effective (λ _ _ → isSetℤ _ _) isEquivRel∼ _ _ a/b≡0
+
+a≡0→a/b≡0 : (x : ℤ × ℕ₊₁) → x .fst ≡ 0 → [ x ] ≡ 0
+a≡0→a/b≡0 (a , b) a≡0 = eq/ _ _ a·1≡0·b
+  where a·1≡0·b : a ·ℤ 1 ≡ 0 ·ℤ (ℕ₊₁→ℤ b)
+        a·1≡0·b = (λ i → a≡0 i ·ℤ 1) ∙ ·ℤ-zeroˡ {s = spos} 1 ∙ sym (·ℤ-zeroˡ (ℕ₊₁→ℤ b))
+
+
+-- ℚ is a field
+
+open CommRingStr (ℚRing .snd)
+open Units        ℚRing
+
+open Helpers      ℤRing
+
+
+hasInverseℚ : (q : ℚ) → ¬ q ≡ 0 → Σ[ p ∈ ℚ ] q · p ≡ 1
+hasInverseℚ = SetQuot.elimProp (λ q → isPropΠ (λ _ → inverseUniqueness q))
+  (λ x x≢0 → let a≢0 = λ a≡0 → x≢0 (a≡0→a/b≡0 x a≡0) in inv-helper x a≢0 , inv·-helper x a≢0)
+  where
+  inv-helper : (x : ℤ × ℕ₊₁) → ¬ x .fst ≡ 0 → ℚ
+  inv-helper (signed spos (suc a) , b) _ = [ ℕ₊₁→ℤ b , 1+ a ]
+  inv-helper (signed sneg (suc a) , b) _ = [ -ℤ ℕ₊₁→ℤ b , 1+ a ]
+  inv-helper (signed spos zero , _) a≢0 = Empty.rec (a≢0 refl)
+  inv-helper (signed sneg zero , _) a≢0 = Empty.rec (a≢0 (sym posneg))
+  inv-helper (posneg i , _) a≢0 = Empty.rec (a≢0 (λ j → posneg (i ∧ ~ j)))
+
+  inv·-helper : (x : ℤ × ℕ₊₁)(a≢0 : ¬ x .fst ≡ 0) → [ x ] · inv-helper x a≢0 ≡ 1
+  inv·-helper (signed spos zero , b) a≢0 = Empty.rec (a≢0 refl)
+  inv·-helper (signed sneg zero , b) a≢0 = Empty.rec (a≢0 (sym posneg))
+  inv·-helper (posneg i , b) a≢0 = Empty.rec (a≢0 (λ j → posneg (i ∧ ~ j)))
+  inv·-helper (signed spos (suc a) , b) _ = eq/ _ _ (helper1 (pos (suc a)) (ℕ₊₁→ℤ b))
+  inv·-helper (signed sneg (suc a) , b) _ = eq/ _ _ (helper2 (pos (suc a)) (ℕ₊₁→ℤ b))
+
+0≢1-ℚ : ¬ Path ℚ 0 1
+0≢1-ℚ p = 0≢1-ℤ (effective (λ _ _ → isSetℤ _ _) isEquivRel∼ _ _ p)
+
+
+-- The instance
+
+ℚField : Field ℓ-zero
+ℚField = makeFieldFromCommRing ℚRing hasInverseℚ 0≢1-ℚ

--- a/Cubical/Algebra/Field/Instances/QuoQ.agda
+++ b/Cubical/Algebra/Field/Instances/QuoQ.agda
@@ -19,7 +19,7 @@ open import Cubical.Data.Int.MoreInts.QuoInt
            ; ·-zeroˡ to ·ℤ-zeroˡ
            ; ·-zeroʳ to ·ℤ-zeroʳ
            ; ·-identityʳ to ·ℤ-identityʳ
-           ; ·-comm to ·ℤ-comm
+           ; ·-comm  to ·ℤ-comm
            ; ·-assoc to ·ℤ-assoc)
 open import Cubical.HITs.SetQuotients as SetQuot hiding (_/_)
 open import Cubical.HITs.Rationals.QuoQ

--- a/Cubical/Data/Int/MoreInts/QuoInt/Base.agda
+++ b/Cubical/Data/Int/MoreInts/QuoInt/Base.agda
@@ -11,7 +11,8 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
 open import Cubical.Relation.Nullary
 
-open import Cubical.Data.Int using () renaming (ℤ to Int ; discreteℤ to discreteInt ; isSetℤ to isSetInt)
+open import Cubical.Data.Int using ()
+  renaming (ℤ to Int ; discreteℤ to discreteInt ; isSetℤ to isSetInt ; 0≢1-ℤ to 0≢1-Int)
 open import Cubical.Data.Nat as ℕ using (ℕ; zero; suc)
 open import Cubical.Data.Bool as Bool using (Bool; not; notnot)
 
@@ -213,3 +214,9 @@ instance
 instance
   fromNegℤ : HasFromNeg ℤ
   fromNegℤ = record { Constraint = λ _ → Unit ; fromNeg = λ n → neg n }
+
+
+-- ℤ is non-trivial
+
+0≢1-ℤ : ¬ 0 ≡ 1
+0≢1-ℤ p = 0≢1-Int (cong ℤ→Int p)

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -552,3 +552,9 @@ private
 
 ·rCancel : (c m n : ℤ) → m · c ≡ n · c → ¬ c ≡ 0 → m ≡ n
 ·rCancel c m n p h = ·lCancel c m n (·Comm c m ∙ p ∙ ·Comm n c) h
+
+
+-- ℤ is non-trivial
+
+0≢1-ℤ : ¬ 0 ≡ 1
+0≢1-ℤ p = encodeℕ _ _ (injPos p)


### PR DESCRIPTION
This PR shows `ℚ` is a field, using the `QuoQ` in library. The codes are basically copied from [my own repo](https://github.com/kangrongji/cubical-classics/blob/master/Classical/Preliminary/QuoQ/Field.agda). I've always thought to move these codes to cubical library and it's time for `ℚ`.