### PR TITLE
H-spaces and homogeneous types

### DIFF
--- a/Cubical/Foundations/Pointed/Base.agda
+++ b/Cubical/Foundations/Pointed/Base.agda
@@ -135,8 +135,7 @@ pointerFun∙ f .snd = refl
 
 -- pointed identity equivalence
 idEquiv∙ : (A : Pointed ℓ) → (A ≃∙ A)
-idEquiv∙ A = (isoToEquiv (iso (λ x → x) (λ x → x) (λ _ → refl) (λ _ → refl))) ,
-             refl
+idEquiv∙ A = idEquiv (typ A) , refl
 
 {-
   Equational reasoning for pointed equivalences

--- a/Cubical/Foundations/Pointed/Homogeneous.agda
+++ b/Cubical/Foundations/Pointed/Homogeneous.agda
@@ -23,6 +23,17 @@ open import Cubical.Foundations.Pointed.Base
 open import Cubical.Foundations.Pointed.Properties
 open import Cubical.Structures.Pointed
 
+{-
+  We might say that a type is homogeneous if its automorphism group acts transitively;
+  this could be phrased with a propositional truncation.
+  Here we demand something much stronger, namely that we are given automorphisms
+  that carry the base point to any given point y.
+  If in addition we require this automorphism to be the identity for the base point,
+  then we recover the notion of a left-invertible H-space, and indeed,
+  any homogeneous type in our sense gives rise to such, as shown in:
+
+    Cubical.Homotopy.HSpace
+-}
 isHomogeneous : ∀ {ℓ} → Pointed ℓ → Type (ℓ-suc ℓ)
 isHomogeneous {ℓ} (A , x) = ∀ y → Path (Pointed ℓ) (A , x) (A , y)
 

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -156,9 +156,9 @@ module _ (A : Pointed ℓ) (X : Pointed ℓ') (hX : HSpace X) where
   fst (μₗ →∙-HSpace g i) a = μXₗ (g .fst a) i
   snd (μₗ →∙-HSpace g i) j = hcomp
     (λ k → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (g .fst (pt A))) (g .snd) k j
-               ; (i = i1) → g .snd (j ∧ k)
-               ; (j = i0) → μXₗ (g .fst (pt A)) i
-               ; (j = i1) → g .snd k})
+             ; (i = i1) → g .snd (j ∧ k)
+             ; (j = i0) → μXₗ (g .fst (pt A)) i
+             ; (j = i1) → g .snd k})
     (μXₗ (g .fst (pt A)) (i ∨ j))
   fst (μᵣ →∙-HSpace f i) a = μXᵣ (f .fst a) i
   snd (μᵣ →∙-HSpace f i) j = hcomp
@@ -183,9 +183,9 @@ module _ (A : Pointed ℓ) (X : Pointed ℓ') (hX : HSpace X) where
         cntfiller : I → I → I → typ X
         cntfiller i j = hfill
           (λ h → λ { (i = i0) → μXₗ (pt X) j
-                    ; (i = i1) → pt X
-                    ; (j = i0) → μXₗᵣ h i
-                    ; (j = i1) → pt X })
+                   ; (i = i1) → pt X
+                   ; (j = i0) → μXₗᵣ h i
+                   ; (j = i1) → pt X })
           (inS (μXₗ (pt X) (i ∨ j)))
 
         k0filler : I → I → I → typ X

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -2,8 +2,13 @@
 module Cubical.Homotopy.HSpace where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Path
 open import Cubical.Foundations.Pointed
+open import Cubical.Foundations.Pointed.Homogeneous
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Structures.Pointed
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
 
@@ -26,6 +31,45 @@ record AssocHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ whe
                     ≡ HSpace.μₗ e (HSpace.μ e y z) i)
                (μ-assoc (pt A) y z)
                refl
