### PR TITLE
More on images

### DIFF
--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -29,7 +29,7 @@ open import Cubical.Data.Sigma
 private
   variable
     ℓ ℓ' ℓ'' : Level
-    A B : Type ℓ
+    A B C : Type ℓ
     f h : A → B
     w x : A
     y z : B
@@ -258,6 +258,10 @@ Subset≡Embedding = ua Subset≃Embedding
 isEmbedding-∘ : isEmbedding f → isEmbedding h → isEmbedding (f ∘ h)
 isEmbedding-∘ {f = f} {h = h} Embf Embh w x
   = compEquiv (cong h , Embh w x) (cong f , Embf (h w) (h x)) .snd
+
+compEmbedding : (B ↪ C) → (A ↪ B) → (A ↪ C)
+(compEmbedding (g , _ ) (f , _ )).fst = g ∘ f
+(compEmbedding (_ , g↪) (_ , f↪)).snd = isEmbedding-∘ g↪ f↪
 
 isEmbedding→embedsFibersIntoSingl
   : isEmbedding f

--- a/Cubical/Functions/Image.agda
+++ b/Cubical/Functions/Image.agda
@@ -46,7 +46,8 @@ module _ (f : A → B) where
              → ∣ x , Σ≡Prop isPropIsInImage fx≡y ∣₁)
            y∈im
 
-
+  imageFactorization : fst imageInclusion ∘ restrictToImage ≡ f
+  imageFactorization = refl
 
 {-
   The following is also true for a general modality in place of ∥_∥₁,
@@ -73,3 +74,9 @@ module _ (f : A ↪ B) where
                  (equivToIso (restrictionHasSameFibers y))
                  (isEmbedding→hasPropFibers (snd f) (fst y)) ) ,
       (isSurjectionImageRestriction (fst f)))
+
+{-
+  This is the extension to a 'iff', which is also a general modal fact.
+-}
+isEmbeddingFromIsEquivToImage : (f : A → B) → isEquiv (restrictToImage f) → isEmbedding f
+isEmbeddingFromIsEquivToImage f isEquiv-r = isEmbedding-∘ (snd (imageInclusion f)) (isEquiv→isEmbedding isEquiv-r)

--- a/Cubical/Functions/Image.agda
+++ b/Cubical/Functions/Image.agda
@@ -76,7 +76,7 @@ module _ (f : A ↪ B) where
       (isSurjectionImageRestriction (fst f)))
 
 {-
-  This is the extension to a 'iff', which is also a general modal fact.
+  This is the extension to an 'iff', which is also a general modal fact.
 -}
 isEmbeddingFromIsEquivToImage : (f : A → B) → isEquiv (restrictToImage f) → isEmbedding f
 isEmbeddingFromIsEquivToImage f isEquiv-r = isEmbedding-∘ (snd (imageInclusion f)) (isEquiv→isEmbedding isEquiv-r)


### PR DESCRIPTION
This PR shows, that a map is an embedding iff the restriction to its image is an equivalence.
Also adds a bundled version of the composition of embeddings (not used, but that's what I would have found sooner).