### PR TITLE
[ re agda/#6368 ] Add blanket instance for TypeWithStr

### DIFF
--- a/Cubical/Algebra/Ring/Properties.agda
+++ b/Cubical/Algebra/Ring/Properties.agda
@@ -252,8 +252,6 @@ module RingHomTheory {R : Ring ℓ} {S : Ring ℓ'} (φ : RingHom R S) where
   open IsRingHom (φ .snd)
   private
     instance
-      _ = R
-      _ = S
       _ = snd R
       _ = snd S
     f = fst φ

--- a/Cubical/Algebra/Ring/Quotient.agda
+++ b/Cubical/Algebra/Ring/Quotient.agda
@@ -215,7 +215,6 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
   Iₛ = fst I
   private
     instance
-      _ = R
       _ = snd R
 
   module _ {S : Ring ℓ'} (φ : RingHom R S) where
@@ -223,7 +222,6 @@ module UniversalProperty (R : Ring ℓ) (I : IdealsIn R) where
     open RingHomTheory φ
     private
       instance
-        _ = S
         _ = snd S
       f = fst φ
       module φ = IsRingHom (snd φ)

--- a/Cubical/Foundations/Structure.agda
+++ b/Cubical/Foundations/Structure.agda
@@ -25,6 +25,10 @@ str = snd
 ⟨_⟩ : TypeWithStr ℓ S → Type ℓ
 ⟨_⟩ = typ
 
+instance
+  mkTypeWithStr : ∀ {ℓ} {S : Type ℓ → Type ℓ'} {X} → {{S X}} → TypeWithStr ℓ S
+  mkTypeWithStr {{i}} = _ , i
+
 -- An S-structure should have a notion of S-homomorphism, or rather S-isomorphism.
 -- This will be implemented by a function ι : StrEquiv S ℓ'
 -- that gives us for any two types with S-structure (X , s) and (Y , t) a family:
@@ -41,4 +45,3 @@ EquivAction {ℓ} S = {X Y : Type ℓ} → X ≃ Y → S X ≃ S Y
 EquivAction→StrEquiv : {S : Type ℓ → Type ℓ''}
   → EquivAction S → StrEquiv S ℓ''
 EquivAction→StrEquiv α (X , s) (Y , t) e = equivFun (α e) s ≡ t
-


### PR DESCRIPTION
I would like to merge https://github.com/agda/agda/pull/6368, but this requires a (very small) change to the cubical library. I would say it is an improvement, since it means less instances have to be declared by hand.