### PR TITLE
Naive injectivity implies isEmbedding even if only B is a set

### DIFF
--- a/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
+++ b/Cubical/Algebra/CommRing/Localisation/UniversalProperty.agda
@@ -390,7 +390,7 @@ module _ (R' : CommRing ℓ) (S' : ℙ (fst R')) (SMultClosedSubset : isMultClos
   S⁻¹R≃A = fst χ , isEmbedding×isSurjection→isEquiv (Embχ , Surχ)
    where
    Embχ : isEmbedding (fst χ)
-   Embχ = injEmbedding squash/ Aset (ker≡0→inj λ {x} → kerχ≡0 x)
+   Embχ = injEmbedding Aset (ker≡0→inj λ {x} → kerχ≡0 x)
     where
     kerχ≡0 : (r/s : S⁻¹R) → fst χ r/s ≡ 0a → r/s ≡ 0ₗ
     kerχ≡0 = SQ.elimProp (λ _ → isPropΠ λ _ → squash/ _ _) kerχ≡[]

--- a/Cubical/Categories/Functor/Properties.agda
+++ b/Cubical/Categories/Functor/Properties.agda
@@ -166,7 +166,7 @@ module _ {F : Functor C D} where
 
   isFull+Faithful→isFullyFaithful : isFull F → isFaithful F → isFullyFaithful F
   isFull+Faithful→isFullyFaithful full faith x y = isEmbedding×isSurjection→isEquiv
-    (injEmbedding (C .isSetHom) (D .isSetHom) (faith x y _ _) , full x y)
+    (injEmbedding (D .isSetHom) (faith x y _ _) , full x y)
 
 
   -- Fully-faithful functor is conservative

--- a/Cubical/Data/Fin/LehmerCode.agda
+++ b/Cubical/Data/Fin/LehmerCode.agda
@@ -106,7 +106,7 @@ punchOut∘In {n} i j | inr (i′ , _) with n
 isEquivPunchOut : {i : Fin (suc n)} → isEquiv (punchOut i)
 isEquivPunchOut {i = i} = isEmbedding×isSurjection→isEquiv (isEmbPunchOut , isSurPunchOut) where
   isEmbPunchOut : isEmbedding (punchOut i)
-  isEmbPunchOut = injEmbedding isSetFinExcept isSetFin λ {_} {_} → punchOut-injective i _ _
+  isEmbPunchOut = injEmbedding isSetFin λ {_} {_} → punchOut-injective i _ _
   isSurPunchOut : isSurjection (punchOut i)
   isSurPunchOut b = ∥_∥₁.∣ _ , (punchOut∘In i b) ∣₁
 

--- a/Cubical/Data/Fin/Properties.agda
+++ b/Cubical/Data/Fin/Properties.agda
@@ -141,7 +141,7 @@ private
   expand×Emb : ∀ k → isEmbedding (expand× {k})
   expand×Emb 0 = Empty.rec ∘ ¬Fin0 ∘ fst
   expand×Emb (suc k)
-    = injEmbedding (isSetΣ isSetFin (λ _ → isSetℕ)) isSetℕ (expand×Inj k)
+    = injEmbedding isSetℕ (expand×Inj k)
 
 -- A Residue is a family of types representing evidence that a
 -- natural is congruent to a value of a finite type.
@@ -492,7 +492,7 @@ factorEquiv {suc n} {m} = intro , isEmbedding×isSurjection→isEquiv (isEmbeddi
     io′≡ip′ : (fst o , toℕ (snd o)) ≡ (fst p , toℕ (snd p))
     io′≡ip′ = expand×Inj _ (cong fst io≡ip)
   isEmbeddingIntro : isEmbedding intro
-  isEmbeddingIntro = injEmbedding (isSet× isSetFin isSetFin) isSetFin intro-injective
+  isEmbeddingIntro = injEmbedding isSetFin intro-injective
 
   elimF : ∀ nm → fiber intro nm
   elimF nm = ((nn , nn<n) , (mm , mm<m)) , toℕ-injective (reduce n (toℕ nm) .snd) where

--- a/Cubical/Data/FinSet/Cardinality.agda
+++ b/Cubical/Data/FinSet/Cardinality.agda
@@ -597,7 +597,7 @@ injBool→FinProp true false p = Empty.rec (snotz (cong (card ∘ fst) p))
 injBool→FinProp false true p = Empty.rec (znots (cong (card ∘ fst) p))
 
 isEmbeddingBool→FinProp : isEmbedding (Bool→FinProp {ℓ = ℓ})
-isEmbeddingBool→FinProp = injEmbedding isSetBool isSetFinProp (λ {x} {y} → injBool→FinProp x y)
+isEmbeddingBool→FinProp = injEmbedding isSetFinProp (λ {x} {y} → injBool→FinProp x y)
 
 card-case : (P : FinProp ℓ) → {n : ℕ} → card (P .fst) ≡ n → Σ[ x ∈ Bool ] Bool→FinProp x ≡ P
 card-case P {n = 0} p = false , FinProp≡ (𝟘 , isProp⊥*) P .fst (cong fst (sym (card≡0 {X = P .fst} p)))

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -150,14 +150,14 @@ isEmbedding≡hasPropFibers
 -- implies isEmbedding as long as B is an h-set.
 module _
   {f : A → B}
-  (iSB : isSet B)
+  (isSetB : isSet B)
   (inj : ∀{w x} → f w ≡ f x → w ≡ x)
   where
 
   injective→hasPropFibers : hasPropFibers f
   injective→hasPropFibers y (x , fx≡y) (x' , fx'≡y) =
     Σ≡Prop
-      (λ _ → iSB _ _)
+      (λ _ → isSetB _ _)
       (inj (fx≡y ∙ sym (fx'≡y)))
 
   injEmbedding : isEmbedding f

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -55,24 +55,7 @@ isEmbedding→Inj
 isEmbedding→Inj {f = f} embb w x p
   = equiv-proof (embb w x) p .fst .fst
 
--- If A and B are h-sets, then injective functions between
--- them are embeddings.
---
--- Note: It doesn't appear to be possible to omit either of
--- the `isSet` hypotheses.
-injEmbedding
-  : {f : A → B}
-  → isSet A → isSet B
-  → (∀{w x} → f w ≡ f x → w ≡ x)
-  → isEmbedding f
-injEmbedding {f = f} iSA iSB inj w x
-  = isoToIsEquiv (iso (cong f) inj sect retr)
-  where
-  sect : section (cong f) inj
-  sect p = iSB (f w) (f x) _ p
-
-  retr : retract (cong f) inj
-  retr p = iSA w x _ p
+-- The converse implication holds if B is an h-set, see injEmbedding below.
 
 
 -- If `f` is an embedding, we'd expect the fibers of `f` to be
@@ -162,6 +145,23 @@ isEmbedding≡hasPropFibers
            hasPropFibers→isEmbedding
            (λ _ → hasPropFibersIsProp _ _)
            (λ _ → isPropIsEmbedding _ _))
+
+-- We use the characterization as hasPropFibers to show that naive injectivity
+-- implies isEmbedding as long as B is an h-set.
+module _
+  {f : A → B}
+  (iSB : isSet B)
+  (inj : ∀{w x} → f w ≡ f x → w ≡ x)
+  where
+
+  injective→hasPropFibers : hasPropFibers f
+  injective→hasPropFibers y (x , fx≡y) (x' , fx'≡y) =
+    Σ≡Prop
+      (λ _ → iSB _ _)
+      (inj (fx≡y ∙ sym (fx'≡y)))
+
+  injEmbedding : isEmbedding f
+  injEmbedding = hasPropFibers→isEmbedding injective→hasPropFibers
 
 isEquiv→hasPropFibers : isEquiv f → hasPropFibers f
 isEquiv→hasPropFibers e b = isContr→isProp (equiv-proof e b)

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -187,24 +187,6 @@ isEmbedding→Injection :
   ∀ x → (a (f x) ≡ a (g x)) ≡ (f x ≡ g x)
 isEmbedding→Injection a e {f = f} {g} x = sym (ua (cong a , e (f x) (g x)))
 
--- if `f` has a retract, then `cong f` has, as well. If `B` is a set, then `cong f`
--- further has a section, making `f` an embedding.
-module _ {f : A → B} (retf : hasRetract f) where
-  open Σ retf renaming (fst to g ; snd to ϕ)
-
-  congRetract : f w ≡ f x → w ≡ x
-  congRetract {w = w} {x = x} p = sym (ϕ w) ∙∙ cong g p ∙∙ ϕ x
-
-  isRetractCongRetract : retract (cong {x = w} {y = x} f) congRetract
-  isRetractCongRetract p = transport (PathP≡doubleCompPathˡ _ _ _ _) (λ i j → ϕ (p j) i)
-
-  hasRetract→hasRetractCong : hasRetract (cong {x = w} {y = x} f)
-  hasRetract→hasRetractCong = congRetract , isRetractCongRetract
-
-  retractableIntoSet→isEmbedding : isSet B → isEmbedding f
-  retractableIntoSet→isEmbedding setB w x =
-    isoToIsEquiv (iso (cong f) congRetract (λ _ → setB _ _ _ _) (hasRetract→hasRetractCong .snd))
-
 Embedding-into-Discrete→Discrete : A ↪ B → Discrete B → Discrete A
 Embedding-into-Discrete→Discrete (f , isEmbeddingF) _≟_ x y with f x ≟ f y
 ... | yes p = yes (invIsEq (isEmbeddingF x y) p)

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -151,17 +151,26 @@ isEmbedding≡hasPropFibers
 module _
   {f : A → B}
   (isSetB : isSet B)
-  (inj : ∀{w x} → f w ≡ f x → w ≡ x)
   where
 
-  injective→hasPropFibers : hasPropFibers f
-  injective→hasPropFibers y (x , fx≡y) (x' , fx'≡y) =
-    Σ≡Prop
-      (λ _ → isSetB _ _)
-      (inj (fx≡y ∙ sym (fx'≡y)))
+  module _
+    (inj : ∀{w x} → f w ≡ f x → w ≡ x)
+    where
 
-  injEmbedding : isEmbedding f
-  injEmbedding = hasPropFibers→isEmbedding injective→hasPropFibers
+    injective→hasPropFibers : hasPropFibers f
+    injective→hasPropFibers y (x , fx≡y) (x' , fx'≡y) =
+      Σ≡Prop
+        (λ _ → isSetB _ _)
+        (inj (fx≡y ∙ sym (fx'≡y)))
+
+    injEmbedding : isEmbedding f
+    injEmbedding = hasPropFibers→isEmbedding injective→hasPropFibers
+
+  retractableIntoSet→isEmbedding : hasRetract f → isEmbedding f
+  retractableIntoSet→isEmbedding (g , ret) = injEmbedding inj
+    where
+    inj : f w ≡ f x → w ≡ x
+    inj {w = w} {x = x} p = sym (ret w) ∙∙ cong g p ∙∙ ret x
 
 isEquiv→hasPropFibers : isEquiv f → hasPropFibers f
 isEquiv→hasPropFibers e b = isContr→isProp (equiv-proof e b)

--- a/Cubical/HITs/SetQuotients/EqClass.agda
+++ b/Cubical/HITs/SetQuotients/EqClass.agda
@@ -124,7 +124,7 @@ module _
       (λ x y q → Prop.rec (squash/ _ _) (λ r → eq/ _ _ r) (inj/→∥' x y q))
 
   isEmbedding/→∥ : isEmbedding /→∥
-  isEmbedding/→∥ = injEmbedding squash/ (isSet∥ X R) (λ {x} {y} → inj/→∥ x y)
+  isEmbedding/→∥ = injEmbedding (isSet∥ X R) (λ {x} {y} → inj/→∥ x y)
 
   surj/→∥ : (P : X ∥ R) → ((x , _) : Σ[ x ∈ X ] ((a : X) → P .fst a .fst ≃ ∥ R a x ∥₁)) → ∥R∥ x ≡ P
   surj/→∥ P (x , p) i .fst a .fst = ua (p a) (~ i)


### PR DESCRIPTION
This PR removes an unnecessary assumption from `injEmbedding` in `Cubical.Functions.Embedding`. The naive definition of injectivity, `∀{w x} → f w ≡ f x → w ≡ x`, is already sufficient for `f` to be an embedding if `B` is a set, we don't need that `A` is a set.

I also deleted `retractableIntoSet→isEmbedding`, because it shows the same thing under the stronger assumption that `f` has a retract.