### PR TITLE
abstractify QuotientAlgebra

### DIFF
--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -109,6 +109,11 @@ module _ {R : CommRing ℓ} where
         (values : FinVec ⟨ A ⟩ n)
         (relationsHold : (i : Fin m) → evPoly A (relation i) values ≡ 0a (snd A))
         where abstract
+        {-
+          We repeat the abstract keyword here because the contents of a child module are not
+          covered by the outer abstract keyword. This behaves like a single big abstract
+          block as long as the child module is anonymous.
+        -}
 
         private
           freeHom : CommAlgebraHom (Polynomials n) A

--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -149,13 +149,13 @@ module _ {R : CommRing ℓ} where
                          relationsHold
 
       unique :
-             {A : CommAlgebra R ℓ}
+             (A : CommAlgebra R ℓ)
              (values : FinVec ⟨ A ⟩ n)
              (relationsHold : (i : Fin m) → evPoly A (relation i) values ≡ 0a (snd A))
              (f : CommAlgebraHom FPAlgebra A)
              → ((i : Fin n) → fst f (generator i) ≡ values i)
              → inducedHom A values relationsHold ≡ f
-      unique {A = A} values relationsHold f hasCorrectValues =
+      unique A values relationsHold f hasCorrectValues =
         injectivePrecomp
           (Polynomials n)
           relationsIdeal
