### PR TITLE
Move _$_ from Reflection.Base to Foundations.Function

### DIFF
--- a/Cubical/Algebra/CommRing/Localisation/Limit.agda
+++ b/Cubical/Algebra/CommRing/Localisation/Limit.agda
@@ -570,8 +570,8 @@ module _ (R' : CommRing ℓ) {n : ℕ} (f : FinVec (fst R') (suc n)) where
     where
     χφSquare< : ∀ i j → i < j → χˡ i j .fst (φ i .fst a) ≡ χʳ i j .fst (φ j .fst a)
     χφSquare< i j i<j =
-      χˡ i j .fst (φ i .fst a)          ≡⟨ cong (_$ a) (cᴬ .coneOutCommutes singPairL) ⟩
-      cᴬ .coneOut (pair i j i<j) .fst a ≡⟨ cong (_$ a) (sym (cᴬ .coneOutCommutes singPairR)) ⟩
+      χˡ i j .fst (φ i .fst a)          ≡⟨ cong (_$r a) (cᴬ .coneOutCommutes singPairL) ⟩
+      cᴬ .coneOut (pair i j i<j) .fst a ≡⟨ cong (_$r a) (sym (cᴬ .coneOutCommutes singPairR)) ⟩
       χʳ i j .fst (φ j .fst a)          ∎
 
 
@@ -613,4 +613,4 @@ module _ (R' : CommRing ℓ) {n : ℕ} (f : FinVec (fst R') (suc n)) where
      (RingHom≡ (funExt λ a → cong fst (applyEqualizerLemma a .snd (θtriple a))))
      where
      θtriple : (a : A) → Σ[ x ∈ R ] ∀ i → x /1ˢ ≡ φ i .fst a
-     θtriple a = fst θ a , λ i → cong (_$ a) (isConeMorθ (sing i))
+     θtriple a = fst θ a , λ i → cong (_$r a) (isConeMorθ (sing i))

--- a/Cubical/Algebra/CommRing/Localisation/PullbackSquare.agda
+++ b/Cubical/Algebra/CommRing/Localisation/PullbackSquare.agda
@@ -531,7 +531,7 @@ module _ (R' : CommRing ℓ) (f g : (fst R')) where
 
   applyEqualizerLemma : ∀ a → ∃![ χa ∈ R ] (χa /1ᶠ ≡ fst φ a) × (χa /1ᵍ ≡ fst ψ a)
   applyEqualizerLemma a =
-    equalizerLemma 1∈⟨f,g⟩ (fst φ a) (fst ψ a) (cong (_$ a) (sym ψχ₂≡φχ₁))
+    equalizerLemma 1∈⟨f,g⟩ (fst φ a) (fst ψ a) (cong (_$r a) (sym ψχ₂≡φχ₁))
 
   χ : CommRingHom A R'
   fst χ a = applyEqualizerLemma a .fst .fst
@@ -579,8 +579,8 @@ module _ (R' : CommRing ℓ) (f g : (fst R')) where
     (RingHom≡ (funExt (λ a → cong fst (applyEqualizerLemma a .snd (θtriple a)))))
       where
       θtriple : ∀ a → Σ[ x ∈ R ] (x /1ᶠ ≡ fst φ a) × (x /1ᵍ ≡ fst ψ a)
-      θtriple a = fst θ a , sym (cong (_$ a) (θCoh .snd))
-                          , sym (cong (_$ a) (θCoh .fst))
+      θtriple a = fst θ a , sym (cong (_$r a) (θCoh .snd))
+                          , sym (cong (_$r a) (θCoh .fst))
 
 
  -- packaging it all up

--- a/Cubical/Algebra/CommRing/Quotient/Base.agda
+++ b/Cubical/Algebra/CommRing/Quotient/Base.agda
@@ -47,15 +47,15 @@ module Quotient-FGideal-CommRing-Ring
   (g : RingHom (CommRing→Ring A) B)
   {n : ℕ}
   (v : FinVec ⟨ A ⟩ n)
