### PR TITLE
Allow nullification to take a family of types as input rather than just one type

### DIFF
--- a/Cubical/HITs/Nullification/Base.agda
+++ b/Cubical/HITs/Nullification/Base.agda
@@ -6,20 +6,21 @@ open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv.PathSplit
 open isPathSplitEquiv
 
-isNull : ∀ {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') → Type (ℓ-max ℓ ℓ')
-isNull S A = isPathSplitEquiv (const {A = A} {B = S})
+module _ {ℓα ℓs} {A : Type ℓα} (S : A → Type ℓs) where
+  isNull : ∀ {ℓ} (X : Type ℓ) → Type (ℓ-max (ℓ-max ℓα ℓs) ℓ)
+  isNull X = (α : A) → isPathSplitEquiv (const {A = X} {B = S α})
 
-data Null {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') : Type (ℓ-max ℓ ℓ') where
-  ∣_∣ : A → Null S A
-  -- the image of every map (S → Null S A) is contractible in Null S A
-  hub   : (f : S → Null S A) → Null S A
-  spoke : (f : S → Null S A) (s : S) → hub f ≡ f s
-  -- the image of every map (S → x ≡ y) for x y : A is contractible in x ≡ y
-  ≡hub   : ∀ {x y} (p : S → x ≡ y) → x ≡ y
-  ≡spoke : ∀ {x y} (p : S → x ≡ y) (s : S) → ≡hub p ≡ p s
+  data Null {ℓ} (X : Type ℓ) : Type (ℓ-max (ℓ-max ℓα ℓs) ℓ) where
+    ∣_∣ : X → Null X
+    -- the image of every map (S α → Null S X) is contractible in Null S X
+    hub   : (α : A) → (f : (S α) → Null X) → Null X
+    spoke : (α : A) → (f : (S α) → Null X) (s : S α) → hub α f ≡ f s
+    -- the image of every map (S α → x ≡ y) for x y : X is contractible in x ≡ y
+    ≡hub   : ∀ {x y} {α} (p : S α → x ≡ y) → x ≡ y
+    ≡spoke : ∀ {x y} {α} (p : S α → x ≡ y) (s : S α) → ≡hub p ≡ p s
 
-isNull-Null : ∀ {ℓ ℓ'} {S : Type ℓ} {A : Type ℓ'} → isNull S (Null S A)
-fst (sec isNull-Null) f     = hub   f
-snd (sec isNull-Null) f i s = spoke f s i
-fst (secCong isNull-Null x y) p i     = ≡hub   (funExt⁻ p) i
-snd (secCong isNull-Null x y) p i j s = ≡spoke (funExt⁻ p) s i j
+  isNull-Null : ∀ {ℓ} {X : Type ℓ} → isNull (Null X)
+  fst (sec (isNull-Null α)) f =     hub   α f
+  snd (sec (isNull-Null α)) f i s = spoke α f s i
+  fst (secCong (isNull-Null α) x y) p i     = ≡hub   (funExt⁻ p) i
+  snd (secCong (isNull-Null α) x y) p i j s = ≡spoke (funExt⁻ p) s i j

--- a/Cubical/HITs/Nullification/Properties.agda
+++ b/Cubical/HITs/Nullification/Properties.agda
@@ -2,6 +2,7 @@
 module Cubical.HITs.Nullification.Properties where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
@@ -21,13 +22,13 @@ open import Cubical.HITs.Nullification.Base
 open Modality
 open isPathSplitEquiv
 
-rec : ∀ {ℓ ℓ' ℓ''} {S : Type ℓ} {A : Type ℓ'} {B : Type ℓ''}
-      → (nB : isNull S B) → (A → B) → Null S A → B
+rec : ∀ {ℓα ℓs ℓ ℓ'} {A : Type ℓα} {S : A → Type ℓs} {X : Type ℓ} {Y : Type ℓ'}
+      → (nB : isNull S Y) → (X → Y) → Null S X → Y
 rec nB g ∣ x ∣ = g x
