### PR TITLE
Cubical subtyping demo: get rid of inS/outS

### DIFF
--- a/Cubical/Algebra/CommAlgebra/Localisation.agda
+++ b/Cubical/Algebra/CommAlgebra/Localisation.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification -vtc.conv.coerce:30 #-}
 module Cubical.Algebra.CommAlgebra.Localisation where
 
 open import Cubical.Foundations.Prelude
@@ -76,7 +76,7 @@ module AlgLoc (R' : CommRing ℓ)
                     (S/1⊆S⁻¹Rˣ s s∈S')
 
 
- S⁻¹RHasAlgUniversalProp : hasLocAlgUniversalProp S⁻¹RAsCommAlg S⋆1⊆S⁻¹Rˣ
+ S⁻¹RHasAlgUniversalProp : hasLocAlgUniversalProp S⁻¹RAsCommAlg (λ x y → S⋆1⊆S⁻¹Rˣ x y)
  S⁻¹RHasAlgUniversalProp B' S⋆1⊆Bˣ = χᴬ , χᴬuniqueness
   where
   B = fromCommAlg B' .fst
@@ -131,7 +131,7 @@ module AlgLoc (R' : CommRing ℓ)
 
  -- an immediate corollary:
  isContrHomS⁻¹RS⁻¹R : isContr (CommAlgebraHom S⁻¹RAsCommAlg S⁻¹RAsCommAlg)
- isContrHomS⁻¹RS⁻¹R = S⁻¹RHasAlgUniversalProp S⁻¹RAsCommAlg S⋆1⊆S⁻¹Rˣ
+ isContrHomS⁻¹RS⁻¹R = S⁻¹RHasAlgUniversalProp S⁻¹RAsCommAlg λ x y → S⋆1⊆S⁻¹Rˣ x y
 
  S⁻¹RAlgCharEquiv : (A' : CommRing ℓ) (φ : CommRingHom R' A')
                   → PathToS⁻¹R  R' S' SMultClosedSubset A' φ
@@ -191,10 +191,10 @@ module AlgLocTwoSubsets (R' : CommRing ℓ)
                                               isContrS₁⁻¹R≅S₂⁻¹R
   where
   χ₁ : CommAlgebraHom S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg
-  χ₁ = S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg S₁⊆S₂⁻¹Rˣ .fst
+  χ₁ = S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg (λ x y → S₁⊆S₂⁻¹Rˣ x y) .fst
 
   χ₂ : CommAlgebraHom S₂⁻¹RAsCommAlg S₁⁻¹RAsCommAlg
-  χ₂ = S₂⁻¹RHasAlgUniversalProp S₁⁻¹RAsCommAlg S₂⊆S₁⁻¹Rˣ .fst
+  χ₂ = S₂⁻¹RHasAlgUniversalProp S₁⁻¹RAsCommAlg (λ x y → S₂⊆S₁⁻¹Rˣ x y) .fst
 
   χ₁∘χ₂≡id : χ₁ ∘a χ₂ ≡ idCommAlgebraHom _
   χ₁∘χ₂≡id = isContr→isProp isContrHomS₂⁻¹RS₂⁻¹R _ _
@@ -223,13 +223,13 @@ module AlgLocTwoSubsets (R' : CommRing ℓ)
    uniqueness : (φ : CommAlgebraEquiv S₁⁻¹RAsCommAlg S₂⁻¹RAsCommAlg) → center ≡ φ
    uniqueness φ = Σ≡Prop (λ _ → isPropIsAlgebraHom _ _ _ _)
                          (equivEq (cong fst
-                           (S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg S₁⊆S₂⁻¹Rˣ .snd
+                           (S₁⁻¹RHasAlgUniversalProp S₂⁻¹RAsCommAlg (λ x y → S₁⊆S₂⁻¹Rˣ x y) .snd
                              (AlgebraEquiv→AlgebraHom φ))))
 
 
  isPropS₁⁻¹R≡S₂⁻¹R  : isProp (S₁⁻¹RAsCommAlg ≡ S₂⁻¹RAsCommAlg)
  isPropS₁⁻¹R≡S₂⁻¹R S₁⁻¹R≡S₂⁻¹R  =
-   isContr→isProp (isContrS₁⁻¹R≡S₂⁻¹R  S₁⊆S₂⁻¹Rˣ S₂⊆S₁⁻¹Rˣ) S₁⁻¹R≡S₂⁻¹R
+   isContr→isProp (isContrS₁⁻¹R≡S₂⁻¹R S₁⊆S₂⁻¹Rˣ S₂⊆S₁⁻¹Rˣ) S₁⁻¹R≡S₂⁻¹R
     where
     S₁⊆S₂⁻¹Rˣ : ∀ s₁ → s₁ ∈ S₁ → s₁ ⋆ 1a ∈ S₂⁻¹Rˣ
     S₁⊆S₂⁻¹Rˣ s₁ s₁∈S₁ =
@@ -240,7 +240,6 @@ module AlgLocTwoSubsets (R' : CommRing ℓ)
     S₂⊆S₁⁻¹Rˣ s₂ s₂∈S₂ =
       transport (λ i → _⋆_ ⦃ (sym S₁⁻¹R≡S₂⁻¹R) i .snd ⦄ s₂ (1a ⦃ (sym S₁⁻¹R≡S₂⁻¹R) i .snd ⦄)
                      ∈ (CommAlgebra→CommRing ((sym S₁⁻¹R≡S₂⁻¹R) i)) ˣ) (S₂⋆1⊆S₂⁻¹Rˣ s₂ s₂∈S₂)
-
 
 
 -- A crucial result for the construction of the structure sheaf

--- a/Cubical/Codata/M.agda
+++ b/Cubical/Codata/M.agda
@@ -24,9 +24,7 @@ module Helpers where
   compPathD : {ℓ ℓ' : _} {X : Type ℓ} (F : X → Type ℓ') {A B C : X} (P : A ≡ B) (Q : B ≡ C)
               → ∀ {x y z} → (\ i → F (P i)) [ x ≡ y ] → (\ i → F (Q i)) [ y ≡ z ] → (\ i → F ((P ∙ Q) i)) [ x ≡ z ]
   compPathD F {A = A} P Q {x} p q i =
-     comp (\ j → F (hfill (λ j → \ { (i = i0) → A ; (i = i1) → Q j })
-                          (inS (P i))
-                          j))
+     comp (\ j → F (hfill (λ j → \ { (i = i0) → A ; (i = i1) → Q j }) (P i) j))
           (λ j → \ { (i = i0) → x; (i = i1) → q j })
           (p i)
 

--- a/Cubical/Codata/M/Bisimilarity.agda
+++ b/Cubical/Codata/M/Bisimilarity.agda
@@ -65,7 +65,7 @@ module _ {X : Type₀} {C : IxCont X} where
   -- We predefine `u'` so that Agda will agree that `contr-T-fst` is productive.
   private
     module Tails x a φ (u : Partial φ (T {x} a)) y (p : C .snd x (hcomp (λ i .o → u o .snd .head≈ i) (a .head)) y) where
-      q = transp (\ i → C .snd x (hfill (\ i o → u o .snd .head≈ i) (inS (a .head)) (~ i)) y) i0 p
+      q = transp (\ i → C .snd x (hfill (\ i o → u o .snd .head≈ i) (a .head) (~ i)) y) i0 p
       a' = a .tails y q
       u' : Partial φ (T a')
       u' (φ = i1) = u 1=1 .fst .tails y p
@@ -82,7 +82,7 @@ module _ {X : Type₀} {C : IxCont X} where
   -- the main argument of transport, which is guardedness-preserving.
   {-# TERMINATING #-}
   contr-T-snd : ∀ x a φ → (u : Partial φ (T {x} a)) → a ≈ contr-T-fst x a φ u
-  contr-T-snd x a φ u .head≈ i = hfill (λ { i (φ = i1) → u 1=1 .snd .head≈ i }) (inS (a .head)) i
+  contr-T-snd x a φ u .head≈ i = hfill (λ { i (φ = i1) → u 1=1 .snd .head≈ i }) (a .head) i
   contr-T-snd x a φ u .tails≈ y pa pb peq =
     let r = contr-T-snd y (a .tails y pa) φ (\ { (φ = i1) → u 1=1 .fst .tails y pb , u 1=1 .snd .tails≈ y pa pb peq }) in
       transport (\ i → a .tails y pa
@@ -100,7 +100,7 @@ module _ {X : Type₀} {C : IxCont X} where
   contr-T-φ-fst x a u i .head = u 1=1 .fst .head
   contr-T-φ-fst x a u i .tails y p
    = let
-        q = (transp (\ i → C .snd x (hfill (\ i o → u o .snd .head≈ i) (inS (a .head)) (~ i)) y) i0 p)
+        q = (transp (\ i → C .snd x (hfill (\ i o → u o .snd .head≈ i) (a .head) (~ i)) y) i0 p)
       in contr-T-φ-fst y (a .tails y q)
                        (\ o → u o .fst .tails y p
                             , u o .snd .tails≈ y q p \ j → transp (\ i → C .snd x (u 1=1 .snd .head≈ (~ i ∨ j)) y) j p)
@@ -135,7 +135,7 @@ module _ {X : Type₀} {C : IxCont X} where
                         , u _ .snd .tails≈ y (transp (λ k → C .snd x (u _ .snd .head≈ (~ k ∧ l)) y) (~ l) (peq l)) pb
                                \ j → lemma (C .snd x (u 1=1 .fst .head) y) (λ h → C .snd x (eqh h) y) pa pb peq l j)
                    z)
-           (transpFill {A = F i0} i0 (\ i → inS (F i)) u0 l)
+           (transpFill {A = F i0} i0 (\ i → F i) u0 l)
            (u _ .snd .tails≈ y pa pb peq))
          r
          i

--- a/Cubical/Core/Glue.agda
+++ b/Cubical/Core/Glue.agda
@@ -71,7 +71,7 @@ private
     -- Glue can be seen as a subtype of Type that, at φ, is definitionally equal to the left type
     -- of the given equivalences.
     Glue-S : Type ℓ' [ φ ↦ T ]
-    Glue-S = inS (Glue A Te)
+    Glue-S = Glue A Te
 
     -- Which means partial elements of T are partial elements of Glue
     coeT→G :
@@ -136,4 +136,4 @@ private
     -- transport in Glue reduces to transport in A + the application of the equivalences in forward and backward
     -- direction.
     transp-S : (t0 : T0) → T1 [ i1 ↦ (λ _ → invEq e1 (transportA (equivFun e0 t0))) ]
-    transp-S t0 = inS (transport (λ i → Glue (A i) (Te i)) t0)
+    transp-S t0 = transport (λ i → Glue (A i) (Te i)) t0

--- a/Cubical/Core/Primitives.agda
+++ b/Cubical/Core/Primitives.agda
@@ -9,16 +9,13 @@ module Cubical.Core.Primitives where
 
 open import Agda.Builtin.Cubical.Path public
 open import Agda.Builtin.Cubical.Sub public
-  renaming ( inc to inS
-           ; primSubOut to outS
-           )
+  renaming ( primSubOut to outS )
 open import Agda.Primitive.Cubical public
   renaming ( primIMin       to _∧_  -- I → I → I
            ; primIMax       to _∨_  -- I → I → I
            ; primINeg       to ~_   -- I → I
            ; isOneEmpty     to empty
            ; primComp       to comp
-           ; primHComp      to hcomp
            ; primTransp     to transp
            ; itIsOne        to 1=1 )
 
@@ -38,6 +35,9 @@ open import Agda.Primitive public
            ; Set   to Type
            ; Setω  to Typeω )
 open import Agda.Builtin.Sigma public
+
+hcomp : ∀ {ℓ} {A : Type ℓ} {φ} (u : I → Partial φ A) (u0 : Sub A φ (u i0)) → Sub A φ (u i1)
+hcomp u u0 = primHComp u u0
 
 -- This file document the Cubical Agda primitives. The primitives
 -- themselves are bound by the Agda files imported above.
@@ -174,8 +174,8 @@ hfill : {A : Type ℓ}
         (i : I) → A
 hfill {φ = φ} u u0 i =
   hcomp (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
-                 ; (i = i0) → outS u0 })
-        (outS u0)
+                 ; (i = i0) → u0 })
+        (outS u0) -- want ext at φ∨i, have ext at φ, can't coerce
 
 -- Heterogeneous composition can defined as in CHM, however we use the
 -- builtin one as it doesn't require u0 to be a cubical subtype. This
@@ -200,8 +200,8 @@ fill : (A : ∀ i → Type (ℓ' i))
 fill A {φ = φ} u u0 i =
   comp (λ j → A (i ∧ j))
        (λ j → λ { (φ = i1) → u (i ∧ j) 1=1
-                ; (i = i0) → outS u0 })
-       (outS u0)
+                ; (i = i0) → u0 })
+       u0
 
 -- Σ-types
 infix 2 Σ-syntax

--- a/Cubical/Data/Equality.agda
+++ b/Cubical/Data/Equality.agda
@@ -204,11 +204,11 @@ isPropIsContr (a0 , p0) (a1 , p1) j =
   ( eqToPath (p0 a1) j ,
     hcomp (λ i → λ { (j = i0) →  λ x → pathToEq-eqToPath (p0 x) i
                    ; (j = i1) →  λ x → pathToEq-eqToPath (p1 x) i })
-          (λ x → pathToEq (λ i → hcomp (λ k → λ { (i = i0) → eqToPath (p0 a1) j
+          (inS (λ x → pathToEq (λ i → hcomp (λ k → λ { (i = i0) → eqToPath (p0 a1) j
                                                 ; (i = i1) → eqToPath (p0 x) (j ∨ k)
                                                 ; (j = i0) → eqToPath (p0 x) (i ∧ k)
                                                 ; (j = i1) → eqToPath (p1 x) i })
-                                       (eqToPath (p0 (eqToPath (p1 x) i)) j))))
+                                       (eqToPath (p0 (eqToPath (p1 x) i)) j)))))
 
 -- We now prove that isEquiv is a proposition
 isPropIsEquiv : {A B : Type ℓ} {f : A → B} (h1 h2 : isEquiv f) → Path _ h1 h2

--- a/Cubical/Data/FinData/Properties.agda
+++ b/Cubical/Data/FinData/Properties.agda
@@ -63,7 +63,7 @@ inj-toℕ {ℕsuc n}  {zero} {suc l} x = ⊥.rec (ℕznots x)
 inj-toℕ {ℕsuc n} {suc k} {zero}   x = ⊥.rec (ℕsnotz x)
 inj-toℕ {ℕsuc n} {suc k} {suc l}  x = cong suc (inj-toℕ (injSuc x))
 
-inj-cong : {n : ℕ} → {k l : Fin n} → (p : toℕ k ≡ toℕ l) → cong toℕ (inj-toℕ p) ≡ p
+inj-cong : {n : ℕ} → {k l : Fin n} → (p : toℕ k ≡ toℕ l) → cong toℕ (inj-toℕ {k = k} {l} p) ≡ p
 inj-cong p = isSetℕ _ _ _ _
 
 isPropFin0 : isProp (Fin 0)

--- a/Cubical/Data/Int/MoreInts/BiInvInt/Base.agda
+++ b/Cubical/Data/Int/MoreInts/BiInvInt/Base.agda
@@ -153,7 +153,8 @@ fwd-sucPred (pos (suc n)) i j
                    ; (i = i1) → suc (fwd (pos n))
                    ; (j = i1) → suc-adj (fwd (pos n)) k i
                    })
-          (suc (sym-filler (pred-suc (fwd (pos n))) i j))
+          (inS (suc (sym-filler (pred-suc (fwd (pos n))) i j)))
+          -- overloaded constructors are my Achilles heel
 
 fwd-sucPred (negsuc n) i j
   = hcomp (λ k → λ { (j = i0) → fwd (negsuc n)

--- a/Cubical/Data/Queue/Untruncated2List.agda
+++ b/Cubical/Data/Queue/Untruncated2List.agda
@@ -104,7 +104,7 @@ module Untruncated2List {ℓ} (A : Type ℓ) (Aset : isSet A) where
          { (j = i0) → Q⟨ ++-assoc xs [ z ] (rev ys) i , [] ⟩
          ; (j = i1) → tilt xs (rev (rev ys)) z i
          })
-       (inS (flushEq' (xs ++ [ z ]) (rev ys) j))
+       (flushEq' (xs ++ [ z ]) (rev ys) j)
        i
 
    helper : I → Q

--- a/Cubical/Data/Sigma/Properties.agda
+++ b/Cubical/Data/Sigma/Properties.agda
@@ -230,7 +230,7 @@ leftInv (Σ-cong-iso-fst {A = A} {B = B} isom) (x , y) = ΣPathP (leftInv isom x
       coh i j = fill (λ k → B (α≡ρ i (~ k))) (λ k → (λ
         { (i = i0) → ctrP (~ k)
         ; (i = i1) → σ (~ k)
-        })) (inS b) (~ j)
+        })) b (~ j)
 
 Σ-cong-fst : (p : A ≡ A') → Σ A (B ∘ transport p) ≡ Σ A' B
 Σ-cong-fst {B = B} p i = Σ (p i) (B ∘ transp (λ j → p (i ∨ j)) i)

--- a/Cubical/Experiments/Problem.agda
+++ b/Cubical/Experiments/Problem.agda
@@ -83,31 +83,31 @@ test1 : ℤ
 test1 = winding2 (λ i j → surf j i)
 
 test2 : ℤ
-test2 = winding2 (λ i j → hcomp (λ _ → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test2 = winding2 (λ i j → hcomp (λ _ → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))
 
 test3 : ℤ
-test3 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) base)
+test3 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) S².base)
 
 test4 : ℤ
-test4 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) base)
+test4 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) S².base)
 
 test5 : ℤ
