### PR TITLE
Remove cong′, duplicate of congS from Prelude

### DIFF
--- a/Cubical/Codata/Conat/Properties.agda
+++ b/Cubical/Codata/Conat/Properties.agda
@@ -152,7 +152,7 @@ module IsSet where
   force (≡-stable ¬¬p i) = ≡′-stable (λ ¬p → ¬¬p (λ p → ¬p (cong force p))) i
   ≡′-stable {zero}  {zero}  ¬¬p′ = refl
   ≡′-stable {suc x} {suc y} ¬¬p′ =
-     cong′ suc (≡-stable λ ¬p → ¬¬p′ λ p → ¬p (cong pred′′ p))
+     congS suc (≡-stable λ ¬p → ¬¬p′ λ p → ¬p (cong pred′′ p))
   ≡′-stable {zero}  {suc y} ¬¬p′ = ⊥.rec (¬¬p′ conat-absurd)
   ≡′-stable {suc x} {zero}  ¬¬p′ = ⊥.rec (¬¬p′ λ p → conat-absurd (sym p))
 

--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -16,12 +16,6 @@ private
     ℓ ℓ' : Level
     A : Type ℓ
 
--- Less polymorphic version of `cong`, to avoid some unresolved metas
-cong′ : ∀ {B : Type ℓ'} (f : A → B) {x y : A} (p : x ≡ y)
-      → Path B (f x) (f y)
-cong′ f = cong f
-{-# INLINE cong′ #-}
-
 module _ {A : I → Type ℓ} {x : A i0} {y : A i1} where
   toPathP⁻ : x ≡ transport⁻ (λ i → A i) y → PathP A x y
   toPathP⁻ p = symP (toPathP (sym p))

--- a/Cubical/Homotopy/Freudenthal.agda
+++ b/Cubical/Homotopy/Freudenthal.agda
@@ -52,7 +52,7 @@ module _ {ℓ} (n : HLevel) {A : Pointed ℓ} (connA : isConnected (suc (suc n))
         (λ a r → ∣ a , (rCancel' (merid a) ∙ rCancel' (merid (pt A)) ⁻¹) ∙ r ∣)
         (λ b r → ∣ b , r ∣)
         (funExt λ r →
-          cong′ (λ w → ∣ pt A , w ∣)
+          congS (λ w → ∣ pt A , w ∣)
             (cong (_∙ r) (rCancel' (rCancel' (merid (pt A))))
               ∙ lUnit r ⁻¹))
 

--- a/Cubical/Homotopy/HSpace.agda
+++ b/Cubical/Homotopy/HSpace.agda
@@ -110,11 +110,11 @@ HSpace-homogeneous A h = Iso.inv (HSpace-Π∙-Iso A) s
     k x = pointed-sip⁻ A (typ A , x) (sym (h (pt A)) ∙ h x)
 
     k₀ : k (pt A) ≡ idEquiv∙ A
-    k₀ = cong′ (pointed-sip⁻ A A) (lCancel (h (pt A))) ∙ pointed-sip⁻-refl A
+    k₀ = congS (pointed-sip⁻ A A) (lCancel (h (pt A))) ∙ pointed-sip⁻-refl A
 
     s : Π∙ A (λ x → A →∙ (typ A , x)) (idfun∙ A)
     fst s x = ≃∙map (k x)
-    snd s = cong′ ≃∙map k₀
+    snd s = congS ≃∙map k₀
 
 LeftInvHSpace-homogeneous : (A : Pointed ℓ) → (h : isHomogeneous A)
                             → LeftInvHSpace (HSpace-homogeneous A h)


### PR DESCRIPTION
Doesn't look like it's used anywhere either.