+
+record LeftInvHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ where
+  constructor LeftInvHSp
+  field
+    μ-equiv : (x : typ A) → isEquiv (HSpace.μ e x)
+
+  -- every left-invertible H-space is strongly homogeneous
+  isHomogeneousHSp : isHomogeneous A
+  isHomogeneousHSp x = pointed-sip A (fst A , x)
+                       ((HSpace.μ e x , μ-equiv x) , HSpace.μᵣ e x)
+
+{- H-space structures on A are exactly pointed sections of the evaluation map,
+   expressed here with a pointed Π-type -}
+HSpace-Π∙-Iso : {ℓ : Level} (A : Pointed ℓ) → Iso (HSpace A)
+                (Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A))
+fst (fst (Iso.fun (HSpace-Π∙-Iso A) e) x) = HSpace.μ e x
+snd (fst (Iso.fun (HSpace-Π∙-Iso A) e) x) = HSpace.μᵣ e x
+fst (snd (Iso.fun (HSpace-Π∙-Iso A) e) i) x = HSpace.μₗ e x i
+snd (snd (Iso.fun (HSpace-Π∙-Iso A) e) i) j = invEq slideSquareEquiv
+  (flipSquare (HSpace.μₗᵣ e)) i j
+HSpace.μ (Iso.inv (HSpace-Π∙-Iso A) s) x = fst (fst s x)
+HSpace.μₗ (Iso.inv (HSpace-Π∙-Iso A) s) x i = fst (snd s i) x
+HSpace.μᵣ (Iso.inv (HSpace-Π∙-Iso A) s) x = snd (fst s x)
+HSpace.μₗᵣ (Iso.inv (HSpace-Π∙-Iso A) s) = flipSquare
+  (equivFun slideSquareEquiv (λ i j → snd (snd s i) j))
+fst (fst (Iso.rightInv (HSpace-Π∙-Iso A) s k) x) = fst (fst s x)
+snd (fst (Iso.rightInv (HSpace-Π∙-Iso A) s k) x) = snd (fst s x)
+fst (snd (Iso.rightInv (HSpace-Π∙-Iso A) s k) i) x = fst (snd s i) x
+snd (snd (Iso.rightInv (HSpace-Π∙-Iso A) s k) i) j = retEq slideSquareEquiv
+  (λ i' j' → snd (snd s i') j') k i j
+HSpace.μ (Iso.leftInv (HSpace-Π∙-Iso A) e k) x = HSpace.μ e x
+HSpace.μₗ (Iso.leftInv (HSpace-Π∙-Iso A) e k) x = HSpace.μₗ e x
+HSpace.μᵣ (Iso.leftInv (HSpace-Π∙-Iso A) e k) x = HSpace.μᵣ e x
+HSpace.μₗᵣ (Iso.leftInv (HSpace-Π∙-Iso A) e k) = flipSquare
+  (secEq slideSquareEquiv (flipSquare (HSpace.μₗᵣ e)) k)
+
+HSpace-Π∙-Equiv : {ℓ : Level} (A : Pointed ℓ) → HSpace A ≃
+                  Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
+HSpace-Π∙-Equiv A = isoToEquiv (HSpace-Π∙-Iso A)
 
 -- Instances
 open HSpace

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -9,6 +9,7 @@ open import Cubical.Foundations.Pointed.Homogeneous
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
 open import Cubical.Structures.Pointed
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
@@ -38,10 +39,34 @@ record LeftInvHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ w
   field
     μ-equiv : (x : typ A) → isEquiv (HSpace.μ e x)
 
+  open HSpace e
+
+  μ≃ : typ A → typ A ≃ typ A
+  μ≃ x = (μ x , μ-equiv x)
+
+  μ⁻¹ : typ A → typ A → typ A
+  μ⁻¹ x = invIsEq (μ-equiv x)
+
+  μ⁻¹ₗ : (x : typ A) → μ⁻¹ (pt A) x ≡ x
+  μ⁻¹ₗ x = sym (invEq (equivAdjointEquiv (μ≃ (pt A))) (μₗ x))
+
+  μ⁻¹ᵣ : (x : typ A) → μ⁻¹ x x ≡ (pt A)
+  μ⁻¹ᵣ x = sym (invEq (equivAdjointEquiv (μ≃ x)) (μᵣ x))
+
   -- every left-invertible H-space is strongly homogeneous
   isHomogeneousHSp : isHomogeneous A
   isHomogeneousHSp x = pointed-sip A (fst A , x)
                        ((HSpace.μ e x , μ-equiv x) , HSpace.μᵣ e x)
+
+module _ {ℓ ℓ' : Level} {A : Pointed ℓ} {B : Pointed ℓ'} (hb : HSpace B)
+         (hi : LeftInvHSpace hb) where
+
+  open HSpace hb
+  open LeftInvHSpace hi
+
+  -- this could be given a direct proof
+  →∙HSpace≡ : {f g : A →∙ B} → f .fst ≡ g .fst → f ≡ g
+  →∙HSpace≡ {f} {g} p = →∙Homogeneous≡ isHomogeneousHSp p
 
 {- H-space structures on A are exactly pointed sections of the evaluation map,
    expressed here with a pointed Π-type -}
@@ -86,6 +111,11 @@ HSpace-homogeneous A h = Iso.inv (HSpace-Π∙-Iso A) s
     s : Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
     fst s x = ≃∙map (k x)
     snd s = cong′ ≃∙map k₀
+
+LeftInvHSpace-homogeneous : {ℓ : Level} (A : Pointed ℓ) → (h : isHomogeneous A)
+                            → LeftInvHSpace (HSpace-homogeneous A h)
+LeftInvHSpace.μ-equiv (LeftInvHSpace-homogeneous A h) x =
+  equivIsEquiv (fst (pointed-sip⁻ A (typ A , x) (sym (h (pt A)) ∙ h x)))
 
 -- Instances
 open HSpace

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -3,6 +3,7 @@ module Cubical.Homotopy.HSpace where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Path
+open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Pointed
 open import Cubical.Foundations.Pointed.Homogeneous
 open import Cubical.Foundations.HLevels
@@ -70,6 +71,21 @@ HSpace.μₗᵣ (Iso.leftInv (HSpace-Π∙-Iso A) e k) = flipSquare
 HSpace-Π∙-Equiv : {ℓ : Level} (A : Pointed ℓ) → HSpace A ≃
                   Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
 HSpace-Π∙-Equiv A = isoToEquiv (HSpace-Π∙-Iso A)
+
+{- every strongly homogeneous structure on A gives rise
+   to a left-invertible H-space structure, by a slight modification -}
+HSpace-homogeneous : {ℓ : Level} (A : Pointed ℓ) → isHomogeneous A → HSpace A
+HSpace-homogeneous A h = Iso.inv (HSpace-Π∙-Iso A) s
+  where
+    k : (x : typ A) → A ≃∙ (typ A , x)
+    k x = pointed-sip⁻ A (typ A , x) (sym (h (pt A)) ∙ h x)
+
+    k₀ : k (pt A) ≡ idEquiv∙ A
+    k₀ = cong′ (pointed-sip⁻ A A) (lCancel (h (pt A))) ∙ pointed-sip⁻-refl A
+
+    s : Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
+    fst s x = ≃∙map (k x)
+    snd s = cong′ ≃∙map k₀
 
 -- Instances
 open HSpace

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -145,57 +145,61 @@ S1-AssocHSpace : AssocHSpace S1-HSpace
 μ-assoc-filler S1-AssocHSpace _ _ = refl
 
 -- →∙
-→∙-HSpace : (A : Pointed ℓ) (X : Pointed ℓ') (hX : HSpace X) → HSpace (A →∙ X ∙)
-fst (μ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f g) a = μX (f .fst a) (g .fst a)
-snd (μ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f g) =
-  (λ i → μX (f .snd i) (g .fst (pt A))) ∙∙ μXₗ (g .fst (pt A)) ∙∙ g .snd
-fst (μₗ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) g i) a = μXₗ (g .fst a) i
-snd (μₗ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) g i) j = hcomp
-  (λ k → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (g .fst (pt A))) (g .snd) k j
-             ; (i = i1) → g .snd (j ∧ k)
-             ; (j = i0) → μXₗ (g .fst (pt A)) i
-             ; (j = i1) → g .snd k})
-  (μXₗ (g .fst (pt A)) (i ∨ j))
-fst (μᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f i) a = μXᵣ (f .fst a) i
-snd (μᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f i) j = hcomp
-  (λ k → λ { (i = i0) → doubleCompPath-filler (λ i' → μX (f .snd i') (pt X)) (μXₗ (pt X)) refl k j
-           ; (i = i1) → f .snd (j ∨ (~ k))
-           ; (j = i0) → μXᵣ (f .snd (~ k)) i
-           ; (j = i1) → pt X }) (hcomp
-     (λ k → λ { (i = i0) → μXₗ (pt X) j
-              ; (i = i1) → pt X
-              ; (j = i0) → μXₗᵣ k i
-              ; (j = i1) → pt X }) (μXₗ (pt X) (i ∨ j)))
-fst (μₗᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) k i) a = μXₗᵣ k i
-snd (μₗᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) k i) j = hcomp
-  (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
-           ; (i = i1) → pt X
-           ; (j = i0) → μXₗᵣ k i
-           ; (j = i1) → pt X
-           ; (k = i0) → k0filler i j h
-           ; (k = i1) → k1filler i j h } )
-  (cntfiller i j k)
-    where
-      cntfiller : I → I → I → typ X
-      cntfiller i j = hfill
-        (λ h → λ { (i = i0) → μXₗ (pt X) j
-                  ; (i = i1) → pt X
-                  ; (j = i0) → μXₗᵣ h i
-                  ; (j = i1) → pt X })
-        (inS (μXₗ (pt X) (i ∨ j)))
+module _ (A : Pointed ℓ) (X : Pointed ℓ') (hX : HSpace X) where
 
-      k0filler : I → I → I → typ X
-      k0filler i j = hfill
-        (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
-                 ; (i = i1) → pt X
-                 ; (j = i0) → μXₗ (pt X) i
-                 ; (j = i1) → pt X})
-        (inS (μXₗ (pt X) (i ∨ j)))
+  open HSpace hX renaming (μ to μX ; μₗ to μXₗ ; μᵣ to μXᵣ ; μₗᵣ to μXₗᵣ)
 