-test5 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) base)
+test5 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) S².base)
 
 test6 : ℤ
-test6 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) base)
+test6 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) S².base)
 
 test7 : ℤ
-test7 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → surf j k ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test7 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → surf j k ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))
 
 test8 : ℤ
-test8 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) (surf i j))
+test8 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) (S².surf i j))
 
 test9 : ℤ
-test9 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) (surf i j))
+test9 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) (S².surf i j))
 
 test10 : ℤ
-test10 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test10 = winding2 (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))
 
 
 
@@ -123,28 +123,28 @@ test1' : ℤ
 test1' = winding2' (λ i j → surf j i)
 
 test2' : ℤ
-test2' = winding2' (λ i j → hcomp (λ _ → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test2' = winding2' (λ i j → hcomp (λ _ → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))
 
 test3' : ℤ
-test3' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) base)
+test3' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) S².base)
 
 test4' : ℤ
-test4' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) base)
+test4' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) S².base)
 
 test5' : ℤ
-test5' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) base)
+test5' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) S².base)
 
 test6' : ℤ
-test6' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) base)
+test6' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) S².base)
 
 test7' : ℤ
-test7' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → surf j k ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test7' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → surf j k ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))
 
 test8' : ℤ
-test8' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) (surf i j))
+test8' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → surf k i ; (j = i1) → base}) (S².surf i j))
 
 test9' : ℤ
-test9' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) (surf i j))
+test9' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → base ; (i = i1) → base ; (j = i0) → base ; (j = i1) → surf k i}) (S².surf i j))
 
 test10' : ℤ
-test10' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (surf i j))
+test10' = winding2' (λ i j → hcomp (λ k → λ { (i = i0) → surf j k ; (i = i1) → base ; (j = i0) → base ; (j = i1) → base}) (S².surf i j))

--- a/Cubical/Foundations/CartesianKanOps.agda
+++ b/Cubical/Foundations/CartesianKanOps.agda
@@ -54,7 +54,7 @@ coei→j A i j a =
     (λ j → λ { (i = i0) → coe0→i A j a
              ; (i = i1) → coe1→i A j a
              })
-    (inS (coei→0 A i a))
+    (coei→0 A i a)
     j
 
 -- "squeeze"
@@ -125,8 +125,8 @@ fill1→i : ∀ {ℓ} (A : ∀ i → Type ℓ)
 fill1→i A {φ = φ} u u1 i =
   comp (λ j → A (i ∨ ~ j))
        (λ j → λ { (φ = i1) → u (i ∨ ~ j) 1=1
-                ; (i = i1) → outS u1 })
-       (outS u1)
+                ; (i = i1) → u1 })
+       u1
 
 filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
@@ -138,8 +138,8 @@ filli→0 : ∀ {ℓ} (A : ∀ i → Type ℓ)
 filli→0 A {φ = φ} u i ui =
   comp (λ j → A (i ∧ ~ j))
        (λ j → λ { (φ = i1) → u (i ∧ ~ j) 1=1
-                ; (i = i0) → outS ui })
-       (outS ui)
+                ; (i = i0) → ui })
+       ui
 
 filli→j : ∀ {ℓ} (A : ∀ i → Type ℓ)
        {φ : I}
@@ -154,7 +154,7 @@ filli→j A {φ = φ} u i ui j =
              ; (i = i0) → fill (\ i → A i) (\ i → u i) ui j
              ; (i = i1) → fill1→i A u ui j
              })
-    (inS (filli→0 A u i ui))
+    (filli→0 A u i ui)
     j
 
 -- We can reconstruct fill from hfill, coei→j, and the path coei→i ≡ id.
@@ -166,15 +166,15 @@ fill' : ∀ {ℓ} (A : I → Type ℓ)
        ---------------------------
        (i : I) → A i [ φ ↦ u i ]
 fill' A {φ = φ} u u0 i =
-  inS (hcomp (λ j → λ {(φ = i1) → coei→i A i (u i 1=1) j; (i = i0) → coei→i A i (outS u0) j}) t)
+  inS (hcomp (λ j → λ {(φ = i1) → coei→i A i (u i 1=1) j; (i = i0) → coei→i A i u0 j}) t)
   where
   t : A i
-  t = hfill {φ = φ} (λ j v → coei→j A j i (u j v)) (inS (coe0→i A i (outS u0))) i
+  t = hfill {φ = φ} (λ j v → coei→j A j i (u j v)) (coe0→i A i u0) i
 
 fill'-cap :  ∀ {ℓ} (A : I → Type ℓ)
              {φ : I}
              (u : ∀ i → Partial φ (A i))
              (u0 : A i0 [ φ ↦ u i0 ])
              ---------------------------
-             → outS (fill' A u u0 i0) ≡ outS (u0)
+             → (fill' A u u0 i0) ≡ (u0)
 fill'-cap A u u0 = refl

--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -38,7 +38,7 @@ lUnit-filler {x = x} p j k i =
                   ; (i = i1) → p (~ k ∨ j )
                   ; (k = i0) → p i
                -- ; (k = i1) → compPath-filler refl p j i
-                  }) (inS (p (~ k ∧ i ))) j
+                  }) (p (~ k ∧ i )) j
 
 lUnit : (p : x ≡ y) → p ≡ refl ∙ p
 lUnit p j i = lUnit-filler p i1 j i
@@ -59,7 +59,7 @@ rCancel-filler {x = x} p k j i =
                   ; (i = i1) → p (~ k ∧ ~ j)
                -- ; (j = i0) → compPath-filler p (p ⁻¹) k i
                   ; (j = i1) → x
-                  }) (inS (p (i ∧ ~ j))) k
+                  }) (p (i ∧ ~ j)) k
 
 rCancel : (p : x ≡ y) → p ∙ p ⁻¹ ≡ refl
 rCancel {x = x} p j i = rCancel-filler p i1 j i
@@ -72,7 +72,7 @@ rCancel-filler' {x = x} {y} p i j k =
       ; (k = i0) → x
       ; (k = i1) → p (~ i)
       })
-    (inS (p k))
+    (p k)
     (~ i)
 
 rCancel' : ∀ {ℓ} {A : Type ℓ} {x y : A} (p : x ≡ y) → p ∙ p ⁻¹ ≡ refl
@@ -127,7 +127,7 @@ assocP {A = A} {B = B} {C = C} p q r k i =
     comp (\ j' → hfill  (λ j → λ {
                      (i = i0) → A i0
                    ; (i = i1) → compPath-filler' (λ i₁ → B i₁) (λ i₁ → C i₁) (~ k) j })
-                     (inS (compPath-filler (λ i₁ → A i₁) (λ i₁ → B i₁) k i)) j')
+                     (compPath-filler (λ i₁ → A i₁) (λ i₁ → B i₁) k i) j')
      (λ j → λ
       { (i = i0) → p i0
       ; (i = i1) →
@@ -135,7 +135,7 @@ assocP {A = A} {B = B} {C = C} p q r k i =
             { (j = i0) → B k
             ; (j = i1) → C l
             ; (k = i1) → C (j ∧ l)
-            })) (inS (B ( j ∨ k)) ) j')
+            })) (B ( j ∨ k) ) j')
           (λ l → λ
             { (j = i0) → q k
             ; (j = i1) → r l
@@ -198,7 +198,7 @@ cong-∙∙-filler {A = A} f p q r k j i =
                    ; (j = i0) → f (doubleCompPath-filler p q r k i)
                    ; (i = i0) → f (p (~ k))
                    ; (i = i1) → f (r k) }))
-    (inS (f (q i)))
+    (f (q i))
     k
 
 cong-∙∙ : ∀ {B : Type ℓ} (f : A → B) (p : w ≡ x) (q : x ≡ y) (r : y ≡ z)
@@ -210,38 +210,38 @@ cong-∙ : ∀ {B : Type ℓ} (f : A → B) (p : x ≡ y) (q : y ≡ z)
 cong-∙ f p q = cong-∙∙ f refl p q
 
 hcomp-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
-               (h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
-               → (hcomp u (outS u0) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+               (h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → u0}) ])
+               → (hcomp u u0 ≡ h2 i1) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
 hcomp-unique {φ = φ} u u0 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
-                                                            ; (i = i1) → outS (h2 k) })
+                                                            ; (i = i1) → h2 k })
                                                    (outS u0))
 
 
 lid-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
-               (h1 h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
-               → (outS (h1 i1) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+               (h1 h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → u0}) ])
+               → (h1 i1 ≡ h2 i1) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
 lid-unique {φ = φ} u u0 h1 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
