### PR TITLE
Triangular numbers

### DIFF
--- a/Cubical/Algebra/CommSemiring/Base.agda
+++ b/Cubical/Algebra/CommSemiring/Base.agda
@@ -38,6 +38,22 @@ record CommSemiringStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 CommSemiring : ∀ ℓ → Type (ℓ-suc ℓ)
 CommSemiring ℓ = TypeWithStr ℓ CommSemiringStr
 
+CommSemiring→Semiring : CommSemiring ℓ → Semiring ℓ
+CommSemiring→Semiring CS .fst = CS .fst
+CommSemiring→Semiring CS .snd =  str
+  where open IsCommSemiring
+        open CommSemiringStr
+        open SemiringStr
+
+        CS-str = (CS .snd)
+
+        str : SemiringStr (CS .fst)
+        0r str = CS-str .0r
+        1r str = CS-str .1r
+        _+_ str = CS-str ._+_
+        _·_ str = CS-str ._·_
+        isSemiring str = (CS-str .isCommSemiring) .isSemiring
+
 makeIsCommSemiring : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R}
                  (is-setR : isSet R)
                  (+Assoc : (x y z : R) → x + (y + z) ≡ (x + y) + z)

--- a/Cubical/Algebra/CommSemiring/Base.agda
+++ b/Cubical/Algebra/CommSemiring/Base.agda
@@ -40,41 +40,44 @@ CommSemiring ℓ = TypeWithStr ℓ CommSemiringStr
 
 CommSemiring→Semiring : CommSemiring ℓ → Semiring ℓ
 CommSemiring→Semiring CS .fst = CS .fst
-CommSemiring→Semiring CS .snd =  str
-  where open IsCommSemiring
-        open CommSemiringStr
-        open SemiringStr
+CommSemiring→Semiring CS .snd = str
+  where
+    open IsCommSemiring
+    open CommSemiringStr
+    open SemiringStr
 
-        CS-str = (CS .snd)
+    CS-str = CS .snd
 
-        str : SemiringStr (CS .fst)
-        0r str = CS-str .0r
-        1r str = CS-str .1r
-        _+_ str = CS-str ._+_
-        _·_ str = CS-str ._·_
-        isSemiring str = (CS-str .isCommSemiring) .isSemiring
+    str : SemiringStr (CS .fst)
+    0r str = CS-str .0r
+    1r str = CS-str .1r
+    _+_ str = CS-str ._+_
+    _·_ str = CS-str ._·_
+    isSemiring str = (CS-str .isCommSemiring) .isSemiring
 
-makeIsCommSemiring : {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R}
-                 (is-setR : isSet R)
-                 (+Assoc : (x y z : R) → x + (y + z) ≡ (x + y) + z)
-                 (+IdR : (x : R) → x + 0r ≡ x)
-                 (+Comm : (x y : R) → x + y ≡ y + x)
-                 (·Assoc : (x y z : R) → x · (y · z) ≡ (x · y) · z)
-                 (·IdR : (x : R) → x · 1r ≡ x)
-                 (·DistR+ : (x y z : R) → x · (y + z) ≡ (x · y) + (x · z))
-                 (AnnihilL : (x : R) → 0r · x ≡ 0r)
-                 (·Comm : (x y : R) → x · y ≡ y · x)
-               → IsCommSemiring 0r 1r _+_ _·_
+makeIsCommSemiring :
+  {R : Type ℓ} {0r 1r : R} {_+_ _·_ : R → R → R}
+  (is-setR : isSet R)
+  (+Assoc : (x y z : R) → x + (y + z) ≡ (x + y) + z)
+  (+IdR : (x : R) → x + 0r ≡ x)
+  (+Comm : (x y : R) → x + y ≡ y + x)
+  (·Assoc : (x y z : R) → x · (y · z) ≡ (x · y) · z)
+  (·IdR : (x : R) → x · 1r ≡ x)
+  (·DistR+ : (x y z : R) → x · (y + z) ≡ (x · y) + (x · z))
+  (AnnihilL : (x : R) → 0r · x ≡ 0r)
+  (·Comm : (x y : R) → x · y ≡ y · x)
+  → IsCommSemiring 0r 1r _+_ _·_
 makeIsCommSemiring {_+_ = _+_} {_·_ = _·_}
   is-setR +Assoc +IdR +Comm ·Assoc ·IdR ·DistR+ AnnihilL ·Comm = x