-      k1filler : I → I → I → typ X
-      k1filler i j = hfill
-        (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
-                 ; (i = i1) → pt X
-                 ; (j = i0) → μXᵣ (pt X) i
-                 ; (j = i1) → pt X })
-        (inS (cntfiller i j i1))
+  →∙-HSpace : HSpace (A →∙ X ∙)
+  fst (μ →∙-HSpace f g) a = μX (f .fst a) (g .fst a)
+  snd (μ →∙-HSpace f g) =
+    (λ i → μX (f .snd i) (g .fst (pt A))) ∙∙ μXₗ (g .fst (pt A)) ∙∙ g .snd
+  fst (μₗ →∙-HSpace g i) a = μXₗ (g .fst a) i
+  snd (μₗ →∙-HSpace g i) j = hcomp
+    (λ k → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (g .fst (pt A))) (g .snd) k j
+               ; (i = i1) → g .snd (j ∧ k)
+               ; (j = i0) → μXₗ (g .fst (pt A)) i
+               ; (j = i1) → g .snd k})
+    (μXₗ (g .fst (pt A)) (i ∨ j))
+  fst (μᵣ →∙-HSpace f i) a = μXᵣ (f .fst a) i
+  snd (μᵣ →∙-HSpace f i) j = hcomp
+    (λ k → λ { (i = i0) → doubleCompPath-filler (λ i' → μX (f .snd i') (pt X)) (μXₗ (pt X)) refl k j
+             ; (i = i1) → f .snd (j ∨ (~ k))
+             ; (j = i0) → μXᵣ (f .snd (~ k)) i
+             ; (j = i1) → pt X }) (hcomp
+       (λ k → λ { (i = i0) → μXₗ (pt X) j
+                ; (i = i1) → pt X
+                ; (j = i0) → μXₗᵣ k i
+                ; (j = i1) → pt X }) (μXₗ (pt X) (i ∨ j)))
+  fst (μₗᵣ →∙-HSpace k i) a = μXₗᵣ k i
+  snd (μₗᵣ →∙-HSpace k i) j = hcomp
+    (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+             ; (i = i1) → pt X
+             ; (j = i0) → μXₗᵣ k i
+             ; (j = i1) → pt X
+             ; (k = i0) → k0filler i j h
+             ; (k = i1) → k1filler i j h } )
+    (cntfiller i j k)
+      where
+        cntfiller : I → I → I → typ X
+        cntfiller i j = hfill
+          (λ h → λ { (i = i0) → μXₗ (pt X) j
+                    ; (i = i1) → pt X
+                    ; (j = i0) → μXₗᵣ h i
+                    ; (j = i1) → pt X })
+          (inS (μXₗ (pt X) (i ∨ j)))
+
+        k0filler : I → I → I → typ X
+        k0filler i j = hfill
+          (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+                   ; (i = i1) → pt X
+                   ; (j = i0) → μXₗ (pt X) i
+                   ; (j = i1) → pt X})
+          (inS (μXₗ (pt X) (i ∨ j)))
+
+        k1filler : I → I → I → typ X
+        k1filler i j = hfill
+          (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+                   ; (i = i1) → pt X
+                   ; (j = i0) → μXᵣ (pt X) i
+                   ; (j = i1) → pt X })
+          (inS (cntfiller i j i1))

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -14,7 +14,11 @@ open import Cubical.Structures.Pointed
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
 