-  (gnull : (k : Fin n) → g $ v k ≡ RingStr.0r (snd B))
+  (gnull : (k : Fin n) → g $r v k ≡ RingStr.0r (snd B))
   where
 
   open RingStr (snd B) using (0r)
 
-  zeroOnGeneratedIdeal : (x : ⟨ A ⟩) → x ∈ fst (generatedIdeal A v) → g $ x ≡ 0r
+  zeroOnGeneratedIdeal : (x : ⟨ A ⟩) → x ∈ fst (generatedIdeal A v) → g $r x ≡ 0r
   zeroOnGeneratedIdeal x x∈FGIdeal =
     PT.elim
-      (λ _ → isSetRing B (g $ x) 0r)
+      (λ _ → isSetRing B (g $r x) 0r)
       (λ {(α , isLC) → subst _ (sym isLC) (cancelLinearCombination A B g _ α v gnull)})
       x∈FGIdeal
 
@@ -69,7 +69,7 @@ module Quotient-FGideal-CommRing-CommRing
   (g : CommRingHom A B)
   {n : ℕ}
   (v : FinVec ⟨ A ⟩ n)
-  (gnull : (k : Fin n) → g $ v k ≡ CommRingStr.0r (snd B))
+  (gnull : (k : Fin n) → g $r v k ≡ CommRingStr.0r (snd B))
   where
 
   inducedHom : CommRingHom (A / (generatedIdeal _ v)) B

--- a/Cubical/Algebra/Field/Base.agda
+++ b/Cubical/Algebra/Field/Base.agda
@@ -17,7 +17,6 @@ open import Cubical.Algebra.Semigroup
 open import Cubical.Algebra.Monoid
 open import Cubical.Algebra.AbGroup
 open import Cubical.Algebra.Ring
-  hiding (_$_)
 open import Cubical.Algebra.CommRing
 
 open import Cubical.Displayed.Base
@@ -166,8 +165,8 @@ FieldEquiv : (R : Field ℓ) (S : Field ℓ') → Type (ℓ-max ℓ ℓ')
 FieldEquiv R S = Σ[ e ∈ (R .fst ≃ S .fst) ] IsFieldEquiv (R .snd) e (S .snd)
 
 
-_$_ : {R S : Field ℓ} → (φ : FieldHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
-φ $ x = φ .fst x
+_$f_ : {R S : Field ℓ} → (φ : FieldHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
+φ $f x = φ .fst x
 
 
 FieldEquiv→FieldHom : {A B : Field ℓ} → FieldEquiv A B → FieldHom A B

--- a/Cubical/Algebra/Ring/Base.agda
+++ b/Cubical/Algebra/Ring/Base.agda
@@ -155,8 +155,8 @@ IsRingEquiv M e N = IsRingHom M (e .fst) N
 RingEquiv : (R : Ring ℓ) (S : Ring ℓ') → Type (ℓ-max ℓ ℓ')
 RingEquiv R S = Σ[ e ∈ (⟨ R ⟩ ≃ ⟨ S ⟩) ] IsRingEquiv (R .snd) e (S .snd)
 
-_$_ : {R : Ring ℓ} {S : Ring ℓ'} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
-φ $ x = φ .fst x
+_$r_ : {R : Ring ℓ} {S : Ring ℓ'} → (φ : RingHom R S) → (x : ⟨ R ⟩) → ⟨ S ⟩
+φ $r x = φ .fst x
 
 RingEquiv→RingHom : {A B : Ring ℓ} → RingEquiv A B → RingHom A B
 RingEquiv→RingHom (e , eIsHom) = e .fst , eIsHom

--- a/Cubical/Algebra/Ring/Quotient.agda
+++ b/Cubical/Algebra/Ring/Quotient.agda
@@ -233,7 +233,7 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
       if S is from a different universe. Instead, the condition, that
       Iₛ is contained in the kernel of φ is rephrased explicitly.
     -}
-    inducedHom : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r) → RingHom (R / I) S
+    inducedHom : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $r x ≡ 0r) → RingHom (R / I) S
     fst (inducedHom Iₛ⊆kernel) =
       elim
         (λ _ → isSetRing S)
@@ -252,13 +252,13 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
     pres- (snd (inducedHom Iₛ⊆kernel)) =
       elimProp (λ _ → isSetRing S _ _) φ.pres-
 
-    solution : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r))
-               → (x : ⟨ R ⟩) → inducedHom p $ [ x ] ≡ φ $ x
+    solution : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $r x ≡ 0r))
+               → (x : ⟨ R ⟩) → inducedHom p $r [ x ] ≡ φ $r x
     solution p x = refl
 