-                                                            ; (i = i0) → outS (h1 k)
-                                                            ; (i = i1) → outS (h2 k) })
+                                                            ; (i = i0) → h1 k
+                                                            ; (i = i1) → h2 k })
                                                    (outS u0))
 
 
 transp-hcomp : ∀ {ℓ} (φ : I) {A' : Type ℓ}
-                     (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A') ]) (let B = \ (i : I) → outS (A i))
+                     (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A') ]) (let B = \ (i : I) → A i)
                  → ∀ {ψ} (u : I → Partial ψ (B i0)) → (u0 : B i0 [ ψ ↦ u i0 ]) →
-                 (transp (\ i → B i) φ (hcomp u (outS u0)) ≡ hcomp (\ i o → transp (\ i → B i) φ (u i o)) (transp (\ i → B i) φ (outS u0)))
+                 (transp (\ i → B i) φ (hcomp u u0) ≡ hcomp (\ i o → transp (\ i → B i) φ (u i o)) (transp (\ i → B i) φ u0))
                    [ ψ ↦ (\ { (ψ = i1) → (\ i → transp (\ i → B i) φ (u i1 1=1))}) ]
-transp-hcomp φ A u u0 = inS (sym (outS (hcomp-unique
-               ((\ i o → transp (\ i → B i) φ (u i o))) (inS (transp (\ i → B i) φ (outS u0)))
-                 \ i → inS (transp (\ i → B i) φ (hfill u u0 i)))))
+transp-hcomp φ A u u0 = sym (hcomp-unique
+               ((\ i o → transp (\ i → B i) φ (u i o))) (transp (\ i → B i) φ u0)
+                 \ i → (transp (\ i → B i) φ (hfill u u0 i)))
   where
-    B = \ (i : I) → outS (A i)
+    B = \ (i : I) → A i
 
 
 hcomp-cong : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
                                      (u' : I → Partial φ A) → (u0' : A [ φ ↦ u' i0 ]) →
-             (ueq : ∀ i → PartialP φ (\ o → u i o ≡ u' i o)) → (outS u0 ≡ outS u0') [ φ ↦ (\ { (φ = i1) → ueq i0 1=1}) ]
-             → (hcomp u (outS u0) ≡ hcomp u' (outS u0')) [ φ ↦ (\ { (φ = i1) → ueq i1 1=1 }) ]
+             (ueq : ∀ i → PartialP φ (\ o → u i o ≡ u' i o)) → (u0 ≡ u0') [ φ ↦ (\ { (φ = i1) → ueq i0 1=1}) ]
+             → (hcomp u u0 ≡ hcomp u' u0') [ φ ↦ (\ { (φ = i1) → ueq i1 1=1 }) ]
 hcomp-cong u u0 u' u0' ueq 0eq = inS (\ j → hcomp (\ i o → ueq i o j) (outS 0eq j))
 
 
@@ -251,7 +251,7 @@ congFunct-filler {x = x} f p q i j z =
   hfill (λ k → λ { (i = i0) → f x
                  ; (i = i1) → f (q k)
                  ; (j = i0) → f (compPath-filler p q k i)})
-       (inS (f (p i)))
+       (f (p i))
        z
 
 congFunct : ∀ {ℓ} {B : Type ℓ} (f : A → B) (p : x ≡ y) (q : y ≡ z) → cong f (p ∙ q) ≡ cong f p ∙ cong f q
@@ -277,7 +277,7 @@ symDistr-filler : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ 
 symDistr-filler {A = A} {z = z} p q i j k =
   hfill (λ k → λ { (i = i0) → q (k ∨ j)
                  ; (i = i1) → p (~ k ∧ j) })
-       (inS (invSides-filler q (sym p) i j))
+       (invSides-filler q (sym p) i j)
        k
 
 symDistr : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : x ≡ y) (q : y ≡ z) → sym (p ∙ q) ≡ sym q ∙ sym p
@@ -287,27 +287,27 @@ symDistr p q i j = symDistr-filler p q j i i1
 -- due to size issues. But what we can write (compare to hfill) is:
 hcomp-equivFillerSub : {ϕ : I} → (p : I → Partial ϕ A) → (a : A [ ϕ ↦ p i0 ])
                      → (i : I)
-                     → A [ ϕ ∨ i ∨ ~ i ↦ (λ { (i = i0) → outS a
-                                            ; (i = i1) → hcomp (λ i → p (~ i)) (hcomp p (outS a))
+                     → A [ ϕ ∨ i ∨ ~ i ↦ (λ { (i = i0) → a
+                                            ; (i = i1) → hcomp (λ i → p (~ i)) (hcomp p a)
                                             ; (ϕ = i1) → p i0 1=1 }) ]
 hcomp-equivFillerSub {ϕ = ϕ} p a i =
-  inS (hcomp (λ k → λ { (i = i1) → hfill (λ j → p (~ j)) (inS (hcomp p (outS a))) k
-                      ; (i = i0) → outS a
+  inS (hcomp (λ k → λ { (i = i1) → hfill (λ j → p (~ j)) (hcomp p a) k
+                      ; (i = i0) → a
                       ; (ϕ = i1) → p (~ k ∧ i) 1=1 })
              (hfill p a i))
 
 hcomp-equivFiller : {ϕ : I} → (p : I → Partial ϕ A) → (a : A [ ϕ ↦ p i0 ])
                   → (i : I) → A
-hcomp-equivFiller p a i = outS (hcomp-equivFillerSub p a i)
+hcomp-equivFiller p a i = hcomp-equivFillerSub p a i
 
 
-pentagonIdentity : (p : x ≡ y) → (q : y ≡ z) → (r : z ≡ w) → (s : w ≡ v)
+pentagonIdentity : ∀ {A : Type ℓ} {v w x y z : A} (p : x ≡ y) → (q : y ≡ z) → (r : z ≡ w) → (s : w ≡ v)
                       →
             (assoc p q (r ∙ s) ∙ assoc (p ∙ q) r s)
                               ≡
    cong (p ∙_) (assoc q r s) ∙∙ assoc p (q ∙ r) s ∙∙ cong (_∙ s) (assoc p q r)
 
-pentagonIdentity {x = x} {y} p q r s =
+pentagonIdentity {A = A} {x = x} {y} p q r s =
         (λ i →
               (λ j → cong (p ∙_) (assoc q r s) (i ∧ j))
            ∙∙ (λ j → lemma₀₀ i j ∙ lemma₀₁ i j)
@@ -352,7 +352,7 @@ pentagonIdentity {x = x} {y} p q r s =
                              (λ k → λ { (j = i1) → r k
                                       ; (i₁ = i1) → r k
                                       ; (i₁ = i0)(j = i0) → y })
-                             (inS (q (i₁ ∨ j))) i))
+                             (q (i₁ ∨ j)) i))
 
     lemma₁₁ : ( i j : I) → (r (i ∨ j)) ≡ _
     lemma₁₁ i j i₁ =
@@ -364,7 +364,7 @@ pentagonIdentity {x = x} {y} p q r s =
               }) (r (i ∨ j ∨ i₁))
 
 
-    lemma₁₀-back :  I → I → I → _
+    lemma₁₀-back : I → I → I → A
     lemma₁₀-back i j i₁ =
         hcomp
          (λ k → λ {
@@ -379,12 +379,12 @@ pentagonIdentity {x = x} {y} p q r s =
                          (q (k ∨ j ∨ ~ i))
          ; (i = i0)(j = i0) → (p ∙ q) i₁
          })
-        (hcomp
+        (outS (hcomp
            (λ k → λ { (i₁ = i0) → x
                     ; (i₁ = i1) → q ((j ∨ ~ i ) ∧ k)
                     ; (j = i0)(i = i1) → p i₁
             })
-            (p i₁))
+            (p i₁)))
 
 
     lemma₁₀-front : I → I → I → _
@@ -429,7 +429,7 @@ pentagonIdentity {x = x} {y} p q r s =
                              ; (j = i1) → q (i₂ ∨ ~ i)
                              ; (i = i0) → (p ∙ q) j
                             }))
-                         (inS ((compPath-filler p q (~ i) j))) k
+                         (compPath-filler p q (~ i) j) k
           ; (z = i1) → compPath-filler p q k j
          })
          (compPath-filler p q (~ i ∧ ~ z) j)
@@ -489,7 +489,7 @@ pentagonIdentity {x = x} {y} p q r s =
   hfill (λ k → λ { (i = i1) → p k
                   ; (j = i0) → p k
                   ; (j = i1) → p k})
-        (inS (p i0)) k
+        (p i0) k
 
 ∙∙lCancel : ∀ {ℓ} {A : Type ℓ} {x y : A}
          → (p : x ≡ y)

--- a/Cubical/Foundations/Isomorphism.agda
+++ b/Cubical/Foundations/Isomorphism.agda
@@ -61,17 +61,17 @@ module _ (i : Iso A B) where
       fill0 : I → I → A
       fill0 i = hfill (λ k → λ { (i = i1) → t x0 k
                                ; (i = i0) → g y })
-                      (inS (g (p0 (~ i))))
+                      (g (p0 (~ i)))
 
       fill1 : I → I → A
       fill1 i = hfill (λ k → λ { (i = i1) → t x1 k
                                ; (i = i0) → g y })
-                      (inS (g (p1 (~ i))))
+                      (g (p1 (~ i)))
 
       fill2 : I → I → A
       fill2 i = hfill (λ k → λ { (i = i1) → fill1 k i1
                                ; (i = i0) → fill0 k i1 })
-                      (inS (g y))
+                      (g y)
 
       p : x0 ≡ x1
       p i = fill2 i i1

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -59,12 +59,12 @@ PathPIsoPath A x y .Iso.rightInv q k i =
       (λ j → λ
         { (i = i0) → x
         ; (i = i1) → q j })
-      (inS (transp (λ j → A (i ∧ j)) (~ i) x))
+      (transp (λ j → A (i ∧ j)) (~ i) x)
 
   slide : I → _
   slide i = transp (λ l → A (i ∨ l)) i (transp (λ l → A (i ∧ l)) (~ i) x)
 
-  ∧∨Square : I → I → _
+  ∧∨Square : I → I → A _
   ∧∨Square i j =
     hcomp
       (λ l → λ
@@ -81,8 +81,8 @@ PathPIsoPath A x y .Iso.leftInv q k i =
         { (i = i0) → x
         ; (i = i1) → transp (λ l → A (j ∨ l)) j (q j)
         })
-      (inS (transp (λ l → A (i ∧ l)) (~ i) x))
-      (λ j → inS (transp (λ l → A (i ∧ (j ∨ l))) (~ i ∨ j) (q (i ∧ j)))))
+      (transp (λ l → A (i ∧ l)) (~ i) x)
+      (λ j → transp (λ l → A (i ∧ (j ∨ l))) (~ i ∨ j) (q (i ∧ j))))
     k
 
 PathP≃Path : (A : I → Type ℓ) (x : A i0) (y : A i1) →
@@ -119,7 +119,7 @@ compPathl-cancel p q = p ∙ (sym p ∙ q) ≡⟨ assoc p (sym p) q ⟩
 
 compPathr-cancel : ∀ {ℓ} {A : Type ℓ} {x y z : A} (p : z ≡ y) (q : x ≡ y) → (q ∙ sym p) ∙ p ≡ q
 compPathr-cancel {x = x} p q i j =
-  hcomp-equivFiller (doubleComp-faces (λ _ → x) (sym p) j) (inS (q j)) (~ i)
+  hcomp-equivFiller (doubleComp-faces (λ _ → x) (sym p) j) (q j) (~ i)
 
 compPathl-isEquiv : {x y z : A} (p : x ≡ y) → isEquiv (λ (q : y ≡ z) → p ∙ q)
 compPathl-isEquiv p = isoToIsEquiv (iso (p ∙_) (sym p ∙_) (compPathl-cancel p) (compPathl-cancel (sym p)))
@@ -193,9 +193,9 @@ module _ {a₀₀ a₁₁ : A} {a₋ : a₀₀ ≡ a₁₁}
     slideSquareInv : Square refl a₁₋ a₋₀ a₋ → Square a₋ a₁₋ a₋₀ refl
     slideSquareInv sq i j = hcomp (λ k → slideSquareFaces i j (~ k)) (sq i j)
     fillerTo : ∀ p → slideSquare (slideSquareInv p) ≡ p
-    fillerTo p k i j = hcomp-equivFiller (λ k → slideSquareFaces i j (~ k)) (inS (p i j)) (~ k)
+    fillerTo p k i j = hcomp-equivFiller (λ k → slideSquareFaces i j (~ k)) (p i j) (~ k)
     fillerFrom : ∀ p → slideSquareInv (slideSquare p) ≡ p
-    fillerFrom p k i j = hcomp-equivFiller (slideSquareFaces i j) (inS (p i j)) (~ k)
+    fillerFrom p k i j = hcomp-equivFiller (slideSquareFaces i j) (p i j) (~ k)
 
 -- The type of fillers of a square is equivalent to the double composition identites
 Square≃doubleComp : {a₀₀ a₀₁ a₁₀ a₁₁ : A}
@@ -289,7 +289,7 @@ congPathIso {A = A} {B} e {a₀} {a₁} .Iso.rightInv q k i =
               { (i = i0) → retEq (e i0) a₀ j
               ; (i = i1) → retEq (e i1) a₁ j
               })
-            (inS (invEq (e i) (q i)))
+            (invEq (e i) (q i))
             j)
       ; (k = i1) → q i
       })

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -114,7 +114,7 @@ _∙∙_∙∙_ : w ≡ x → x ≡ y → y ≡ z → w ≡ z
 doubleCompPath-filler : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)
                       → PathP (λ j → p (~ j) ≡ r j) q (p ∙∙ q ∙∙ r)
 doubleCompPath-filler p q r j i =
-  hfill (doubleComp-faces p r i) (inS (q i)) j
+  hfill (doubleComp-faces p r i) (q i) j
 
 -- any two definitions of double composition are equal
 compPath-unique : (p : x ≡ y) (q : y ≡ z) (r : z ≡ w)
@@ -127,7 +127,7 @@ compPath-unique p q r (α , α-filler) (β , β-filler) t
                                 ; (t = i1) → β-filler j i
                                 ; (i = i0) → p (~ j)
                                 ; (i = i1) → r j })
-                       (inS (q i)) j
+                       (q i) j
 
 {- For single homogenous path composition, we take `p = refl`:
 
@@ -211,7 +211,7 @@ compPathP-filler {A = A} {x = x} {B = B} p q j i =
   fill (λ j → compPath-filler (λ i → A i) B j i)
        (λ j → λ { (i = i0) → x ;
                   (i = i1) → q j })
-       (inS (p i)) j
+       (p i) j
 
 compPathP'-filler : {B : A → Type ℓ'} {x' : B x} {y' : B y} {z' : B z} {p : x ≡ y} {q : y ≡ z}
   (P : PathP (λ i → B (p i)) x' y') (Q : PathP (λ i → B (q i)) y' z')
@@ -220,7 +220,7 @@ compPathP'-filler {B = B} {x' = x'} {p = p} {q = q} P Q j i =
   fill (λ j → B (compPath-filler p q j i))
        (λ j → λ { (i = i0) → x'  ;
                   (i = i1) → Q j })
-       (inS (P i))
+       (P i)
        j
 
 -- Syntax for chains of equational reasoning
@@ -370,7 +370,7 @@ doubleWhiskFiller :
                (p ◁ pq ▷ q)
 doubleWhiskFiller p pq q k i =
   hfill (λ j → λ {(i = i0) → p (~ j) ; (i = i1) → q j})
-        (inS (pq i))
+        (pq i)
         k
 
 _◁_ : ∀ {ℓ} {A : I → Type ℓ} {a₀ a₀' : A i0} {a₁ : A i1}
@@ -414,7 +414,7 @@ isContrSingl a .snd p i .snd j = p .snd (i ∧ j)
 isContrSinglP : (A : I → Type ℓ) (a : A i0) → isContr (singlP A a)
 isContrSinglP A a .fst = _ , transport-filler (λ i → A i) a
 isContrSinglP A a .snd (x , p) i =
-  _ , λ j → fill A (λ j → λ {(i = i0) → transport-filler (λ i → A i) a j; (i = i1) → p j}) (inS a) j
+  _ , λ j → fill A (λ j → λ {(i = i0) → transport-filler (λ i → A i) a j; (i = i1) → p j}) a j
 
 -- Higher cube types
 

--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -19,10 +19,10 @@ open import Cubical.Foundations.Function using (_∘_)
 transpFill : ∀ {ℓ} {A : Type ℓ}
              (φ : I)
              (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A) ])