-  where x : IsCommSemiring _ _ _ _
-        IsCommSemiring.isSemiring x =
-          makeIsSemiring
-            is-setR +Assoc +IdR +Comm ·Assoc
-            ·IdR (λ x → ·Comm _ x ∙ (·IdR x))
-            ·DistR+ (λ x y z → (x + y) · z       ≡⟨ ·Comm (x + y) z ⟩
-                               z · (x + y)       ≡⟨ ·DistR+ z x y ⟩
-                               (z · x) + (z · y) ≡[ i ]⟨ (·Comm z x i + ·Comm z y i) ⟩
-                               (x · z) + (y · z) ∎ )
-            ( λ x → ·Comm x _ ∙ AnnihilL x) AnnihilL
-        IsCommSemiring.·Comm x = ·Comm
+  where
+    x : IsCommSemiring _ _ _ _
+    IsCommSemiring.isSemiring x =
+      makeIsSemiring
+        is-setR +Assoc +IdR +Comm ·Assoc
+        ·IdR (λ x → ·Comm _ x ∙ (·IdR x))
+        ·DistR+ (λ x y z → (x + y) · z       ≡⟨ ·Comm (x + y) z ⟩
+                           z · (x + y)       ≡⟨ ·DistR+ z x y ⟩
+                           (z · x) + (z · y) ≡[ i ]⟨ (·Comm z x i + ·Comm z y i) ⟩
+                           (x · z) + (y · z) ∎ )
+        ( λ x → ·Comm x _ ∙ AnnihilL x) AnnihilL
+    IsCommSemiring.·Comm x = ·Comm

--- a/Cubical/Algebra/CommSemiring/Instances/Nat.agda
+++ b/Cubical/Algebra/CommSemiring/Instances/Nat.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --safe #-}
+module Cubical.Algebra.CommSemiring.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+import Cubical.Data.Nat as Nat
+
+open import Cubical.Algebra.CommSemiring
+
+ℕasCSR : CommSemiring ℓ-zero
+ℕasCSR .fst  = Nat.ℕ
+ℕasCSR .snd  = str
+  where open CommSemiringStr
+
+        str : CommSemiringStr Nat.ℕ
+        0r str = Nat.zero
+        1r str = Nat.suc Nat.zero
+        _+_ str = Nat._+_
+        _·_ str = Nat._·_
+        isCommSemiring str =
+          makeIsCommSemiring
+            Nat.isSetℕ
+            Nat.+-assoc Nat.+-zero Nat.+-comm
+            Nat.·-assoc Nat.·-identityʳ
+            (λ x y z → sym (Nat.·-distribˡ x y z))
+            (λ _ → refl)
+            Nat.·-comm

--- a/Cubical/Algebra/CommSemiring/Instances/Nat.agda
+++ b/Cubical/Algebra/CommSemiring/Instances/Nat.agda
@@ -8,7 +8,7 @@ import Cubical.Data.Nat as Nat
 
 open import Cubical.Algebra.CommSemiring
 
-open import Cubical.Data.Nat using (ℕ) public
+open import Cubical.Data.Nat using (ℕ; suc; zero) public
 
 ℕasCSR : CommSemiring ℓ-zero
 ℕasCSR .fst  = ℕ
@@ -16,8 +16,8 @@ open import Cubical.Data.Nat using (ℕ) public
   where open CommSemiringStr
 
         str : CommSemiringStr ℕ
-        0r str = Nat.zero
-        1r str = Nat.suc Nat.zero
+        0r str = zero
+        1r str = suc zero
         _+_ str = Nat._+_
         _·_ str = Nat._·_
         isCommSemiring str =

--- a/Cubical/Algebra/CommSemiring/Instances/Nat.agda
+++ b/Cubical/Algebra/CommSemiring/Instances/Nat.agda
@@ -5,10 +5,9 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 
 import Cubical.Data.Nat as Nat
+open import Cubical.Data.Nat using (ℕ; suc; zero) public
 
 open import Cubical.Algebra.CommSemiring
-
-open import Cubical.Data.Nat using (ℕ; suc; zero) public
 
 ℕasCSR : CommSemiring ℓ-zero
 ℕasCSR .fst  = ℕ

--- a/Cubical/Algebra/CommSemiring/Instances/Nat.agda
+++ b/Cubical/Algebra/CommSemiring/Instances/Nat.agda
@@ -8,12 +8,14 @@ import Cubical.Data.Nat as Nat
 
 open import Cubical.Algebra.CommSemiring
 
+open import Cubical.Data.Nat using (ℕ) public
+
 ℕasCSR : CommSemiring ℓ-zero
-ℕasCSR .fst  = Nat.ℕ
+ℕasCSR .fst  = ℕ
 ℕasCSR .snd  = str
   where open CommSemiringStr
 
-        str : CommSemiringStr Nat.ℕ
+        str : CommSemiringStr ℕ
         0r str = Nat.zero
         1r str = Nat.suc Nat.zero
         _+_ str = Nat._+_

--- a/Cubical/Algebra/CommSemiring/Instances/Nat.agda
+++ b/Cubical/Algebra/CommSemiring/Instances/Nat.agda
@@ -5,25 +5,26 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 
 import Cubical.Data.Nat as Nat
