### PR TITLE
Make ∥∥-rec and ∥∥-elim more general

### DIFF
--- a/Cubical/Data/Equality/PropositionalTruncation.agda
+++ b/Cubical/Data/Equality/PropositionalTruncation.agda
@@ -24,9 +24,9 @@ private
 squash₁ : (x y : ∥ A ∥₁) → x ≡ y
 squash₁ x y = pathToEq (squash₁Path x y)
 
-∥∥-rec : {A : Type ℓ} {P : Type ℓ} → isProp P → (A → P) → ∥ A ∥₁ → P
+∥∥-rec : {A : Type ℓ} {P : Type ℓ'} → isProp P → (A → P) → ∥ A ∥₁ → P
 ∥∥-rec Pprop = recPropTruncPath (isPropToIsPropPath Pprop)
 
-∥∥-elim : {A : Type ℓ} {P : ∥ A ∥₁ → Type ℓ} → ((a : ∥ A ∥₁) → isProp (P a)) →
+∥∥-elim : {A : Type ℓ} {P : ∥ A ∥₁ → Type ℓ'} → ((a : ∥ A ∥₁) → isProp (P a)) →
                 ((x : A) → P ∣ x ∣₁) → (a : ∥ A ∥₁) → P a
 ∥∥-elim Pprop = elimPropTruncPath (λ a → isPropToIsPropPath (Pprop a))


### PR DESCRIPTION
The universe level of `∥∥-rec` and `∥∥-elim` in the new `Cubical.Data.Equality.PropositionalTruncation` hasn't been sufficiently generalized. It is quite bothersome, so I've made a quick fix.