### PR TITLE
Bump cabal version bound on base

### DIFF
--- a/cubical-utils.cabal
+++ b/cubical-utils.cabal
@@ -10,5 +10,5 @@ executable Everythings
   hs-source-dirs:   .
   main-is:          Everythings.hs
   default-language: Haskell2010
-  build-depends:      base      >= 4.9.0.0 && < 4.17
+  build-depends:      base      >= 4.9.0.0 && < 4.18
                     , directory >= 1.0.0.0 && < 1.4


### PR DESCRIPTION
I'm fairly sure this is what's causing the CI failure on #845, but I don't have GHC 9.4 on my machine, so I'm abusing CI to test it :wink: 