### PR TITLE
Update install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,8 +41,7 @@ Then, execute following:
 > cabal v2-install agda agda-mode
 ```
 
-where RELEASE  is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use
-```git tag --list``` for a full list of releases.
+where RELEASE  is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2. You can use ```git tag --list``` for a full list of releases.
 This should put the agda and agda-mode executables in the folder
 `~/.cabal/bin` (the location can be configured with `--symlink-bindir` flag).
 
@@ -122,8 +121,7 @@ in a cabal sandbox do the following:
 > make
 ```
 
-where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use
-```git tag --list``` for a full list of releases.
+where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2. You can use ```git tag --list``` for a full list of releases.
 If you have cabal v2 installed the sandbox command should be replaced
 by `cabal v1-sandbox init`.
 
@@ -199,8 +197,7 @@ In order to install Agda using stack do the following:
 > stack build --stack-yaml stack-VERSION.yaml
 ```
 
-Where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda (for example v2.6.2.2, use
-```git tag --list``` for a full list of releases) and
+Where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda (for example v2.6.2.2, use ```git tag --list``` for a full list of releases) and
 VERSION is a suitable version of ghc (for example 8.6.3). This
 should put the agda and agda-mode executables in the folder
 `agda/.stack-work/install/.../.../.../bin`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,7 @@
 Installation of agda/cubical
 ============================
 
-The cubical library should compile on the latest official release
+The cubical library should compile on the [latest official release](https://wiki.portal.chalmers.se/agda/Main/Download)
 of Agda:
 
 https://github.com/agda/agda
@@ -189,10 +189,13 @@ In order to install Agda using stack do the following:
 ```
 > git clone https://github.com/agda/agda
 > cd agda
-> stack build --stack-yaml stack-"version".yaml
+> git checkout RELEASE
+> stack build --stack-yaml stack-VERSION.yaml
 ```
 
-Where "version" is a suitable version of ghc (for example 8.6.3). This
+Where RELEASE is the latest release of agda (for example v2.6.2.2, use 
+```git tag --list``` for a full list of releases) and 
+VERSION is a suitable version of ghc (for example 8.6.3). This
 should put the agda and agda-mode executables in the folder
 `agda/.stack-work/install/.../.../.../bin`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,10 +36,13 @@ Then, execute following:
 > cabal v2-update
 > git clone https://github.com/agda/agda
 > cd agda
+> git checkout RELEASE
 > touch doc/user-manual.pdf
 > cabal v2-install agda agda-mode
 ```
 
+where RELEASE  is the latest release of agda, for example v2.6.2.2, use 
+```git tag --list``` for a full list of releases.
 This should put the agda and agda-mode executables in the folder
 `~/.cabal/bin` (the location can be configured with `--symlink-bindir` flag).
 
@@ -113,11 +116,14 @@ in a cabal sandbox do the following:
 ```
 > git clone https://github.com/agda/agda
 > cd agda
+> git checkout RELEASE
 > cabal sandbox init
 > cabal update
 > make
 ```
 
+where RELEASE is the latest release of agda, for example v2.6.2.2, use 
+```git tag --list``` for a full list of releases.
 If you have cabal v2 installed the sandbox command should be replaced
 by `cabal v1-sandbox init`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ Then, execute following:
 > cabal v2-install agda agda-mode
 ```
 
-where RELEASE  is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use 
+where RELEASE  is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use
 ```git tag --list``` for a full list of releases.
 This should put the agda and agda-mode executables in the folder
 `~/.cabal/bin` (the location can be configured with `--symlink-bindir` flag).
@@ -122,7 +122,7 @@ in a cabal sandbox do the following:
 > make
 ```
 
-where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use 
+where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use
 ```git tag --list``` for a full list of releases.
 If you have cabal v2 installed the sandbox command should be replaced
 by `cabal v1-sandbox init`.
@@ -199,8 +199,8 @@ In order to install Agda using stack do the following:
 > stack build --stack-yaml stack-VERSION.yaml
 ```
 
-Where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda (for example v2.6.2.2, use 
-```git tag --list``` for a full list of releases) and 
+Where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda (for example v2.6.2.2, use
+```git tag --list``` for a full list of releases) and
 VERSION is a suitable version of ghc (for example 8.6.3). This
 should put the agda and agda-mode executables in the folder
 `agda/.stack-work/install/.../.../.../bin`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ Then, execute following:
 > cabal v2-install agda agda-mode
 ```
 
-where RELEASE  is the latest release of agda, for example v2.6.2.2, use 
+where RELEASE  is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use 
 ```git tag --list``` for a full list of releases.
 This should put the agda and agda-mode executables in the folder
 `~/.cabal/bin` (the location can be configured with `--symlink-bindir` flag).
@@ -122,7 +122,7 @@ in a cabal sandbox do the following:
 > make
 ```
 
-where RELEASE is the latest release of agda, for example v2.6.2.2, use 
+where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda, for example v2.6.2.2, use 
 ```git tag --list``` for a full list of releases.
 If you have cabal v2 installed the sandbox command should be replaced
 by `cabal v1-sandbox init`.
@@ -199,7 +199,7 @@ In order to install Agda using stack do the following:
 > stack build --stack-yaml stack-VERSION.yaml
 ```
 
-Where RELEASE is the latest release of agda (for example v2.6.2.2, use 
+Where RELEASE is the [latest release](https://wiki.portal.chalmers.se/agda/Main/Download) of agda (for example v2.6.2.2, use 
 ```git tag --list``` for a full list of releases) and 
 VERSION is a suitable version of ghc (for example 8.6.3). This
 should put the agda and agda-mode executables in the folder


### PR DESCRIPTION
As mentioned here: #932 , our install instructions lack the step of checking out a specific tag of agda, corresponding to the latest release. This PR fixes that by mentioning the step and pointing to [the agda wiki](https://wiki.portal.chalmers.se/agda/Main/Download) as a source for figuring out what the latest release is.