### PR TITLE
Another update to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ There is also a [discord server](https://discord.gg/yjTKHzepMx), shared with [ag
 
 Compiling, using and installing
 -------------------------------
-This library compiles with the latest official release of
+This library checks with the latest official release of
 [Agda](https://github.com/agda/agda/). For detailed install
 instructions see the
 [INSTALL](https://github.com/agda/cubical/blob/master/INSTALL.md)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Agda versions as written below, correspond to tags.
 | `v0.2`                  | `v2.6.1.3`     |
 | `v0.1`                  | `v2.6.0.1`     |
 
+For example, if you have Agda 2.6.2.2, you can switch to version 0.4 of the cubical library with
+```
+git checkout v0.4
+```
+
 Learning materials
 ------------------
 * Introductory material from the HoTTest summer school:


### PR DESCRIPTION
I changed the claim that the library 'compiles' with Agda to 'checks' with Agda. 
In light of #982, I added an example how to check out the right tag of the library for some Agda version (maybe that wasn't the reason for the problem in #982, though).