### PR TITLE
Abstract interface for QuotientAlgebra

### DIFF
--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -163,12 +163,13 @@ module _ {R : CommRing ℓ} where
           (inducedHom A values relationsHold)
           f
           (sym (
-           {!f'                                   ≡⟨ sym (inv f') ⟩
+           f'                                    ≡⟨ sym (inv f') ⟩
            freeInducedHom A (evaluateAt A f')    ≡⟨ cong (freeInducedHom A)
                                                          (funExt hasCorrectValues) ⟩
-           freeInducedHom A values               ≡⟨ cong (freeInducedHom A) refl ⟩
+           freeInducedHom A values               ≡⟨ cong (freeInducedHom A)
+                                                         (sym (funExt (inducedHomOnGenerators A values relationsHold))) ⟩
            freeInducedHom A (evaluateAt A iHom') ≡⟨ inv iHom' ⟩
-           iHom'                                 ∎!}))
+           iHom'                                 ∎))
         where
           {-
                      Poly n
@@ -237,12 +238,12 @@ module _ {R : CommRing ℓ} where
       Iso.fun FPHomIso = evaluateAtFP
       Iso.inv FPHomIso = inducedHomFP _
       Iso.rightInv (FPHomIso {A}) =
-        λ b → {!Σ≡Prop
+        λ b → Σ≡Prop
                 (λ x → isPropΠ
                   (λ i → isSetCommAlgebra A
                           (evPoly A (relation i) x)
                           (0a (snd A))))
-                refl!}
+                (funExt (inducedHomOnGenerators A (fst b) (snd b)))
       Iso.leftInv (FPHomIso {A}) =
         λ a → Σ≡Prop (λ f → isPropIsCommAlgebraHom {ℓ} {R} {ℓ} {ℓ} {FPAlgebra} {A} f)
                  λ i → fst (unique {A}

--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -31,7 +31,7 @@ open import Cubical.Algebra.CommRing.FGIdeal using (inclOfFGIdeal)
 open import Cubical.Algebra.CommAlgebra
 open import Cubical.Algebra.CommAlgebra.FreeCommAlgebra
   renaming (inducedHom to freeInducedHom)
-open import Cubical.Algebra.CommAlgebra.QuotientAlgebra
+open import Cubical.Algebra.CommAlgebra.QuotientAlgebraAbstract
   renaming (inducedHom to quotientInducedHom)
 open import Cubical.Algebra.CommAlgebra.Ideal
 open import Cubical.Algebra.CommAlgebra.FGIdeal
@@ -133,7 +133,7 @@ module _ {R : CommRing ℓ} where
         (relationsHold : (i : Fin m) → evPoly A (relation i) values ≡ 0a (snd A))
         (i : Fin n)
         → fst (inducedHom A values relationsHold) (generator i) ≡ values i
-      inducedHomOnGenerators _ _ _ _ = refl
+      inducedHomOnGenerators _ _ _ _ = {!refl!}
 
       unique :
              {A : CommAlgebra R ℓ}
@@ -150,12 +150,12 @@ module _ {R : CommRing ℓ} where
           (inducedHom A values relationsHold)
           f
           (sym (
-           f'     ≡⟨ sym (inv f') ⟩
+           {!f'     ≡⟨ sym (inv f') ⟩
            freeInducedHom A (evaluateAt A f')    ≡⟨ cong (freeInducedHom A)
                                                          (funExt hasCorrectValues) ⟩
            freeInducedHom A values               ≡⟨ cong (freeInducedHom A) refl ⟩
            freeInducedHom A (evaluateAt A iHom') ≡⟨ inv iHom' ⟩
-           iHom' ∎))
+           iHom' ∎!}))
         where
           {-
                      Poly n
@@ -224,12 +224,12 @@ module _ {R : CommRing ℓ} where
       Iso.fun FPHomIso = evaluateAtFP
       Iso.inv FPHomIso = inducedHomFP _
       Iso.rightInv (FPHomIso {A}) =
-        λ b → Σ≡Prop
+        λ b → {!Σ≡Prop
                 (λ x → isPropΠ
                   (λ i → isSetCommAlgebra A
                           (evPoly A (relation i) x)
                           (0a (snd A))))
-                refl
+                refl!}
       Iso.leftInv (FPHomIso {A}) =
         λ a → Σ≡Prop (λ f → isPropIsCommAlgebraHom {ℓ} {R} {ℓ} {ℓ} {FPAlgebra} {A} f)
                  λ i → fst (unique {A}

--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -458,3 +458,7 @@ module Instances (R : CommRing ℓ) where
         toFrom : toA ∘a fromA ≡ idCAlgHom R/⟨xs⟩
         toFrom = injectivePrecomp (initialCAlg R) ⟨xs⟩ R/⟨xs⟩ (toA ∘a fromA) (idCAlgHom R/⟨xs⟩)
                    (isContr→isProp (initialityContr R R/⟨xs⟩) _ _)
+
+  module _ {m : ℕ} (x : ⟨ R ⟩) where
+    R/⟨x⟩FP : FinitePresentation (initialCAlg R / generatedIdeal (initialCAlg R) (replicateFinVec 1 x))
+    R/⟨x⟩FP = R/⟨xs⟩FP (replicateFinVec 1 x)

--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -133,7 +133,20 @@ module _ {R : CommRing ℓ} where
         (relationsHold : (i : Fin m) → evPoly A (relation i) values ≡ 0a (snd A))
         (i : Fin n)
         → fst (inducedHom A values relationsHold) (generator i) ≡ values i
-      inducedHomOnGenerators _ _ _ _ = {!refl!}
+      inducedHomOnGenerators A values relationsHold i =
+        cong (λ f → fst f (var i))
+        (inducedHom∘quotientHom (Polynomials n) relationsIdeal A freeHom isInKernel)
+        where
+          -- TODO: this where block is duplicated
+          freeHom : CommAlgebraHom (Polynomials n) A
+          freeHom = freeInducedHom A values
+          isInKernel :   fst (generatedIdeal (Polynomials n) relation)
+                       ⊆ fst (kernel (Polynomials n) A freeHom)
+          isInKernel = inclOfFGIdeal
+                         (CommAlgebra→CommRing (Polynomials n))
+                         relation
+                         (kernel (Polynomials n) A freeHom)
+                         relationsHold
 
       unique :
              {A : CommAlgebra R ℓ}
@@ -150,12 +163,12 @@ module _ {R : CommRing ℓ} where
           (inducedHom A values relationsHold)
           f
           (sym (
-           {!f'     ≡⟨ sym (inv f') ⟩
+           {!f'                                   ≡⟨ sym (inv f') ⟩
            freeInducedHom A (evaluateAt A f')    ≡⟨ cong (freeInducedHom A)
                                                          (funExt hasCorrectValues) ⟩
            freeInducedHom A values               ≡⟨ cong (freeInducedHom A) refl ⟩
            freeInducedHom A (evaluateAt A iHom') ≡⟨ inv iHom' ⟩
-           iHom' ∎!}))
+           iHom'                                 ∎!}))
         where
           {-
                      Poly n

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -136,6 +136,11 @@ module _ {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
   pres- (snd (inducedHom B ϕ kernel⊆I)) = elimProp (λ _ → isSetCommAlgebra B _ _) (pres- (snd ϕ))
   pres⋆ (snd (inducedHom B ϕ kernel⊆I)) = λ r → elimProp (λ _ → isSetCommAlgebra B _ _) (pres⋆ (snd ϕ) r)
 
+  inducedHom∘quotientHom : (B : CommAlgebra R ℓ) (ϕ : CommAlgebraHom A B)
+               → (I⊆kerϕ : fst I ⊆ fst (kernel A B ϕ))
+               → inducedHom B ϕ I⊆kerϕ ∘a quotientHom A I ≡ ϕ
+  inducedHom∘quotientHom B ϕ I⊆kerϕ = Σ≡Prop (isPropIsCommAlgebraHom {M = A} {N = B}) (funExt (λ a → refl))
+
   injectivePrecomp : (B : CommAlgebra R ℓ) (f g : CommAlgebraHom (A / I) B)
                      → f ∘a (quotientHom A I) ≡ g ∘a (quotientHom A I)
                      → f ≡ g

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -1,0 +1,86 @@
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.CommAlgebra.QuotientAlgebraAbstract where
+
+-- many unused imports...
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Powerset using (_∈_; _⊆_)
+open import Cubical.Foundations.Structure
+
+open import Cubical.HITs.SetQuotients hiding (_/_)
+open import Cubical.Data.Unit
+open import Cubical.Data.Sigma.Properties using (Σ≡Prop)
+
+open import Cubical.Algebra.CommRing
+import Cubical.Algebra.CommRing.QuotientRing as CommRing
+import Cubical.Algebra.Ring.QuotientRing as Ring
+open import Cubical.Algebra.CommRing.Ideal hiding (IdealsIn)
+open import Cubical.Algebra.CommAlgebra
+open import Cubical.Algebra.CommAlgebra.Ideal
+open import Cubical.Algebra.CommAlgebra.Kernel
+open import Cubical.Algebra.CommAlgebra.Instances.Unit
+import Cubical.Algebra.CommAlgebra.QuotientAlgebra as Impl
+open import Cubical.Algebra.Algebra.Base using (IsAlgebraHom; isPropIsAlgebraHom)
+open import Cubical.Algebra.Ring
+open import Cubical.Algebra.Ring.Ideal using (isIdeal)
+open import Cubical.Algebra.CommRingSolver.Reflection
+open import Cubical.Algebra.Algebra.Properties
+open AlgebraHoms using (compAlgebraHom)
+
+
+module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
+  abstract
+    _/_ : CommAlgebra R ℓ
+    _/_ = Impl._/_ A I
+
+    quotientHom : CommAlgebraHom A (_/_)
+    quotientHom = Impl.quotientHom A I
+
+module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
+  abstract
+    CommForget/ : RingEquiv (CommAlgebra→Ring (A / I)) ((CommAlgebra→Ring A) Ring./ (CommIdeal→Ideal I))
+    CommForget/ = Impl.CommForget/ A I
+
+    inducedHom : (B : CommAlgebra R ℓ) (ϕ : CommAlgebraHom A B)
+                 → (fst I) ⊆ (fst (kernel A B ϕ))
+                 → CommAlgebraHom (A / I) B
+    inducedHom = Impl.inducedHom A I
+
+
+    injectivePrecomp : (B : CommAlgebra R ℓ) (f g : CommAlgebraHom (A / I) B)
+                       → f ∘a (quotientHom A I) ≡ g ∘a (quotientHom A I)
+                       → f ≡ g
+    injectivePrecomp = Impl.injectivePrecomp A I
+
+module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) where
+  abstract
+{-
+    -- level problems
+    oneIdealQuotient : CommAlgebraEquiv (A / (1Ideal A)) (UnitCommAlgebra R)
+    oneIdealQuotient = Impl.oneIdealQuotient A
+-}
+
+    zeroIdealQuotient : CommAlgebraEquiv A (A / (0Ideal A))
+    zeroIdealQuotient = Impl.zeroIdealQuotient A
+
+{-
+-- level problems
+abstract
+
+  [_]/ : {ℓ : Level} {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
+         → (a : fst A) → fst (A / I)
+  [_]/ = Impl.[_]/
+-}
+
+module _ {ℓ = ℓ} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
+
+  abstract
+    kernel≡I : kernel A (A / I) (quotientHom A I) ≡ I
+    kernel≡I = Impl.kernel≡I A I
+
+abstract
+  isZeroFromIdeal : {ℓ : Level} {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
+                  → (x : ⟨ A ⟩) → x ∈ (fst I) → fst (quotientHom A I) x ≡ CommAlgebraStr.0a (snd (A / I))
+  isZeroFromIdeal {ℓ} {R} {A} {I} = Impl.isZeroFromIdeal {ℓ} {R} {A} {I}

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -51,7 +51,7 @@ module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn 
     inducedHom∘quotientHom : (B : CommAlgebra R ℓ) (ϕ : CommAlgebraHom A B)
                  → (I⊆kerϕ : fst I ⊆ fst (kernel A B ϕ))
                  → inducedHom B ϕ I⊆kerϕ ∘a quotientHom A I ≡ ϕ
-    inducedHom∘quotientHom = {!Impl.inducedHom∘quotientHom!}
+    inducedHom∘quotientHom = Impl.inducedHom∘quotientHom A I
 
     injectivePrecomp : (B : CommAlgebra R ℓ) (f g : CommAlgebraHom (A / I) B)
                        → f ∘a (quotientHom A I) ≡ g ∘a (quotientHom A I)

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -1,33 +1,23 @@
 {-# OPTIONS --safe #-}
 module Cubical.Algebra.CommAlgebra.QuotientAlgebraAbstract where
 
--- many unused imports...
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Equiv
-open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Powerset using (_∈_; _⊆_)
-open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Structure using (⟨_⟩)
 
-open import Cubical.HITs.SetQuotients hiding (_/_)
-open import Cubical.Data.Unit
-open import Cubical.Data.Sigma.Properties using (Σ≡Prop)
-
-open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing using (CommRing)
 import Cubical.Algebra.CommRing.QuotientRing as CommRing
 import Cubical.Algebra.Ring.QuotientRing as Ring
-open import Cubical.Algebra.CommRing.Ideal hiding (IdealsIn)
+open import Cubical.Algebra.CommRing.Ideal using (CommIdeal→Ideal)
 open import Cubical.Algebra.CommAlgebra
-open import Cubical.Algebra.CommAlgebra.Ideal
-open import Cubical.Algebra.CommAlgebra.Kernel
-open import Cubical.Algebra.CommAlgebra.Instances.Unit
-import Cubical.Algebra.CommAlgebra.QuotientAlgebra as Impl
-open import Cubical.Algebra.Algebra.Base using (IsAlgebraHom; isPropIsAlgebraHom)
-open import Cubical.Algebra.Ring
-open import Cubical.Algebra.Ring.Ideal using (isIdeal)
-open import Cubical.Algebra.CommRingSolver.Reflection
-open import Cubical.Algebra.Algebra.Properties
+open import Cubical.Algebra.CommAlgebra.Ideal using (IdealsIn; 1Ideal; 0Ideal)
+open import Cubical.Algebra.CommAlgebra.Kernel using (kernel)
+open import Cubical.Algebra.CommAlgebra.Instances.Unit using (UnitCommAlgebra)
+open import Cubical.Algebra.Ring using (RingEquiv)
+open import Cubical.Algebra.Algebra.Properties using (module AlgebraHoms)
 open AlgebraHoms using (compAlgebraHom)
+
+import Cubical.Algebra.CommAlgebra.QuotientAlgebra as Impl
 
 
 -- Note that anonymous modules have a shared abstract scope.

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -48,6 +48,10 @@ module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn 
                  → CommAlgebraHom (A / I) B
     inducedHom = Impl.inducedHom A I
 
+    inducedHom∘quotientHom : (B : CommAlgebra R ℓ) (ϕ : CommAlgebraHom A B)
+                 → (I⊆kerϕ : fst I ⊆ fst (kernel A B ϕ))
+                 → inducedHom B ϕ I⊆kerϕ ∘a quotientHom A I ≡ ϕ
+    inducedHom∘quotientHom = {!Impl.inducedHom∘quotientHom!}
 
     injectivePrecomp : (B : CommAlgebra R ℓ) (f g : CommAlgebraHom (A / I) B)
                        → f ∘a (quotientHom A I) ≡ g ∘a (quotientHom A I)

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -30,6 +30,8 @@ open import Cubical.Algebra.Algebra.Properties
 open AlgebraHoms using (compAlgebraHom)
 
 
+-- Note that anonymous modules have a shared abstract scope.
+
 module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
   abstract
     _/_ : CommAlgebra R ℓ
@@ -59,27 +61,25 @@ module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn 
     injectivePrecomp = Impl.injectivePrecomp A I
 
 module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) where
+  T : Type ℓ
+  T = CommAlgebraEquiv {ℓ = ℓ} {R = R} {ℓ' = ℓ} {ℓ'' = ℓ} (A Impl./ (1Ideal A)) (UnitCommAlgebra R)
+
+  oneIdealQuotient-0 : T
+  oneIdealQuotient-0 = Impl.oneIdealQuotient A
+
   abstract
-{-
-    -- level problems
-    oneIdealQuotient : CommAlgebraEquiv (A / (1Ideal A)) (UnitCommAlgebra R)
+    oneIdealQuotient : CommAlgebraEquiv (A / (1Ideal A)) (UnitCommAlgebra R {ℓ' = ℓ})
     oneIdealQuotient = Impl.oneIdealQuotient A
--}
 
     zeroIdealQuotient : CommAlgebraEquiv A (A / (0Ideal A))
     zeroIdealQuotient = Impl.zeroIdealQuotient A
 
-{-
--- level problems
 abstract
-
   [_]/ : {ℓ : Level} {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
          → (a : fst A) → fst (A / I)
-  [_]/ = Impl.[_]/
--}
+  [_]/ {A = A} {I = I} = Impl.[_]/ {A = A} {I = I}
 
 module _ {ℓ = ℓ} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where
-
   abstract
     kernel≡I : kernel A (A / I) (quotientHom A I) ≡ I
     kernel≡I = Impl.kernel≡I A I

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebraAbstract.agda
@@ -61,11 +61,6 @@ module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn 
     injectivePrecomp = Impl.injectivePrecomp A I
 
 module _ {ℓ : Level} {R : CommRing ℓ} (A : CommAlgebra R ℓ) where
-  T : Type ℓ
-  T = CommAlgebraEquiv {ℓ = ℓ} {R = R} {ℓ' = ℓ} {ℓ'' = ℓ} (A Impl./ (1Ideal A)) (UnitCommAlgebra R)
-
-  oneIdealQuotient-0 : T
-  oneIdealQuotient-0 = Impl.oneIdealQuotient A
 
   abstract
     oneIdealQuotient : CommAlgebraEquiv (A / (1Ideal A)) (UnitCommAlgebra R {ℓ' = ℓ})


### PR DESCRIPTION
This PR provides an abstract interface to the `Cubical.Algebra.CommAlgebra.QuotientAlgebra` module as an attempt to reduce long type checking times.

`FPAlgebra` is the only module that uses `QuotientAlgebra` so far, and relatively small changes were necessary for it to use `QuotientAlgebraAbstract` instead. A witness `inducedHom∘quotientHom` had to be added to `QuotientAlgebra` for an equality that was a definitional equality before.