-             (u0 : outS (A i0))
+             (u0 : outS (A i0)) -- TODO: Sorts
            → --------------------------------------
-             PathP (λ i → outS (A i)) u0 (transp (λ i → outS (A i)) φ u0)
-transpFill φ A u0 i = transp (λ j → outS (A (i ∧ j))) (~ i ∨ φ) u0
+             PathP (λ i → A i) u0 (transp (λ i → A i) φ u0)
+transpFill φ A u0 i = transp (λ j → A (i ∧ j)) (~ i ∨ φ) u0
 
 transport⁻ : ∀ {ℓ} {A B : Type ℓ} → A ≡ B → B → A
 transport⁻ p = transport (λ i → p (~ i))

--- a/Cubical/Foundations/Univalence.agda
+++ b/Cubical/Foundations/Univalence.agda
@@ -52,8 +52,8 @@ ua-unglue e i x = unglue (i ∨ ~ i) x
 
 ua-glue : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : Partial (~ i) A)
             (y : B [ _ ↦ (λ { (i = i0) → e .fst (x 1=1) }) ])
-          → ua e i {- [ _ ↦ (λ { (i = i0) → x 1=1 ; (i = i1) → outS y }) ] -}
-ua-glue e i x y = glue {φ = i ∨ ~ i} (λ { (i = i0) → x 1=1 ; (i = i1) → outS y }) (outS y)
+          → ua e i [ _ ↦ (λ { (i = i0) → x 1=1 ; (i = i1) → outS y }) ]
+ua-glue e i x y = glue {φ = i ∨ ~ i} (λ { (i = i0) → x 1=1 ; (i = i1) → y }) y
 
 module _ {A B : Type ℓ} (e : A ≃ B) {x : A} {y : B} where
   -- sometimes more useful are versions of these functions with the (i : I) factored in
@@ -62,7 +62,7 @@ module _ {A B : Type ℓ} (e : A ≃ B) {x : A} {y : B} where
   ua-ungluePath p i = ua-unglue e i (p i)
 
   ua-gluePath : e .fst x ≡ y → PathP (λ i → ua e i) x y
-  ua-gluePath p i = ua-glue e i (λ { (i = i0) → x }) (inS (p i))
+  ua-gluePath p i = ua-glue e i (λ { (i = i0) → x }) (p i)
 
   -- ua-ungluePath and ua-gluePath are definitional inverses
   ua-ungluePath-Equiv : (PathP (λ i → ua e i) x y) ≃ (e .fst x ≡ y)
@@ -73,11 +73,11 @@ module _ {A B : Type ℓ} (e : A ≃ B) {x : A} {y : B} where
 -- strengthening the types of ua-unglue and ua-glue gives a nicer formulation of this, see below
 
 ua-unglue-glue : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : Partial (~ i) A) (y : B [ _ ↦ _ ])
-                 → ua-unglue e i (ua-glue e i x y) ≡ outS y
+                 → ua-unglue e i (ua-glue e i x y) ≡ y
 ua-unglue-glue _ _ _ _ = refl
 
 ua-glue-unglue : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : ua e i)
-                 → ua-glue e i (λ { (i = i0) → x }) (inS (ua-unglue e i x)) ≡ x
+                 → ua-glue e i (λ { (i = i0) → x }) (ua-unglue e i x) ≡ x
 ua-glue-unglue _ _ _ = refl
 
 -- mainly for documentation purposes, ua-unglue and ua-glue wrapped in cubical subtypes
@@ -85,28 +85,28 @@ ua-glue-unglue _ _ _ = refl
 ua-unglueS : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A) (y : B)
              → ua e i [ _ ↦ (λ { (i = i0) → x        ; (i = i1) → y }) ]
              → B      [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → y }) ]
-ua-unglueS e i x y s = inS (ua-unglue e i (outS s))
+ua-unglueS e i x y s = ua-unglue e i s
 
 ua-glueS : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A) (y : B)
            → B      [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → y }) ]
            → ua e i [ _ ↦ (λ { (i = i0) → x        ; (i = i1) → y }) ]
-ua-glueS e i x y s = inS (ua-glue e i (λ { (i = i0) → x }) (inS (outS s)))
+ua-glueS e i x y s = ua-glue e i (λ { (i = i0) → x }) (outS s)
 
 ua-unglueS-glueS : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A) (y : B)
                      (s : B [ _ ↦ (λ { (i = i0) → e .fst x ; (i = i1) → y }) ])
-                   → outS (ua-unglueS e i x y (ua-glueS e i x y s)) ≡ outS s
+                   → ua-unglueS e i x y (ua-glueS e i x y s) ≡ s
 ua-unglueS-glueS _ _ _ _ _ = refl
 
 ua-glueS-unglueS : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A) (y : B)
                      (s : ua e i [ _ ↦ (λ { (i = i0) → x ; (i = i1) → y }) ])
-                   → outS (ua-glueS e i x y (ua-unglueS e i x y s)) ≡ outS s
+                   → ua-glueS e i x y (ua-unglueS e i x y s) ≡ s
 ua-glueS-unglueS _ _ _ _ _ = refl
 
 
 -- a version of ua-glue with a single endpoint, identical to `ua-gluePath e {x} refl i`
 ua-gluePt : ∀ {A B : Type ℓ} (e : A ≃ B) (i : I) (x : A)
             → ua e i {- [ _ ↦ (λ { (i = i0) → x ; (i = i1) → e .fst x }) ] -}
-ua-gluePt e i x = ua-glue e i (λ { (i = i0) → x }) (inS (e .fst x))
+ua-gluePt e i x = ua-glue e i (λ { (i = i0) → x }) (e .fst x)
 
 
 -- Proof of univalence using that unglue is an equivalence:
@@ -120,15 +120,15 @@ equiv-proof (unglueIsEquiv A φ f) = λ (b : A) →
       u i = λ{ (φ = i1) → equivCtr (f 1=1 .snd) b .snd (~ i) }
       ctr : fiber (unglue φ) b
       ctr = ( glue (λ { (φ = i1) → equivCtr (f 1=1 .snd) b .fst }) (hcomp u b)
-            , λ j → hfill u (inS b) (~ j))
+            , λ j → hfill u b (~ j))
   in ( ctr
      , λ (v : fiber (unglue φ) b) i →
          let u' : I → Partial (φ ∨ ~ i ∨ i) A
              u' j = λ { (φ = i1) → equivCtrPath (f 1=1 .snd) b v i .snd (~ j)
-                      ; (i = i0) → hfill u (inS b) j
+                      ; (i = i0) → hfill u b j
                       ; (i = i1) → v .snd (~ j) }
          in ( glue (λ { (φ = i1) → equivCtrPath (f 1=1 .snd) b v i .fst }) (hcomp u' b)
-            , λ j → hfill u' (inS b) (~ j)))
+            , λ j → hfill u' b (~ j)))
 
 -- Any partial family of equivalences can be extended to a total one
 -- from Glue [ φ ↦ (T,f) ] A to A

--- a/Cubical/Functions/Embedding.agda
+++ b/Cubical/Functions/Embedding.agda
@@ -91,7 +91,7 @@ private
       → hfill (λ j → λ { (i = i0) → (x , refl)
                       ; (i = i1) → (w , sq j)
                       })
-          (inS (q (~ i) , λ j → f (q (~ i ∨ j))))
+          (q (~ i) , λ j → f (q (~ i ∨ j)))
           i1
       }
 

--- a/Cubical/HITs/DunceCap/Properties.agda
+++ b/Cubical/HITs/DunceCap/Properties.agda
@@ -53,7 +53,7 @@ contrDunce (surf i j) k
                                 ; (k = i1) → base
                                 ; (l = i0) → loop (k ∨ i)
                                 ; (l = i1) → surf k i })
-                       (inS (loop k)) i
+                       (loop k) i
 
 isContr-Dunce : isContr Dunce
 fst isContr-Dunce = base

--- a/Cubical/HITs/James/Inductive/Coherence.agda
+++ b/Cubical/HITs/James/Inductive/Coherence.agda
@@ -34,7 +34,7 @@ private
         ; (i = i1) → doubleCompPath-filler (refl {x = a}) refl refl k j
         ; (j = i0) → a
         ; (j = i1) → a})
-      (inS a) k
+        a k
 
     degenerate1' : (i j k : I) → A
     degenerate1' i j k =
@@ -43,7 +43,7 @@ private
         ; (i = i1) → compPath-filler (refl {x = a}) refl k j
         ; (j = i0) → a
         ; (j = i1) → a})
-      (inS a) k
+      a k
 
     degenerate1'' : (i j k : I) → A
     degenerate1'' i j k =
@@ -52,7 +52,7 @@ private
         ; (i = i1) → compPath-filler (refl {x = a}) (refl ∙ refl) k j
         ; (j = i0) → a
         ; (j = i1) → degenerate1 i k i1})
-      (inS a) k
+      a k
 
     module _
       {B : Type ℓ'}(f : A → B) where
@@ -64,7 +64,7 @@ private
           ; (i = i1) → doubleCompPath-filler (refl {x = f a}) refl refl k j
           ; (j = i0) → f a
           ; (j = i1) → f a })
-        (inS (f a)) k
+        (f a) k
 
       degenerate3 : (i j k : I) → B
       degenerate3 i j k =
@@ -73,7 +73,7 @@ private
           ; (i = i1) → doubleCompPath-filler (refl {x = f a}) refl refl k j
           ; (j = i0) → f a
           ; (j = i1) → f a })
-        (inS (f a)) k
+        (f a) k
 
       someCommonDegenerateCube : (i j k : I) → B
       someCommonDegenerateCube i j k =
@@ -93,7 +93,7 @@ private
         ; (i = i1) → doubleCompPath-filler (refl {x = a}) refl refl j k
         ; (j = i0) → a
         ; (j = i1) → (refl {x = a} ∙∙ refl ∙∙ refl) k })
-      (inS a) k
+      a k
 
     degenerate5 : (i j k : I) → A
     degenerate5 i j k =
@@ -113,7 +113,7 @@ private
         ; (i = i1) → a
         ; (j = i0) → a
         ; (j = i1) → compPath-filler (refl {x = a}) refl (~ i) k })
-      (inS a) k
+      a k
 
 
 -- Cubes of which mostly are constructed by J rule
@@ -173,7 +173,7 @@ module _
       ; (i = i1) → doubleCompPath-filler p' q' r' k j
       ; (j = i0) → h   i (~ k)
       ; (j = i1) → h'' i  k })
-    (inS (h' i j)) k
+    (h' i j) k
 
   doubleCompPath-cong : (f : A → B)
     (p : a ≡ b)(q : b ≡ c)(r : c ≡ d)
@@ -226,7 +226,7 @@ module _
       ; (i = i1) → q j
       ; (j = i0) → f a
       ; (j = i1) → f c })
-    (inS (comp-cong-square' _ _ _ h i j)) k
+    (comp-cong-square' _ _ _ h i j) k
 
   comp-cong-helper : cong f (p ∙ r) ≡ q
   comp-cong-helper i j =

--- a/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
+++ b/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
@@ -155,7 +155,7 @@ module _
           ; (i = i1) → square-helper (j ∨ ~ k) i1
           ; (j = i0) → square-helper (~ k) i
           ; (j = i1) → inl (unit x₀ xs i) })
-        (inS (push-square x₀ xs j i)) k
+        (push-square x₀ xs j i) k
         where
           square-helper : (i j : I) → 𝕁ames
           square-helper i j =

--- a/Cubical/HITs/James/Inductive/PushoutFormula.agda
+++ b/Cubical/HITs/James/Inductive/PushoutFormula.agda
@@ -125,7 +125,7 @@ module _
       ; (i = i1) → inr (unit [] (~ j ∧ k))
       ; (j = i0) → compPath-filler (push []) (λ i → inr (unit [] i)) k i
       ; (j = i1) → push [] i })
-    (push [] i)
+    (Pushout.push [] i)
 
   X⋁X→P0→X⋁X : (x : X∙ ⋁ X∙) → P0→X⋁X (X⋁X→P0 x) ≡ x
   X⋁X→P0→X⋁X (inl x) = refl
@@ -136,7 +136,7 @@ module _
       ; (i = i1) → inr x₀
       ; (j = i0) → P0→X⋁X (compPath-filler (push []) refl k i)
       ; (j = i1) → push tt i })
-    (push tt i)
+    (Pushout.push tt i)
 
   P0≃X⋁X : 𝕁amesPush 0 ≃ X∙ ⋁ X∙
   P0≃X⋁X = isoToEquiv (iso P0→X⋁X X⋁X→P0 X⋁X→P0→X⋁X P0→X⋁X→P0)

--- a/Cubical/HITs/James/Inductive/Reduced.agda
+++ b/Cubical/HITs/James/Inductive/Reduced.agda
@@ -112,7 +112,7 @@ module _
       ; (i = i1) → x₀ ∷ 𝕁1→𝕁Red→𝕁1 xs j
       ; (j = i0) → x₀ ∷ 𝕁Red→𝕁1 (𝕁1→𝕁Red xs)
       ; (j = i1) → unit xs (i ∨ ~ k)})