-record HSpace {ℓ : Level} (A : Pointed ℓ) : Type ℓ where
+private
+  variable
+    ℓ ℓ' : Level
+
+record HSpace (A : Pointed ℓ) : Type ℓ where
   constructor HSp
   field
     μ : typ A → typ A → typ A
@@ -22,24 +26,24 @@ record HSpace {ℓ : Level} (A : Pointed ℓ) : Type ℓ where
     μᵣ : (x : typ A) → μ x (pt A) ≡ x
     μₗᵣ : μₗ (pt A) ≡ μᵣ (pt A)
 
-record AssocHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ where
+record AssocHSpace {A : Pointed ℓ} (e : HSpace A) : Type ℓ where
   constructor AssocHSp
+  open HSpace e
   field
     μ-assoc : (x y z : _)
-      → HSpace.μ e (HSpace.μ e x y) z ≡ HSpace.μ e x (HSpace.μ e y z)
+      → μ (μ x y) z ≡ μ x (μ y z)
 
     μ-assoc-filler : (y z : typ A)
-      → PathP (λ i → HSpace.μ e (HSpace.μₗ e y i) z
-                    ≡ HSpace.μₗ e (HSpace.μ e y z) i)
+      → PathP (λ i → μ (μₗ y i) z
+                    ≡ μₗ (μ y z) i)
                (μ-assoc (pt A) y z)
                refl
 