-rec nB g (hub f) = fst (sec nB) (λ s → rec nB g (f s))
-rec nB g (spoke f s i) = snd (sec nB) (λ s → rec nB g (f s)) i s
-rec nB g (≡hub {x} {y} p i) = fst (secCong nB (rec nB g x) (rec nB g y)) (λ i s → rec nB g (p s i)) i
-rec nB g (≡spoke {x} {y} p s i j) = snd (secCong nB (rec nB g x) (rec nB g y)) (λ i s → rec nB g (p s i)) i j s
+rec nB g (hub α f) = fst (sec (nB α)) (λ s → rec nB g (f s))
+rec nB g (spoke α f s i) = snd (sec (nB α)) (λ s → rec nB g (f s)) i s
+rec nB g (≡hub {x} {y} {α} p i) = fst (secCong (nB α) (rec nB g x) (rec nB g y)) (λ i s → rec nB g (p s i)) i
+rec nB g (≡spoke {x} {y} {α} p s i j) = snd (secCong (nB α) (rec nB g x) (rec nB g y)) (λ i s → rec nB g (p s i)) i j s
 
 toPathP⁻ : ∀ {ℓ} (A : I → Type ℓ) {x : A i0} {y : A i1} → x ≡ transport⁻ (λ i → A i) y → PathP A x y
 toPathP⁻ A p i = toPathP {A = λ i → A (~ i)} (sym p) (~ i)
@@ -38,103 +39,103 @@ toPathP⁻-sq x j i = hcomp (λ l → λ { (i = i0) → transportRefl x j
                                    ; (i = i1) → x ; (j = i1) → x })
                           (transportRefl x (i ∨ j))
 
-module _ {ℓ ℓ' ℓ''} {S : Type ℓ} {A : Type ℓ'} {B : Null S A → Type ℓ''} where
+module _ {ℓα ℓs ℓ ℓ'} {A : Type ℓα} {S : A → Type ℓs} {X : Type ℓ} {Y : Null S X → Type ℓ'} where
 
   private
-    secCongDep' : ∀ (nB : (x : Null S A) → isNull S (B x)) {x y : Null S A} (p : x ≡ y)
-                  → (∀ (bx : B x) (by : B y) → hasSection (cong₂ (λ x (b : B x) (_ : S) → b) p))
-    secCongDep' nB p = secCongDep (λ _ → const) p (λ a → secCong (nB a))
+    secCongDep' : ∀ (nY : (x : Null S X) → isNull S (Y x)) {x y : Null S X} {α} (p : x ≡ y)
+                  → (∀ (bx : Y x) (by : Y y) → hasSection (cong₂ (λ x (b : Y x) (_ : S α) → b) p))
+    secCongDep' nY {α = α} p = secCongDep (λ _ → const) p (λ a → secCong (nY a α))
 
-  elim : (nB : (x : Null S A) → isNull S (B x)) → ((a : A) → B ∣ a ∣) → (x : Null S A) → B x
-  elim nB g ∣ x ∣ = g x
-  elim nB g (hub f)
-    = fst (sec (nB (hub f)))
-          (λ s → transport (λ i → B (spoke f s (~ i))) (elim nB g (f s)))
+  elim : (nY : (x : Null S X) → isNull S (Y x)) → ((a : X) → Y ∣ a ∣) → (x : Null S X) → Y x
+  elim nY g ∣ x ∣ = g x
+  elim nY g (hub α f)
+    = fst (sec (nY (hub α f) α))
+          (λ s → transport (λ i → Y (spoke α f s (~ i))) (elim nY g (f s)))
 
-  elim nB g (spoke f s i)
-    = toPathP⁻ (λ i → B (spoke f s i))
-               (funExt⁻ ( snd (sec (nB (hub f)))
-                              (λ s → transport (λ i → B (spoke f s (~ i))) (elim nB g (f s))) ) s) i
+  elim nY g (spoke α f s i)
+    = toPathP⁻ (λ i → Y (spoke α f s i))
+               (funExt⁻ ( snd (sec (nY (hub α f) α))
+                              (λ s → transport (λ i → Y (spoke α f s (~ i))) (elim nY g (f s))) ) s) i
 