@@ -195,7 +195,7 @@ module _ {R : CommRing ℓ} where
           , (inducedHomOnGenerators A values relationsHold) )
         , λ {(f , mapsValues)
             → Σ≡Prop (λ _ → isPropΠ (λ _ → isSetCommAlgebra A _ _))
-                     (unique values relationsHold f mapsValues)}
+                     (unique A values relationsHold f mapsValues)}
 
       {- ∀ A : Comm-R-Algebra,
          ∀ J : Finitely-generated-Ideal,
@@ -246,7 +246,7 @@ module _ {R : CommRing ℓ} where
                 (funExt (inducedHomOnGenerators A (fst b) (snd b)))
       Iso.leftInv (FPHomIso {A}) =
         λ a → Σ≡Prop (λ f → isPropIsCommAlgebraHom {ℓ} {R} {ℓ} {ℓ} {FPAlgebra} {A} f)
-                 λ i → fst (unique {A}
+                 λ i → fst (unique A
                              (fst (evaluateAtFP {A} a))
                              (snd (evaluateAtFP a))
                              a
@@ -305,13 +305,13 @@ module Instances (R : CommRing ℓ) where
         inverse1 : fromA ∘a toA ≡ idAlgebraHom _
         inverse1 =
           fromA ∘a toA
-            ≡⟨ sym (unique _ _ _ _ _ (λ i → cong (fst fromA) (
+            ≡⟨ sym (unique _ _ _ _ _ _ (λ i → cong (fst fromA) (
                  fst toA (generator n emptyGen i)
                    ≡⟨ inducedHomOnGenerators _ _ _ _ _ _ ⟩
                  Construction.var i
                    ∎))) ⟩
           inducedHom n emptyGen B (generator _ _) (relationsHold _ _)
-            ≡⟨ unique _ _ _ _ _ (λ i → refl) ⟩
+            ≡⟨ unique _ _ _ _ _ _ (λ i → refl) ⟩
           idAlgebraHom _
             ∎
         inverse2 : toA ∘a fromA ≡ idAlgebraHom _
@@ -345,7 +345,7 @@ module Instances (R : CommRing ℓ) where
       iHom = inducedHom 0 emptyGen B (λ ()) (λ ())
       uniqueness : (f : CommAlgebraHom R[⊥]/⟨0⟩ B) →
                    iHom ≡ f
-      uniqueness f = unique 0 emptyGen {A = B} (λ ()) (λ ()) f (λ ())
+      uniqueness f = unique 0 emptyGen B (λ ()) (λ ()) f (λ ())
 
   initialCAlgFP : FinitePresentation (initialCAlg R)
   n initialCAlgFP = 0

--- a/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/FPAlgebra.agda
@@ -133,7 +133,20 @@ module _ {R : CommRing ℓ} where
         (relationsHold : (i : Fin m) → evPoly A (relation i) values ≡ 0a (snd A))
         (i : Fin n)
         → fst (inducedHom A values relationsHold) (generator i) ≡ values i
-      inducedHomOnGenerators _ _ _ _ = refl
+      inducedHomOnGenerators A values relationsHold i =
+        cong (λ f → fst f (var i))
+        (inducedHom∘quotientHom (Polynomials n) relationsIdeal A freeHom isInKernel)
+        where
+          -- TODO: this where block is duplicated
+          freeHom : CommAlgebraHom (Polynomials n) A
+          freeHom = freeInducedHom A values
+          isInKernel :   fst (generatedIdeal (Polynomials n) relation)
+                       ⊆ fst (kernel (Polynomials n) A freeHom)
+          isInKernel = inclOfFGIdeal
+                         (CommAlgebra→CommRing (Polynomials n))
+                         relation
+                         (kernel (Polynomials n) A freeHom)
+                         relationsHold
 
       unique :
              {A : CommAlgebra R ℓ}
@@ -150,12 +163,13 @@ module _ {R : CommRing ℓ} where
           (inducedHom A values relationsHold)
           f
           (sym (
-           f'     ≡⟨ sym (inv f') ⟩
+           f'                                    ≡⟨ sym (inv f') ⟩
            freeInducedHom A (evaluateAt A f')    ≡⟨ cong (freeInducedHom A)
                                                          (funExt hasCorrectValues) ⟩
-           freeInducedHom A values               ≡⟨ cong (freeInducedHom A) refl ⟩
+           freeInducedHom A values               ≡⟨ cong (freeInducedHom A)
+                                                         (sym (funExt (inducedHomOnGenerators A values relationsHold))) ⟩
            freeInducedHom A (evaluateAt A iHom') ≡⟨ inv iHom' ⟩
-           iHom' ∎))
+           iHom'                                 ∎))
         where
           {-
                      Poly n
@@ -229,7 +243,7 @@ module _ {R : CommRing ℓ} where
                   (λ i → isSetCommAlgebra A
                           (evPoly A (relation i) x)
                           (0a (snd A))))
-                refl
+                (funExt (inducedHomOnGenerators A (fst b) (snd b)))
       Iso.leftInv (FPHomIso {A}) =
         λ a → Σ≡Prop (λ f → isPropIsCommAlgebraHom {ℓ} {R} {ℓ} {ℓ} {FPAlgebra} {A} f)
                  λ i → fst (unique {A}
@@ -444,3 +458,7 @@ module Instances (R : CommRing ℓ) where
         toFrom : toA ∘a fromA ≡ idCAlgHom R/⟨xs⟩
         toFrom = injectivePrecomp (initialCAlg R) ⟨xs⟩ R/⟨xs⟩ (toA ∘a fromA) (idCAlgHom R/⟨xs⟩)
                    (isContr→isProp (initialityContr R R/⟨xs⟩) _ _)
+
+  module _ {m : ℕ} (x : ⟨ R ⟩) where
+    R/⟨x⟩FP : FinitePresentation (initialCAlg R / generatedIdeal (initialCAlg R) (replicateFinVec 1 x))
+    R/⟨x⟩FP = R/⟨xs⟩FP (replicateFinVec 1 x)

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -210,19 +210,15 @@ module _ {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where abstr
     I                  ∎
 
 
-module _ where abstract
-  private
-    module _ (R : CommRing ℓ) where abstract
-      open CommRingStr (snd R)
-      lemma : (y : (fst R)) → y ≡ y - 0r
-      lemma = solve R
+module _
+  {R : CommRing ℓ}
+  {A : CommAlgebra R ℓ}
+  {I : IdealsIn A}
+  where abstract
 
-  isZeroFromIdeal : {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
-                    → (x : ⟨ A ⟩) → x ∈ (fst I) → fst (quotientHom A I) x ≡ CommAlgebraStr.0a (snd (A / I))
-  isZeroFromIdeal {A = A} {I = I} x x∈I = eq/ x 0a (subst (λ y → y ∈ (fst I)) step x∈I )
+  isZeroFromIdeal : (x : ⟨ A ⟩) → x ∈ (fst I) → fst (quotientHom A I) x ≡ CommAlgebraStr.0a (snd (A / I))
+  isZeroFromIdeal x x∈I = eq/ x 0a (subst (_∈ fst I) (step x) x∈I )
     where
       open CommAlgebraStr (snd A)
-      step : x ≡ x - 0a
-      step = lemma (CommAlgebra→CommRing A) x
-      0' : ⟨ A / I ⟩
-      0' = fst (quotientHom A I) 0a
+      step : (x : ⟨ A ⟩) → x ≡ x - 0a
+      step = solve (CommAlgebra→CommRing A)

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -142,6 +142,11 @@ module _ {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where abstr
   pres- (snd (inducedHom B ϕ kernel⊆I)) = elimProp (λ _ → isSetCommAlgebra B _ _) (pres- (snd ϕ))
   pres⋆ (snd (inducedHom B ϕ kernel⊆I)) = λ r → elimProp (λ _ → isSetCommAlgebra B _ _) (pres⋆ (snd ϕ) r)
 
+  inducedHom∘quotientHom : (B : CommAlgebra R ℓ) (ϕ : CommAlgebraHom A B)
+               → (I⊆kerϕ : fst I ⊆ fst (kernel A B ϕ))
+               → inducedHom B ϕ I⊆kerϕ ∘a quotientHom A I ≡ ϕ
+  inducedHom∘quotientHom B ϕ I⊆kerϕ = Σ≡Prop (isPropIsCommAlgebraHom {M = A} {N = B}) (funExt (λ a → refl))
+
   injectivePrecomp : (B : CommAlgebra R ℓ) (f g : CommAlgebraHom (A / I) B)
                      → f ∘a (quotientHom A I) ≡ g ∘a (quotientHom A I)
                      → f ≡ g

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -30,6 +30,13 @@ private
   variable
     ℓ : Level
 
+{-
+  The definition of the quotient algebra (_/_ below) is marked abstract to avoid
+  long type checking times. All other definitions that need to "look into" this
+  abstract definition must be in the same abstract scope. Note that anonymous
+  modules share an abstract scope but named modules do not.
+-}
+
 module _ {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where abstract
   open CommRingStr {{...}} hiding (_-_; -_; ·IdL ; ·DistR+) renaming (_·_ to _·R_; _+_ to _+R_)
   open CommAlgebraStr {{...}}

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -210,13 +210,13 @@ module _ {R : CommRing ℓ} (A : CommAlgebra R ℓ) (I : IdealsIn A) where abstr
     I                  ∎
 
 
-private
-  module _ (R : CommRing ℓ) where abstract
-    open CommRingStr (snd R)
-    lemma : (y : (fst R)) → y ≡ y - 0r
-    lemma = solve R
-
 module _ where abstract
+  private
+    module _ (R : CommRing ℓ) where abstract
+      open CommRingStr (snd R)
+      lemma : (y : (fst R)) → y ≡ y - 0r
+      lemma = solve R
+
   isZeroFromIdeal : {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
                     → (x : ⟨ A ⟩) → x ∈ (fst I) → fst (quotientHom A I) x ≡ CommAlgebraStr.0a (snd (A / I))
   isZeroFromIdeal {A = A} {I = I} x x∈I = eq/ x 0a (subst (λ y → y ∈ (fst I)) step x∈I )

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -216,7 +216,7 @@ private
     lemma : (y : (fst R)) → y ≡ y - 0r
     lemma = solve R
 
-abstract
+module _ where abstract
   isZeroFromIdeal : {R : CommRing ℓ} {A : CommAlgebra R ℓ} {I : IdealsIn A}
                     → (x : ⟨ A ⟩) → x ∈ (fst I) → fst (quotientHom A I) x ≡ CommAlgebraStr.0a (snd (A / I))
   isZeroFromIdeal {A = A} {I = I} x x∈I = eq/ x 0a (subst (λ y → y ∈ (fst I)) step x∈I )


### PR DESCRIPTION
This PR declares almost all definitions in `Cubical.Algebra.CommAlgebra.QuotientAlgebra` as `abstract` in an attempt to reduce long type checking times.

`FPAlgebra` (the only module that uses `QuotientAlgebra` so far) had to be slightly adjusted too. A witness `inducedHom∘quotientHom` had to be added to `QuotientAlgebra` for an equality that was a definitional equality before.

This replaces #856.