### PR TITLE
Avoid unnecessary `syntax` declarations

### DIFF
--- a/Cubical/Algebra/Algebra/Properties.agda
+++ b/Cubical/Algebra/Algebra/Properties.agda
@@ -85,7 +85,8 @@ module AlgebraHoms where
   compAlgebraHom f g .fst = g .fst ∘ f .fst
   compAlgebraHom f g .snd = compIsAlgebraHom (g .snd) (f .snd)
 
-  syntax compAlgebraHom f g = g ∘a f
+  _∘a_ : AlgebraHom B C → AlgebraHom A B → AlgebraHom A C
+  _∘a_ = flip compAlgebraHom
 
   compIdAlgebraHom : (φ : AlgebraHom A B) → compAlgebraHom (idAlgebraHom A) φ ≡ φ
   compIdAlgebraHom φ = AlgebraHom≡ refl

--- a/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
+++ b/Cubical/Algebra/CommAlgebra/QuotientAlgebra.agda
@@ -24,7 +24,7 @@ open import Cubical.Algebra.Ring
 open import Cubical.Algebra.Ring.Ideal using (isIdeal)
 open import Cubical.Tactics.CommRingSolver.Reflection
 open import Cubical.Algebra.Algebra.Properties
-open AlgebraHoms using (compAlgebraHom)
+open AlgebraHoms using (_∘a_)
 
 private
   variable

--- a/Cubical/Algebra/Ring/Properties.agda
+++ b/Cubical/Algebra/Ring/Properties.agda
@@ -182,7 +182,8 @@ module RingHoms where
   fst (compRingHom f g) x = g .fst (f .fst x)
   snd (compRingHom f g) = compIsRingHom (g .snd) (f .snd)
 
