### PR TITLE
Use commAlgebraFromCommRing in the equivalence between algebras and over-rings

### DIFF
--- a/Cubical/Algebra/CommAlgebra/Base.agda
+++ b/Cubical/Algebra/CommAlgebra/Base.agda
@@ -153,6 +153,20 @@ module _ {R : CommRing ℓ} where
         makeIsCommAlgebra is-set +Assoc +IdR +InvR +Comm ·Assoc ·IdL ·DistL+ ·Comm
                                     ·Assoc⋆ ⋆DistR+ ⋆DistL+ ⋆IdL ⋆AssocL
 
+      commAlgebraFromCommRing→CommRing : CommAlgebra→CommRing commAlgebraFromCommRing ≡ S
+      -- Note that this is not definitional: the proofs of the axioms might differ.
+      commAlgebraFromCommRing→CommRing i .fst  = ⟨ S ⟩
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr.0r = 0r
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr.1r = 1S
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr._+_ = _+_
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr._·_ = _·_
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr.-_ = -_
+      commAlgebraFromCommRing→CommRing i .snd .CommRingStr.isCommRing =
+        isProp→PathP (λ i → isPropIsCommRing _ _ _ _ _)
+          (CommRingStr.isCommRing (snd (CommAlgebra→CommRing commAlgebraFromCommRing)))
+          isCommRing
+          i
+
   IsCommAlgebraEquiv : {A : Type ℓ'} {B : Type ℓ''}
     (M : CommAlgebraStr R A) (e : A ≃ B) (N : CommAlgebraStr R B)
     → Type _

--- a/Cubical/Algebra/CommAlgebra/Properties.agda
+++ b/Cubical/Algebra/CommAlgebra/Properties.agda
@@ -58,7 +58,6 @@ A ≃CAlg⟨ f ⟩ g = g ∘≃a f
 -- An R-algebra is the same as a CommRing A with a CommRingHom φ : R → A
 module CommAlgChar (R : CommRing ℓ) where
  open Iso
- open IsRingHom
  open CommRingTheory
 
 
@@ -66,24 +65,18 @@ module CommAlgChar (R : CommRing ℓ) where
  CommRingWithHom = Σ[ A ∈ CommRing ℓ ] CommRingHom R A
 
  toCommAlg : CommRingWithHom → CommAlgebra R ℓ
- toCommAlg (A , φ , φIsHom) = ⟨ A ⟩ , ACommAlgStr
+ toCommAlg (A , φ , φIsHom) =
+  commAlgebraFromCommRing
+    A
+    (λ r a → (φ r) · a)
+    (λ r s x → cong (_· x) (pres· r s) ∙ sym (·Assoc _ _ _))
+    (λ r x y → ·DistR+ _ _ _)
+    (λ r s x → cong (_· x) (pres+ r s) ∙ ·DistL+ _ _ _)
+    (λ x → cong (_· x) pres1 ∙ ·IdL x)
+    λ r x y → sym (·Assoc _ _ _)
   where
   open CommRingStr (snd A)
-  ACommAlgStr : CommAlgebraStr R ⟨ A ⟩
-  CommAlgebraStr.0a ACommAlgStr = 0r
-  CommAlgebraStr.1a ACommAlgStr = 1r
-  CommAlgebraStr._+_ ACommAlgStr = _+_
-  CommAlgebraStr._·_ ACommAlgStr = _·_
-  CommAlgebraStr.- ACommAlgStr = -_
-  CommAlgebraStr._⋆_ ACommAlgStr r a = (φ r) · a
-  CommAlgebraStr.isCommAlgebra ACommAlgStr = makeIsCommAlgebra
-   is-set +Assoc +IdR +InvR +Comm ·Assoc ·IdL ·DistL+ ·Comm
-   (λ _ _ x → cong (λ y →  y · x) (pres· φIsHom _ _) ∙ sym (·Assoc _ _ _))
-   (λ _ _ _ → ·DistR+ _ _ _)
-   (λ _ _ x → cong (λ y → y · x) (pres+ φIsHom _ _) ∙ ·DistL+ _ _ _)
-   (λ x → cong (λ y → y · x) (pres1 φIsHom) ∙ ·IdL x)
-   (λ _ _ _ → sym (·Assoc _ _ _))
-
+  open IsRingHom φIsHom
 
  fromCommAlg : CommAlgebra R ℓ → CommRingWithHom
  fromCommAlg A = (CommAlgebra→CommRing A) , φ , φIsHom
@@ -149,6 +142,8 @@ module CommAlgChar (R : CommRing ℓ) where
  leftInv CommAlgIso = CommAlgRoundTrip
 
  open RingHoms
+ open IsRingHom
+
  isCommRingWithHomHom : (A B : CommRingWithHom) → CommRingHom (fst A) (fst B) → Type ℓ
  isCommRingWithHomHom (_ , f) (_ , g) h = h ∘r f ≡ g
 

--- a/Cubical/Algebra/CommAlgebra/Properties.agda
+++ b/Cubical/Algebra/CommAlgebra/Properties.agda
@@ -95,16 +95,9 @@ module CommAlgChar (R : CommRing ℓ) where
  CommRingWithHomRoundTrip (A , φ) = ΣPathP (APath , φPathP)
   where
   open CommRingStr
-  -- note that the proofs of the axioms might differ!
+
   APath : fst (fromCommAlg (toCommAlg (A , φ))) ≡ A
-  fst (APath i) = ⟨ A ⟩
-  0r (snd (APath i)) = 0r (snd A)
-  1r (snd (APath i)) = 1r (snd A)
-  _+_ (snd (APath i)) = _+_ (snd A)
-  _·_ (snd (APath i)) = _·_ (snd A)
-  -_ (snd (APath i)) = -_ (snd A)
-  isCommRing (snd (APath i)) = isProp→PathP (λ i → isPropIsCommRing _ _ _ _ _ )
-             (isCommRing (snd (fst (fromCommAlg (toCommAlg (A , φ)))))) (isCommRing (snd A)) i
+  APath = commAlgebraFromCommRing→CommRing A _ _ _ _ _ _
 
   -- this only works because fst (APath i) = fst A definitionally!
   φPathP : PathP (λ i → CommRingHom R (APath i)) (snd (fromCommAlg (toCommAlg (A , φ)))) φ


### PR DESCRIPTION
This small PR uses the `commAlgebraFromCommRing` construction more consequently, in code that was written before it. We also single out a property of the construction (`commAlgebraFromCommRing→CommRing`) from the surrounding proof.