-record LeftInvHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ where
+record LeftInvHSpace {A : Pointed ℓ} (e : HSpace A) : Type ℓ where
   constructor LeftInvHSp
-  field
-    μ-equiv : (x : typ A) → isEquiv (HSpace.μ e x)
-
   open HSpace e
+  field
+    μ-equiv : (x : typ A) → isEquiv (μ x)
 
   μ≃ : typ A → typ A ≃ typ A
   μ≃ x = (μ x , μ-equiv x)
@@ -53,12 +57,12 @@ record LeftInvHSpace {ℓ : Level} {A : Pointed ℓ} (e : HSpace A) : Type ℓ w
   μ⁻¹ᵣ : (x : typ A) → μ⁻¹ x x ≡ (pt A)
   μ⁻¹ᵣ x = sym (invEq (equivAdjointEquiv (μ≃ x)) (μᵣ x))
 
-  -- every left-invertible H-space is strongly homogeneous
+  -- every left-invertible H-space is (strongly) homogeneous
   isHomogeneousHSp : isHomogeneous A
   isHomogeneousHSp x = pointed-sip A (fst A , x)
-                       ((HSpace.μ e x , μ-equiv x) , HSpace.μᵣ e x)
+                       ((μ x , μ-equiv x) , μᵣ x)
 
-module _ {ℓ ℓ' : Level} {A : Pointed ℓ} {B : Pointed ℓ'} (hb : HSpace B)
+module _ {A : Pointed ℓ} {B : Pointed ℓ'} (hb : HSpace B)
          (hi : LeftInvHSpace hb) where
 
   open HSpace hb
@@ -70,7 +74,7 @@ module _ {ℓ ℓ' : Level} {A : Pointed ℓ} {B : Pointed ℓ'} (hb : HSpace B)
 
 {- H-space structures on A are exactly pointed sections of the evaluation map,
    expressed here with a pointed Π-type -}
-HSpace-Π∙-Iso : {ℓ : Level} (A : Pointed ℓ) → Iso (HSpace A)
+HSpace-Π∙-Iso : (A : Pointed ℓ) → Iso (HSpace A)
                 (Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A))
 fst (fst (Iso.fun (HSpace-Π∙-Iso A) e) x) = HSpace.μ e x
 snd (fst (Iso.fun (HSpace-Π∙-Iso A) e) x) = HSpace.μᵣ e x
@@ -93,13 +97,13 @@ HSpace.μᵣ (Iso.leftInv (HSpace-Π∙-Iso A) e k) x = HSpace.μᵣ e x
 HSpace.μₗᵣ (Iso.leftInv (HSpace-Π∙-Iso A) e k) = flipSquare
   (secEq slideSquareEquiv (flipSquare (HSpace.μₗᵣ e)) k)
 
