### PR TITLE
Remove commutativity assumption to `bigOpSplit++`

### DIFF
--- a/Cubical/Algebra/DistLattice/BigOps.agda
+++ b/Cubical/Algebra/DistLattice/BigOps.agda
@@ -64,7 +64,7 @@ module Join (L' : DistLattice ℓ) where
 
  ⋁Split++ : ∀ {n m : ℕ} (V : FinVec L n) (W : FinVec L m)
            → ⋁ (V ++Fin W) ≡ ⋁ V ∨l ⋁ W
- ⋁Split++ = bigOpSplit++ ∨lComm
+ ⋁Split++ = bigOpSplit++
 
  ⋁Meetrdist : ∀ {n} → (x : L) → (V : FinVec L n)
                 → x ∧l ⋁ V ≡ ⋁ λ i → x ∧l V i

--- a/Cubical/Algebra/Monoid/BigOp.agda
+++ b/Cubical/Algebra/Monoid/BigOp.agda
@@ -52,9 +52,8 @@ module MonoidBigOp (M' : Monoid ℓ) where
   ≡⟨ ·Assoc _ _ _ ⟩
     V zero · bigOp (V ∘ suc) · (W zero · bigOp (W ∘ suc)) ∎
 
- bigOpSplit++ : (∀ x y → x · y ≡ y · x)
-              → {n m : ℕ} → (V : FinVec M n) → (W : FinVec M m)
+ bigOpSplit++ : {n m : ℕ} → (V : FinVec M n) → (W : FinVec M m)
               → bigOp (V ++Fin W) ≡ bigOp V · bigOp W
 
- bigOpSplit++ comm {n = zero} V W = sym (·IdL _)
- bigOpSplit++ comm {n = suc n} V W = cong (V zero ·_) (bigOpSplit++ comm (V ∘ suc) W) ∙ ·Assoc _ _ _
+ bigOpSplit++ {n = zero} V W = sym (·IdL _)
+ bigOpSplit++ {n = suc n} V W = cong (V zero ·_) (bigOpSplit++ (V ∘ suc) W) ∙ ·Assoc _ _ _

--- a/Cubical/Algebra/Ring/BigOps.agda
+++ b/Cubical/Algebra/Ring/BigOps.agda
@@ -48,7 +48,7 @@ module Sum (R' : Ring ℓ) where
 
  ∑Split++ : ∀ {n m : ℕ} (V : FinVec R n) (W : FinVec R m)
           → ∑ (V ++Fin W) ≡ ∑ V + ∑ W
- ∑Split++ = bigOpSplit++ +Comm
+ ∑Split++ = bigOpSplit++
 
  ∑Mulrdist : ∀ {n} → (x : R) → (V : FinVec R n)
                 → x · ∑ V ≡ ∑ λ i → x · V i
@@ -125,6 +125,7 @@ module Product (R' : Ring ℓ) where
  ∏Ext = bigOpExt
  ∏0r = bigOpε
  ∏Last = bigOpLast
+ ΠSplit++ = bigOpSplit++
 
 -- only holds in CommRings!
 -- ∏Split : ∀ {n} → (V W : FinVec R n) → ∏ (λ i → V i · W i) ≡ ∏ V · ∏ W


### PR DESCRIPTION
`bigOpSplit++` only needs associativity.