-    (x₀ ∷ 𝕁1→𝕁Red→𝕁1 xs j)
+    (inS (x₀ ∷ 𝕁1→𝕁Red→𝕁1 xs j))
   𝕁1→𝕁Red→𝕁1 (coh xs i j) t = coh (𝕁1→𝕁Red→𝕁1 xs t) i j
 
   𝕁Red∞→𝕁1∞ : 𝕁Red∞ → 𝕁1∞

--- a/Cubical/HITs/James/LoopSuspEquiv.agda
+++ b/Cubical/HITs/James/LoopSuspEquiv.agda
@@ -66,7 +66,7 @@ module _
         ; (i = i1) → square1 x₀ xs j k
         ; (j = i0) → push (x₀ , xs) (~ k)
         ; (j = i1) → push (x₀ , unit xs i) (~ k) })
-      (inr (flipSquare xs i j))
+      (Pushout.inr (flipSquare xs i j))
 
     center : Total
     center = inl []
@@ -92,7 +92,7 @@ module _
       ; (i = i1) → doubleCompPath-filler (pathL (x ∷ xs)) (push (x₀ , x ∷ xs)) (λ i → inr (unit (x ∷ xs) (~ i))) k j
       ; (j = i0) → pathL (x ∷ xs) (~ k)
       ; (j = i1) → square1 x xs (~ k) (~ i) })
-    (push (x₀ , x ∷ xs) (i ∧ j))
+    (Pushout.push (x₀ , x ∷ xs) (i ∧ j))
 
   module _
     (conn : isConnected 2 X) where

--- a/Cubical/HITs/Join/Base.agda
+++ b/Cubical/HITs/Join/Base.agda
@@ -20,7 +20,7 @@ facek01 i j k = hfill (λ l → λ { (j = i0) → push base base (~ l ∧ ~ k)
                                ; (j = i1) → push base base (~ l ∧ ~ k)
                                ; (k = i0) → push (loop j) base (~ l)
                                ; (k = i1) → inl base })
-                      (inS (push base base (~ k))) i
+                      (join.push base base (~ k)) i
 
 border-contraction : I → I → I → I → join S¹ S¹
 border-contraction i j k m =
@@ -30,7 +30,7 @@ border-contraction i j k m =
                  ; (j = i1) → push base (loop k) (i ∧ ~ l)
                  ; (k = i0) → facek01 (~ i) j l
                  ; (k = i1) → facek01 (~ i) j l })
-        (inS (push (loop j) (loop k) i)) m
+        (join.push (loop j) (loop k) i) m
 
 S³→joinS¹S¹ : S³ → join S¹ S¹
 S³→joinS¹S¹ base = inl base
@@ -51,7 +51,7 @@ connection i j k l =
                  ; (j = i1) → base
                  ; (i = i0) → base
                  ; (i = i1) → base })
-        (inS base) l
+        S³.base l
 
 S³→joinS¹S¹→S³ : ∀ x → joinS¹S¹→S³ (S³→joinS¹S¹ x) ≡ x
 S³→joinS¹S¹→S³ base l = base

--- a/Cubical/HITs/Join/Properties.agda
+++ b/Cubical/HITs/Join/Properties.agda
@@ -308,7 +308,7 @@ joinSwitch = isoToEquiv (iso switch switch invol invol)
         ; (j = i0) → push (inr b) a (~ i)
         ; (j = i1) → push (inl c) a (~ i ∧ ~ k)
         })
-      (push (push c b (~ j)) a (~ i))
+      (inS (push (push c b (~ j)) a (~ i)))
 
   invol : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''}
     (u : join (join A B) C) → switch (switch u) ≡ u
@@ -336,7 +336,7 @@ joinSwitch = isoToEquiv (iso switch switch invol invol)
           ; (j = i1) → push (inl a) c (i ∨ (~ k ∨ l))
           ; (l = i1) → push (push a b i) c j
           })
-        (push (push a b i) c j))
+        (inS (push (push a b i) c j)))
 
 {-
   Direct proof of associativity.
@@ -361,7 +361,7 @@ joinAssocDirect {A = A} {B} {C} =
         ; (j = i0) → push a (inl b) i
         ; (j = i1) → push a (inr c) (i ∨ k)
         })
-      (push a (push b c j) i)
+      (inS (push a (push b c j) i))
 
   back : join A (join B C) → join (join A B) C
   back (inl a) = inl (inl a)
@@ -378,7 +378,7 @@ joinAssocDirect {A = A} {B} {C} =
         ; (j = i0) → inl (push a b i)
         ; (j = i1) → push (inl a) c (i ∨ ~ k)
         })
-      (push (push a b i) c j)
+      (inS (push (push a b i) c j))
 
   forwardBack : ∀ u → forward (back u) ≡ u
   forwardBack (inl a) = refl
@@ -405,7 +405,7 @@ joinAssocDirect {A = A} {B} {C} =
           ; (j = i1) → push a (inr c) (i ∨ (k ∧ ~ l))
           ; (l = i1) → push a (push b c j) i
           })
-        (push a (push b c j) i))
+        (inS (push a (push b c j) i)))
 
   backForward : ∀ u → back (forward u) ≡ u
   backForward (inl (inl a)) = refl
@@ -432,7 +432,7 @@ joinAssocDirect {A = A} {B} {C} =
           ; (j = i1) → push (inl a) c (i ∨ (~ k ∨ l))
           ; (l = i1) → push (push a b i) c j
           })
-        (push (push a b i) c j))
+        (inS (push (push a b i) c j)))
 
 -- commutativity
 join-commFun : ∀ {ℓ'} {A : Type ℓ} {B : Type ℓ'} → join A B → join B A

--- a/Cubical/HITs/KleinBottle/Properties.agda
+++ b/Cubical/HITs/KleinBottle/Properties.agda
@@ -57,7 +57,7 @@ kleinBottle≃Σ = isoToEquiv (iso fro to froTo toFro)
         { (j = i0) → loop1Inv g l
         ; (j = i1) → loop1 g
         })
-      (inS (loop1 (unglue (j ∨ ~ j) g)))
+      (loop1 (unglue (j ∨ ~ j) g))
       l
 
   to : Σ S¹ invS¹Loop → KleinBottle

--- a/Cubical/HITs/Modulo/FinEquiv.agda
+++ b/Cubical/HITs/Modulo/FinEquiv.agda
@@ -57,7 +57,7 @@ module Reduction {k₀ : ℕ} where
             ; (i = i1) → snd (lemma₁ n ii) j
             ; (j = i1) → step n i
             })
-        (inS (rstep≡ n (residuePath n) i j))
+        (rstep≡ n (residuePath n) i j)
         i1
 
   residue : Modulo k → Fin k

--- a/Cubical/HITs/Pushout/Flattening.agda
+++ b/Cubical/HITs/Pushout/Flattening.agda
@@ -46,7 +46,7 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
     bwd (inr c , x) = inr (c , x)
     bwd (push a i , x) = hcomp (λ j → λ { (i = i0) → push (a , x) (~ j)
                                         ; (i = i1) → inr (g a , x) })
-                               (inr (g a , ua-unglue (e a) i x))
+                               (Pushout.inr (g a , ua-unglue (e a) i x))
 
     bwd-fwd : ∀ x → bwd (fwd x) ≡ x
     bwd-fwd (inl (b , x)) = refl
@@ -55,7 +55,7 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
       hcomp (λ k → λ { (i = i0) → push (a , ua-gluePt (e a) i0 x) (~ k)
                      ; (i = i1) → inr (g a , ua-gluePt (e a) i1 x)
                      ; (j = i1) → push (a , x) (i ∨ ~ k) })
-            (inr (g a , ua-unglue (e a) i (ua-gluePt (e a) i x)))
+            (Pushout.inr (g a , ua-unglue (e a) i (ua-gluePt (e a) i x)))
       -- Note: the (j = i1) case typechecks because of the definitional equalities:
       --  ua-gluePt e i0 x ≡ x , ua-gluePt e i1 x ≡ e .fst x,
       --  ua-unglue-glue : ua-unglue e i (ua-gluePt e i x) ≡ e .fst x
@@ -68,7 +68,7 @@ module FlatteningLemma {ℓa ℓb ℓc} {A : Type ℓa} {B : Type ℓb} {C : Typ
       {- k = i0 -} (λ i x → ua-unglue e i x)
       {- k = i1 -} (λ i x → x)
     sq e i k x = ua-glue e (i ∨ ~ k) (λ { ((i ∨ ~ k) = i0) → x })
-                                     (inS (ua-unglue e i x))
+                                     (ua-unglue e i x)
       -- Note: this typechecks because of the definitional equalities:
       --  ua-unglue e i0 x ≡ e .fst x, ua-glue e i1 _ (inS y) ≡ y, ua-unglue e i1 x ≡ x,
       --  ua-glue-unglue : ua-glue e i (λ { (i = i0) → x }) (inS (ua-unglue e i x)) ≡ x

--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -265,7 +265,7 @@ record 3x3-span : Type₁ where
                                  ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) (~ t) j)
                                  ; (j = i0) → forward-l (doubleCompPath-filler (λ k → inl (H11 a k)) (push (f21 a)) (λ k → inr (H31 a (~ k))) t i)
                                  ; (j = i1) → forward-r (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) t i) })
-                        (inS (push (push a j) i))
+                        (Pushout.push (push a j) i)
 
   A□○→A○□ : A□○ → A○□
   A□○→A○□ (inl x) = forward-l x
@@ -290,7 +290,7 @@ record 3x3-span : Type₁ where
                                  ; (i = i1) → inr (doubleCompPath-filler (λ k → inl (H13 a k)) (push (f23 a)) (λ k → inr (H33 a (~ k))) (~ t) j)
                                  ; (j = i0) → backward-l (doubleCompPath-filler (λ k → inl (H11 a (~ k))) (push (f12 a)) (λ k → inr (H13 a k)) t i)
                                  ; (j = i1) → backward-r (doubleCompPath-filler (λ k → inl (H31 a (~ k))) (push (f32 a)) (λ k → inr (H33 a k)) t i) })
-                        (inS (push (push a j) i))
+                        (Pushout.push (push a j) i)
 
   A○□→A□○ : A○□ → A□○
   A○□→A□○ (inl x) = backward-l x

--- a/Cubical/HITs/S1/Base.agda
+++ b/Cubical/HITs/S1/Base.agda
@@ -30,7 +30,7 @@ module _ where
   transpS¹ φ u0 = refl
 
   compS1 : ∀ (φ : I) (u : ∀ i → Partial φ S¹) (u0 : S¹ [ φ ↦ u i0 ]) →
-    comp (λ _ → S¹) (\ i → u i) (outS u0) ≡ hcomp u (outS u0)
+    comp (λ _ → S¹) (\ i → u i) u0 ≡ hcomp u u0
   compS1 φ u u0 = refl
 
 -- ΩS¹ ≡ ℤ
@@ -57,10 +57,10 @@ decodeSquare : (n : ℤ) → PathP (λ i → base ≡ loop i) (intLoop (predℤ 
 decodeSquare (pos zero) i j    = loop (i ∨ ~ j)
 decodeSquare (pos (suc n)) i j = hfill (λ k → λ { (j = i0) → base
                                                 ; (j = i1) → loop k } )
-                                       (inS (intLoop (pos n) j)) i
+                                       (intLoop (pos n) j) i
 decodeSquare (negsuc n) i j = hfill (λ k → λ { (j = i0) → base
                                              ; (j = i1) → loop (~ k) })
-                                    (inS (intLoop (negsuc n) j)) (~ i)
+                                    (intLoop (negsuc n) j) (~ i)
 
 decode : (x : S¹) → helix x → base ≡ x
 decode base         = intLoop
@@ -158,13 +158,13 @@ private
   ΩS¹→basedΩS¹-filler l i x j =
     hfill (λ t → λ { (j = i0) → loop (i ∧ t)
                    ; (j = i1) → loop (i ∧ t) })
-          (inS (x j)) l
+          (x j) l
 
   basedΩS¹→ΩS¹-filler : (_ i : I) → basedΩS¹ (loop i) → I → S¹
   basedΩS¹→ΩS¹-filler l i x j =
     hfill (λ t → λ { (j = i0) → loop (i ∧ (~ t))
                    ; (j = i1) → loop (i ∧ (~ t)) })
-          (inS (x j)) l
+          (x j) l
 
   ΩS¹→basedΩS¹ : (i : I) → ΩS¹ → basedΩS¹ (loop i)
   ΩS¹→basedΩS¹ i x j = ΩS¹→basedΩS¹-filler i1 i x j
@@ -223,7 +223,7 @@ private
   refl-conjugation i x j =
     hfill (λ t → λ { (j = i0) → base
                    ; (j = i1) → base })
-          (inS (x j)) (~ i)
+          (x j) (~ i)
 
   basechange : (x : S¹) → basedΩS¹ x → ΩS¹
   basechange base y = y
@@ -237,7 +237,7 @@ private
   basedΩS¹→ΩS¹≡basechange i j y =
     hfill (λ t → λ { (i = i0) → refl-conjugation t y
                    ; (i = i1) → loop-conjugation t y })
-          (inS (basedΩS¹→ΩS¹ i y)) j
+          (basedΩS¹→ΩS¹ i y) j
 
   -- so for any loop i, the extended basechange is an equivalence
   basechange-isequiv-aux : (i : I) → isEquiv (basechange (loop i))
@@ -406,7 +406,7 @@ filler-rot : I → I → I → S¹
 filler-rot i j = hfill (λ k → λ { (i = i0) → loop (j ∨ ~ k)
                    ; (i = i1) → loop (j ∧ k)
                    ; (j = i0) → loop (i ∨ ~ k)
-                   ; (j = i1) → loop (i ∧ k) }) (inS base)
+                   ; (j = i1) → loop (i ∧ k) }) S¹.base
 
 isPropFamS¹ : ∀ {ℓ} (P : S¹ → Type ℓ) (pP : (x : S¹) → isProp (P x)) (b0 : P base) →
               PathP (λ i → P (loop i)) b0 b0
