### PR TITLE
remove duplicate of Pushout.elimProp

### DIFF
--- a/Cubical/HITs/Pushout/Properties.agda
+++ b/Cubical/HITs/Pushout/Properties.agda
@@ -359,17 +359,6 @@ record 3x3-span : Type₁ where
   3x3-lemma : A□○ ≡ A○□
   3x3-lemma = isoToPath 3x3-Iso
 
-PushoutToProp : {f : A → B} {g : A → C}
-                {D : Pushout f g → Type ℓ'''}
-              → ((x : Pushout f g) → isProp (D x))
-              → ((a : B) → D (inl a))
-              → ((c : C) → D (inr c))
-              → (x : Pushout f g) → D x
-PushoutToProp isset baseB baseC (inl x) = baseB x
-PushoutToProp isset baseB baseC (inr x) = baseC x
-PushoutToProp {f = f} {g = g} isset baseB baseC (push a i) =
-  isOfHLevel→isOfHLevelDep 1 isset (baseB (f a)) (baseC (g a)) (push a) i
-
 -- explicit characterisation of equivalences
 -- Pushout f₁ g₁ ≃ Pushout f₂ g₂ avoiding
 -- transports

--- a/Cubical/Homotopy/HopfInvariant/HopfMap.agda
+++ b/Cubical/Homotopy/HopfInvariant/HopfMap.agda
@@ -44,7 +44,7 @@ open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Group.Instances.Int
 open import Cubical.Algebra.Group.GroupPath
 
-open import Cubical.HITs.Pushout
+open import Cubical.HITs.Pushout as Pushout
 open import Cubical.HITs.Join
 open import Cubical.HITs.S1 renaming (_·_ to _*_)
 open import Cubical.HITs.Sn
@@ -93,7 +93,7 @@ conCP² x y = sRec2 squash₂ (λ p q → ∣ p ∙ sym q ∣₂) (conCP²' x) (
         → A (inl base)
         → ((a : hopfS¹.TotalSpaceHopfPush) → A a)
     indLem {A = A} p b =
-      PushoutToProp p
+      Pushout.elimProp _ p
         (sphereElim 0 (λ _ → p _) b)
         (sphereElim 0 (λ _ → p _) (subst A (push (base , base)) b))
 

--- a/Cubical/ZCohomology/Groups/CP2.agda
+++ b/Cubical/ZCohomology/Groups/CP2.agda
@@ -26,7 +26,7 @@ open import Cubical.Algebra.Group.Morphisms
 open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.Group.Instances.Unit
 
-open import Cubical.HITs.Pushout
+open import Cubical.HITs.Pushout as Pushout
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
 open import Cubical.HITs.Susp
@@ -72,7 +72,7 @@ leftInv characFunSpaceCP² _ =
 H⁰CP²≅ℤ : GroupIso (coHomGr 0 CP²) ℤGroup
 H⁰CP²≅ℤ =
   H⁰-connected (inr tt)
-    (PushoutToProp (λ _ → squash₁)
+    (Pushout.elimProp _ (λ _ → squash₁)
       (sphereElim _ (λ _ → isOfHLevelSuc 1 squash₁)
         ∣ sym (push (north , base)) ∣₁)
     λ _ → ∣ refl ∣₁)

--- a/Cubical/ZCohomology/Groups/Wedge.agda
+++ b/Cubical/ZCohomology/Groups/Wedge.agda
@@ -25,7 +25,7 @@ open import Cubical.HITs.Susp
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
 open import Cubical.HITs.Wedge
-open import Cubical.HITs.Pushout
+open import Cubical.HITs.Pushout as Pushout
 
 open import Cubical.Homotopy.Connected
 
@@ -246,6 +246,7 @@ module _ {ℓ ℓ'} (A : Pointed ℓ) (B : Pointed ℓ') where
 
   wedgeConnected : ((x : typ A) → ∥ pt A ≡ x ∥₁) → ((x : typ B) → ∥ pt B ≡ x ∥₁) → (x : A ⋁ B) → ∥ inl (pt A) ≡ x ∥₁
   wedgeConnected conA conB =
-    PushoutToProp (λ _ → isPropPropTrunc)
-                  (λ a → PT.rec isPropPropTrunc (λ p → ∣ cong inl p ∣₁) (conA a))
-                   λ b → PT.rec isPropPropTrunc (λ p → ∣ push tt ∙ cong inr p ∣₁) (conB b)
+    Pushout.elimProp _
+      (λ _ → isPropPropTrunc)
+      (λ a → PT.rec isPropPropTrunc (λ p → ∣ cong inl p ∣₁) (conA a))
+      (λ b → PT.rec isPropPropTrunc (λ p → ∣ push tt ∙ cong inr p ∣₁) (conB b))


### PR DESCRIPTION
This PR removes `PushoutToProp` from `Cubical.HITs.Pushout.Properties`, which was just a duplicate of `elimProp`, with the same definition.