-    unique : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $ x ≡ 0r))
-             → (ψ : RingHom (R / I) S) → (ψIsSolution : (x : ⟨ R ⟩) → ψ $ [ x ] ≡ φ $ x)
-             → (x : ⟨ R ⟩) → ψ $ [ x ] ≡ inducedHom p $ [ x ]
+    unique : (p : ((x : ⟨ R ⟩) → x ∈ Iₛ → φ $r x ≡ 0r))
+             → (ψ : RingHom (R / I) S) → (ψIsSolution : (x : ⟨ R ⟩) → ψ $r [ x ] ≡ φ $r x)
+             → (x : ⟨ R ⟩) → ψ $r [ x ] ≡ inducedHom p $r [ x ]
     unique p ψ ψIsSolution x = ψIsSolution x
 
 {-

--- a/Cubical/Data/Graph/Base.agda
+++ b/Cubical/Data/Graph/Base.agda
@@ -28,8 +28,8 @@ Edge (TypeGr ℓ) A B = A → B
 record GraphHom (G  : Graph ℓv  ℓe ) (G' : Graph ℓv' ℓe')
                 : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-max ℓv' ℓe'))) where
   field
-    _$_ : Node G → Node G'
-    _<$>_ : ∀ {x y : Node G} → Edge G x y → Edge G' (_$_ x) (_$_ y)
+    _$g_ : Node G → Node G'
+    _<$g>_ : ∀ {x y : Node G} → Edge G x y → Edge G' (_$g_ x) (_$g_ y)
 
 open GraphHom public
 
