### PR TITLE
Alternative definition of the torus

### DIFF
--- a/Cubical/Foundations/GroupoidLaws.agda
+++ b/Cubical/Foundations/GroupoidLaws.agda
@@ -209,22 +209,40 @@ cong-∙ : ∀ {B : Type ℓ} (f : A → B) (p : x ≡ y) (q : y ≡ z)
          → cong f (p ∙ q) ≡ (cong f p) ∙ (cong f q)
 cong-∙ f p q = cong-∙∙ f refl p q
 
-hcomp-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
-               (h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
-               → (hcomp u (outS u0) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+hcomp-unique : ∀ {ℓ} {A : Type ℓ} {φ}
+             → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ])
+             → (h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
+             → (hcomp u (outS u0) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
 hcomp-unique {φ = φ} u u0 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
-                                                            ; (i = i1) → outS (h2 k) })
-                                                   (outS u0))
+                                                         ; (i = i1) → outS (h2 k) })
+                                                (outS u0))
 
 
-lid-unique : ∀ {ℓ} {A : Type ℓ} {φ} → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ]) →
-               (h1 h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
-               → (outS (h1 i1) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
-lid-unique {φ = φ} u u0 h1 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
-                                                            ; (i = i0) → outS (h1 k)
-                                                            ; (i = i1) → outS (h2 k) })
-                                                   (outS u0))
+hlid-unique : ∀ {ℓ} {A : Type ℓ} {φ}
+            → (u : I → Partial φ A) → (u0 : A [ φ ↦ u i0 ])
+            → (h1 h2 : ∀ i → A [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
+            → (outS (h1 i1) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+hlid-unique {φ = φ} u u0 h1 h2 = inS (\ i → hcomp (\ k → \ { (φ = i1) → u k 1=1
+                                                           ; (i = i0) → outS (h1 k)
+                                                           ; (i = i1) → outS (h2 k) })
+                                                  (outS u0))
 
+comp-unique : ∀ {ℓ} {A : I → Type ℓ} {φ}
+            → (u : (i : I) → Partial φ (A i)) → (u0 : A i0 [ φ ↦ u i0 ])
+            → (h2 : ∀ i → A i [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
+            → (comp A u (outS u0) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+comp-unique {A = A} {φ = φ} u u0 h2 = inS (\ i → comp A (\ k → \ { (φ = i1) → u k 1=1
+                                                                 ; (i = i1) → outS (h2 k) })
+                                                        (outS u0))
+
+lid-unique : ∀ {ℓ} {A : I → Type ℓ} {φ}
+           → (u : (i : I) → Partial φ (A i)) → (u0 : A i0 [ φ ↦ u i0 ])
+           → (h1 h2 : ∀ i → A i [ (φ ∨ ~ i) ↦ (\ { (φ = i1) → u i 1=1; (i = i0) → outS u0}) ])
+           → (outS (h1 i1) ≡ outS (h2 i1)) [ φ ↦ (\ { (φ = i1) → (\ i → u i1 1=1)}) ]
+lid-unique {A = A} {φ = φ} u u0 h1 h2 = inS (\ i → comp A (\ k → \ { (φ = i1) → u k 1=1
+                                                                   ; (i = i0) → outS (h1 k)
+                                                                   ; (i = i1) → outS (h2 k) })
+                                                          (outS u0))
 
 transp-hcomp : ∀ {ℓ} (φ : I) {A' : Type ℓ}
                      (A : (i : I) → Type ℓ [ φ ↦ (λ _ → A') ]) (let B = \ (i : I) → outS (A i))

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -240,6 +240,43 @@ sym≡cong-sym P = sym-cong-sym≡id (sym P)
 symIso : {a b : A} → Iso (a ≡ b) (b ≡ a)
 symIso = iso sym sym (λ _ → refl) λ _ → refl
 
+-- Vertical composition of squares (along their first dimension)
+-- See Cubical.Foundations.Prelude for horizontal composition
+
+module _ {ℓ : Level} {A : Type ℓ}
+  {a₀₀ a₀₁ : A} {a₀₋ : a₀₀ ≡ a₀₁}
+  {a₁₀ a₁₁ : A} {a₁₋ : a₁₀ ≡ a₁₁}
+  {a₂₀ a₂₁ : A} {a₂₋ : a₂₀ ≡ a₂₁}
+  {a₋₀ : a₀₀ ≡ a₁₀} {a₋₁ : a₀₁ ≡ a₁₁}
+  {b₋₀ : a₁₀ ≡ a₂₀} {b₋₁ : a₁₁ ≡ a₂₁}
+  where
+
+  -- "Pointwise" composition
+  _∙v_ : (p : Square a₀₋ a₁₋ a₋₀ a₋₁) (q : Square a₁₋ a₂₋ b₋₀ b₋₁)
+       → Square a₀₋ a₂₋ (a₋₀ ∙ b₋₀) (a₋₁ ∙ b₋₁)
+  (p ∙v q) i j = ((λ i → p i j) ∙ (λ i → q i j)) i
+
+  -- "Direct" composition
+  _∙v'_ : (p : Square a₀₋ a₁₋ a₋₀ a₋₁) (q : Square a₁₋ a₂₋ b₋₀ b₋₁)
+        → Square a₀₋ a₂₋ (a₋₀ ∙ b₋₀) (a₋₁ ∙ b₋₁)
+  (p ∙v' q) i =
+    comp (λ k → compPath-filler a₋₀ b₋₀ k i ≡ compPath-filler a₋₁ b₋₁ k i)
+         (λ where k (i = i0) → a₀₋
+                  k (i = i1) → q k)
+         (p i)
+
+  -- The two ways of composing squares are equal, because they are
+  -- correct "lids" for the same box
+  ∙v≡∙v' : (p : Square a₀₋ a₁₋ a₋₀ a₋₁) (q : Square a₁₋ a₂₋ b₋₀ b₋₁)
+         → p ∙v q ≡ p ∙v' q
+  ∙v≡∙v' p q l i = outS
+    (comp-unique {A = λ k → compPath-filler a₋₀ b₋₀ k i ≡ compPath-filler a₋₁ b₋₁ k i}
+                 (λ where k (i = i0) → a₀₋
+                          k (i = i1) → q k)
+                 (inS (p i))
+                 (λ k → inS λ j → compPath-filler (λ i → p i j) (λ i → q i j) k i))
+    (~ l)
+
 -- Inspect
 
 module _ {A : Type ℓ} {B : Type ℓ'} where
@@ -379,34 +416,30 @@ compPathR→PathP∙∙ {p = p} {q = q} {r = r} {s = s} P j i =
                    ; (j = i1) → doubleCompPath-filler  p s (sym q) (~ k) i})
           (P j i)
 
-comm→PathP : {a b c d : A}  {p : a ≡ c} {q : b ≡ d} {r : a ≡ b} {s : c ≡ d}
-  → p ∙ s ≡ r ∙ q
-  → PathP (λ i → p i ≡ q i) r s
-comm→PathP {p = p} {q = q} {r = r} {s = s} P i j =
-  hcomp
-    (λ k → λ
-      { (i = i0) → r (j ∧ k)
-      ; (i = i1) → s (j ∨ ~ k)
-      ; (j = i0) → compPath-filler p s (~ k) i
-      ; (j = i1) → compPath-filler' r q (~ k) i
-      })
-    (P j i)
+compPath→Square-faces : {a b c d : A} (p : a ≡ c) (q : b ≡ d) (r : a ≡ b) (s : c ≡ d)
+  → (i j k : I) → Partial (i ∨ ~ i ∨ j ∨ ~ j) A
+compPath→Square-faces p q r s i j k = λ where
+  (i = i0) → r (j ∧ k)
+  (i = i1) → s (j ∨ ~ k)
+  (j = i0) → compPath-filler p s (~ k) i
+  (j = i1) → compPath-filler' r q (~ k) i
 
-Square→compPath : ∀ {ℓ} {A : Type ℓ} {x y z w : A} {p : x ≡ y} {q : y ≡ z} {r : x ≡ w} {s : w ≡ z}
-  → Square r q p s → p ∙ q ≡ r ∙ s
+compPath→Square : {a b c d : A} {p : a ≡ c} {q : b ≡ d} {r : a ≡ b} {s : c ≡ d}
+  → p ∙ s ≡ r ∙ q → Square r s p q
+compPath→Square {p = p} {q = q} {r = r} {s = s} P i j =
+  hcomp (compPath→Square-faces p q r s i j) (P j i)
+
+Square→compPath : {a b c d : A} {p : a ≡ c} {q : b ≡ d} {r : a ≡ b} {s : c ≡ d}
+  → Square r s p q → p ∙ s ≡ r ∙ q
 Square→compPath {p = p} {q = q} {r = r} {s = s} sq i j =
-  hcomp (λ k → λ {(i = i0) → compPath-filler p q k j
-                 ; (i = i1) → compPath-filler' r s k j
-                 ; (j = i0) → r (~ k ∧ i)
-                 ; (j = i1) → q (k ∨ i)})
-        (sq j i)
+  hcomp (λ k → compPath→Square-faces p q r s j i (~ k)) (sq j i)
 
-Square→compPathΩ² : ∀ {ℓ} {A : Type ℓ} {x : A} (sq : Square (λ _ → x) refl refl refl)
+Square→compPathΩ² : {a : A} (sq : Square (λ _ → a) refl refl refl)
              → Square→compPath sq ≡ cong (_∙ refl) (flipSquare sq)
-Square→compPathΩ² {x = x} sq k i j =
-  hcomp (λ r → λ {(i = i0) → rUnit (λ _ → x) r j
-                 ; (i = i1) → rUnit (λ _ → x) r j
-                 ; (j = i0) → x
-                 ; (j = i1) → x
+Square→compPathΩ² {a = a} sq k i j =
+  hcomp (λ r → λ {(i = i0) → rUnit (λ _ → a) r j
+                 ; (i = i1) → rUnit (λ _ → a) r j
+                 ; (j = i0) → a
+                 ; (j = i1) → a
                  ; (k = i1) → cong (λ x → rUnit x r) (flipSquare sq) i j})
         (sq j i)

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -491,7 +491,8 @@ Cube :
 Cube a₀₋₋ a₁₋₋ a₋₀₋ a₋₁₋ a₋₋₀ a₋₋₁ =
   PathP (λ i → Square (a₋₀₋ i) (a₋₁₋ i) (a₋₋₀ i) (a₋₋₁ i)) a₀₋₋ a₁₋₋
 
--- Vertical composition of squares
+-- Horizontal composition of squares (along their second dimension)
+-- See Cubical.Foundations.Path for vertical composition
 
 _∙₂_ :
   {a₀₀ a₀₁ a₀₂ : A} {a₀₋ : a₀₀ ≡ a₀₁} {b₀₋ : a₀₁ ≡ a₀₂}

--- a/Cubical/HITs/Torus/Base.agda
+++ b/Cubical/HITs/Torus/Base.agda
@@ -8,6 +8,8 @@ equivalent to two circles
 module Cubical.HITs.Torus.Base where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Path
+open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Univalence
@@ -93,3 +95,51 @@ module _ where
 
   test2 : windingTorus (line1 ∙ line2 ∙ sym line1 ∙ sym line1) ≡ (negsuc 0 , pos 1)
   test2 = refl
+
+-- An alternative definition of the torus
+
+data Torus' : Type₀ where
+  point' : Torus'
+  line1' : point' ≡ point'
+  line2' : point' ≡ point'
+  square' : line1' ∙ line2' ≡ line2' ∙ line1'
+
+Torus'≡Torus : Torus' ≡ Torus
+Torus'≡Torus = isoToPath (iso to from to-from from-to)
+  where
+    to : Torus' → Torus
+    to point' = point
+    to (line1' i) = line1 i
+    to (line2' i) = line2 i
+    to (square' i j) = Square→compPath square i j
+
+    from : Torus → Torus'
+    from point = point'
+    from (line1 i) = line1' i
+    from (line2 i) = line2' i
+    from (square i j) = compPath→Square square' i j
+
+    to-from : ∀ x → to (from x) ≡ x
+    to-from point = refl
+    to-from (line1 i) = refl
+    to-from (line2 i) = refl
+    to-from (square i j) k =
+      hcomp-equivFiller (λ k → compPath→Square-faces line1 line1 line2 line2 i j (~ k))
+                        (inS (square i j))
+                        (~ k)
+
+    from-to : ∀ x → from (to x) ≡ x
+    from-to point' = refl
+    from-to (line1' i) = refl
+    from-to (line2' i) = refl
+    from-to (square' i j) k = cube i j k
+      where
+        cube : Cube ((λ j k → line1' j) ∙v' (λ j k → line2' j)) ((λ j k → line2' j) ∙v' (λ j k → line1' j))
+                    (λ i k → point') (λ i k → point')
+                    (λ i j → from (to (square' i j))) square'
+        cube =
+          sym (∙v≡∙v' _ _) ◁
+          (λ i j k → hcomp-equivFiller (compPath→Square-faces line1' line1' line2' line2' j i)
+                                       (inS (square' i j))
+                                       (~ k))
+          ▷ ∙v≡∙v' _ _

--- a/Cubical/Homotopy/EilenbergMacLane/GroupStructure.agda
+++ b/Cubical/Homotopy/EilenbergMacLane/GroupStructure.agda
@@ -48,7 +48,7 @@ module _ {G : AbGroup ℓ} where
       → PathP (λ i → Path (EM₁ (AbGroup→Group G))
                (emloop h i) (emloop h i)) (emloop g) (emloop g)
     helper g h =
-      comm→PathP
+      compPath→Square
         ((sym (emloop-comp _ h g)
           ∙∙ cong emloop (+Comm h g)
           ∙∙ emloop-comp _ g h))


### PR DESCRIPTION
An alternative definition of the torus whose surface is `p ∙ q ≡ q ∙ p` rather than `Square p p q q`, with a proof that the two definitions are equivalent.

The forward and inverse maps make use of a single 3-dimensional "tube" that connects `p ∙ q ≡ q ∙ p` to `Square p p q q` (`compPath→Square-faces`), so that the homotopies follow from the fact that `hcomp` behaves like an equivalence (`hcomp-equivFillerSub`).

But this isn't quite enough to make the proof go through; many thanks to @plt-amy and @kangrongji for explaining [what was wrong](https://github.com/agda/agda/issues/6017#issuecomment-1212409372) and [how to fix it](https://github.com/kangrongji/cubical-experiments/blob/main/Torus.agda), respectively.

The core of the issue is that there are two ways to compose two squares along a chosen "first" direction: *pointwise*, where we abstract over the second dimension and compose along the first with `_∙_`; or directly, using `comp` to compose the two `PathP`s in the varying path space `compPath-filler p q i j ≡ compPath-filler p q i j`. These two composites are equal, by uniqueness of composites, because they are both lids for the same cube (see `∙v≡∙v'`); but they don't *compute* to the same thing.

In `from-to (square' i j)`, the left boundary is the dependent function `from-to` applied to the composite `line1' ∙ line2'`, which turns out to be the "direct" composite `(λ j → refl) ∙v' (λ j → refl)`, but the cube given by `hcomp-equivFiller` has `(λ j → refl) ∙v (λ j → refl)` (in other words, `λ j → refl`) as its boundary, so we need to fix up the boundary with `∙v≡∙v'`.

cc. @mortberg

#### Bureaucracy

- Is there a good reason for calling `_∙₂_` "vertical" composition? I think this is based on the way we draw squares, which is not really set in stone. On the other hand, since `_∙₂_` composes `PathP`s along their *second* dimension, it really corresponds to *horizontal* composition in a 2-category. This is why I named the operation above `∙v`: it composes `PathP`s along their *first* dimension.
- Should we also have `_∙h_` (alias for `_∙₂_`), `_∙h'_` and `∙h≡∙h'`? The proofs would essentially be the same up to `flipSquare`, so maybe it's not worth cluttering the library?
- I'm not sure where the composition stuff should go, and more generally the relationship between `Cubical.Foundations.{Prelude,GroupoidLaws,Path}` seems kind of blurry. I put it in `Path` for now, the only constraint is that `∙v≡∙v'` depends on `comp-unique` in `GroupoidLaws` (and also that I'd like composition-related thing to be as close together as possible).
- I renamed the old `lid-unique` to `hlid-unique` and introduced heterogeneous counterparts `comp-unique` and `lid-unique`, so this is a breaking change (but nothing uses `lid-unique` in the library).
- I renamed `comm→PathP` to `compPath→Square` for homogeneity.
- Generally, names: please feel free to suggest.
- This interacts with https://github.com/agda/cubical/pull/906 as it introduces more `inS`/`outS`.