-open import Cubical.Data.Nat using (ℕ; suc; zero) public
+open import Cubical.Data.Nat using (ℕ; suc; zero)
 
 open import Cubical.Algebra.CommSemiring
 
 ℕasCSR : CommSemiring ℓ-zero
 ℕasCSR .fst  = ℕ
 ℕasCSR .snd  = str
-  where open CommSemiringStr
+  where
+    open CommSemiringStr
 
-        str : CommSemiringStr ℕ
-        0r str = zero
-        1r str = suc zero
-        _+_ str = Nat._+_
-        _·_ str = Nat._·_
-        isCommSemiring str =
-          makeIsCommSemiring
-            Nat.isSetℕ
-            Nat.+-assoc Nat.+-zero Nat.+-comm
-            Nat.·-assoc Nat.·-identityʳ
-            (λ x y z → sym (Nat.·-distribˡ x y z))
-            (λ _ → refl)
-            Nat.·-comm
+    str : CommSemiringStr ℕ
+    0r str = zero
+    1r str = suc zero
+    _+_ str = Nat._+_
+    _·_ str = Nat._·_
+    isCommSemiring str =
+      makeIsCommSemiring
+        Nat.isSetℕ
+        Nat.+-assoc Nat.+-zero Nat.+-comm
+        Nat.·-assoc Nat.·-identityʳ
+        (λ x y z → sym (Nat.·-distribˡ x y z))
+        (λ _ → refl)
+        Nat.·-comm

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -16,14 +16,14 @@ open import Cubical.Algebra.Semiring.BigOps
 open import Cubical.Tactics.NatSolver.Reflection
 open import Cubical.Tactics.NatSolver.NatExpression
 
-open Sum (CommSemiring→Semiring ℕ)
-open CommSemiringStr (snd ℕ) using (·DistL+;·DistR+)
+open Sum (CommSemiring→Semiring ℕasCSR)
+open CommSemiringStr (snd ℕasCSR) using (·DistL+;·DistR+)
 
 -- the first n natural number, i.e. {0,1,...,n-1}
-first : (n : fst ℕ) → FinVec (fst ℕ) n
+first : (n : ℕ) → FinVec ℕ n
 first n i = toℕ i
 
-firstDecompose : (n : fst ℕ) → first (suc n) ∘ weakenFin ≡ first n
+firstDecompose : (n : ℕ) → first (suc n) ∘ weakenFin ≡ first n
 firstDecompose n i l =
   elim
     (λ l → first (suc _) (weakenFin l) ≡ first _ l)
@@ -31,7 +31,7 @@ firstDecompose n i l =
     (λ _ → weakenRespToℕ _)
     l i
 
-sumFormula : (n : fst ℕ) → 2 · (∑ (first (suc n))) ≡ n · (n + 1)
+sumFormula : (n : ℕ) → 2 · (∑ (first (suc n))) ≡ n · (n + 1)
 sumFormula zero = refl
 sumFormula (suc n) =
   2 · ∑ (first (2 + n))                                                ≡⟨ step0 ⟩
@@ -48,5 +48,5 @@ sumFormula (suc n) =
     step3 = ·DistR+ 2 (∑ (first (1 + n))) (suc n)
     step4 = cong (λ u → u + 2 · (suc n)) (sumFormula n)
 