-HSpace-Π∙-Equiv : {ℓ : Level} (A : Pointed ℓ) → HSpace A ≃
+HSpace-Π∙-Equiv : (A : Pointed ℓ) → HSpace A ≃
                   Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
 HSpace-Π∙-Equiv A = isoToEquiv (HSpace-Π∙-Iso A)
 
-{- every strongly homogeneous structure on A gives rise
+{- every (strongly) homogeneous structure on A gives rise
    to a left-invertible H-space structure, by a slight modification -}
-HSpace-homogeneous : {ℓ : Level} (A : Pointed ℓ) → isHomogeneous A → HSpace A
+HSpace-homogeneous : (A : Pointed ℓ) → isHomogeneous A → HSpace A
 HSpace-homogeneous A h = Iso.inv (HSpace-Π∙-Iso A) s
   where
     k : (x : typ A) → A ≃∙ (typ A , x)
@@ -112,7 +116,7 @@ HSpace-homogeneous A h = Iso.inv (HSpace-Π∙-Iso A) s
     fst s x = ≃∙map (k x)
     snd s = cong′ ≃∙map k₀
 
-LeftInvHSpace-homogeneous : {ℓ : Level} (A : Pointed ℓ) → (h : isHomogeneous A)
+LeftInvHSpace-homogeneous : (A : Pointed ℓ) → (h : isHomogeneous A)
                             → LeftInvHSpace (HSpace-homogeneous A h)
 LeftInvHSpace.μ-equiv (LeftInvHSpace-homogeneous A h) x =
   equivIsEquiv (fst (pointed-sip⁻ A (typ A , x) (sym (h (pt A)) ∙ h x)))
@@ -139,3 +143,59 @@ S1-AssocHSpace : AssocHSpace S1-HSpace
         (λ { base → refl ; (loop i) → refl})
         refl
 μ-assoc-filler S1-AssocHSpace _ _ = refl
+
+-- →∙
+→∙-HSpace : (A : Pointed ℓ) (X : Pointed ℓ') (hX : HSpace X) → HSpace (A →∙ X ∙)
+fst (μ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f g) a = μX (f .fst a) (g .fst a)
+snd (μ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f g) =
+  (λ i → μX (f .snd i) (g .fst (pt A))) ∙∙ μXₗ (g .fst (pt A)) ∙∙ g .snd
+fst (μₗ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) g i) a = μXₗ (g .fst a) i
+snd (μₗ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) g i) j = hcomp
+  (λ k → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (g .fst (pt A))) (g .snd) k j
+             ; (i = i1) → g .snd (j ∧ k)
+             ; (j = i0) → μXₗ (g .fst (pt A)) i
+             ; (j = i1) → g .snd k})
+  (μXₗ (g .fst (pt A)) (i ∨ j))
+fst (μᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f i) a = μXᵣ (f .fst a) i
+snd (μᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) f i) j = hcomp
+  (λ k → λ { (i = i0) → doubleCompPath-filler (λ i' → μX (f .snd i') (pt X)) (μXₗ (pt X)) refl k j
+           ; (i = i1) → f .snd (j ∨ (~ k))
+           ; (j = i0) → μXᵣ (f .snd (~ k)) i
+           ; (j = i1) → pt X }) (hcomp
+     (λ k → λ { (i = i0) → μXₗ (pt X) j
+              ; (i = i1) → pt X
+              ; (j = i0) → μXₗᵣ k i
+              ; (j = i1) → pt X }) (μXₗ (pt X) (i ∨ j)))
+fst (μₗᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) k i) a = μXₗᵣ k i
+snd (μₗᵣ (→∙-HSpace A X (HSp μX μXₗ μXᵣ μXₗᵣ)) k i) j = hcomp
+  (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+           ; (i = i1) → pt X
+           ; (j = i0) → μXₗᵣ k i
+           ; (j = i1) → pt X
+           ; (k = i0) → k0filler i j h
+           ; (k = i1) → k1filler i j h } )
+  (cntfiller i j k)
+    where
+      cntfiller : I → I → I → typ X
+      cntfiller i j = hfill
+        (λ h → λ { (i = i0) → μXₗ (pt X) j
+                  ; (i = i1) → pt X
+                  ; (j = i0) → μXₗᵣ h i
+                  ; (j = i1) → pt X })
+        (inS (μXₗ (pt X) (i ∨ j)))
+
+      k0filler : I → I → I → typ X
+      k0filler i j = hfill
+        (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+                 ; (i = i1) → pt X
+                 ; (j = i0) → μXₗ (pt X) i
+                 ; (j = i1) → pt X})
+        (inS (μXₗ (pt X) (i ∨ j)))
+
+      k1filler : I → I → I → typ X
+      k1filler i j = hfill
+        (λ h → λ { (i = i0) → doubleCompPath-filler refl (μXₗ (pt X)) refl h j
+                 ; (i = i1) → pt X
+                 ; (j = i0) → μXᵣ (pt X) i
+                 ; (j = i1) → pt X })
+        (inS (cntfiller i j i1))

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -39,11 +39,18 @@ pointed-sip-idEquiv∙ : (A : Pointed ℓ) → pointed-sip A A (idEquiv∙ A) �
 fst (pointed-sip-idEquiv∙ A i j) = uaIdEquiv i j
 snd (pointed-sip-idEquiv∙ A i j) = glue {φ = i ∨ ~ j ∨ j} (λ _ → pt A) (pt A)
 
