### PR TITLE
Less eta-equality for algebraic structures

### DIFF
--- a/Cubical/Algebra/Monoid/Base.agda
+++ b/Cubical/Algebra/Monoid/Base.agda
@@ -25,6 +25,7 @@ private
     ℓ ℓ' : Level
 
 record IsMonoid {A : Type ℓ} (ε : A) (_·_ : A → A → A) : Type ℓ where
+  no-eta-equality
   constructor ismonoid
 
   field
@@ -37,6 +38,7 @@ record IsMonoid {A : Type ℓ} (ε : A) (_·_ : A → A → A) : Type ℓ where
 unquoteDecl IsMonoidIsoΣ = declareRecordIsoΣ IsMonoidIsoΣ (quote IsMonoid)
 
 record MonoidStr (A : Type ℓ) : Type ℓ where
+  no-eta-equality
   constructor monoidstr
 
   field
@@ -118,7 +120,7 @@ isPropIsMonoid ε _·_ =
     (fields:
       data[ ε ∣ autoDUARel _ _ ∣ presε ]
       data[ _·_ ∣ autoDUARel _ _ ∣ pres· ]
-      prop[ isMonoid ∣ (λ _ _ → isPropIsMonoid _ _) ])
+      prop[ isMonoid ∣ (λ _ str → isPropIsMonoid (str .fst .snd) (str .snd)) ])
   where
   open MonoidStr
   open IsMonoidHom

--- a/Cubical/Algebra/Semigroup/Base.agda
+++ b/Cubical/Algebra/Semigroup/Base.agda
@@ -41,7 +41,7 @@ record IsSemigroup {A : Type ℓ} (_·_ : A → A → A) : Type ℓ where
 unquoteDecl IsSemigroupIsoΣ = declareRecordIsoΣ IsSemigroupIsoΣ (quote IsSemigroup)
 
 record SemigroupStr (A : Type ℓ) : Type ℓ where
-
+  no-eta-equality
   constructor semigroupstr
 
   field
@@ -65,6 +65,7 @@ record IsSemigroupEquiv {A : Type ℓ} {B : Type ℓ}
   (M : SemigroupStr A) (e : A ≃ B) (N : SemigroupStr B)
   : Type ℓ
   where
+  no-eta-equality
 
   -- Shorter qualified names
   private
@@ -93,7 +94,7 @@ isPropIsSemigroup _·_ =
   𝒮ᴰ-Record (𝒮-Univ _) IsSemigroupEquiv
     (fields:
       data[ _·_ ∣ autoDUARel _ _ ∣ isHom ]
-      prop[ isSemigroup ∣ (λ _ _ → isPropIsSemigroup _) ])
+      prop[ isSemigroup ∣ (λ _ f → isPropIsSemigroup (f .snd)) ])
 
 SemigroupPath : (M N : Semigroup ℓ) → SemigroupEquiv M N ≃ (M ≡ N)
 SemigroupPath = ∫ 𝒮ᴰ-Semigroup .UARel.ua

--- a/Cubical/HITs/FreeGroup/Properties.agda
+++ b/Cubical/HITs/FreeGroup/Properties.agda
@@ -53,25 +53,29 @@ freeGroupGroup : Type ℓ → Group ℓ
 freeGroupGroup A = FreeGroup A , freeGroupGroupStr
 
 -- The recursion principle for the FreeGroup
-rec : {Group : Group ℓ'} → (A → Group .fst) → GroupHom (freeGroupGroup A) Group
-rec {Group = G , groupstr 1g _·g_ invg (isgroup (ismonoid isSemigroupg ·gIdR ·gIdL) ·gInvR ·gInvL)} f = f' , isHom
-  where
-  f' : FreeGroup _ → G
-  f' (η a)                  = f a
-  f' (g1 · g2)              = (f' g1) ·g (f' g2)
-  f' ε                      = 1g
-  f' (inv g)                = invg (f' g)
-  f' (assoc g1 g2 g3 i)     = IsSemigroup.·Assoc isSemigroupg (f' g1) (f' g2) (f' g3) i
-  f' (idr g i)              = sym (·gIdR (f' g)) i
-  f' (idl g i)              = sym (·gIdL (f' g)) i
-  f' (invr g i)             = ·gInvR (f' g) i
-  f' (invl g i)             = ·gInvL (f' g) i
-  f' (trunc g1 g2 p q i i₁) = IsSemigroup.is-set isSemigroupg (f' g1) (f' g2) (cong f' p) (cong f' q) i i₁
+module _ {(G , str) : Group ℓ'} (f : A → G) where
+  -- {groupstr 1g _·g_ invg (isgroup (ismonoid isSemigroupg ·gIdR ·gIdL) ·gInvR ·gInvL)}
+  module G = GroupStr str
+  module GM = IsMonoid (G.isMonoid)
+  rec : GroupHom (freeGroupGroup A) (G , str)
+  rec = f' , isHom
+    where
+    f' : FreeGroup _ → G
+    f' (η a)                  = f a
+    f' (g1 · g2)              = (f' g1) G.· (f' g2)
+    f' ε                      = G.1g
+    f' (inv g)                = G.inv (f' g)
+    f' (assoc g1 g2 g3 i)     = IsSemigroup.·Assoc GM.isSemigroup (f' g1) (f' g2) (f' g3) i
+    f' (idr g i)              = sym (G.·IdR (f' g)) i
+    f' (idl g i)              = sym (G.·IdL (f' g)) i
+    f' (invr g i)             = G.·InvR (f' g) i
+    f' (invl g i)             = G.·InvL (f' g) i
+    f' (trunc g1 g2 p q i i₁) = IsSemigroup.is-set GM.isSemigroup (f' g1) (f' g2) (cong f' p) (cong f' q) i i₁
 
-  isHom : IsGroupHom freeGroupGroupStr f' _
-  IsGroupHom.pres·   isHom = λ g1 g2 → refl
-  IsGroupHom.pres1   isHom = refl
-  IsGroupHom.presinv isHom = λ g → refl
+    isHom : IsGroupHom freeGroupGroupStr f' _
+    IsGroupHom.pres·   isHom = λ g1 g2 → refl
+    IsGroupHom.pres1   isHom = refl
+    IsGroupHom.presinv isHom = λ g → refl
 
 -- The induction principle for the FreeGroup for hProps
 elimProp : {B : FreeGroup A → Type ℓ'}

--- a/Cubical/HITs/FreeGroupoid/Properties.agda
+++ b/Cubical/HITs/FreeGroupoid/Properties.agda
@@ -130,7 +130,6 @@ _∣·∣₂_ = rec2 ∥freeGroupoid∥₂IsSet (λ g1 g2 → ∣ g1 · g2 ∣�
 ∥freeGroupoid∥₂Group : Type ℓ → Group ℓ
 ∥freeGroupoid∥₂Group A = ∥ FreeGroupoid A ∥₂ , ∥freeGroupoid∥₂GroupStr
 
-
 forgetfulHom : GroupHom (freeGroupGroup A) (∥freeGroupoid∥₂Group A)
 forgetfulHom = rec (λ a → ∣ η a ∣₂)
 


### PR DESCRIPTION
Use "no-eta-equality" for the records defining algebraic structures. @plt-amy helped :-) 