### PR TITLE
Make triangle identities in definition of unit-counit adjunction pointwise

### DIFF
--- a/Cubical/Categories/Adjoint.agda
+++ b/Cubical/Categories/Adjoint.agda
@@ -52,35 +52,8 @@ module UnitCounit where
       -- counit
       ε : (funcComp F G) ⇒ 𝟙⟨ D ⟩
       -- triangle identities
-      Δ₁ : PathP (λ i → NatTrans (F-lUnit {F = F} i) (F-rUnit {F = F} i))
-        (seqTransP F-assoc (F ∘ʳ η) (ε ∘ˡ F))
-        (1[ F ])
-      Δ₂ : PathP (λ i → NatTrans (F-rUnit {F = G} i) (F-lUnit {F = G} i))
-        (seqTransP (sym F-assoc) (η ∘ˡ G) (G ∘ʳ ε))
-        (1[ G ])
-
-  {-
-   Helper function for building unit-counit adjunctions between categories,
-   using that equality of natural transformations in a category is equality on objects
-  -}
-
-  module _ {ℓC ℓC' ℓD ℓD'}
-    {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F : Functor C D} {G : Functor D C}
-    (η : 𝟙⟨ C ⟩ ⇒ (funcComp G F))
-    (ε : (funcComp F G) ⇒ 𝟙⟨ D ⟩)
-    (Δ₁ : ∀ c → F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧ ≡ D .id)
-    (Δ₂ : ∀ d → η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫ ≡ C .id)
-    where
-
-    make⊣ : F ⊣ G
-    make⊣ ._⊣_.η = η
-    make⊣ ._⊣_.ε = ε
-    make⊣ ._⊣_.Δ₁ =
-      makeNatTransPathP F-lUnit F-rUnit
-        (funExt λ c → cong (D ._⋆_ (F ⟪ η ⟦ c ⟧ ⟫)) (transportRefl _) ∙ Δ₁ c)
-    make⊣ ._⊣_.Δ₂ =
-      makeNatTransPathP F-rUnit F-lUnit
-        (funExt λ d → cong (C ._⋆_ (η ⟦ G ⟅ d ⟆ ⟧)) (transportRefl _) ∙ Δ₂ d)
+      Δ₁ : ∀ c → F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧ ≡ D .id
+      Δ₂ : ∀ d → η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫ ≡ C .id
 
 module NaturalBijection where
   -- Adjoint def 2: natural bijection
@@ -223,78 +196,31 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (
 
         -- DELTA 1
 
-        expL : ∀ (c)
-            → (seqTransP F-assoc (F ∘ʳ η') (ε' ∘ˡ F) .N-ob c)
-              ≡ F ⟪ η' ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε' ⟦ F ⟅ c ⟆ ⟧
-        expL c = seqTransP F-assoc (F ∘ʳ η') (ε' ∘ˡ F) .N-ob c
-              ≡⟨ refl ⟩
-                seqP {C = D} {p = refl} (F ⟪ η' ⟦ c ⟧ ⟫) (ε' ⟦ F ⟅ c ⟆ ⟧)
-              ≡⟨ seqP≡seq {C = D} _ _ ⟩
-                F ⟪ η' ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε' ⟦ F ⟅ c ⟆ ⟧
-              ∎
-
-        body : ∀ (c)
-            → (idTrans F) ⟦ c ⟧ ≡ (seqTransP F-assoc (F ∘ʳ η') (ε' ∘ˡ F) .N-ob c)
-        body c = (idTrans F) ⟦ c ⟧
-              ≡⟨ refl ⟩
-                D .id
-              ≡⟨ sym (D .⋆IdL _) ⟩
-                D .id ⋆⟨ D ⟩ D .id
-              ≡⟨ snd adjNat' (cong (λ v → (η' ⟦ c ⟧) ⋆⟨ C ⟩ v) (G .F-id)) ⟩
-                F ⟪ η' ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε' ⟦ F ⟅ c ⟆ ⟧
-              ≡⟨ sym (expL c) ⟩
-                seqTransP F-assoc (F ∘ʳ η') (ε' ∘ˡ F) .N-ob c
-              ∎
-
-        Δ₁' : PathP (λ i → NatTrans (F-lUnit {F = F} i) (F-rUnit {F = F} i))
-                    (seqTransP F-assoc (F ∘ʳ η') (ε' ∘ˡ F))
-                    (1[ F ])
-        Δ₁' = makeNatTransPathP F-lUnit F-rUnit (sym (funExt body))
+        Δ₁' : ∀ c → F ⟪ η' ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε' ⟦ F ⟅ c ⟆ ⟧ ≡ D .id
+        Δ₁' c =
+            F ⟪ η' ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε' ⟦ F ⟅ c ⟆ ⟧
+          ≡⟨ sym (snd adjNat' (cong (λ v → (η' ⟦ c ⟧) ⋆⟨ C ⟩ v) (G .F-id))) ⟩
+            D .id ⋆⟨ D ⟩ D .id
+          ≡⟨ D .⋆IdL _ ⟩
+            D .id
+          ∎
 
         -- DELTA 2
 