@@ -45,8 +45,8 @@ Diag ℓd G = GraphHom G (TypeGr ℓd)
 record DiagMor {G : Graph ℓv ℓe} (F : Diag ℓd G) (F' : Diag ℓd' G)
                : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc (ℓ-max ℓd ℓd')))) where
   field
-    nat : ∀ (x : Node G) → F $ x → F' $ x
-    comSq : ∀ {x y : Node G} (f : Edge G x y) → nat y ∘ F <$> f ≡ F' <$> f ∘ nat x
+    nat : ∀ (x : Node G) → F $g x → F' $g x
+    comSq : ∀ {x y : Node G} (f : Edge G x y) → nat y ∘ F <$g> f ≡ F' <$g> f ∘ nat x
 
 open DiagMor public
 

--- a/Cubical/Data/Graph/Examples.agda
+++ b/Cubical/Data/Graph/Examples.agda
@@ -64,9 +64,9 @@ record ωDiag ℓ : Type (ℓ-suc ℓ) where
     ωEdge : ∀ n → ωNode n → ωNode (suc n)
 
   asDiag : Diag ℓ ωGr
-  asDiag $ n = ωNode n
-  _<$>_ asDiag {m} {n} f with areAdj m n
-  asDiag <$> tt | yes (adj m) = ωEdge m
+  asDiag $g n = ωNode n
+  _<$g>_ asDiag {m} {n} f with areAdj m n
+  asDiag <$g> tt | yes (adj m) = ωEdge m
 
 
 -- The finite connected subgraphs of ω: 𝟘,𝟙,𝟚,𝟛,...
@@ -101,9 +101,9 @@ record [_]Diag ℓ (k : ℕ) : Type (ℓ-suc ℓ) where
     []Edge : ∀ (n : Fin k) → []Node (finj n) → []Node (fsuc n)
 
   asDiag : Diag ℓ [ suc k ]Gr
-  asDiag $ n = []Node n
-  _<$>_ asDiag {m} {n} f with areAdjFin m n
-  _<$>_ asDiag {.(finj n)} {fsuc n} f | yes (adj .n) = []Edge n
+  asDiag $g n = []Node n
+  _<$g>_ asDiag {m} {n} f with areAdjFin m n
+  _<$g>_ asDiag {.(finj n)} {fsuc n} f | yes (adj .n) = []Edge n
 
 
 -- Disjoint union of graphs
@@ -124,9 +124,9 @@ module _ {ℓv ℓe ℓv' ℓe'} where
       ⊎Edger : ∀ {x y} → Edge G' x y → ⊎Node (inr x) → ⊎Node (inr y)
 
     asDiag : Diag ℓ (G ⊎Gr G')
-    asDiag $ x = ⊎Node x
-    _<$>_ asDiag {inl x} {inl y} f = ⊎Edgel (lower f)
-    _<$>_ asDiag {inr x} {inr y} f = ⊎Edger (lower f)
+    asDiag $g x = ⊎Node x
+    _<$g>_ asDiag {inl x} {inl y} f = ⊎Edgel (lower f)
+    _<$g>_ asDiag {inr x} {inr y} f = ⊎Edger (lower f)
 
 
 -- Cartesian product of graphs
@@ -153,9 +153,9 @@ module _ {ℓv ℓe ℓv' ℓe'} where
       ×Edge₂ : ∀ (x : Node (fst G)) {x' y'} (f : Edge (fst G') x' y') → ×Node (x , x') → ×Node (x , y')
 
     asDiag : Diag ℓ (G ×Gr G')
-    asDiag $ x = ×Node x
-    _<$>_ asDiag {x , x'} {y , y'} f with snd G x y | snd G' x' y'
-    _<$>_ asDiag {x , x'} {y , y'} (inl f) | yes _ | yes p' = subst _ p' (×Edge₁ f x')
-    _<$>_ asDiag {x , x'} {y , y'} (inr f) | yes p | yes _  = subst _ p  (×Edge₂ x f )
-    _<$>_ asDiag {x , x'} {y , y'} f | yes p | no  _  = subst _ p  (×Edge₂ x (lower f) )
-    _<$>_ asDiag {x , x'} {y , y'} f | no  _ | yes p' = subst _ p' (×Edge₁ (lower f) x')
+    asDiag $g x = ×Node x
+    _<$g>_ asDiag {x , x'} {y , y'} f with snd G x y | snd G' x' y'
+    _<$g>_ asDiag {x , x'} {y , y'} (inl f) | yes _ | yes p' = subst _ p' (×Edge₁ f x')
+    _<$g>_ asDiag {x , x'} {y , y'} (inr f) | yes p | yes _  = subst _ p  (×Edge₂ x f )
+    _<$g>_ asDiag {x , x'} {y , y'} f | yes p | no  _  = subst _ p  (×Edge₂ x (lower f) )
+    _<$g>_ asDiag {x , x'} {y , y'} f | no  _ | yes p' = subst _ p' (×Edge₁ (lower f) x')

--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -20,6 +20,12 @@ private
 idfun : (A : Type ℓ) → A → A
 idfun _ x = x
 
+infixr -1 _$_
+
+_$_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} → ((a : A) → B a) → (a : A) → B a
+f $ a = f a
+{-# INLINE _$_ #-}
+
 infixr 9 _∘_
 
 _∘_ : (g : {a : A} → (b : B a) → C a b) → (f : (a : A) → B a) → (a : A) → C a (f a)

--- a/Cubical/HITs/Colimit/Base.agda
+++ b/Cubical/HITs/Colimit/Base.agda
@@ -19,8 +19,8 @@ open import Cubical.Data.Graph
 record Cocone ℓ {ℓd ℓv ℓe} {I : Graph ℓv ℓe} (F : Diag ℓd I) (X : Type ℓ)
               : Type (ℓ-suc (ℓ-max ℓ (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd)))) where
   field
-    leg : ∀ (j : Node I) → F $ j → X
-    com : ∀ {j k} (f : Edge I j k) → leg k ∘ F <$> f ≡ leg j
+    leg : ∀ (j : Node I) → F $g j → X
+    com : ∀ {j k} (f : Edge I j k) → leg k ∘ F <$g> f ≡ leg j
 
   postcomp : ∀ {ℓ'} {Y : Type ℓ'} → (X → Y) → Cocone ℓ' F Y
   leg (postcomp h) j = h ∘ leg j
@@ -107,8 +107,8 @@ module _ {ℓ ℓ' ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} {X : 
 -- Colimits always exist
 
 data colim {ℓd ℓe ℓv} {I : Graph ℓv ℓe} (F : Diag ℓd I) : Type (ℓ-suc (ℓ-max (ℓ-max ℓv ℓe) (ℓ-suc ℓd))) where
-  colim-leg : ∀ (j : Node I) → F $ j → colim F
-  colim-com : ∀ {j k} (f : Edge I j k) → colim-leg k ∘ F <$> f ≡ colim-leg j
+  colim-leg : ∀ (j : Node I) → F $g j → colim F
+  colim-com : ∀ {j k} (f : Edge I j k) → colim-leg k ∘ F <$g> f ≡ colim-leg j
 
 module _ {ℓd ℓv ℓe} {I : Graph ℓv ℓe} {F : Diag ℓd I} where
 

--- a/Cubical/HITs/Colimit/Examples.agda
+++ b/Cubical/HITs/Colimit/Examples.agda
@@ -18,11 +18,11 @@ open import Cubical.HITs.Pushout
 module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} where
 
   PushoutDiag : (A → B) → (A → C) → Diag (ℓ-max ℓ (ℓ-max ℓ' ℓ'')) ⇐⇒
-  (PushoutDiag f g) $ fzero             = Lift {j = ℓ-max ℓ  ℓ'' } B
-  (PushoutDiag f g) $ fsuc fzero        = Lift {j = ℓ-max ℓ' ℓ'' } A
-  (PushoutDiag f g) $ fsuc (fsuc fzero) = Lift {j = ℓ-max ℓ  ℓ'  } C
-  _<$>_ (PushoutDiag f g) {fsuc fzero} {fzero}             tt (lift a) = lift (f a)
-  _<$>_ (PushoutDiag f g) {fsuc fzero} {fsuc (fsuc fzero)} tt (lift a) = lift (g a)
+  (PushoutDiag f g) $g fzero             = Lift {j = ℓ-max ℓ  ℓ'' } B
+  (PushoutDiag f g) $g fsuc fzero        = Lift {j = ℓ-max ℓ' ℓ'' } A
+  (PushoutDiag f g) $g fsuc (fsuc fzero) = Lift {j = ℓ-max ℓ  ℓ'  } C
+  _<$g>_ (PushoutDiag f g) {fsuc fzero} {fzero}             tt (lift a) = lift (f a)
+  _<$g>_ (PushoutDiag f g) {fsuc fzero} {fsuc (fsuc fzero)} tt (lift a) = lift (g a)
 
 module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {f : A → B} {g : A → C} where
 
@@ -73,4 +73,3 @@ module _ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : Type ℓ''} {f : A
 
   colim≃Pushout : colim (PushoutDiag f g) ≃ Pushout f g
   colim≃Pushout = uniqColimit colimIsColimit isColimPushout
-

--- a/Cubical/Reflection/Base.agda
+++ b/Cubical/Reflection/Base.agda
@@ -16,9 +16,6 @@ open import Agda.Builtin.String
 _>>=_ = R.bindTC
 _<|>_ = R.catchTC
 
-_$_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → (A → B) → A → B
-f $ a = f a
-
 _>>_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → R.TC A → R.TC B → R.TC B
 f >> g = f >>= λ _ → g
 
@@ -52,4 +49,3 @@ makeAuxiliaryDef s ty term =
   R.declareDef (varg name) ty >>
   R.defineFun name [ R.clause [] [] term ] >>
   R.returnTC (R.def name [])
-


### PR DESCRIPTION
Resolves #894. In order to do so,

- renames the `_$_` operators for rings and fields to `_$r_` and `_$f_`
- renames the components of graph homomorphisms from `_$_` and `_<$>_` to `_$g_` and `_<$g>_`

I don't really like these names, but this is an improvement on the current situation.