### PR TITLE
Generalize types of inspect idiom

### DIFF
--- a/Cubical/Foundations/Path.agda
+++ b/Cubical/Foundations/Path.agda
@@ -273,13 +273,13 @@ module _ {ℓ : Level} {A : Type ℓ}
 
 -- Inspect
 
-module _ {A : Type ℓ} {B : Type ℓ'} where
+module _ {A : Type ℓ} {B : A -> Type ℓ'} where
 
-  record Reveal_·_is_ (f : A → B) (x : A) (y : B) : Type (ℓ-max ℓ ℓ') where
+  record Reveal_·_is_ (f : (x : A) → B x) (x : A) (y : B x) : Type (ℓ-max ℓ ℓ') where
     constructor [_]ᵢ
     field path : f x ≡ y
 
-  inspect : (f : A → B) (x : A) → Reveal f · x is f x
+  inspect : (f : (x : A) → B x) (x : A) → Reveal f · x is f x
   inspect f x .Reveal_·_is_.path = refl
 
 -- J is an equivalence


### PR DESCRIPTION
This generalizes some types to allow doing an `inspect` of a dependent function. I've found myself wanting this from time to time, and I haven't noticed the generalization having any adverse effects (I think the fact that `f` is an argument nails down potential ambiguities about `B`).