-pointed-sip⁻ : (A B : Pointed ℓ) → (A ≡ B) → A ≃[ PointedEquivStr ] B
-pointed-sip⁻ A B = invEq (pointedSIP A B)
+{-
+  The following terms have huge normal forms, so they are abstract to avoid
+  type checking speed problems, for example in
 
-pointed-sip⁻-refl : (A : Pointed ℓ) → pointed-sip⁻ A A refl ≡ idEquiv∙ A
-pointed-sip⁻-refl A = sym (invEq (equivAdjointEquiv (pointedSIP A A)) (pointed-sip-idEquiv∙ A))
+    Cubical.Homotopy.HSpace
+-}
+abstract
+  pointed-sip⁻ : (A B : Pointed ℓ) → (A ≡ B) → A ≃[ PointedEquivStr ] B
+  pointed-sip⁻ A B = invEq (pointedSIP A B)
+
+  pointed-sip⁻-refl : (A : Pointed ℓ) → pointed-sip⁻ A A refl ≡ idEquiv∙ A
+  pointed-sip⁻-refl A = sym (invEq (equivAdjointEquiv (pointedSIP A A)) (pointed-sip-idEquiv∙ A))
 
 pointedEquivAction : EquivAction {ℓ} PointedStructure
 pointedEquivAction e = e

--- a/Cubical/Structures/Pointed.agda
+++ b/Cubical/Structures/Pointed.agda
@@ -8,6 +8,7 @@ module Cubical.Structures.Pointed where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Properties
 open import Cubical.Foundations.Univalence
 open import Cubical.Foundations.SIP
 
@@ -33,6 +34,16 @@ pointedSIP = SIP pointedUnivalentStr
 
 pointed-sip : (A B : Pointed ℓ) → A ≃[ PointedEquivStr ] B → (A ≡ B)
 pointed-sip A B = equivFun (pointedSIP A B) -- ≡ λ (e , p) i → ua e i , ua-gluePath e p i
+
+pointed-sip-idEquiv∙ : (A : Pointed ℓ) → pointed-sip A A (idEquiv∙ A) ≡ refl
+fst (pointed-sip-idEquiv∙ A i j) = uaIdEquiv i j
+snd (pointed-sip-idEquiv∙ A i j) = glue {φ = i ∨ ~ j ∨ j} (λ _ → pt A) (pt A)
+
+pointed-sip⁻ : (A B : Pointed ℓ) → (A ≡ B) → A ≃[ PointedEquivStr ] B
+pointed-sip⁻ A B = invEq (pointedSIP A B)
+
+pointed-sip⁻-refl : (A : Pointed ℓ) → pointed-sip⁻ A A refl ≡ idEquiv∙ A
+pointed-sip⁻-refl A = sym (invEq (equivAdjointEquiv (pointedSIP A A)) (pointed-sip-idEquiv∙ A))
 
 pointedEquivAction : EquivAction {ℓ} PointedStructure
 pointedEquivAction e = e


### PR DESCRIPTION
This is a small PR with some connections between H-spaces and homogeneous types.
It also proves that H-space structures can be expressed as a pointed Pi.
It fixes IMO the definition of the pointed identity equivalence.
However, the proof that a homogeneous type can be given an H-space structure is very slow. Any idea what's causing this slowdown?
Once this is faster, I'll add that the corresponding H-space structure is left-invertible.