@@ -440,7 +440,7 @@ private
                    ; (k = i1) → loop j
                    ; (i = i0) → (loop k · loop j) · loop (~ k)
                    ; (i = i1) → loop (~ k ∧ ~ l) · loop j })
-          (inS ((loop (k ∨ i) · loop j) · loop (~ k)))
+          ((loop (k ∨ i) · loop j) · loop (~ k))
 
   rotInv-aux-2 : I → I → I → S¹
   rotInv-aux-2 i j k =
@@ -458,7 +458,7 @@ private
                    ; (k = i1) → loop j
                    ; (i = i0) → loop (k ∨ l) · loop j
                    ; (i = i1) → loop k · (invLooper (loop (~ j) · loop k)) })
-          (inS (loop k · (invLooper (loop (~ j) · loop (k ∨ ~ i)))))
+          (loop k · (invLooper (loop (~ j) · loop (k ∨ ~ i))))
 
   rotInv-aux-4 : I → I → I → I → S¹
   rotInv-aux-4 j k i =
@@ -466,7 +466,7 @@ private
                    ; (k = i1) → loop j
                    ; (i = i0) → loop j · loop (k ∨ l)
                    ; (i = i1) → (invLooper (loop (~ j) · loop k)) · loop k })
-          (inS ((invLooper (loop (~ j) · loop (k ∨ ~ i))) · loop k))
+          ((invLooper (loop (~ j) · loop (k ∨ ~ i))) · loop k)
 
 rotInv-1 : (a b : S¹) → b · a · invLooper b ≡ a
 rotInv-1 base base i = base

--- a/Cubical/HITs/SmashProduct/Base.agda
+++ b/Cubical/HITs/SmashProduct/Base.agda
@@ -96,7 +96,7 @@ _⋀→_ {A = A} {C = C} {B = B} {D = D} (f , fpt) (g , gpt) (push (push tt j) i
                                                 ((λ i → inr (fpt (~ k) , gpt (~ i)))) k i
                   ; (j = i1) → compPath-filler (push (inr (gpt (~ k))))
                                                 ((λ i → inr (fpt (~ i) , gpt (~ k)))) k i})
-        (push (push tt j) i)
+        (Pushout.push (push tt j) i)
 
 _⋀→refl_ : ∀ {ℓ ℓ'} {C : Type ℓ} {D : Type ℓ'}
   → (f : typ A → C)
@@ -522,7 +522,7 @@ module _ {ℓ ℓ' ℓ'' : Level} (A : Pointed ℓ) (B : Pointed ℓ') (C : Poin
                    ; (j = i1) → push (inl (snd A)) k
                    ; (k = i0) → inl tt
                    ; (k = i1) → push (push tt i) (j ∨ ~ r)})
-          (push (push tt (~ j ∧ i)) k)
+          (Pushout.push (push tt (~ j ∧ i)) k)
 
   -- The main result of step 1
   Iso-⋀-⋀×3 : Iso (A ⋀ (B ⋀∙ C)) ⋀×3

--- a/Cubical/HITs/Sn/Properties.agda
+++ b/Cubical/HITs/Sn/Properties.agda
@@ -148,8 +148,8 @@ wedgeconFun zero (suc m) {A = A} hlev f g hom = F₀
      ∙ λ j i → hfill (λ k → λ { (i = i0) → g base
                                 ; (i = i1) → transport (λ i₁ → A base (merid (ptSn (suc m)) i₁))
                                                         (g base)})
-                      (inS (transp (λ i₁ → A base (merid (ptSn (suc m)) (i₁ ∧ i))) (~ i)
-                                   (g base))) (~ j)
+                      (transp (λ i₁ → A base (merid (ptSn (suc m)) (i₁ ∧ i))) (~ i)
+                                   (g base)) (~ j)
 
   indStep₀ : (x : _) (a : _) → PathP (λ i → A x (merid a i))
                                              (g x)
@@ -192,8 +192,8 @@ wedgeconFun (suc n) m {A = A} hlev f g hom = F₁
        ∙ λ j i → hfill (λ k → λ { (i = i0) → f (ptSn (suc m))
                                   ; (i = i1) → transport (λ i₁ → A (merid (ptSn (suc n)) i₁) (ptSn (suc m)))
                                                           (f (ptSn (suc m))) })
-                        (inS (transp (λ i₁ → A (merid (ptSn (suc n)) (i₁ ∧ i)) (ptSn (suc m))) (~ i)
-                                     (f (ptSn (suc m))))) (~ j)
+                        (transp (λ i₁ → A (merid (ptSn (suc n)) (i₁ ∧ i)) (ptSn (suc m))) (~ i)
+                                     (f (ptSn (suc m)))) (~ j)
 
   indStep₁ : (a : _) (y : _) → PathP (λ i → A (merid a i) y)
                                              (f y)
@@ -239,16 +239,16 @@ wedgeconRight (suc n) m {A = A} hlev f g hom = right
                     ; (i = i1) → transpLemma₁ n m hlev f g hom (ptSn (suc n)) j
                     ; (j = i0) → lem a (~ k) i
                     ; (j = i1) → g (merid a i)})
-          (hcomp (λ k →  λ { (i = i0) → hom (~ j)
+          (outS (hcomp (λ k →  λ { (i = i0) → hom (~ j)
                             ; (i = i1) → compPath-lem (transpLemma₁ n m hlev f g hom a) (transpLemma₁ n m hlev f g hom (ptSn (suc n))) k j
                             ; (j = i1) → g (merid a i)})
-                 (hcomp (λ k → λ { (i = i0) → hom (~ j)
+                 (outS (hcomp (λ k → λ { (i = i0) → hom (~ j)
                                   ; (j = i0) → transp (λ i₂ → A (merid a (i₂ ∧ i)) (ptSn (suc m))) (~ i)
                                                        (f (ptSn (suc m)))
                                   ; (j = i1) → transp (λ j → A (merid a (i ∧ (j ∨ k))) (ptSn (suc m))) (k ∨ ~ i)
                                                        (g (merid a (i ∧ k))) })
                         (transp (λ i₂ → A (merid a (i₂ ∧ i)) (ptSn (suc m))) (~ i)
-                                (hom (~ j)))))
+                                (hom (~ j)))))))
 wedgeconLeft zero zero {A = A} hlev f g hom x = refl
 wedgeconLeft zero (suc m) {A = A} hlev f g hom = help
   where
@@ -269,17 +269,17 @@ wedgeconLeft zero (suc m) {A = A} hlev f g hom = help
                     ; (i = i1) → transpLemma₀ m hlev f g hom (ptSn (suc m)) j
                     ; (j = i0) → left₁ a (~ k) i
                     ; (j = i1) → f (merid a i)})
-          (hcomp (λ k →  λ { (i = i0) → hom j
+          (outS (hcomp (λ k →  λ { (i = i0) → hom j
                             ; (i = i1) → compPath-lem (transpLemma₀ m hlev f g hom a)
                                                        (transpLemma₀ m hlev f g hom (ptSn (suc m))) k j
                             ; (j = i1) → f (merid a i)})
-                 (hcomp (λ k → λ { (i = i0) → hom j
+                 (outS (hcomp (λ k → λ { (i = i0) → hom j
                                   ; (j = i0) → transp (λ i₂ → A base (merid a (i₂ ∧ i))) (~ i)
                                                        (g base)
                                   ; (j = i1) → transp (λ j → A base (merid a (i ∧ (j ∨ k)))) (k ∨ ~ i)
                                                        (f (merid a (i ∧ k)))})
                         (transp (λ i₂ → A base (merid a (i₂ ∧ i))) (~ i)
-                                (hom j))))
+                                (hom j))))))
 wedgeconLeft (suc n) m {A = A} hlev f g hom _ = refl
 
 ---------- Connectedness -----------
@@ -369,8 +369,7 @@ SuspS¹-hom = wedgeconFun _ _ (λ _ _ → isOfHLevelTrunc 4 _ _ _ _)
 rCancelS¹ : (x : S¹) → ptSn 1 ≡ x * (invLooper x)
 rCancelS¹ base = refl
 rCancelS¹ (loop i) j =
-  hcomp (λ r → λ {(i = i0) → base ; (i = i1) → base ; (j = i0) → base})
-        base
+  hcomp (λ r → λ {(i = i0) → base ; (i = i1) → base ; (j = i0) → base}) S¹.base
 
 SuspS¹-inv : (x : S¹) → Path (Path (hLevelTrunc 4 (S₊ 2)) _ _)
                          (cong ∣_∣ₕ (σ (S₊∙ 1) (invLooper x)))
@@ -430,7 +429,7 @@ private
                    ; (j = i1) → merid south (k ∧ ~ r)
                    ; (k = i0) → north
                    ; (k = i1) → merid (merid base j) (~ r)})
-          (inS (merid (merid (loop i) j) k))
+          (Susp.merid (merid (loop i) j) k)
           r
 
 joinS¹S¹→S³' : join S¹ S¹ → S₊ 3
@@ -672,7 +671,7 @@ invSusp∘S¹×S¹→S² (loop i) (loop j) k =
                   ; (j = i1) → m-b (~ r ∨ k)
                   ; (k = i0) → cp-filler base r j
                   ; (k = i1) → invSusp (cp-filler base r (~ j))})
-          (inS (m-b j))
+          (m-b j)
           r
 
   i-Boundary₂ : I → I → I → S₊ 2
@@ -714,4 +713,4 @@ SuspS¹→S²-S¹×S¹→S² (loop i) (loop j) k =
                  ; (k = i0) → SuspS¹→S²
                        (compPath-filler (merid (loop i)) (sym (merid base)) r j)
                  ; (k = i1) → surf j i})
-           (surf j i))
+           (S².surf j i))

--- a/Cubical/Homotopy/BlakersMassey.agda
+++ b/Cubical/Homotopy/BlakersMassey.agda
@@ -282,7 +282,7 @@ module BlakersMassey {ℓ₁ ℓ₂ ℓ₃ : Level}
                      ; (u = i1) → fiber→[q₀₀=q₁₀=q₁₁] q₁₀ i r p .snd l v
                      ; (v = i0) → push q₁₀ ((i ∨ l) ∧ ~ u)
                      ; (v = i1) → push q₁₀ ((i ∧ ~ l) ∨ u) })
-            (push q₁₀ ((i ∨ (v ∧ u)) ∧ (v ∨ (i ∧ ~ u))))
+            (PushoutGen.push q₁₀ ((i ∨ (v ∧ u)) ∧ (v ∨ (i ∧ ~ u))))
 
   {- Definitions of fiber←→ -}
 
@@ -344,7 +344,7 @@ module BlakersMassey {ℓ₁ ℓ₂ ℓ₃ : Level}
                      ; (u = i1) → fiber←[q₀₀=q₀₁=q₁₁] q₀₁ i r p .snd l v
                      ; (v = i0) → push q₀₁ ((i ∨ u) ∧ ~ l)
                      ; (v = i1) → push q₀₁ ((i ∧ ~ u) ∨ l) })
-           (push q₀₁ ((i ∨ (~ v ∧ u)) ∧ (~ v ∨ (i ∧ ~ u))))
+           (PushoutGen.push q₀₁ ((i ∨ (~ v ∧ u)) ∧ (~ v ∨ (i ∧ ~ u))))
 
   module Fiber→
     {x₁ : X}{y₀ : Y}(q₁₀ : Q x₁ y₀) =
@@ -601,7 +601,7 @@ module BlakersMassey {ℓ₁ ℓ₂ ℓ₃ : Level}
                          ; (i = i1) → r (j ∧ k)
                          ; (j = i0) → push q₀₀ (~ i)
                          ; (j = i1) → r (i ∧ k) })
-                (inS (q i j)) k'
+                (q i j) k'
 
     transpLeftCodeβ' :
         {p : PushoutQ} → (r : inl x₀ ≡ p) → (q : fiberSquare q₀₀ q₀₀ refl refl)

--- a/Cubical/Homotopy/Group/Base.agda
+++ b/Cubical/Homotopy/Group/Base.agda
@@ -213,7 +213,7 @@ isNaturalΩSphereMap A B homogB f 0 g =
         { (i = i0) → post∘∙ _ f .snd j
         ; (i = i1) → post∘∙ _ f .snd j
         })
-      (inS (f ∘∙ g i))
+      (f ∘∙ g i)
       j .fst false
 isNaturalΩSphereMap A B homogB f (n@(suc _)) g =
   →∙Homogeneous≡ homogB (funExt lem)
@@ -228,7 +228,7 @@ isNaturalΩSphereMap A B homogB f (n@(suc _)) g =
         { (i = i0) → post∘∙ _ f .snd j
         ; (i = i1) → post∘∙ _ f .snd j
         })
-      (inS (f ∘∙ g i))
+      (f ∘∙ g i)
       j .fst a
 
 SphereMapΩ : ∀ {ℓ} {A : Pointed ℓ} (n : ℕ)

--- a/Cubical/Homotopy/Group/LES.agda
+++ b/Cubical/Homotopy/Group/LES.agda
@@ -47,7 +47,7 @@ module _ {ℓ : Level} {A : Type ℓ} {x y : A} (p : x ≡ x) (q : x ≡ y) wher
                  ; (i = i1) → y
                  ; (j = i0) → q (i ∨ k)
                  ; (j = i1) → q (i ∨ k)})
-        (inS (PP j i))
+        (PP j i)
         k
 
   ←∙∙lCancel-fill : sym q ∙∙ p ∙∙ q ≡ refl → I → I → I → A
@@ -56,7 +56,7 @@ module _ {ℓ : Level} {A : Type ℓ} {x y : A} (p : x ≡ x) (q : x ≡ y) wher
                    ; (i = i1) → q (j ∨ ~ k)
                    ; (j = i0) → doubleCompPath-filler (sym q) p q (~ k) i
                    ; (j = i1) → y})