-  elim nB g (≡hub {x} {y} p i)
-    = hcomp (λ k → λ { (i = i0) → transportRefl (elim nB g x) k
-                     ; (i = i1) → transportRefl (elim nB g y) k })
-            (fst (secCongDep' nB (≡hub p) (transport refl (elim nB g x)) (transport refl (elim nB g y)))
-                 (λ i s → transport (λ j → B (≡spoke p s (~ j) i)) (elim nB g (p s i))) i)
+  elim nY g (≡hub {x} {y} p i)
+    = hcomp (λ k → λ { (i = i0) → transportRefl (elim nY g x) k
+                     ; (i = i1) → transportRefl (elim nY g y) k })
+            (fst (secCongDep' nY (≡hub p) (transport refl (elim nY g x)) (transport refl (elim nY g y)))
+                 (λ i s → transport (λ j → Y (≡spoke p s (~ j) i)) (elim nY g (p s i))) i)
 
-  elim nB g (≡spoke {x} {y} p s j i)
-    = hcomp (λ k → λ { (i = i0) → toPathP⁻-sq (elim nB g x) k j
-                     ; (i = i1) → toPathP⁻-sq (elim nB g y) k j
-                     ; (j = i1) → elim nB g (p s i) })
+  elim nY g (≡spoke {x} {y} p s j i)
+    = hcomp (λ k → λ { (i = i0) → toPathP⁻-sq (elim nY g x) k j
+                     ; (i = i1) → toPathP⁻-sq (elim nY g y) k j
+                     ; (j = i1) → elim nY g (p s i) })
             (q₂ j i)
 
-    where q₁ : Path (PathP (λ i → B (≡hub p i)) (transport refl (elim nB g x)) (transport refl (elim nB g y)))
-                    (fst (secCongDep' nB (≡hub p) (transport refl (elim nB g x)) (transport refl (elim nB g y)))
-                         (λ i s → transport (λ j → B (≡spoke p s (~ j) i)) (elim nB g (p s i))))
-                    (λ i → transport (λ j → B (≡spoke p s (~ j) i)) (elim nB g (p s i)))
-          q₁ j i = snd (secCongDep' nB (≡hub p) (transport refl (elim nB g x)) (transport refl (elim nB g y)))
-                       (λ i s → transport (λ j → B (≡spoke p s (~ j) i)) (elim nB g (p s i))) j i s
+    where q₁ : Path (PathP (λ i → Y (≡hub p i)) (transport refl (elim nY g x)) (transport refl (elim nY g y)))
+                    (fst (secCongDep' nY (≡hub p) (transport refl (elim nY g x)) (transport refl (elim nY g y)))
+                         (λ i s → transport (λ j → Y (≡spoke p s (~ j) i)) (elim nY g (p s i))))
+                    (λ i → transport (λ j → Y (≡spoke p s (~ j) i)) (elim nY g (p s i)))
+          q₁ j i = snd (secCongDep' nY (≡hub p) (transport refl (elim nY g x)) (transport refl (elim nY g y)))
+                       (λ i s → transport (λ j → Y (≡spoke p s (~ j) i)) (elim nY g (p s i))) j i s
 
-          q₂ : PathP (λ j → PathP (λ i → B (≡spoke p s j i)) (toPathP⁻ (λ _ → B x) (λ _ → transport refl (elim nB g x)) j)
-                                                             (toPathP⁻ (λ _ → B y) (λ _ → transport refl (elim nB g y)) j))
-                     (fst (secCongDep' nB (≡hub p) (transport refl (elim nB g x)) (transport refl (elim nB g y)))
-                        (λ i s → transport (λ j → B (≡spoke p s (~ j) i)) (elim nB g (p s i))))
-                     (λ i → elim nB g (p s i))
-          q₂ j i = toPathP⁻ (λ j → B (≡spoke p s j i)) (λ j → q₁ j i) j
+          q₂ : PathP (λ j → PathP (λ i → Y (≡spoke p s j i)) (toPathP⁻ (λ _ → Y x) (λ _ → transport refl (elim nY g x)) j)
+                                                             (toPathP⁻ (λ _ → Y y) (λ _ → transport refl (elim nY g y)) j))
+                     (fst (secCongDep' nY (≡hub p) (transport refl (elim nY g x)) (transport refl (elim nY g y)))
+                        (λ i s → transport (λ j → Y (≡spoke p s (~ j) i)) (elim nY g (p s i))))
+                     (λ i → elim nY g (p s i))
+          q₂ j i = toPathP⁻ (λ j → Y (≡spoke p s j i)) (λ j → q₁ j i) j
 
 -- nullification is a modality
 
-NullModality : ∀ {ℓ} (S : Type ℓ) → Modality ℓ
+NullModality : ∀ {ℓα ℓs} {A : Type ℓα} (S : A → Type ℓs) → Modality (ℓ-max ℓα ℓs)
 isModal       (NullModality S) = isNull S
-isPropIsModal (NullModality S) = isPropIsPathSplitEquiv _
+isPropIsModal (NullModality S) = isPropΠ (λ α → isPropIsPathSplitEquiv _)
 ◯             (NullModality S) = Null S
-◯-isModal     (NullModality S) = isNull-Null
+◯-isModal     (NullModality S) = isNull-Null S -- isNull-Null
 η             (NullModality S) = ∣_∣
 ◯-elim        (NullModality S) = elim
 ◯-elim-β      (NullModality S) = λ _ _ _ → refl
-◯-=-isModal   (NullModality S) x y = fromIsEquiv _ e
-  where e : isEquiv (λ (p : x ≡ y) → const {B = S} p)
-        e = transport (λ i → isEquiv {B = funExtPath {A = S} {f = const x} {g = const y} (~ i)}
+◯-=-isModal   (NullModality S) x y α = fromIsEquiv _ e
+  where e : isEquiv (λ (p : x ≡ y) → const {B = S α} p)
+        e = transport (λ i → isEquiv {B = funExtPath {A = S α} {f = const x} {g = const y} (~ i)}
                                      (λ p → ua-gluePath funExtEquiv {x = const p} {y = cong const p} refl (~ i)))
-                      (isEquivCong (_ , toIsEquiv _ isNull-Null))
+                      (isEquivCong (_ , toIsEquiv _ (isNull-Null S α)))
 
-idemNull : ∀ {ℓ} (S A : Type ℓ) → isNull S A → A ≃ Null S A
+idemNull : ∀ {ℓ} {A : Type ℓ} (S : A → Type ℓ) (X : Type ℓ) → isNull S A → A ≃ Null S A
 idemNull S A nA = ∣_∣ , isModalToIsEquiv (NullModality S) nA
 
--- nullification is localization at a map (S → 1)
+-- nullification is localization at a family of maps (S α → 1)
 
-module Null-iso-Localize {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') where
+module Null-iso-Localize {ℓα ℓs ℓ} {A : Type ℓα} (S : A → Type ℓs) (X : Type ℓ) where
 
-  to : Null S A → Localize {A = Unit} (λ _ → const {B = S} tt) A
+  to : Null S X → Localize {A = A} (λ α → const {B = S α} tt) X
   to ∣ x ∣ = ∣ x ∣
-  to (hub f) = ext tt (to ∘ f) tt
-  to (spoke f s i) = isExt tt (to ∘ f) s i
-  to (≡hub {x} {y} p i) = ≡ext tt (const (to x)) (const (to y)) (cong to ∘ p) tt i
-  to (≡spoke {x} {y} p s i j) = ≡isExt tt (const (to x)) (const (to y)) (cong to ∘ p) s i j
+  to (hub α f) = ext α (to ∘ f) tt
+  to (spoke α f s i) = isExt α (to ∘ f) s i
+  to (≡hub {x} {y} {α} p i) = ≡ext α (const (to x)) (const (to y)) (cong to ∘ p) tt i
+  to (≡spoke {x} {y} {α} p s i j) = ≡isExt α (const (to x)) (const (to y)) (cong to ∘ p) s i j
 
-  from : Localize {A = Unit} (λ _ → const {B = S} tt) A → Null S A
+  from : Localize {A = A} (λ α → const {B = S α} tt) X → Null S X
   from ∣ x ∣ = ∣ x ∣
-  from (ext tt f tt) = hub (from ∘ f)
-  from (isExt tt f s i) = spoke (from ∘ f) s i
-  from (≡ext tt g h p tt i) = ≡hub {x = from (g tt)} {from (h tt)} (cong from ∘ p) i
-  from (≡isExt tt g h p s i j) = ≡spoke {x = from (g tt)} {from (h tt)} (cong from ∘ p) s i j
+  from (ext α f tt) = hub α (from ∘ f)
+  from (isExt α f s i) = spoke α (from ∘ f) s i
+  from (≡ext α g h p tt i) = ≡hub {x = from (g tt)} {from (h tt)} (cong from ∘ p) i
+  from (≡isExt α g h p s i j) = ≡spoke {x = from (g tt)} {from (h tt)} (cong from ∘ p) s i j
 
-  to-from : ∀ (x : Localize {A = Unit} (λ _ → const {B = S} tt) A) → to (from x) ≡ x
+  to-from : ∀ (x : Localize {A = A} (λ α → const {B = S α} tt) X) → to (from x) ≡ x
   to-from ∣ x ∣ k = ∣ x ∣
-  to-from (ext tt f tt) k = ext tt (λ s → to-from (f s) k) tt
-  to-from (isExt tt f s i) k = isExt tt (λ s → to-from (f s) k) s i
-  to-from (≡ext tt g h p tt i) k = ≡ext tt (λ _ → to-from (g tt) k) (λ _ → to-from (h tt) k) (λ s j → to-from (p s j) k) tt i
-  to-from (≡isExt tt g h p s i j) k = ≡isExt tt (λ _ → to-from (g tt) k) (λ _ → to-from (h tt) k) (λ s j → to-from (p s j) k) s i j
+  to-from (ext α f tt) k = ext α (λ s → to-from (f s) k) tt
+  to-from (isExt α f s i) k = isExt α (λ s → to-from (f s) k) s i
+  to-from (≡ext α g h p tt i) k = ≡ext α (λ _ → to-from (g tt) k) (λ _ → to-from (h tt) k) (λ s j → to-from (p s j) k) tt i
+  to-from (≡isExt α g h p s i j) k = ≡isExt α (λ _ → to-from (g tt) k) (λ _ → to-from (h tt) k) (λ s j → to-from (p s j) k) s i j
 
-  from-to : ∀ (x : Null S A) → from (to x) ≡ x
+  from-to : ∀ (x : Null S X) → from (to x) ≡ x
   from-to ∣ x ∣ k = ∣ x ∣
-  from-to (hub f) k = hub (λ s → from-to (f s) k)
-  from-to (spoke f s i) k = spoke (λ s → from-to (f s) k) s i
+  from-to (hub α f) k = hub α (λ s → from-to (f s) k)
+  from-to (spoke α f s i) k = spoke α (λ s → from-to (f s) k) s i
   from-to (≡hub {x} {y} p i) k = ≡hub {x = from-to x k} {from-to y k} (λ s j → from-to (p s j) k) i
   from-to (≡spoke {x} {y} p s i j) k = ≡spoke {x = from-to x k} {from-to y k} (λ s j → from-to (p s j) k) s i j
 
-  isom : Iso (Null S A) (Localize {A = Unit} (λ _ → const {B = S} tt) A)
+  isom : Iso (Null S X) (Localize {A = A} (λ α → const {B = S α} tt) X)
   isom = iso to from to-from from-to
 
-Null≃Localize : ∀ {ℓ ℓ'} (S : Type ℓ) (A : Type ℓ') → Null S A ≃ Localize (λ _ → const tt) A
-Null≃Localize S A = isoToEquiv (Null-iso-Localize.isom S A)
+Null≃Localize : ∀ {ℓα ℓs ℓ} {A : Type ℓα} (S : A → Type ℓs) (X : Type ℓ) → Null S X ≃ Localize (λ α → const {B = S α} tt) X
+Null≃Localize S X = isoToEquiv (Null-iso-Localize.isom S X)

--- a/Cubical/HITs/Truncation/FromNegTwo/Base.agda
+++ b/Cubical/HITs/Truncation/FromNegTwo/Base.agda
@@ -22,7 +22,7 @@ open import Cubical.HITs.Sn.Base
 --   ≡spoke : ∀ {x y} (p : S (-1+ n) → x ≡ y) (s : S (-1+ n)) → ≡hub p ≡ p s
 
 hLevelTrunc : ∀ {ℓ} → HLevel → Type ℓ → Type ℓ
-hLevelTrunc n A = Null (S (-1+ n)) A
+hLevelTrunc n A = Null {A = Unit} (λ _ → S (-1+ n)) A
 
 -- Note that relative to the HoTT book, this notation is off by +2
 ∥_∥_ : ∀ {ℓ} → Type ℓ → HLevel → Type ℓ

--- a/Cubical/HITs/Truncation/FromNegTwo/Properties.agda
+++ b/Cubical/HITs/Truncation/FromNegTwo/Properties.agda
@@ -40,8 +40,8 @@ isSphereFilled : ℕ₋₁ → Type ℓ → Type ℓ
 isSphereFilled n A = (f : S n → A) → sphereFill n f
 
 isSphereFilledTrunc : {n : HLevel} → isSphereFilled (-1+ n) (hLevelTrunc n A)
-isSphereFilledTrunc {n = zero}  f = hub f , ⊥.elim
-isSphereFilledTrunc {n = suc n} f = hub f , spoke f
+isSphereFilledTrunc {n = zero}  f = hub tt f , ⊥.elim
+isSphereFilledTrunc {n = suc n} f = hub tt f , spoke tt f
 
 isSphereFilled→isOfHLevelSuc : {n : HLevel} → isSphereFilled (ℕ→ℕ₋₁ n) A → isOfHLevel (suc n) A
 isSphereFilled→isOfHLevelSuc {A = A} {zero} h x y = sym (snd (h f) north) ∙ snd (h f) south
@@ -97,18 +97,18 @@ isOfHLevel→isSphereFilled {A = A} {suc (suc n)} h = helper λ x y → isOfHLev
 
 -- isNull (S n) A ≃ (isSphereFilled n A) × (∀ (x y : A) → isSphereFilled n (x ≡ y))
 
-isOfHLevel→isSnNull : {n : HLevel} → isOfHLevel n A → isNull (S (-1+ n)) A
-fst (sec (isOfHLevel→isSnNull h)) f     = fst (isOfHLevel→isSphereFilled h f)
-snd (sec (isOfHLevel→isSnNull h)) f i s = snd (isOfHLevel→isSphereFilled h f) s i
-fst (secCong (isOfHLevel→isSnNull h) x y) p = fst (isOfHLevel→isSphereFilled (isOfHLevelPath _ h x y) (funExt⁻ p))
-snd (secCong (isOfHLevel→isSnNull h) x y) p i j s = snd (isOfHLevel→isSphereFilled (isOfHLevelPath _ h x y) (funExt⁻ p)) s i j
+isOfHLevel→isSnNull : {n : HLevel} → isOfHLevel n A → isNull {A = Unit} (λ _ → S (-1+ n)) A
+fst (sec (isOfHLevel→isSnNull h _)) f     = fst (isOfHLevel→isSphereFilled h f)
+snd (sec (isOfHLevel→isSnNull h _)) f i s = snd (isOfHLevel→isSphereFilled h f) s i
+fst (secCong (isOfHLevel→isSnNull h _) x y) p = fst (isOfHLevel→isSphereFilled (isOfHLevelPath _ h x y) (funExt⁻ p))
+snd (secCong (isOfHLevel→isSnNull h _) x y) p i j s = snd (isOfHLevel→isSphereFilled (isOfHLevelPath _ h x y) (funExt⁻ p)) s i j
 
-isSnNull→isOfHLevel : {n : HLevel} → isNull (S (-1+ n)) A → isOfHLevel n A
-isSnNull→isOfHLevel {n = zero}  nA = fst (sec nA) ⊥.rec , λ y → fst (secCong nA _ y) (funExt ⊥.elim)
-isSnNull→isOfHLevel {n = suc n} nA = isSphereFilled→isOfHLevelSuc (λ f → fst (sec nA) f , λ s i → snd (sec nA) f i s)
+isSnNull→isOfHLevel : {n : HLevel} → isNull {A = Unit} (λ _ → S (-1+ n)) A → isOfHLevel n A
+isSnNull→isOfHLevel {n = zero}  nA = fst (sec (nA tt)) ⊥.rec , λ y → fst (secCong (nA tt) _ y) (funExt ⊥.elim)
+isSnNull→isOfHLevel {n = suc n} nA = isSphereFilled→isOfHLevelSuc (λ f → fst (sec (nA tt)) f , λ s i → snd (sec (nA tt)) f i s)
 
 isOfHLevelTrunc : (n : HLevel) → isOfHLevel n (hLevelTrunc n A)
-isOfHLevelTrunc zero    = hub ⊥.rec , λ _ → ≡hub ⊥.rec
+isOfHLevelTrunc zero    = hub tt ⊥.rec , λ _ → ≡hub ⊥.rec
 isOfHLevelTrunc (suc n) = isSphereFilled→isOfHLevelSuc isSphereFilledTrunc
 
 -- isOfHLevelTrunc n = isSnNull→isOfHLevel isNull-Null


### PR DESCRIPTION
The current version of nullification in the library only took a single type S as input. However, the definition in [RSS] is defined for a family of types. Many of the examples of nullification in [RSS] and in my papers really require the more general definition with a family of types, so I suggest changing the definition in the library.

In the first commit I changed the definition of nullification following the notation in `Localization/`, which is already defined for families of maps. In the second commit I updated the files in the library that refer to nullification to use the more general definition, which turned out to just be truncation. It type checks successfully for me on agda 2.6.2.2.

[RSS] Rijke, Shulman, Spitters, *Modalities in homotopy type theory*