-        body2 : ∀ (d)
-            →  seqP {C = C} {p = refl} ((η' ∘ˡ G) ⟦ d ⟧) ((G ∘ʳ ε') ⟦ d ⟧) ≡ C .id
-        body2 d = seqP {C = C} {p = refl} ((η' ∘ˡ G) ⟦ d ⟧) ((G ∘ʳ ε') ⟦ d ⟧)
-                ≡⟨ seqP≡seq {C = C} _ _ ⟩
-                  ((η' ∘ˡ G) ⟦ d ⟧) ⋆⟨ C ⟩ ((G ∘ʳ ε') ⟦ d ⟧)
-                ≡⟨ refl ⟩
-                  (η' ⟦ G ⟅ d ⟆ ⟧) ⋆⟨ C ⟩ (G ⟪ ε' ⟦ d ⟧ ⟫)
-                ≡⟨ fst adjNat' (cong (λ v → v ⋆⟨ D ⟩ (ε' ⟦ d ⟧)) (sym (F .F-id))) ⟩
-                  C .id ⋆⟨ C ⟩ C .id
-                ≡⟨ C .⋆IdL _ ⟩
-                  C .id
-                ∎
-
-        Δ₂' : PathP (λ i → NatTrans (F-rUnit {F = G} i) (F-lUnit {F = G} i))
-              (seqTransP (sym F-assoc) (η' ∘ˡ G) (G ∘ʳ ε'))
-              (1[ G ])
-        Δ₂' = makeNatTransPathP F-rUnit F-lUnit (funExt body2)
+        Δ₂' : ∀ d → η' ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε' ⟦ d ⟧ ⟫ ≡ C .id
+        Δ₂' d =
+            (η' ⟦ G ⟅ d ⟆ ⟧) ⋆⟨ C ⟩ (G ⟪ ε' ⟦ d ⟧ ⟫)
+          ≡⟨ fst adjNat' (cong (λ v → v ⋆⟨ D ⟩ (ε' ⟦ d ⟧)) (sym (F .F-id))) ⟩
+            C .id ⋆⟨ C ⟩ C .id
+          ≡⟨ C .⋆IdL _ ⟩
+            C .id
+          ∎
 
 
   module _ (adj : F ⊣ G) where
     open _⊣_ adj
     open _⊣²_
     open NatTrans
-
-    -- helper functions for working with this Adjoint definition
-
-    δ₁ : ∀ {c} → (F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧) ≡ D .id
-    δ₁ {c} = (F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧)
-          ≡⟨ sym (seqP≡seq {C = D} _ _) ⟩
-            seqP {C = D} {p = refl} (F ⟪ η ⟦ c ⟧ ⟫) (ε ⟦ F ⟅ c ⟆ ⟧)
-          ≡⟨ (λ j → (Δ₁ j) .N-ob c) ⟩
-            D .id
-          ∎
-
-    δ₂ : ∀ {d} → (η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫) ≡ C .id
-    δ₂ {d} = (η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫)
-        ≡⟨ sym (seqP≡seq {C = C} _ _) ⟩
-          seqP {C = C} {p = refl} (η ⟦ G ⟅ d ⟆ ⟧) (G ⟪ ε ⟦ d ⟧ ⟫)
-        ≡⟨ (λ j → (Δ₂ j) .N-ob d) ⟩
-          C .id
-        ∎
-
 
     adj→adj' : F ⊣² G
     -- ∀ {c d} → Iso (D [ F ⟅ c ⟆ , d ]) (C [ c , G ⟅ d ⟆ ])