-    useSolver : ∀ (n : fst ℕ) → n · (n + 1) + 2 · (suc n) ≡ (suc n) · (suc (n + 1))
+    useSolver : ∀ (n : ℕ) → n · (n + 1) + 2 · (suc n) ≡ (suc n) · (suc (n + 1))
     useSolver = solve

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -1,0 +1,52 @@
+{-# OPTIONS --safe #-}
+module Cubical.Data.Nat.Triangular where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.FinData
+
+open import Cubical.Data.Nat.Base hiding (ℕ; elim)
+open import Cubical.Data.Nat.Properties
+
+open import Cubical.Algebra.CommSemiring
+open import Cubical.Algebra.CommSemiring.Instances.Nat
+open import Cubical.Algebra.Semiring.BigOps
+
+open import Cubical.Tactics.NatSolver.Reflection
+open import Cubical.Tactics.NatSolver.NatExpression
+
+open Sum (CommSemiring→Semiring ℕ)
+open CommSemiringStr (snd ℕ) using (·DistL+;·DistR+)
+
+-- the first n natural number, i.e. {0,1,...,n-1}
+first : (n : fst ℕ) → FinVec (fst ℕ) n
+first n i = toℕ i
+
+firstDecompose : (n : fst ℕ) → first (suc n) ∘ weakenFin ≡ first n
+firstDecompose n i l =
+  elim
+    (λ l → first (suc _) (weakenFin l) ≡ first _ l)
+    refl
+    (λ _ → weakenRespToℕ _)
+    l i
+
+sumFormula : (n : fst ℕ) → 2 · (∑ (first (suc n))) ≡ n · (n + 1)
+sumFormula zero = refl
+sumFormula (suc n) =
+  2 · ∑ (first (2 + n))                                                ≡⟨ step0 ⟩
+  2 · (∑ (first (2 + n) ∘ weakenFin) + first (2 + n) (fromℕ (suc n)))  ≡⟨ step1 ⟩
+  2 · (∑ (first (2 + n) ∘ weakenFin) + (suc n))                        ≡⟨ step2 ⟩
+  2 · (∑ (first (1 + n)) + (suc n))                                    ≡⟨ step3 ⟩
+  2 · ∑ (first (1 + n)) + 2 · (suc n)                                  ≡⟨ step4 ⟩
+  n · (n + 1) + 2 · (suc n)                                            ≡⟨ useSolver n ⟩
+  (suc n) · (suc (n + 1))                                              ∎
+  where
+    step0 = cong (λ u → 2 · u) (∑Last (first (2 + n)))
+    step1 = cong (λ u → 2 · (∑ (first (2 + n) ∘ weakenFin) + u)) (toFromId _)
+    step2 = cong (λ u → 2 · ((∑ u) + (suc n))) (firstDecompose (suc n))
+    step3 = ·DistR+ 2 (∑ (first (1 + n))) (suc n)
+    step4 = cong (λ u → u + 2 · (suc n)) (sumFormula n)
+
+    useSolver : ∀ (n : fst ℕ) → n · (n + 1) + 2 · (suc n) ≡ (suc n) · (suc (n + 1))
+    useSolver = solve

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -11,7 +11,6 @@ open import Cubical.Algebra.CommSemiring.Instances.Nat
 open import Cubical.Algebra.Semiring.BigOps
 
 open import Cubical.Tactics.NatSolver.Reflection
-open import Cubical.Tactics.NatSolver.NatExpression
 
 open Sum (CommSemiring→Semiring ℕasCSR)
 open CommSemiringStr (snd ℕasCSR)

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -6,9 +6,6 @@ open import Cubical.Foundations.Function
 
 open import Cubical.Data.FinData
 
-open import Cubical.Data.Nat.Base hiding (ℕ; elim)
-open import Cubical.Data.Nat.Properties
-
 open import Cubical.Algebra.CommSemiring
 open import Cubical.Algebra.CommSemiring.Instances.Nat
 open import Cubical.Algebra.Semiring.BigOps
@@ -17,7 +14,7 @@ open import Cubical.Tactics.NatSolver.Reflection
 open import Cubical.Tactics.NatSolver.NatExpression
 
 open Sum (CommSemiring→Semiring ℕasCSR)
-open CommSemiringStr (snd ℕasCSR) using (·DistL+;·DistR+)
+open CommSemiringStr (snd ℕasCSR)
 
 -- the first n natural number, i.e. {0,1,...,n-1}
 first : (n : ℕ) → FinVec ℕ n

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -1,4 +1,11 @@
 {-# OPTIONS --safe #-}
+{-
+  In this module, the commonly known identity between the sum of the first (n+1) natural
+  numbers (also known as the n-th triangular number) and the product ½ · n · (n+1) is
+  proven in the equivalent form:
+
+        2 · (∑ (first (suc n))) ≡ n · (n + 1)
+-}
 module Cubical.Data.Nat.Triangular where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -5,6 +5,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 
 open import Cubical.Data.FinData
+open import Cubical.Data.Nat using (ℕ; suc; zero)
 
 open import Cubical.Algebra.CommSemiring
 open import Cubical.Algebra.CommSemiring.Instances.Nat

--- a/Cubical/Data/Nat/Triangular.agda
+++ b/Cubical/Data/Nat/Triangular.agda
@@ -4,7 +4,7 @@ module Cubical.Data.Nat.Triangular where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 
-open import Cubical.Data.FinData
+open import Cubical.Data.FinData as Fin
 open import Cubical.Data.Nat using (ℕ; suc; zero)
 
 open import Cubical.Algebra.CommSemiring
@@ -22,7 +22,7 @@ first n i = toℕ i
 
 firstDecompose : (n : ℕ) → first (suc n) ∘ weakenFin ≡ first n
 firstDecompose n i l =
-  elim
+  Fin.elim
     (λ l → first (suc _) (weakenFin l) ≡ first _ l)
     refl
     (λ _ → weakenRespToℕ _)


### PR DESCRIPTION
Proves the usual formula for triangular numbers in this form:
```agda
(n : fst ℕ) → 2 · (∑ (first (suc n))) ≡ n · (n + 1)
```
Depends on #1042 #1043 (both merged now)

I just proved this, because I wondered how if it is as little work as I thought it is.
Judging from this PR, it looks pleasant, but I actually had to do some refactoring to make it so.