-          (inS (PP j i))
+          (PP j i)
           k
 
   →∙∙lCancel : PathP (λ i → p i ≡ y) q q → sym q ∙∙ p ∙∙ q ≡ refl

--- a/Cubical/Homotopy/Group/Pi4S3/BrunerieExperiments.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/BrunerieExperiments.agda
@@ -91,7 +91,7 @@ tee12 (surf i j) y =
       ; (j = i0) → base y
       ; (j = i1) → base (rotLoopInv y (~ i) k)
       })
-    (loop (unglue (i ∨ ~ i ∨ j ∨ ~ j) y) i j)
+    (PostTotalHopf.loop (unglue (i ∨ ~ i ∨ j ∨ ~ j) y) i j)
 
 tee34 : PostTotalHopf → join S¹ S¹
 tee34 (base x) = inl x

--- a/Cubical/Homotopy/Group/Pi4S3/S3PushoutIso.agda
+++ b/Cubical/Homotopy/Group/Pi4S3/S3PushoutIso.agda
@@ -133,7 +133,7 @@ module Pushout⋁↪fold⋁S²WedgeCon {ℓ : Level } {A : Type ℓ}
                                             (cong g (push (inr base))) (~ k) j
                    ; (j = i0) → f (push (push tt i) (~ k))
                    ; (j = i1) → g (push (push tt i) (~ k))})
-      (inS (r≡l base i j))
+      (r≡l base i j)
       k
 
   lp-base≡rp-base : lp base ≡ rp base
@@ -157,7 +157,7 @@ module Pushout⋁↪fold⋁S²WedgeCon {ℓ : Level } {A : Type ℓ}
                                    (cong g (push (inl x))) k j
                     ; (j = i0) → f (push (inl x) (i ∧ k))
                     ; (j = i1) → g (push (inl x) (i ∧ k))})
-          (inS (lp x j))
+          (lp x j)
           k
 
   inrfill : (x : S²) → I → I → I → A
@@ -169,7 +169,7 @@ module Pushout⋁↪fold⋁S²WedgeCon {ℓ : Level } {A : Type ℓ}
                     ; (i = i1) → f∘inr≡g∘inr x j
                     ; (j = i0) → f (push (inr x) (i ∨ ~ k))
                     ; (j = i1) → g (push (inr x) (i ∨ ~ k))})
-                      (inS (r≡l x (~ i) j))
+                      (r≡l x (~ i) j)
                       k
 
   main : (x : Pushout⋁↪fold⋁S²) → f x ≡ g x
@@ -249,7 +249,7 @@ In order to define this, we need the following cubes/coherences in
                                ; (j = i0) → push (push tt (~ r)) (~ k)
                                ; (r = i0) → push (inr (surf i j)) (~ k)
                                ; (r = i1) → push (inl (surf i j)) (~ k)})
-                     (inr (surf i j)) ∣ₕ
+                     (Pushout.inr (surf i j)) ∣ₕ
 
 →Ω²∥Pushout⋁↪fold⋁S²∥₅Id : (x : S²)
   → →Ω²∥Pushout⋁↪fold⋁S²∥₅ x base ≡  λ i j → ∣ inl (x , surf i j) ∣ₕ
@@ -264,7 +264,7 @@ In order to define this, we need the following cubes/coherences in
                                ; (j = i0) → push (push tt (~ r)) (~ k)
                                ; (r = i0) → push (inr (surf i j)) (~ k)
                                ; (r = i1) → push (inl (surf i j)) (~ k)})
-                     (inr (surf i j)) ∣ₕ
+                     (Pushout.inr (surf i j)) ∣ₕ
 
 push-inl∙push-inr⁻ : (y : S²) → Path Pushout⋁↪fold⋁S² (inl (y , base)) (inl (base , y))
 push-inl∙push-inr⁻ y i = (push (inl y) ∙ sym (push (inr y))) i
@@ -282,7 +282,7 @@ push-inl∙push-inr⁻-filler r i j k =
                   ; (j = i1) → push-inl∙push-inr⁻∙ (~ r) k
                   ; (k = i0) → inl (surf i j , base)
                   ; (k = i1) → inl (surf i j , base)})
-        (inS (inl (surf i j , base)))
+        (Pushout.inl (surf i j , base))
         r
 
 push-inl∙push-inr⁻-hLevFiller : (y : S²)
@@ -326,7 +326,7 @@ S²→Pushout⋁↪fold⋁S²↺' (surf i j) (push (push a k) l) =
                    ; (k = i1) → inl (surf i j , base)
                    ; (l = i0) → inl (surf i j , base)
                    ; (l = i1) → inl (surf i j , base)})
-         (inl (surf i j , base)) ∣ₕ
+         (Pushout.inl (surf i j , base)) ∣ₕ
 
 {- For easier treatment later, we state its inverse explicitly -}
 S²→Pushout⋁↪fold⋁S²↺'⁻ : (x : S²) → Pushout⋁↪fold⋁S² → ∥Pushout⋁↪fold⋁S²∥₅
@@ -431,7 +431,7 @@ secS²→Pushout⋁↪fold⋁S²↺ x =
                        ; (j = i1) → push (push tt k) (~ r)
                        ; (k = i0) → push (inl (surf i j)) (~ r)
                        ; (k = i1) → push (inr (surf i j)) (~ r)})
-               (inr (surf i j)) ∣ₕ
+               (Pushout.inr (surf i j)) ∣ₕ
 
       μ-coh : Path (Square {A = ∥Pushout⋁↪fold⋁S²∥₅}
              (λ _ → ∣ inl (base , base) ∣) (λ _ → ∣ inl (base , base) ∣)

--- a/Cubical/Homotopy/Hopf.agda
+++ b/Cubical/Homotopy/Hopf.agda
@@ -107,7 +107,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
                       ; (i = i1) → inr (secEq (μ-eq' a) b (~ k ∨ j))
                       ; (j = i0) → push a (secEq (μ-eq' a) b (~ k)) i
                       ; (j = i1) → push a b i})
-               (push a b i))
+               (inS (push a b i)))
 
     r : retract F G
     r (inl x) = refl
@@ -118,10 +118,10 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
                       ; (j = i0) → (push (x , invEq (μ-eq' x) (μ e x y))
                                   ∙ (λ i₁ → inr (retEq≡secEq (μ-eq' x) y (~ k) i₁))) i
                       ; (j = i1) → push (x , y) i})
-         (hcomp (λ k → λ { (i = i0) → inl x
+         (outS (hcomp (λ k → λ { (i = i0) → inl x
                       ; (i = i1) → inr (μ e x (retEq (μ-eq' x) y k))
                       ; (j = i1) → push (x , retEq (μ-eq' x) y k) i})
-                ((push (x , invEq (μ-eq' x) (μ e x y))) i))
+                (Pushout.push (x , invEq (μ-eq' x) (μ e x y)) i)))
 
     theIso : Iso TotalSpaceHopfPush (join (typ A) (typ A))
     fun theIso = F
@@ -140,7 +140,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
     inv' (merid a i , y) =
       hcomp (λ k → λ { (i = i0) → push (y , a) (~ k)
                       ; (i = i1) → inr y})
-            (inr (ua-unglue (μ-eq a) i y))
+            (Pushout.inr (ua-unglue (μ-eq a) i y))
       where
 
       pp : PathP (λ i → ua (μ-eq a) i → TotalSpaceHopfPush)
@@ -184,7 +184,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
       hcomp (λ k → λ { (i = i0) → push (x , y) (~ k)
                       ; (i = i1) → inr (μ e x y)
                       ; (j = i1) → push (x , y) (i ∨ ~ k)})
-            (inr (μ e x y))
+            (Pushout.inr (μ e x y))
 
     theIso : Iso TotalSpaceHopfPush (Σ (Susp (typ A)) Hopf)
     fun theIso = TotalSpaceHopfPush→TotalSpace
@@ -205,7 +205,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
     fill (λ k → ua (μ-eq y) i)
          (λ j → λ { (i = i0) → μ e z x
                   ; (i = i1) → μ-assoc e-ass z x y j})
-          (inS (ua-gluePt (μ-eq y) i (μ e z x)))
+          (ua-gluePt (μ-eq y) i (μ e z x))
           j
 
   TotalSpaceHopfPush→≃Hopf : (x : TotalSpaceHopfPush) → typ A ≃ Hopf (induced x)
@@ -326,7 +326,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
     hcomp (λ k → λ { (i = i0) → inl x
                     ; (i = i1)
                      → inr (secEq (_ , Push→TotalSpaceHopf-equiv x) y k)})
-      (push (x , invEq (_ , Push→TotalSpaceHopf-equiv x) y) i)
+      (Pushout.push (x , invEq (_ , Push→TotalSpaceHopf-equiv x) y) i)
 
   IsoTotalSpacePush²'ΣPush : Iso TotalSpacePush²'
            (Pushout {A = typ A × Σ (Susp (typ A)) Hopf} fst snd)
@@ -344,14 +344,14 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
                              ; (i = i1)
                               → inr (secEq (_
                                     , Push→TotalSpaceHopf-equiv x) y k)})
-                          (inS (push (x
+                          (Pushout.push (x
                                     , invEq (_
-                                     , Push→TotalSpaceHopf-equiv x) y) i)) k)
+                                     , Push→TotalSpaceHopf-equiv x) y) i) k)
                     ; (j = i1)
                      → push (x
                            , (secEq (_
                             , Push→TotalSpaceHopf-equiv x) y k)) i})
-          (push (x , (secEq (_ , Push→TotalSpaceHopf-equiv x) y i0)) i)
+          (Pushout.push (x , (secEq (_ , Push→TotalSpaceHopf-equiv x) y i0)) i)
   leftInv IsoTotalSpacePush²'ΣPush (inl x) = refl
   leftInv IsoTotalSpacePush²'ΣPush (inr x) = refl
   leftInv IsoTotalSpacePush²'ΣPush (push (x , y) i) j =
@@ -360,7 +360,7 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
                                            , Push→TotalSpaceHopf-equiv x)
                                         (Push→TotalSpaceHopf x y) (j ∨ k))
                     ; (j = i1) → push (x , y) i})
-          (hcomp (λ k → λ { (i = i0) → inl x
+          (outS (hcomp (λ k → λ { (i = i0) → inl x
                            ; (i = i1) → inr (retEq≡secEq
                                               (Push→TotalSpaceHopf x
                                              , Push→TotalSpaceHopf-equiv x)
@@ -370,8 +370,8 @@ module Hopf {ℓ : Level} {A : Pointed ℓ} {e : HSpace A}
                                                (Push→TotalSpaceHopf x
                                               , Push→TotalSpaceHopf-equiv x)
                                                (Push→TotalSpaceHopf x y)) i})
-            (push (x , retEq (Push→TotalSpaceHopf x
-                            , Push→TotalSpaceHopf-equiv x) y j) i))
+            (Pushout.push (x , retEq (Push→TotalSpaceHopf x
+                            , Push→TotalSpaceHopf-equiv x) y j) i)))
 
   joinIso₂ : Iso TotalSpacePush² (join (typ A) (join (typ A) (typ A)))
   joinIso₂ =
@@ -542,7 +542,7 @@ module S¹Hopf where
                    ; (i = i1) → push (rotInv-3 y x t) x j
                    ; (j = i0) → inl (assocSquare-3 i t x y)
                    ; (j = i1) → inr x })
-          (push ((rotInv-2 x y (i ∨ j)) · (invLooper (invLooper y · x))) (rotInv-2 x y (i ∨ j)) j)
+          (join.push ((rotInv-2 x y (i ∨ j)) · (invLooper (invLooper y · x))) (rotInv-2 x y (i ∨ j)) j)
 
   JoinS¹S¹→TotalHopf→JoinS¹S¹ : ∀ x → TotalHopf→JoinS¹S¹ (JoinS¹S¹→TotalHopf x) ≡ x
   JoinS¹S¹→TotalHopf→JoinS¹S¹ (inl x) i = inl x
@@ -574,7 +574,7 @@ module S¹Hopf where
                    ; (x = i0) (y = i1) → base
                    ; (x = i1) (y = i0) → base
                    ; (x = i1) (y = i1) → base })
-          (inS (rotInv-2 (loop y · loop x) (loop y · loop x · loop (~ y)) i)) j
+          (rotInv-2 (loop y · loop x) (loop y · loop x · loop (~ y)) i) j
 
   -- See assocFiller-3-endpoint
   -- TODO : use cubical extension types when available to remove assocFiller-4-endpoint
@@ -620,7 +620,7 @@ module S¹Hopf where
     hfill (λ t → λ { (j = i0) → ((invLooper (y · x · invLooper y) · (y · x) , I0)
                                 , invLooper (y · x · invLooper y) · (y · x) · (rotInv-1 x y t))
                    ; (j = i1) → ((invLooper (x · invLooper y) · x , I1) , x) })
-          (inS ((invLooper (x' · invLooper y) · x' , seg j) , rotInv-2 x' (x' · invLooper y) j)) i
+          ((invLooper (x' · invLooper y) · x' , seg j) , rotInv-2 x' (x' · invLooper y) j) i
 
   filler-4-1 : (_ j : I) → (y : S¹) → Glue S¹ (Border y j) → PseudoHopf
   filler-4-1 i j y x =
@@ -628,7 +628,7 @@ module S¹Hopf where
     hfill (λ t → λ { (j = i0) → ((invLooper (y · x · invLooper y) · (y · x) , I0)
                                 , (rotInv-4 y (y · x) (~ t)) · x)
                    ; (j = i1) → ((invLooper (x · invLooper y) · x , I1) , x) })
-          (inS ((invLooper (x' · invLooper y) · x' , seg j) , unglue (j ∨ ~ j) x)) i
+          ((invLooper (x' · invLooper y) · x' , seg j) , unglue (j ∨ ~ j) x) i
 
   filler-4-2 : (_ j : I) → (y : S¹) → Glue S¹ (Border y j) → TotalHopf
   filler-4-2 i j y x =

--- a/Cubical/Homotopy/HopfInvariant/Homomorphism.agda
+++ b/Cubical/Homotopy/HopfInvariant/Homomorphism.agda
@@ -171,7 +171,7 @@ H²C*≅ℤ n f g = compGroupIso is (Hⁿ-Sⁿ≅ℤ (suc n))
       lem₂ i j = h (hcomp (λ k → λ { (i = i1) → inr (fst f north)
                                      ; (j = i0) → inr (snd f (~ i))
                                      ; (j = i1) → push (inl north) (i ∨ ~ k)})
-                           (inr (snd f (~ i ∧ ~ j))))
+                           (Pushout.inr (snd f (~ i ∧ ~ j))))
 
   is : GroupIso (coHomGr (2 +ℕ n) (C* n f g)) (coHomGr (2 +ℕ n) (S₊ (2 +ℕ n)))
   Iso.fun (fst is) = ∘inr

--- a/Cubical/Homotopy/HopfInvariant/HopfMap.agda
+++ b/Cubical/Homotopy/HopfInvariant/HopfMap.agda
@@ -394,7 +394,7 @@ Gysin-e≡genCP² =
                 ; (i  = i1) → ∣ merid base (~ j ∨ ~ k) ∣
                 ; (j = i0) → ∣ merid a (~ k ∨ i) ∣
                 ; (j = i1) → ∣ merid base (~ i ∨ ~ k) ∣ₕ})
-             ∣ south ∣)
+             (inS ∣ south ∣))
 
   setHelp : (x : S₊ 2)
     → isSet (preThom.Q (CP² , inl tt) fibr (inr x) →∙ coHomK-ptd 2)

--- a/Cubical/Homotopy/Loopspace.agda
+++ b/Cubical/Homotopy/Loopspace.agda
@@ -80,7 +80,7 @@ snd (Ω→ {A = A} {B = B} (f , p)) = ∙∙lCancel p
             (sym (snd f)) (cong (fst f) q) (snd f) k) j
        ; (j = i0) → snd f k
        ; (j = i1) → snd f k})
-    (inS (cong-∙ (fst f) p q i j))
+    (cong-∙ (fst f) p q i j)
     k
 
 Ω→pres∙ : ∀ {ℓ ℓ'} {A : Pointed ℓ} {B : Pointed ℓ'} (f : A →∙ B)
@@ -228,7 +228,7 @@ EH-filler {A = A} n α β i j z =
                                 ∙ cong (λ x → rUnit x (~ k)) α) j
                   ; (j = i0) → rUnit refl (~ k)
                   ; (j = i1) → rUnit refl (~ k)})
-        (inS (mainPath n α β i j)) z
+        (mainPath n α β i j) z
 
 {- Eckmann-Hilton -}
 EH : ∀ {ℓ} {A : Pointed ℓ} (n : ℕ) → isComm∙ ((Ω^ (suc n)) A)
@@ -329,7 +329,7 @@ syllepsis {A = A} n α β k i j =
     hfill (λ k → λ { (i = i1) → refl
                     ; (j = i0) → rUnit refl (~ i)
                     ; (j = i1) → lUnit guy (~ i ∧ k)})
-          (inS (rUnit refl (~ i ∧ ~ j))) z
+          (rUnit refl (~ i ∧ ~ j)) z
 
   i=i1 : I → I → I → typ (Ω (Ω A))
   i=i1 r j k =

--- a/Cubical/Homotopy/MayerVietorisCofiber.agda
+++ b/Cubical/Homotopy/MayerVietorisCofiber.agda
@@ -66,7 +66,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           { (j = i0) → inl* (Y .snd) (~ i)
           ; (j = i1) → inr* (Z .snd) (~ i)
           })
-        (inS (inj* (push (X .snd) j)))
+        (inj* (push (X .snd) j))
         (~ i)
 
     cap0 : (j : I) → D hub
@@ -79,7 +79,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           { (k = i0) → cap0 j
           ; (k = i1) → hub*
           })