@@ -304,7 +230,7 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (
     adj→adj' .adjIso {d = d} .inv g = F ⟪ g ⟫ ⋆⟨ D ⟩ ε ⟦ d ⟧
     -- invertibility follows from the triangle identities
     adj→adj' .adjIso {c = c} {d} .rightInv g
-      = η ⟦ c ⟧ ⋆⟨ C ⟩ G ⟪ F ⟪ g ⟫ ⋆⟨ D ⟩ ε ⟦ d ⟧ ⟫ -- step0 ∙ step1 ∙ step2 ∙ (C .⋆IdR _)
+      = η ⟦ c ⟧ ⋆⟨ C ⟩ G ⟪ F ⟪ g ⟫ ⋆⟨ D ⟩ ε ⟦ d ⟧ ⟫
       ≡⟨ cong (λ v → η ⟦ c ⟧ ⋆⟨ C ⟩ v) (G .F-seq _ _) ⟩
         η ⟦ c ⟧ ⋆⟨ C ⟩ (G ⟪ F ⟪ g ⟫ ⟫ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫)
       ≡⟨ sym (C .⋆Assoc _ _ _) ⟩
@@ -314,7 +240,7 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (
         (g ⋆⟨ C ⟩ η ⟦ G ⟅ d ⟆ ⟧) ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫
       ≡⟨ C .⋆Assoc _ _ _ ⟩
         g ⋆⟨ C ⟩ (η ⟦ G ⟅ d ⟆ ⟧ ⋆⟨ C ⟩ G ⟪ ε ⟦ d ⟧ ⟫)
-      ≡⟨ lCatWhisker {C = C} _ _ _ δ₂ ⟩
+      ≡⟨ lCatWhisker {C = C} _ _ _ (Δ₂ d) ⟩
         g ⋆⟨ C ⟩ C .id
       ≡⟨ C .⋆IdR _ ⟩
         g
@@ -334,7 +260,7 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (
       ≡⟨ sym (D .⋆Assoc _ _ _) ⟩
         F ⟪ η ⟦ c ⟧ ⟫ ⋆⟨ D ⟩ ε ⟦ F ⟅ c ⟆ ⟧ ⋆⟨ D ⟩ f
       -- apply triangle identity
-      ≡⟨ rCatWhisker {C = D} _ _ _ δ₁ ⟩
+      ≡⟨ rCatWhisker {C = D} _ _ _ (Δ₁ c) ⟩
         D .id ⋆⟨ D ⟩ f
       ≡⟨ D .⋆IdL _ ⟩
         f

--- a/Cubical/Categories/Presheaf/KanExtension.agda
+++ b/Cubical/Categories/Presheaf/KanExtension.agda
@@ -191,7 +191,10 @@ module Lan {ℓC ℓC' ℓD ℓD'} ℓS
   Δ₂ H = makeNatTransPath (funExt λ c → H .F-id)
 
   adj : Lan ⊣ F*
-  adj = make⊣ η ε Δ₁ Δ₂
+  adj ._⊣_.η = η
+  adj ._⊣_.ε = ε
+  adj ._⊣_.Δ₁ = Δ₁
+  adj ._⊣_.Δ₂ = Δ₂
 
 {-
   Right Kan extension of a functor C → D to a functor PresheafCategory C ℓ → PresheafCategory D ℓ
@@ -340,4 +343,7 @@ module Ran {ℓC ℓC' ℓD ℓD'} ℓS
   Δ₂ H = makeNatTransPath (funExt₂ λ c x → end≡ _ λ c' g → cong (x .fun c') (D.⋆IdL g))
 
   adj : F* ⊣ Ran
-  adj = make⊣ η ε Δ₁ Δ₂
+  adj ._⊣_.η = η
+  adj ._⊣_.ε = ε
+  adj ._⊣_.Δ₁ = Δ₁
+  adj ._⊣_.Δ₂ = Δ₂


### PR DESCRIPTION
Currently, the triangle identities in the definition of a unit-counit adjunction are stated as equalities of natural transformations. In this form they're a pain to state, particularly because the unit and associativity laws for functors don't hold definitionally.

Because natural transformations are equal if they're equal on objects, there's an equivalent definition that just talks about equality on objects and avoids these issues (because those laws do hold definitionally for _functions_). Currently there's a helper function `make⊣` that goes from this simpler condition to the "real", complicated one.

But it seems to be easier overall to just use the simpler condition as the definition, so this PR makes that change. I don't think the complicated condition is particularly useful to have around, what with it being so gnarly.