-  syntax compRingHom f g = g ∘r f
+  _∘r_ : {R : Ring ℓ} {S : Ring ℓ'} {T : Ring ℓ''} → RingHom S T → RingHom R S → RingHom R T
+  _∘r_ = flip compRingHom
 
   compIdRingHom : {R : Ring ℓ} {S : Ring ℓ'} (φ : RingHom R S) → compRingHom (idRingHom R) φ ≡ φ
   compIdRingHom φ = RingHom≡ refl

--- a/Cubical/Categories/Functor/Base.agda
+++ b/Cubical/Categories/Functor/Base.agda
@@ -133,8 +133,9 @@ funcComp : ∀ (G : Functor D E) (F : Functor C D) → Functor C E
 (funcComp G F) .F-id      = cong (G ⟪_⟫) (F .F-id) ∙ G .F-id
 (funcComp G F) .F-seq f g = cong (G ⟪_⟫) (F .F-seq _ _) ∙ G .F-seq _ _
 
-infixr 30 funcComp
-syntax funcComp G F = G ∘F F
+infixr 30 _∘F_
+_∘F_ : Functor D E → Functor C D → Functor C E
+_∘F_ = funcComp
 
 -- hacky lemma to stop Agda from computing too much
 funcCompOb≡ : ∀ (G : Functor D E) (F : Functor C D) (c : ob C)

--- a/Cubical/Categories/Limits/Limits.agda
+++ b/Cubical/Categories/Limits/Limits.agda
@@ -7,6 +7,7 @@ module Cubical.Categories.Limits.Limits where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
 
 open import Cubical.Data.Sigma
 
@@ -89,7 +90,8 @@ module _ {ℓJ ℓJ' ℓC ℓC' : Level} {J : Category ℓJ ℓJ'} {C : Category
   coneOutCommutes (preCompCone f cc) e = ⋆Assoc C _ _ _
                                        ∙ cong (λ x → f ⋆⟨ C ⟩ x) (coneOutCommutes cc e)
 
-  syntax preCompCone f cc = f ★ cc
+  _★_ : {c1 c2 : ob C} (f : C [ c1 , c2 ]) {D : Functor J C} → Cone D c2 → Cone D c1
+  _★_ = preCompCone
 
   natTransPostCompCone : {c : ob C} {D₁ D₂ : Functor J C} (α : NatTrans D₁ D₂)
                        → Cone D₁ c → Cone D₂ c
@@ -105,7 +107,8 @@ module _ {ℓJ ℓJ' ℓC ℓC' : Level} {J : Category ℓJ ℓJ'} {C : Category
     ≡⟨ cong (λ x → x ⋆⟨ C ⟩ α .N-ob v) (cc .coneOutCommutes e) ⟩
       cc .coneOut v ⋆⟨ C ⟩ α .N-ob v ∎
 
-  syntax natTransPostCompCone α cc = cc ★ₙₜ α
+  _★ₙₜ_ : {c : ob C} {D₁ D₂ : Functor J C} → Cone D₁ c → NatTrans D₁ D₂ → Cone D₂ c
+  _★ₙₜ_ = flip natTransPostCompCone
 
   isConeMor : {c1 c2 : ob C} {D : Functor J C}
               (cc1 : Cone D c1) (cc2 : Cone D c2)

--- a/Cubical/Categories/NaturalTransformation/Base.agda
+++ b/Cubical/Categories/NaturalTransformation/Base.agda
@@ -71,11 +71,14 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   open NatTrans
   open NatIso
 
-  infix 10 NatTrans
-  syntax NatTrans F G = F ⇒ G
+  infix 10 _⇒_
+  _⇒_ : Functor C D → Functor C D → Type (ℓ-max (ℓ-max ℓC ℓC') ℓD')
+  _⇒_ = NatTrans
 
-  infix 9 NatIso
-  syntax NatIso F G = F ≅ᶜ G -- c superscript to indicate that this is in the context of categories
+  infix 9 _≅ᶜ_
+  -- c superscript to indicate that this is in the context of categories
+  _≅ᶜ_ : Functor C D → Functor C D → Type (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓD ℓD'))
+  _≅ᶜ_ = NatIso
 
   -- component of a natural transformation
   infix 30 _⟦_⟧
@@ -92,7 +95,8 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
       (D .id) ⋆ᴰ (F .F-hom f)
     ∎
 
-  syntax idTrans F = 1[ F ]
+  1[_] : (F : Functor C D) → NatTrans F F
+  1[_] = idTrans
 
   idNatIso : (F : Functor C D) → NatIso F F
   idNatIso F .trans = idTrans F
@@ -131,8 +135,9 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} where
   compTrans : {F G H : Functor C D} (β : NatTrans G H) (α : NatTrans F G) → NatTrans F H
   compTrans β α = seqTrans α β
 
-  infixl 8 seqTrans
-  syntax seqTrans α β = α ●ᵛ β
+  infixl 8 _●ᵛ_
+  _●ᵛ_ : {F G H : Functor C D} → NatTrans F G → NatTrans G H → NatTrans F H
+  _●ᵛ_ = seqTrans
 
 
   -- vertically sequence natural transformations whose


### PR DESCRIPTION
This PR replaces [`syntax` declarations](https://agda.readthedocs.io/en/latest/language/syntax-declarations.html) which

- do not bind variables and
- do not change the order of arguments in such a way that some argument depends on some later argument

by ordinary infix (or mixfix) operator declarations.

The motivation for avoiding syntax declarations is that Agdas behavior around them can be confusing, for example:
- "jumping to the definition" of a declared syntax does not jump to the syntax declaration but to the definition of the name it stands for.
- When you type an operator that is actually a declared syntax, like `_⇒_` (from `NaturalTransformation.Base`), in a hole and ask for its type (or try to "refine", or "give" the hole), you get a "Not in scope" error. (If I understand correctly, `_⇒_` does indeed not exist as a name. But it is easy to expect it to exist.)
- If you want to import a declared syntax by `open ... using (...)`, you have to write the name it refers to, even though you then never use that name.