### PR TITLE
Experiment with notation for algebra and category theory

### DIFF
--- a/Cubical/Algebra/AbGroup/Notation.agda
+++ b/Cubical/Algebra/AbGroup/Notation.agda
@@ -1,0 +1,12 @@
+module Cubical.Algebra.AbGroup.Notation where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Algebra.Notation.Additive
+
+private variable
+  ℓ : Level
+
+instance
+  +AbGroupProvider : ⦃ A : AbGroup ℓ ⦄ → AdditiveOperationProvider (fst A)
+  +AbGroupProvider ⦃ A ⦄ = record { _+_ = AbGroupStr._+_ (snd A) }

--- a/Cubical/Algebra/AbGroup/Notation.agda
+++ b/Cubical/Algebra/AbGroup/Notation.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.AbGroup.Notation where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/CommMonoid/Notation.agda
+++ b/Cubical/Algebra/CommMonoid/Notation.agda
@@ -1,0 +1,12 @@
+module Cubical.Algebra.CommMonoid.Notation where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Algebra.CommMonoid.Base
+open import Cubical.Algebra.Notation.Additive
+
+private variable
+  ℓ : Level
+
+instance
+  +CommMonoidProvider : ⦃ A : CommMonoid ℓ ⦄ → AdditiveOperationProvider (fst A)
+  +CommMonoidProvider ⦃ A ⦄ = record { _+_ = CommMonoidStr._·_ (snd A) }

--- a/Cubical/Algebra/CommMonoid/Notation.agda
+++ b/Cubical/Algebra/CommMonoid/Notation.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 module Cubical.Algebra.CommMonoid.Notation where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/Monoid/Notation.agda
+++ b/Cubical/Algebra/Monoid/Notation.agda
@@ -1,0 +1,1 @@
+module Cubical.Algebra.CommMonoid.Notation where

--- a/Cubical/Algebra/Monoid/Notation.agda
+++ b/Cubical/Algebra/Monoid/Notation.agda
@@ -1,1 +1,0 @@
-module Cubical.Algebra.CommMonoid.Notation where

--- a/Cubical/Algebra/Notation/Additive.agda
+++ b/Cubical/Algebra/Notation/Additive.agda
@@ -1,0 +1,19 @@
+{-
+
+  Provides an instance-dependent '_+_'
+
+-}
+
+module Cubical.Algebra.Notation.Additive where
+
+open import Cubical.Foundations.Prelude
+
+private variable
+  ℓ : Level
+
+record AdditiveOperationProvider (A : Type ℓ) : Type ℓ where
+  field
+    _+_ : A → A → A
+
+_+_ : {A : Type ℓ} ⦃ provider : AdditiveOperationProvider A ⦄ → A → A → A
+_+_ {A = A} ⦃ provider ⦄ = AdditiveOperationProvider._+_ provider

--- a/Cubical/Algebra/Notation/Additive.agda
+++ b/Cubical/Algebra/Notation/Additive.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --safe #-}
 {-
 
   Provides an instance-dependent '_+_'

--- a/Cubical/Algebra/Notation/Examples.agda
+++ b/Cubical/Algebra/Notation/Examples.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --overlapping-instances --safe #-}
 module Cubical.Algebra.Notation.Examples where
 
 open import Cubical.Foundations.Prelude
@@ -11,16 +12,10 @@ open import Cubical.Algebra.AbGroup.Notation
 private variable
   ℓ : Level
 
-module _ (A : AbGroup ℓ) where
-  instance _ = A
+module _ (A : AbGroup ℓ) (M : CommMonoid ℓ) where
+  instance
+    _ = A
+    _ = M
 
-  _ : (x y : fst A) → x + y ≡ x
-  _ = {!!}
-
-{-
-module _ (M : CommMonoid ℓ) where
-  instance _ = M
-
-  _ : (x y : fst M) → x + y ≡ y + x
-  _ = {!!}
--}
+  _ : (x y : fst A) → x + y ≡ x + y
+  _ = λ _ _ → refl

--- a/Cubical/Algebra/Notation/Examples.agda
+++ b/Cubical/Algebra/Notation/Examples.agda
@@ -1,0 +1,26 @@
+module Cubical.Algebra.Notation.Examples where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Algebra.Notation.Additive
+open import Cubical.Algebra.CommMonoid.Base
+open import Cubical.Algebra.CommMonoid.Notation
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Algebra.AbGroup.Notation
+
+private variable
+  ℓ : Level
+
+module _ (A : AbGroup ℓ) where
+  instance _ = A
+
+  _ : (x y : fst A) → x + y ≡ x
+  _ = {!!}
+
+{-
+module _ (M : CommMonoid ℓ) where
+  instance _ = M
+
+  _ : (x y : fst M) → x + y ≡ y + x
+  _ = {!!}
+-}


### PR DESCRIPTION
This is an experiment concerned with the way operators like `+` or `∘` are overloaded with instance arguments.
Currently, given e.g. ```A : AbGroup ℓ```  this is done by 

```agda
open AbGroupStr ⦃...⦄
instance
  _ = snd A
```

The idea is to gain better notation with more flexibility and overloading by separating the notation from the data structures (just look at the changes). Here are a couple of things that would be nice to have:

- Use operators with the same name from different structures at the same time, for example ```_+_``` from `Semiring` and `CommRing`.
- Choose notation independent of the definition of a structure. For example, a CommMonoid used multiplicative notation in its definition, but one might want to use `+` in some contexts.
- Have more readable output from agda. Currently, goals are sometimes written as something like ```AbGroupStr._+_ _ x y``` instead of ```x + y```. I think that shouldn't happen if ```_+_``` is defined on top level with an instance argument.