-        (inS hub*)
+        hub*
         j
 
     inrFiller : ∀ z → (k i : I) → D (spoke (inr z) i)
@@ -89,7 +89,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
          { (i = i0) → face-i≡0 k i1
          ; (i = i1) → inj* (inr z)
          })
-       (inS (inr* z i))
+       (inr* z i)
        k
 
     fun : ∀ c → D c
@@ -125,7 +125,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           { (i = i0) → spoke (inl (f x)) (~ k)
           ; (i = i1) → spoke (inr (g x)) (~ k)
           })
-        (inj (push x i))
+        (Cone.inj (push x i))
 
     bwdPushout : (w : Pushout f g) → bwd (pushoutToSusp w) ≡ inj w
     bwdPushout (inl y) = spoke (inl y)
@@ -136,7 +136,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           { (i = i0) → spoke (inl (f x)) (~ k)
           ; (i = i1) → spoke (inr (g x)) (~ k)
           })
-        (inS (inj (push x i)))
+        (Cone.inj (push x i))
         (~ k)
 
     bwdMeridPt : refl ≡ cong bwd (merid (X .snd))
@@ -147,7 +147,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           ; (i = i1) → spoke (inr (Z .snd)) (~ k)
           ; (j = i0) → spoke (push _ i) (~ k)
           })
-        (inj (push (X .snd) i))
+        (Cone.inj (push (X .snd) i))
 
     bwdFwd : (c : Cone wedgeToPushout) → bwd (fwd c) ≡ c
     bwdFwd =
@@ -163,7 +163,7 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
               ; (k = i0) → bwdMeridPt l i
               ; (k = i1) → spoke (inr z) i
               })
-            (spoke (inr z) (i ∧ k)))
+            (Cone.spoke (inr z) (i ∧ k)))
 
     fwdBwd : (s : Susp (X .fst)) → fwd (bwd s) ≡ s
     fwdBwd north = refl
@@ -175,5 +175,5 @@ module _ {ℓX ℓB ℓC} {X : Pointed ℓX} {B : Type ℓB} {C : Type ℓC} (f 
           { (i = i0) → north
           ; (i = i1) → merid (X .snd) (~ j)
           })
-        (inS (merid a i))
+        (Susp.merid a i)
         (~ j)

--- a/Cubical/Homotopy/Whitehead.agda
+++ b/Cubical/Homotopy/Whitehead.agda
@@ -177,7 +177,7 @@ module _ (A B : Type) (a₀ : A) (b₀ : B) where
                     ; (j = i0) → push tt (i ∨ ~ k)
                     ; (j = i1) → compPath-filler' (push tt)
                                                   (λ i → inr (merid b₀ i)) k i})
-                        (inr (compPath-filler (merid a)
+                        (Pushout.inr (compPath-filler (merid a)
                                               (sym (merid b₀)) (~ i) j))
 
   rightInv Iso-A0□-⋁ (push a i) j = push tt (i ∧ j)
@@ -234,7 +234,7 @@ module _ (A B : Type) (a₀ : A) (b₀ : B) where
                                    (push (idfun B a)) k j
                     ; (j = i0) → inl (merid a₀ (~ i ∧ k))
                     ; (j = i1) → push a (i ∧ k)})
-          (inl (merid a₀ j))
+          (Pushout.inl (merid a₀ j))
 
   Iso-A□2-Susp× : Iso (A□2 whitehead3x3) (Susp A × B)
   fun Iso-A□2-Susp× (inl x) = north , x

--- a/Cubical/ZCohomology/Groups/Prelims.agda
+++ b/Cubical/ZCohomology/Groups/Prelims.agda
@@ -75,10 +75,10 @@ coHomPointedElimSⁿ n m {B = B} isprop ind =
                                                                              ; (i = i1) → compPath'-filler (sym fId)
                                                                                                             (cong f (merid (ptSn (suc m)))) k j
                                                                              ; (j = i1) → f (merid a i)})
-                                                                    (hcomp (λ k → λ {(i = i0) → f north ;
+                                                                    (outS (hcomp (λ k → λ {(i = i0) → f north ;
                                                                                       (i = i1) → f (merid (ptSn (suc m)) (j ∨ ~ k)) ;
                                                                                       (j = i1) → f (merid a i)})
-                                                                           (f (merid a i)))})))
+                                                                           (f (merid a i))))})))
                        (ind λ a → sym fId ∙∙ cong f (merid a) ∙ cong f (sym (merid (ptSn (suc m)))) ∙∙ fId)
 
 0₀ = 0ₖ 0

--- a/Cubical/ZCohomology/MayerVietorisUnreduced.agda
+++ b/Cubical/ZCohomology/MayerVietorisUnreduced.agda
@@ -84,13 +84,13 @@ module MV {ℓ ℓ' ℓ''} (A : Type ℓ) (B : Type ℓ') (C : Type ℓ'') (f : 
                     ; (i = i1) → lUnitₖ (suc n) (0ₖ (suc n)) (~ j)
                     ; (j = i0) → Kn→ΩKn+1-hom n (h a) (l a) (~ k) i
                     ; (j = i1) → cong₂Funct (λ x y → x +[ (suc n) ]ₖ y) (Kn→ΩKn+1 n (h a)) (Kn→ΩKn+1 n (l a)) (~ k) i })
-          (hcomp (λ k → λ { (i = i0) → rUnitₖ (suc n) (0ₖ (suc n)) (~ j)
+          (outS (hcomp (λ k → λ { (i = i0) → rUnitₖ (suc n) (0ₖ (suc n)) (~ j)
                            ; (i = i1) → lUnitₖ (suc n) (Kn→ΩKn+1 n (l a) k) (~ j)})
-                 (hcomp (λ k → λ { (i = i0) → rUnitₖ (suc n) (0ₖ (suc n)) (~ j)
+                 (outS (hcomp (λ k → λ { (i = i0) → rUnitₖ (suc n) (0ₖ (suc n)) (~ j)
                                   ; (i = i1) → lUnitₖ≡rUnitₖ (suc n) (~ k) (~ j)
                                   ; (j = i0) → Kn→ΩKn+1 n (h a) i
                                   ; (j = i1) → (Kn→ΩKn+1 n (h a) i) +[ (suc n) ]ₖ coHom-pt (suc n)})
-                        (rUnitₖ (suc n) (Kn→ΩKn+1 n (h a) i) (~ j))))
+                        (rUnitₖ (suc n) (Kn→ΩKn+1 n (h a) i) (~ j))))))
 
   dIsHom : (n : ℕ) → IsGroupHom (coHomGr n C .snd) (ST.rec isSetSetTrunc λ a → ∣ d-pre n a ∣₂) (coHomGr (suc n) (Pushout f g) .snd)
   dIsHom n =

--- a/Cubical/ZCohomology/RingStructure/GradedCommutativity.agda
+++ b/Cubical/ZCohomology/RingStructure/GradedCommutativity.agda
@@ -926,7 +926,7 @@ gradedComm'-elimCase (suc (suc k)) (suc n) (suc m) term p q (merid a i) (merid b
        ; (r = i1) → -ₖ'-gen (suc (suc n)) (suc (suc m)) p q
                        (subst coHomK (+'-comm (suc (suc m)) (suc (suc n)))
                         (help₁ l i j))})
-   (hcomp (λ l →
+   (outS (hcomp (λ l →
      λ { (i = i0) → -ₖ'-gen (suc (suc n)) (suc (suc m)) p q
                       (subst coHomK (+'-comm (suc (suc m)) (suc (suc n)))
                         (Kn→ΩKn+10ₖ _ (~ r ∨ ~ l) j))
@@ -946,14 +946,14 @@ gradedComm'-elimCase (suc (suc k)) (suc n) (suc m) term p q (merid a i) (merid b
                                                              (_⌣ₖ_ {n = suc (suc n)} {m = suc m} ∣ merid a i ∣ₕ ∣ b ∣ₕ)))
                                              ∙∙ cong (-ₖ'-gen (suc m) (suc (suc n)) (evenOrOdd (suc m)) p) (transp0₂ n m)) i) j)
                           (Kn→ΩKn+10ₖ _) (~ l) i j))})
-        (hcomp (λ l →
+        (outS (hcomp (λ l →
           λ { (i = i0) → ∣ north ∣
             ; (i = i1) → ∣ north ∣
             ; (j = i0) → Kn→ΩKn+10ₖ _ r i
             ; (j = i1) → Kn→ΩKn+10ₖ _ r i
             ; (r = i0) → lem₄ n m q p a b i1 j i
             ; (r = i1) → lem₅ n m p q a b (~ l) i j})
-            (hcomp (λ l →
+            (outS (hcomp (λ l →
               λ { (i = i0) → ∣ north ∣
                 ; (i = i1) → ∣ north ∣
                 ; (j = i0) → Kn→ΩKn+10ₖ _ (r ∨ ~ l) i
@@ -968,7 +968,7 @@ gradedComm'-elimCase (suc (suc k)) (suc n) (suc m) term p q (merid a i) (merid b
                                                 (gradedComm'-elimCase k n m
                                                   (+-comm n m ∙∙ cong predℕ (+-comm (suc m) n) ∙∙ cong (predℕ ∘ predℕ) term)
                                                   (evenOrOdd (suc n)) (evenOrOdd (suc m)) a b (~ l))))) i j})
-                (lem₆ n m p q a b r i j))))
+                (lem₆ n m p q a b r i j)))))))
   where
   help₁ : I → I → I → coHomK _
   help₁ l i j =

--- a/Cubical/ZCohomology/RingStructure/RingLaws.agda
+++ b/Cubical/ZCohomology/RingStructure/RingLaws.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --safe --experimental-lossy-unification #-}
+{-# OPTIONS --safe --experimental-lossy-unification -vtc.conv.term.sort:10 #-}
 module Cubical.ZCohomology.RingStructure.RingLaws where
 
 open import Cubical.Foundations.HLevels


### PR DESCRIPTION
Implemented to test out https://github.com/agda/agda/issues/6041. This isn't gonna compile because it's using unreleased features, of course. Anyway, something along the way between 2.6.2.2→`master` made it so that `CupProductTensor` has megabytes upon megabytes of unsolved metas... at least that one isn't self-evidently my fault :sweat_smile: 