### PR TITLE
Make variables names _∙∙_∙∙_ consistent with those in doubleComp-faces and remove an unnecessary space

### DIFF
--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -110,12 +110,12 @@ congP₂ f p q i = f i (p i) (q i)
    `doubleCompPath-filler p q r` gives the whole square
 -}
 
-doubleComp-faces : {x y z w : A } (p : x ≡ y) (r : z ≡ w)
+doubleComp-faces : {x y z w : A} (p : x ≡ y) (r : z ≡ w)
                  → (i : I) (j : I) → Partial (i ∨ ~ i) A
 doubleComp-faces p r i j (i = i0) = p (~ j)
 doubleComp-faces p r i j (i = i1) = r j
 
-_∙∙_∙∙_ : w ≡ x → x ≡ y → y ≡ z → w ≡ z
+_∙∙_∙∙_ : x ≡ y → y ≡ z → z ≡ w → x ≡ w
 (p ∙∙ q ∙∙ r) i =
   hcomp (doubleComp-faces p r i) (q i)
 


### PR DESCRIPTION
Hi Maintainers, I am new to Cubical Agda. The variable name order of "x", "y", "z", and "w" is different in the functions \_∙∙\_∙∙\_ and doubleComp-faces which the former depends on, thus "p" and "r" in 2 functions have different types in reading. This confuses beginners like me when I learn their implementations for the first time.
I also notice that throughout the library the order of such plain letter variables is different in different functions. Maybe a rule/guideline of a canonical order can be enforced to reduce these confusions. Or ignore me if it's just a trivial beginner problem.