### PR TITLE
Refactor CI actions

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -32,82 +32,53 @@ on:
 ##
 ########################################################################
 
+########################################################################
+## SETTINGS
+##
+## AGDA_BRANCH picks the branch of Agda to use to build the library.
+## It doesn't really track the branch, so you have to drop caches to
+## get a new branch version if it changes. This will be fixed in the
+## next PR.
+########################################################################
+
 env:
-  GHC_VERSION: 8.6.5
-  CABAL_VERSION: 3.2.0.0
+  AGDA_BRANCH: v2.6.3
+  GHC_VERSION: 9.2.5
+  CABAL_VERSION: 3.6.2.0
   CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
+  CACHE_PATHS: |
+    ~/.cabal/packages
+    ~/.cabal/store
+    ~/.cabal/bin
 
 jobs:
   test-cubical:
     runs-on: ubuntu-latest
     steps:
-
-      ########################################################################
-      ## SETTINGS
-      ##
-      ## AGDA_BRANCH picks the branch of Agda to use to build the library.
-      ########################################################################
-
-      - name: Initialise variables
-        run: |
-          # Pick Agda version
-          echo "AGDA_BRANCH=v2.6.3" >> $GITHUB_ENV
-
-
-      ########################################################################
-      ## CHECKOUT
-      ########################################################################
-
-      # By default github actions do not pull the repo
-      - name: Checkout cubical
-        uses: actions/checkout@v3
-
-      ########################################################################
-      ## CACHING
-      ########################################################################
+      - name: Install cabal
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ env.GHC_VERSION }}
+          cabal-version: ${{ env.CABAL_VERSION }}
+          cabal-update: true
 
       # This caching step allows us to save a lot of building time by only
-      # downloading ghc and cabal, rebuilding Agda, and re-checking unchanged
-      # library files if absolutely necessary i.e. if we change either the
-      # version of Agda, ghc, or cabal that we want to use for the build.
-      - name: Cache cabal packages
-        uses: actions/cache@v3
-        id: cache-cabal
+      # rebuilding Agda, and re-checking unchanged library files if
+      # absolutely necessary i.e. if we change either the version of Agda,
+      # ghc, or cabal that we want to use for the build.
+      - name: Restore external dependencies cache
+        uses: actions/cache/restore@v3
+        id: cache-external-restore
         with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            ~/.cabal/bin
+          path: ${{ env.CACHE_PATHS }}
           key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}
-
-      - name: Cache library build
-        uses: actions/cache@v3
-        id: cache-library
-        with:
-          path: ./_build
-          key: library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-${{ hashFiles('Cubical/**') }}
-          restore-keys: |
-            library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-
 
       ########################################################################
       ## INSTALLATION STEPS
       ########################################################################
 
-      - name: Install cabal
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
-        uses: haskell/actions/setup@v2
-        with:
-          ghc-version: ${{ env.GHC_VERSION }}
-          cabal-version: ${{ env.CABAL_VERSION }}
-
-      - name: Put cabal programs in PATH
-        run: echo "~/.cabal/bin" >> $GITHUB_PATH
-
-      - name: Cabal update
-        run: cabal update
-
       - name: Download and install Agda from github
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        if: steps.cache-external-restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/agda/agda --branch ${{ env.AGDA_BRANCH }} --depth=1
           cd agda
@@ -118,16 +89,44 @@ jobs:
           rm -rf agda
 
       - name: Download and install fix-whitespace
-        if: steps.cache-cabal.outputs.cache-hit != 'true'
+        if: steps.cache-external-restore.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/agda/fix-whitespace --depth=1
           cd fix-whitespace
           ${{ env.CABAL_INSTALL }} fix-whitespace.cabal
           cd ..
 
+      - name: Save external dependencies cache
+        if: steps.cache-external-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        id: cache-external-save
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ steps.cache-external-restore.outputs.cache-primary-key }}
+
+      ########################################################################
+      ## CHECKOUT
+      ########################################################################
+
+      # By default github actions do not pull the repo
+      - name: Checkout cubical
+        uses: actions/checkout@v3
+
       ########################################################################
       ## TESTING
       ########################################################################
+
+      - name: Restore library cache
+        uses: actions/cache/restore@v3
+        id: cache-library-restore
+        with:
+          path: ./_build
+          key: library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-${{ hashFiles('Cubical/**', 'cubical.agda-lib', 'Everythings.hs') }}
+          restore-keys: |
+            library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-
+
+      - name: Put cabal programs in PATH
+        run: echo "~/.cabal/bin" >> $GITHUB_PATH
 
       - name: Test cubical
         run: |
@@ -135,6 +134,14 @@ jobs:
             AGDA_EXEC='~/.cabal/bin/agda -WnoUnsupportedIndexedMatch -W error' \
             FIX_WHITESPACE='~/.cabal/bin/fix-whitespace' \
             EVERYTHINGS='cabal run Everythings'
+
+      - name: Save library cache
+        if: steps.cache-library-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        id: cache-library-save
+        with:
+          path: ./_build
+          key: ${{ steps.cache-library-restore.outputs.cache-primary-key }}
 
       ########################################################################
       ## HTML GENERATION


### PR DESCRIPTION
- split the job into three phases: cabal/ghc, agda, library
- cache all the intermediate binaries
- bump ghc and cabal version

Old action failing to populate caches on unsuccessful library tests was quite infuriating.
Example usage: https://github.com/cmcmA20/cubical-mini/actions/runs/4527022375
Documentation deploy doesn't work as intended but I'm not sure if I haven't botched setting it up in my repo.

@andreasabel FYI