### PR TITLE
Minor update allowing different universe levels in isPropIsPathSplitEquiv

### DIFF
--- a/Cubical/Foundations/Equiv/PathSplit.agda
+++ b/Cubical/Foundations/Equiv/PathSplit.agda
@@ -93,8 +93,8 @@ module _ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} where
   PathSplitEquiv is a proposition and the type
   of path split equivs is equivalent to the type of equivalences
 -}
-isPropIsPathSplitEquiv : ∀ {ℓ} {A B : Type ℓ} (f : A → B) → isProp (isPathSplitEquiv f)
-isPropIsPathSplitEquiv {_} {A} {B} f
+isPropIsPathSplitEquiv : ∀ {ℓ} {ℓ'} {A : Type ℓ} {B : Type ℓ'} (f : A → B) → isProp (isPathSplitEquiv f)
+isPropIsPathSplitEquiv {A = A} {B = B} f
   record { sec = sec-φ ; secCong = secCong-φ }
   record { sec = sec-ψ ; secCong = secCong-ψ } i
   =


### PR DESCRIPTION
A very minor update allowing different universe levels in domain and codomain in one of the functions on path split equivalences (I did need this for something while using the library).