### PR TITLE
Renaming to Sequential Coimits

### DIFF
--- a/Cubical/HITs/James/Inductive.agda
+++ b/Cubical/HITs/James/Inductive.agda
@@ -60,7 +60,7 @@ module JamesInd
   -- It is the direct colimit of 𝕁 n.
 
   𝕁∞ : Type ℓ
-  𝕁∞ = Lim→ 𝕁Seq
+  𝕁∞ = SeqColim 𝕁Seq
 
   -- And of course it is equivalent to James.
 
@@ -116,7 +116,7 @@ module JamesInd
     -- If X is (d+1)-connected, the inclusion inl : 𝕁 n → 𝕁∞ will be (n+1)d-connected.
 
     inl∞ : (n : ℕ) → 𝕁 n → 𝕁∞
-    inl∞ _ = inl
+    inl∞ _ = incl
 
     isConnectedInl : (n : ℕ) → isConnectedFun ((1 + n) · d) (inl∞ n)
     isConnectedInl = connInl X∙ d conn

--- a/Cubical/HITs/James/Inductive/Base.agda
+++ b/Cubical/HITs/James/Inductive/Base.agda
@@ -37,10 +37,10 @@ module _
   open Sequence
 
   𝕁amesSeq : Sequence ℓ
-  𝕁amesSeq .space = 𝕁ames
-  𝕁amesSeq .map   = incl
+  𝕁amesSeq .obj = 𝕁ames
+  𝕁amesSeq .map = incl
 
   -- The 𝕁ames∞ wanted is the direct colimit of 𝕁ames n
 
   𝕁ames∞ : Type ℓ
-  𝕁ames∞ = Lim→ 𝕁amesSeq
+  𝕁ames∞ = SeqColim 𝕁amesSeq

--- a/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
+++ b/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
@@ -112,7 +112,7 @@ module _
   J→𝕁ames (unit xs i) = push∞ (J→𝕁ames xs) i
 
   -- The following is the most complicated part.
-  -- It seems horrible but maincly it's due to correction of boudaries.
+  -- It seems horrible but mainly it's due to correction of boudaries.
 
   𝕁→J→𝕁ames-incl : (xs : 𝕁Red) → J→𝕁ames (𝕁→James (incl xs)) ≡ incl xs
   𝕁→J→𝕁ames-incl [] = refl

--- a/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
+++ b/Cubical/HITs/James/Inductive/ColimitEquivalence.agda
@@ -41,135 +41,135 @@ module _
       (λ i → x₀ ∷ unit xs i) (λ i j → unit (unit xs j) i) i j
 
   _∷∞_ : X → 𝕁ames → 𝕁ames
-  _∷∞_ x (inl xs) = inl (x ∷ xs)
-  _∷∞_ x (push xs i) = (push (x ∷ xs) ∙ (λ i → inl (unit x xs i))) i
+  _∷∞_ x (incl xs)   = incl (x ∷ xs)
+  _∷∞_ x (push xs i) = (push (x ∷ xs) ∙ (λ i → incl (unit x xs i))) i
 
   push∞ : (xs : 𝕁ames) → xs ≡ x₀ ∷∞ xs
-  push∞ (inl xs) = push xs
+  push∞ (incl xs)     = push xs
   push∞ (push xs i) j =
     push-helper {A = 𝕁ames} (push xs) (push (x₀ ∷ xs))
-      (λ i → inl (unit x₀ xs i)) (λ i j → inl (coh xs i j)) j i
+      (λ i → incl (unit x₀ xs i)) (λ i j → incl (coh xs i j)) j i
 
   infixr 5 _∷∞_
 
   -- One side map
 
-  𝕁→James-inl : 𝕁Red → James
-  𝕁→James-inl [] = []
-  𝕁→James-inl (x ∷ xs) = x ∷ 𝕁→James-inl xs
-  𝕁→James-inl (unit x xs i) = unit' x (𝕁→James-inl xs) i
-  𝕁→James-inl (coh xs i j) = coh' (𝕁→James-inl xs) i j
+  𝕁→James-incl : 𝕁Red → James
+  𝕁→James-incl [] = []
+  𝕁→James-incl (x ∷ xs) = x ∷ 𝕁→James-incl xs
+  𝕁→James-incl (unit x xs i) = unit' x (𝕁→James-incl xs) i
+  𝕁→James-incl (coh xs i j) = coh' (𝕁→James-incl xs) i j
 
   𝕁→James : 𝕁ames → James
-  𝕁→James (inl xs) = 𝕁→James-inl xs
-  𝕁→James (push xs i) = unit (𝕁→James-inl xs) i
+  𝕁→James (incl xs)   = 𝕁→James-incl xs
+  𝕁→James (push xs i) = unit (𝕁→James-incl xs) i
 
   -- Commutativity with pseudo-constructors
 
   𝕁→James-∷ : (x : X)(xs : 𝕁ames) → 𝕁→James (x ∷∞ xs) ≡ x ∷ 𝕁→James xs
-  𝕁→James-∷ x (inl xs) = refl
-  𝕁→James-∷ x (push xs i) j = comp-cong-helper 𝕁→James (push (x ∷ xs)) _ (λ i → inl (unit x xs i)) refl j i
+  𝕁→James-∷ x (incl xs)     = refl
+  𝕁→James-∷ x (push xs i) j = comp-cong-helper 𝕁→James (push (x ∷ xs)) _ (λ i → incl (unit x xs i)) refl j i
 
   𝕁→James-push : (xs : 𝕁ames)
     → PathP (λ i → 𝕁→James xs ≡ 𝕁→James-∷ x₀ xs i) (cong 𝕁→James (push∞ xs)) (unit (𝕁→James xs))
-  𝕁→James-push (inl xs) = refl
+  𝕁→James-push (incl xs)       = refl
   𝕁→James-push (push xs i) j k =
     hcomp (λ l → λ
-      { (i = i0) → unit (𝕁→James-inl xs) k
-      ; (i = i1) → unit (x₀ ∷ 𝕁→James-inl xs) k
+      { (i = i0) → unit (𝕁→James-incl xs) k
+      ; (i = i1) → unit (x₀ ∷ 𝕁→James-incl xs) k
       ; (j = i0) →
           push-helper-cong 𝕁→James (push xs) (push (x₀ ∷ xs))
-            (λ i → inl (unit x₀ xs i)) (λ i j → inl (coh xs i j)) k i (~ l)
-      ; (j = i1) → unit (unit (𝕁→James-inl xs) i) k
-      ; (k = i0) → unit (𝕁→James-inl xs) i
+            (λ i → incl (unit x₀ xs i)) (λ i j → incl (coh xs i j)) k i (~ l)
+      ; (j = i1) → unit (unit (𝕁→James-incl xs) i) k
+      ; (k = i0) → unit (𝕁→James-incl xs) i
       ; (k = i1) →
           comp-cong-helper-filler 𝕁→James (push (x₀ ∷ xs)) _
-            (λ i → inl (unit x₀ xs i)) refl j i l })
-    (push-coh-helper _ _ _ (λ i j → unit (unit (𝕁→James-inl xs) j) i) k i j)
+            (λ i → incl (unit x₀ xs i)) refl j i l })
+    (push-coh-helper _ _ _ (λ i j → unit (unit (𝕁→James-incl xs) j) i) k i j)
 
   -- The other-side map
 
   private
     push-square : (x : X)(xs : 𝕁Red)
-      → sym (push (x ∷ xs)) ∙∙ refl ∙∙ (λ i → x ∷∞ push xs i) ≡ (λ i → inl (unit x xs i))
-    push-square x xs i j = push-square-helper (push (x ∷ xs)) (λ i → inl (unit x xs i)) i j
+      → sym (push (x ∷ xs)) ∙∙ refl ∙∙ (λ i → x ∷∞ push xs i) ≡ (λ i → incl (unit x xs i))
+    push-square x xs i j = push-square-helper (push (x ∷ xs)) (λ i → incl (unit x xs i)) i j
 
     coh-cube : (xs : 𝕁Red)
       → SquareP
-          (λ i j → coh-helper _ _ _ (λ i j → push∞ (push xs j) i) i j ≡ inl (coh xs i j))
-          (λ i j → inl (x₀ ∷ x₀ ∷ xs))
+          (λ i j → coh-helper _ _ _ (λ i j → push∞ (push xs j) i) i j ≡ incl (coh xs i j))
+          (λ i j → incl (x₀ ∷ x₀ ∷ xs))
           (λ i j → push-square-helper (push (x₀ ∷ xs))
-                    (λ i → inl (unit x₀ xs i)) j i)
-          (λ i j → inl (x₀ ∷ x₀ ∷ xs))
-          (λ i j → inl (x₀ ∷ x₀ ∷ xs))
+                    (λ i → incl (unit x₀ xs i)) j i)
+          (λ i j → incl (x₀ ∷ x₀ ∷ xs))
+          (λ i j → incl (x₀ ∷ x₀ ∷ xs))
     coh-cube xs =
       coh-cube-helper {A = 𝕁ames} (push xs) (push (x₀ ∷ xs))
-        (λ i → inl (unit x₀ xs i)) (λ i j → inl (coh xs i j))
+        (λ i → incl (unit x₀ xs i)) (λ i j → incl (coh xs i j))
 
   J→𝕁ames : James → 𝕁ames
-  J→𝕁ames [] = inl []
+  J→𝕁ames [] = incl []
   J→𝕁ames (x ∷ xs) = x ∷∞ (J→𝕁ames xs)
   J→𝕁ames (unit xs i) = push∞ (J→𝕁ames xs) i
 
   -- The following is the most complicated part.
-  -- It seems horrible but mainly it's due to correction of boudaries.
+  -- It seems horrible but maincly it's due to correction of boudaries.
 
-  𝕁→J→𝕁ames-inl : (xs : 𝕁Red) → J→𝕁ames (𝕁→James (inl xs)) ≡ inl xs
-  𝕁→J→𝕁ames-inl [] = refl
-  𝕁→J→𝕁ames-inl (x ∷ xs) t = x ∷∞ 𝕁→J→𝕁ames-inl xs t
-  𝕁→J→𝕁ames-inl (unit x xs i) j =
+  𝕁→J→𝕁ames-incl : (xs : 𝕁Red) → J→𝕁ames (𝕁→James (incl xs)) ≡ incl xs
+  𝕁→J→𝕁ames-incl [] = refl
+  𝕁→J→𝕁ames-incl (x ∷ xs) t = x ∷∞ 𝕁→J→𝕁ames-incl xs t
+  𝕁→J→𝕁ames-incl (unit x xs i) j =
     hcomp (λ k → λ
       { (i = i0) → square-helper (j ∨ ~ k) i0
       ; (i = i1) → square-helper (j ∨ ~ k) i1
       ; (j = i0) → square-helper (~ k) i
-      ; (j = i1) → inl (unit x xs i) })
+      ; (j = i1) → incl (unit x xs i) })
     (push-square x xs j i)
     where
       square-helper : (i j : I) → 𝕁ames
       square-helper i j =
         doubleCompPath-cong-filler J→𝕁ames
-          (sym (unit (x ∷ 𝕁→James-inl xs))) refl (λ i → x ∷ unit (𝕁→James-inl xs) i)
-          (λ i j → push∞ (x ∷∞ 𝕁→J→𝕁ames-inl xs i) (~ j))
-          (λ i j → x ∷∞ 𝕁→J→𝕁ames-inl xs i)
-          (λ i j → x ∷∞ push∞ (𝕁→J→𝕁ames-inl xs i) j) i j i1
-  𝕁→J→𝕁ames-inl (coh xs i j) k =
+          (sym (unit (x ∷ 𝕁→James-incl xs))) refl (λ i → x ∷ unit (𝕁→James-incl xs) i)
+          (λ i j → push∞ (x ∷∞ 𝕁→J→𝕁ames-incl xs i) (~ j))
+          (λ i j → x ∷∞ 𝕁→J→𝕁ames-incl xs i)
+          (λ i j → x ∷∞ push∞ (𝕁→J→𝕁ames-incl xs i) j) i j i1
+  𝕁→J→𝕁ames-incl (coh xs i j) k =
     hcomp (λ l → λ
       { (i = i0) → cube-helper i0 j (k ∨ ~ l)
-      ; (i = i1) → inl-filler j k l
+      ; (i = i1) → incl-filler j k l
       ; (j = i0) → cube-helper i i0 (k ∨ ~ l)
       ; (j = i1) → cube-helper i i1 (k ∨ ~ l)
       ; (k = i0) → cube-helper i j (~ l)
-      ; (k = i1) → inl (coh xs i j) })
+      ; (k = i1) → incl (coh xs i j) })
     (coh-cube xs i j k)
     where
       cube-helper : (i j k : I) → 𝕁ames
       cube-helper i j k =
         coh-helper-cong J→𝕁ames _ _ _
-          (λ i j → unit (unit (𝕁→James-inl xs) j) i)
-          (λ i j k → push∞ (push∞ (𝕁→J→𝕁ames-inl xs k) j) i) i j k
+          (λ i j → unit (unit (𝕁→James-incl xs) j) i)
+          (λ i j k → push∞ (push∞ (𝕁→J→𝕁ames-incl xs k) j) i) i j k
 
-      inl-filler : (i j k : I) → 𝕁ames
-      inl-filler i j k =
+      incl-filler : (i j k : I) → 𝕁ames
+      incl-filler i j k =
         hfill (λ k → λ
           { (i = i0) → square-helper (j ∨ ~ k) i0
           ; (i = i1) → square-helper (j ∨ ~ k) i1
           ; (j = i0) → square-helper (~ k) i
-          ; (j = i1) → inl (unit x₀ xs i) })
+          ; (j = i1) → incl (unit x₀ xs i) })
         (inS (push-square x₀ xs j i)) k
         where
           square-helper : (i j : I) → 𝕁ames
           square-helper i j =
             doubleCompPath-cong-filler J→𝕁ames
-              (sym (unit (x₀ ∷ 𝕁→James-inl xs))) refl (λ i → x₀ ∷ unit (𝕁→James-inl xs) i)
-              (λ i j → push∞ (x₀ ∷∞ 𝕁→J→𝕁ames-inl xs i) (~ j))
-              (λ i j → x₀ ∷∞ 𝕁→J→𝕁ames-inl xs i)
-              (λ i j → x₀ ∷∞ push∞ (𝕁→J→𝕁ames-inl xs i) j) i j i1
+              (sym (unit (x₀ ∷ 𝕁→James-incl xs))) refl (λ i → x₀ ∷ unit (𝕁→James-incl xs) i)
+              (λ i j → push∞ (x₀ ∷∞ 𝕁→J→𝕁ames-incl xs i) (~ j))
+              (λ i j → x₀ ∷∞ 𝕁→J→𝕁ames-incl xs i)
+              (λ i j → x₀ ∷∞ push∞ (𝕁→J→𝕁ames-incl xs i) j) i j i1
 
   -- The main equivalence
 
   𝕁→J→𝕁ames : (xs : 𝕁ames) → J→𝕁ames (𝕁→James xs) ≡ xs
-  𝕁→J→𝕁ames (inl xs) = 𝕁→J→𝕁ames-inl xs
-  𝕁→J→𝕁ames (push xs i) j = push∞ (𝕁→J→𝕁ames-inl xs j) i
+  𝕁→J→𝕁ames (incl xs)     = 𝕁→J→𝕁ames-incl xs
+  𝕁→J→𝕁ames (push xs i) j = push∞ (𝕁→J→𝕁ames-incl xs j) i
 
   J→𝕁→James : (xs : James) → 𝕁→James (J→𝕁ames xs) ≡ xs
   J→𝕁→James [] = refl

--- a/Cubical/HITs/James/Inductive/PushoutFormula.agda
+++ b/Cubical/HITs/James/Inductive/PushoutFormula.agda
@@ -26,7 +26,7 @@ open import Cubical.Data.Sigma
 open import Cubical.HITs.Wedge
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Pushout.PushoutProduct
-open import Cubical.HITs.SequentialColimit renaming (incl to incl')
+import Cubical.HITs.SequentialColimit as SColim
 open import Cubical.HITs.James.Inductive.Base
   renaming (𝕁ames to 𝕁amesContruction ; 𝕁ames∞ to 𝕁ames∞Contruction)
 
@@ -264,8 +264,8 @@ module _
 
   private
     inl∞ : (n : ℕ) → 𝕁ames n → 𝕁ames∞
-    inl∞ _ = incl'
+    inl∞ _ = SColim.incl
 
   isConnectedInl : (n : ℕ) → isConnected (1 + n) X
     → (m : ℕ) → isConnectedFun ((1 + m) · n) (inl∞ m)
-  isConnectedInl n conn m = isConnectedIncl∞ _ _ _ (isConnectedIncl>n _ conn _)
+  isConnectedInl n conn m = SColim.isConnectedIncl∞ _ _ _ (isConnectedIncl>n _ conn _)

--- a/Cubical/HITs/James/Inductive/PushoutFormula.agda
+++ b/Cubical/HITs/James/Inductive/PushoutFormula.agda
@@ -26,7 +26,7 @@ open import Cubical.Data.Sigma
 open import Cubical.HITs.Wedge
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Pushout.PushoutProduct
-open import Cubical.HITs.SequentialColimit
+open import Cubical.HITs.SequentialColimit renaming (incl to incl')
 open import Cubical.HITs.James.Inductive.Base
   renaming (𝕁ames to 𝕁amesContruction ; 𝕁ames∞ to 𝕁ames∞Contruction)
 
@@ -264,8 +264,8 @@ module _
 
   private
     inl∞ : (n : ℕ) → 𝕁ames n → 𝕁ames∞
-    inl∞ _ = inl
+    inl∞ _ = incl'
 
   isConnectedInl : (n : ℕ) → isConnected (1 + n) X
     → (m : ℕ) → isConnectedFun ((1 + m) · n) (inl∞ m)
-  isConnectedInl n conn m = isConnectedInl∞ _ _ _ (isConnectedIncl>n _ conn _)
+  isConnectedInl n conn m = isConnectedIncl∞ _ _ _ (isConnectedIncl>n _ conn _)

--- a/Cubical/HITs/James/Inductive/Reduced.agda
+++ b/Cubical/HITs/James/Inductive/Reduced.agda
@@ -66,7 +66,7 @@ module _
   -- If you expand the very definition at end points,
   -- you will find that `𝕁Red` is almost a deformation retraction of `𝕁1`,
   -- and `𝕁0` is almost the same as the original inductive definition of James.
-  -- That explains why the isomorphisms given bellow are maincly of c-c, c-v and refls.
+  -- That explains why the isomorphisms given bellow are mainly of c-c, c-v and refls.
   𝕁0 = 𝕁Path i0
   𝕁1 = 𝕁Path i1
 

--- a/Cubical/HITs/James/Inductive/Reduced.agda
+++ b/Cubical/HITs/James/Inductive/Reduced.agda
@@ -40,8 +40,8 @@ module _
     coh  : (xs : 𝕁Red) → refl ≡ unit x₀ xs
 
   data 𝕁Red∞ : Type ℓ where
-    inl : 𝕁Red → 𝕁Red∞
-    push : (xs : 𝕁Red) → inl xs ≡ inl (x₀ ∷ xs)
+    incl : 𝕁Red → 𝕁Red∞
+    push : (xs : 𝕁Red) → incl xs ≡ incl (x₀ ∷ xs)
 
 
   -- Auxiliary constructions
@@ -66,13 +66,13 @@ module _
   -- If you expand the very definition at end points,
   -- you will find that `𝕁Red` is almost a deformation retraction of `𝕁1`,
   -- and `𝕁0` is almost the same as the original inductive definition of James.
-  -- That explains why the isomorphisms given bellow are mainly of c-c, c-v and refls.
+  -- That explains why the isomorphisms given bellow are maincly of c-c, c-v and refls.
   𝕁0 = 𝕁Path i0
   𝕁1 = 𝕁Path i1
 
   data 𝕁Path∞ (i : I) : Type ℓ where
-    inl : 𝕁Path i → 𝕁Path∞ i
-    push : (xs : 𝕁Path i) → inl xs ≡ inl (unit xs i)
+    incl : 𝕁Path i → 𝕁Path∞ i
+    push : (xs : 𝕁Path i) → incl xs ≡ incl (unit xs i)
 
   𝕁0∞ = 𝕁Path∞ i0
   𝕁1∞ = 𝕁Path∞ i1
@@ -116,19 +116,19 @@ module _
   𝕁1→𝕁Red→𝕁1 (coh xs i j) t = coh (𝕁1→𝕁Red→𝕁1 xs t) i j
 
   𝕁Red∞→𝕁1∞ : 𝕁Red∞ → 𝕁1∞
-  𝕁Red∞→𝕁1∞ (inl xs) = inl (𝕁Red→𝕁1 xs)
+  𝕁Red∞→𝕁1∞ (incl xs) = incl (𝕁Red→𝕁1 xs)
   𝕁Red∞→𝕁1∞ (push xs i) = push (𝕁Red→𝕁1 xs) i
 
   𝕁1∞→𝕁Red∞ : 𝕁1∞ → 𝕁Red∞
-  𝕁1∞→𝕁Red∞ (inl xs) = inl (𝕁1→𝕁Red xs)
+  𝕁1∞→𝕁Red∞ (incl xs) = incl (𝕁1→𝕁Red xs)
   𝕁1∞→𝕁Red∞ (push xs i) = push (𝕁1→𝕁Red xs) i
 
   𝕁Red∞→𝕁1∞→𝕁Red∞ : (xs : 𝕁Red∞) → 𝕁1∞→𝕁Red∞ (𝕁Red∞→𝕁1∞ xs) ≡ xs
-  𝕁Red∞→𝕁1∞→𝕁Red∞ (inl xs) t = inl (𝕁Red→𝕁1→𝕁Red xs t)
+  𝕁Red∞→𝕁1∞→𝕁Red∞ (incl xs) t = incl (𝕁Red→𝕁1→𝕁Red xs t)
   𝕁Red∞→𝕁1∞→𝕁Red∞ (push xs i) t = push (𝕁Red→𝕁1→𝕁Red xs t) i
 
   𝕁1∞→𝕁Red∞→𝕁1∞ : (xs : 𝕁1∞) → 𝕁Red∞→𝕁1∞ (𝕁1∞→𝕁Red∞ xs) ≡ xs
-  𝕁1∞→𝕁Red∞→𝕁1∞ (inl xs) t = inl (𝕁1→𝕁Red→𝕁1 xs t)
+  𝕁1∞→𝕁Red∞→𝕁1∞ (incl xs) t = incl (𝕁1→𝕁Red→𝕁1 xs t)
   𝕁1∞→𝕁Red∞→𝕁1∞ (push xs i) t = push (𝕁1→𝕁Red→𝕁1 xs t) i
 
   𝕁1∞≃𝕁Red∞ : 𝕁1∞ ≃ 𝕁Red∞
@@ -192,19 +192,19 @@ module _
   𝕁ames→𝕁0→𝕁ames (coh xs i j) t = coh (𝕁ames→𝕁0→𝕁ames xs t) i j
 
   𝕁ames∞→𝕁0∞ : 𝕁ames∞ → 𝕁0∞
-  𝕁ames∞→𝕁0∞ (inl xs) = inl (𝕁ames→𝕁0 xs)
+  𝕁ames∞→𝕁0∞ (incl xs)   = incl (𝕁ames→𝕁0 xs)
   𝕁ames∞→𝕁0∞ (push xs i) = push (𝕁ames→𝕁0 xs) i
 
   𝕁0∞→𝕁ames∞ : 𝕁0∞ → 𝕁ames∞
-  𝕁0∞→𝕁ames∞ (inl xs) = inl (𝕁0→𝕁ames xs)
+  𝕁0∞→𝕁ames∞ (incl xs)   = incl (𝕁0→𝕁ames xs)
   𝕁0∞→𝕁ames∞ (push xs i) = push (𝕁0→𝕁ames xs) i
 
   𝕁ames∞→𝕁0∞→𝕁ames∞ : (xs : 𝕁ames∞) → 𝕁0∞→𝕁ames∞ (𝕁ames∞→𝕁0∞ xs) ≡ xs
-  𝕁ames∞→𝕁0∞→𝕁ames∞ (inl xs) t = inl (𝕁ames→𝕁0→𝕁ames xs t)
+  𝕁ames∞→𝕁0∞→𝕁ames∞ (incl xs)   t = incl (𝕁ames→𝕁0→𝕁ames xs t)
   𝕁ames∞→𝕁0∞→𝕁ames∞ (push xs i) t = push (𝕁ames→𝕁0→𝕁ames xs t) i
 
   𝕁0∞→𝕁ames∞→𝕁0∞ : (xs : 𝕁0∞) → 𝕁ames∞→𝕁0∞ (𝕁0∞→𝕁ames∞ xs) ≡ xs
-  𝕁0∞→𝕁ames∞→𝕁0∞ (inl xs) t = inl (𝕁0→𝕁ames→𝕁0 xs t)
+  𝕁0∞→𝕁ames∞→𝕁0∞ (incl xs)   t = incl (𝕁0→𝕁ames→𝕁0 xs t)
   𝕁0∞→𝕁ames∞→𝕁0∞ (push xs i) t = push (𝕁0→𝕁ames→𝕁0 xs t) i
 
   𝕁ames∞≃𝕁0∞ : 𝕁ames∞ ≃ 𝕁0∞
@@ -220,9 +220,9 @@ module _
   -- Test of canonicity
   private
     -- It's good for [].
-    eq1 : 𝕁ames∞≃𝕁Red∞ .fst (inl []) ≡ inl []
+    eq1 : 𝕁ames∞≃𝕁Red∞ .fst (incl []) ≡ incl []
     eq1 = refl
 
     -- Without regularity, "obvious" equality doesn't hold definitionally.
-    eq2 : (x : X) → 𝕁ames∞≃𝕁Red∞ .fst (inl (x ∷ [])) ≡ inl (x ∷ [])
+    eq2 : (x : X) → 𝕁ames∞≃𝕁Red∞ .fst (incl (x ∷ [])) ≡ incl (x ∷ [])
     eq2 _ = transportRefl _

--- a/Cubical/HITs/SequentialColimit/Base.agda
+++ b/Cubical/HITs/SequentialColimit/Base.agda
@@ -10,11 +10,11 @@ private
 
 record Sequence (ℓ : Level) : Type (ℓ-suc ℓ) where
   field
-    space : ℕ → Type ℓ
-    map : {n : ℕ} → space n → space (1 + n)
+    obj : ℕ → Type ℓ
+    map : {n : ℕ} → obj n → obj (1 + n)
 
 open Sequence
 
-data Lim→ (X : Sequence ℓ) : Type ℓ where
-  inl : {n : ℕ} → X .space n → Lim→ X
-  push : {n : ℕ}(x : X .space n) → inl x ≡ inl (X .map x)
+data SeqColim (X : Sequence ℓ) : Type ℓ where
+  incl : {n : ℕ} → X .obj n → SeqColim X
+  push : {n : ℕ} (x : X .obj n) → incl x ≡ incl (X .map x)

--- a/Cubical/HITs/SequentialColimit/Properties.agda
+++ b/Cubical/HITs/SequentialColimit/Properties.agda
@@ -36,18 +36,18 @@ module _
       inclP : {k : ℕ} (x : X .obj k) → P (incl x)
       pushP : {k : ℕ} (x : X .obj k) → PathP (λ i → P (push x i)) (inclP x) (inclP (X .map x))
 
-  record ElimShiftData (n : ℕ)(P : SeqColim X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
+  record ElimDataShifted (n : ℕ)(P : SeqColim X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
     field
       inclP : {k : ℕ} (x : X .obj (k + n)) → P (incl x)
       pushP : {k : ℕ} (x : X .obj (k + n)) → PathP (λ i → P (push x i)) (inclP x) (inclP (X .map x))
 
   open ElimData
-  open ElimShiftData
+  open ElimDataShifted
 
-  ElimData→ElimShiftData : (n : ℕ)(P : SeqColim X → Type ℓ')
-    → ElimData P → ElimShiftData n P
-  ElimData→ElimShiftData n P datum .inclP = datum .inclP
-  ElimData→ElimShiftData n P datum .pushP = datum .pushP
+  ElimData→ElimDataShifted : (n : ℕ)(P : SeqColim X → Type ℓ')
+    → ElimData P → ElimDataShifted n P
+  ElimData→ElimDataShifted n P datum .inclP = datum .inclP
+  ElimData→ElimDataShifted n P datum .pushP = datum .pushP
 
   -- Preliminary lemmas
   -- The difficulty is maincly due to natural numbers having no strict +-commutativity
@@ -58,7 +58,7 @@ module _
 
   module _
     (P : SeqColim X → Type ℓ')
-    (datum : ElimShiftData 0 P) where
+    (datum : ElimDataShifted 0 P) where
 
     +-zero-0 : refl ≡ +-zero 0
     +-zero-0 i j = isSet→SquareP (λ i j → isSetℕ) refl refl refl (+-zero 0) j i
@@ -80,13 +80,13 @@ module _
       (λ i → (x : X .obj (+-zero k i)) →
         PathP (λ i → P (push x i)) (inclP'-filler k i x) (inclP'-filler (1 + k) i (X .map x))) (datum .pushP)
 
-    ElimShiftData0→ElimData : ElimData P
-    ElimShiftData0→ElimData .inclP = inclP'  _
-    ElimShiftData0→ElimData .pushP = pushP' _
+    ElimDataShifted0→ElimData : ElimData P
+    ElimDataShifted0→ElimData .inclP = inclP'  _
+    ElimDataShifted0→ElimData .pushP = pushP' _
 
   module _
     (n : ℕ)(P : SeqColim X → Type ℓ')
-    (datum : ElimShiftData (1 + n) P) where
+    (datum : ElimDataShifted (1 + n) P) where
 
     alg-path-0 : (b : ℕ) → refl ≡ alg-path 0 b
     alg-path-0 b i j = isSet→SquareP (λ i j → isSetℕ) refl refl refl (alg-path 0 b) j i
@@ -124,11 +124,11 @@ module _
           ; (i = i1) → inclP-0-eq j (X .map x) })
         (inclP-0-filler x i)
 
-    elimShiftDataSuc : ElimShiftData n P
-    elimShiftDataSuc .inclP {k = 0}     = inclP-0
-    elimShiftDataSuc .inclP {k = suc k} = inclP-n k
-    elimShiftDataSuc .pushP {k = 0}     = pushP-0
-    elimShiftDataSuc .pushP {k = suc k} = pushP-n k
+    ElimDataShiftedSuc : ElimDataShifted n P
+    ElimDataShiftedSuc .inclP {k = 0}     = inclP-0
+    ElimDataShiftedSuc .inclP {k = suc k} = inclP-n k
+    ElimDataShiftedSuc .pushP {k = 0}     = pushP-0
+    ElimDataShiftedSuc .pushP {k = suc k} = pushP-n k
 
   -- The eliminators
 
@@ -141,26 +141,26 @@ module _
 
   elimShift : (n : ℕ)
     → (P : SeqColim X → Type ℓ')
-    → ElimShiftData n P
+    → ElimDataShifted n P
     → (x : SeqColim X) → P x
-  elimShift 0 _ datum = elim _ (ElimShiftData0→ElimData _ datum)
-  elimShift (suc n) _ datum = elimShift n _ (elimShiftDataSuc _ _ datum)
+  elimShift 0 _ datum = elim _ (ElimDataShifted0→ElimData _ datum)
+  elimShift (suc n) _ datum = elimShift n _ (ElimDataShiftedSuc _ _ datum)
 
   elimShiftβ : (n : ℕ)(k : ℕ)
     → (P : SeqColim X → Type ℓ')
-    → (datum : ElimShiftData n P)
+    → (datum : ElimDataShifted n P)
     → elimShift _ _ datum ∘ incl∞ (k + n) ≡ datum .inclP
   elimShiftβ 0 0 _ datum = sym (inclP'-0-eq _ datum)
   elimShiftβ 0 (suc k) P datum =
     transport (λ i → elimShift _ _ datum ∘ incl∞ (+-zero (suc k) (~ i))
       ≡ inclP'-filler P datum (suc k) (~ i)) refl
   elimShiftβ (suc n) 0 _ datum =
-      elimShiftβ n _ _ (elimShiftDataSuc _ _ datum)
+      elimShiftβ n _ _ (ElimDataShiftedSuc _ _ datum)
     ∙ sym (inclP-0-eq _ _ datum)
   elimShiftβ (suc n) (suc k) P datum =
     transport (λ i → elimShift _ _ datum ∘ incl∞ (alg-path (suc k) n (~ i))
       ≡ inclP-n-filler n P datum (suc k) (~ i))
-      (elimShiftβ n (suc (suc k)) P (elimShiftDataSuc _ _ datum))
+      (elimShiftβ n (suc (suc k)) P (ElimDataShiftedSuc _ _ datum))
 
   -- Lemma to lift sections
 
@@ -223,7 +223,7 @@ module _
           → PathP (λ i → Y (push x i) .fst) (lifting k sec x) (lifting (1 + k) sec (X .map x))
         liftingPath k sec = liftSecPath d _ (conn _) Y (lifting k sec)
 
-        liftingData : ((x : X .obj n) → Y (incl x) .fst) → ElimShiftData n (λ x → Y x .fst)
+        liftingData : ((x : X .obj n) → Y (incl x) .fst) → ElimDataShifted n (λ x → Y x .fst)
         liftingData sec .inclP = lifting _ sec
         liftingData sec .pushP = liftingPath _ sec
 

--- a/Cubical/HITs/SequentialColimit/Properties.agda
+++ b/Cubical/HITs/SequentialColimit/Properties.agda
@@ -28,138 +28,138 @@ module _
   open Sequence
 
   private
-    inl∞ : (n : ℕ) → X .space n → Lim→ X
-    inl∞ n = inl {n = n}
+    incl∞ : (n : ℕ) → X .obj n → SeqColim X
+    incl∞ n = incl {n = n}
 
-  record ElimData (P : Lim→ X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
+  record ElimData (P : SeqColim X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
     field
-      finl  : {k : ℕ}(x : X .space k) → P (inl x)
-      fpush : {k : ℕ}(x : X .space k) → PathP (λ i → P (push x i)) (finl x) (finl (X .map x))
+      inclP : {k : ℕ} (x : X .obj k) → P (incl x)
+      pushP : {k : ℕ} (x : X .obj k) → PathP (λ i → P (push x i)) (inclP x) (inclP (X .map x))
 
-  record ElimShiftData (n : ℕ)(P : Lim→ X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
+  record ElimShiftData (n : ℕ)(P : SeqColim X → Type ℓ') : Type (ℓ-max ℓ ℓ') where
     field
-      finl  : {k : ℕ}(x : X .space (k + n)) → P (inl x)
-      fpush : {k : ℕ}(x : X .space (k + n)) → PathP (λ i → P (push x i)) (finl x) (finl (X .map x))
+      inclP : {k : ℕ} (x : X .obj (k + n)) → P (incl x)
+      pushP : {k : ℕ} (x : X .obj (k + n)) → PathP (λ i → P (push x i)) (inclP x) (inclP (X .map x))
 
   open ElimData
   open ElimShiftData
 
-  ElimData→ElimShiftData : (n : ℕ)(P : Lim→ X → Type ℓ')
+  ElimData→ElimShiftData : (n : ℕ)(P : SeqColim X → Type ℓ')
     → ElimData P → ElimShiftData n P
-  ElimData→ElimShiftData n P datum .finl  = datum .finl
-  ElimData→ElimShiftData n P datum .fpush = datum .fpush
+  ElimData→ElimShiftData n P datum .inclP = datum .inclP
+  ElimData→ElimShiftData n P datum .pushP = datum .pushP
 
   -- Preliminary lemmas
-  -- The difficulty is mainly due to natural numbers having no strict +-commutativity
+  -- The difficulty is maincly due to natural numbers having no strict +-commutativity
 
   private
     alg-path : (a b : ℕ) → a + (1 + b) ≡ 1 + (a + b)
     alg-path a b = +-assoc a 1 b ∙ (λ i → +-comm a 1 i + b)
 
   module _
-    (P : Lim→ X → Type ℓ')
+    (P : SeqColim X → Type ℓ')
     (datum : ElimShiftData 0 P) where
 
     +-zero-0 : refl ≡ +-zero 0
     +-zero-0 i j = isSet→SquareP (λ i j → isSetℕ) refl refl refl (+-zero 0) j i
 
-    finl'-filler : (k : ℕ) → (i : I) → (x : X .space (+-zero k i)) → P (inl x)
-    finl'-filler k i = transport-filler (λ i → (x : X .space (+-zero k i)) → P (inl x)) (datum .finl) i
+    inclP'-filler : (k : ℕ) → (i : I) → (x : X .obj (+-zero k i)) → P (incl x)
+    inclP'-filler k i = transport-filler (λ i → (x : X .obj (+-zero k i)) → P (incl x)) (datum .inclP) i
 
-    finl' : (k : ℕ) → (x : X .space k) → P (inl x)
-    finl' k = finl'-filler k i1
+    inclP' : (k : ℕ) → (x : X .obj k) → P (incl x)
+    inclP' k = inclP'-filler k i1
 
-    finl'-0-eq : datum .finl ≡ finl' 0
-    finl'-0-eq = sym (transportRefl _)
-      ∙ (λ j → transport (λ i → (x : X .space (+-zero-0 j i)) → P (inl x)) (datum .finl {k = 0}))
+    inclP'-0-eq : datum .inclP ≡ inclP' 0
+    inclP'-0-eq = sym (transportRefl _)
+      ∙ (λ j → transport (λ i → (x : X .obj (+-zero-0 j i)) → P (incl x)) (datum .inclP {k = 0}))
 
-    fpush' : (k : ℕ)
-      → (x : X .space k)
-      → PathP (λ i → P (push x i)) (finl' k x) (finl' (1 + k) (X .map x))
-    fpush' k = transport
-      (λ i → (x : X .space (+-zero k i)) →
-        PathP (λ i → P (push x i)) (finl'-filler k i x) (finl'-filler (1 + k) i (X .map x))) (datum .fpush)
+    pushP' : (k : ℕ)
+      → (x : X .obj k)
+      → PathP (λ i → P (push x i)) (inclP' k x) (inclP' (1 + k) (X .map x))
+    pushP' k = transport
+      (λ i → (x : X .obj (+-zero k i)) →
+        PathP (λ i → P (push x i)) (inclP'-filler k i x) (inclP'-filler (1 + k) i (X .map x))) (datum .pushP)
 
     ElimShiftData0→ElimData : ElimData P
-    ElimShiftData0→ElimData .finl  = finl'  _
-    ElimShiftData0→ElimData .fpush = fpush' _
+    ElimShiftData0→ElimData .inclP = inclP'  _
+    ElimShiftData0→ElimData .pushP = pushP' _
 
   module _
-    (n : ℕ)(P : Lim→ X → Type ℓ')
+    (n : ℕ)(P : SeqColim X → Type ℓ')
     (datum : ElimShiftData (1 + n) P) where
 
     alg-path-0 : (b : ℕ) → refl ≡ alg-path 0 b
     alg-path-0 b i j = isSet→SquareP (λ i j → isSetℕ) refl refl refl (alg-path 0 b) j i
 
-    finl-n-filler : (k : ℕ) → (i : I) → ((x : X .space (alg-path k n i)) → P (inl x))
-    finl-n-filler k i = transport-filler (λ i → (x : X .space (alg-path k n i)) → P (inl x)) (datum .finl) i
+    inclP-n-filler : (k : ℕ) → (i : I) → ((x : X .obj (alg-path k n i)) → P (incl x))
+    inclP-n-filler k i = transport-filler (λ i → (x : X .obj (alg-path k n i)) → P (incl x)) (datum .inclP) i
 
-    finl-n : (k : ℕ) → (x : X .space ((1 + k) + n)) → P (inl x)
-    finl-n k = finl-n-filler k i1
+    inclP-n : (k : ℕ) → (x : X .obj ((1 + k) + n)) → P (incl x)
+    inclP-n k = inclP-n-filler k i1
 
-    fpush-n : (k : ℕ)
-      → (x : X .space ((1 + k) + n))
-      → PathP (λ i → P (push x i)) (finl-n k x) (finl-n (1 + k) (X .map x))
-    fpush-n k =
+    pushP-n : (k : ℕ)
+      → (x : X .obj ((1 + k) + n))
+      → PathP (λ i → P (push x i)) (inclP-n k x) (inclP-n (1 + k) (X .map x))
+    pushP-n k =
       transport
-        (λ i → (x : X .space (alg-path k n i)) →
-          PathP (λ i → P (push x i)) (finl-n-filler k i x) (finl-n-filler (1 + k) i (X .map x))) (datum .fpush)
+        (λ i → (x : X .obj (alg-path k n i)) →
+          PathP (λ i → P (push x i)) (inclP-n-filler k i x) (inclP-n-filler (1 + k) i (X .map x))) (datum .pushP)
 
-    finl-0-filler : (x : X .space n) → (i : I) → P (push x i)
-    finl-0-filler x i = transport-filler (λ i → P (push x (~ i))) (datum .finl {k = 0} (X .map x)) (~ i)
+    inclP-0-filler : (x : X .obj n) → (i : I) → P (push x i)
+    inclP-0-filler x i = transport-filler (λ i → P (push x (~ i))) (datum .inclP {k = 0} (X .map x)) (~ i)
 
-    finl-0 : (x : X .space n) → P (inl x)
-    finl-0 x = finl-0-filler x i0
+    inclP-0 : (x : X .obj n) → P (incl x)
+    inclP-0 x = inclP-0-filler x i0
 
-    finl-0-eq : datum .finl {k = 0} ≡ finl-n 0
-    finl-0-eq = sym (transportRefl _)
-      ∙ (λ j → transport (λ i → (x : X .space (alg-path-0 n j i)) → P (inl x)) (datum .finl {k = 0}))
+    inclP-0-eq : datum .inclP {k = 0} ≡ inclP-n 0
+    inclP-0-eq = sym (transportRefl _)
+      ∙ (λ j → transport (λ i → (x : X .obj (alg-path-0 n j i)) → P (incl x)) (datum .inclP {k = 0}))
 
-    fpush-0 :
-        (x : X .space n)
-      → PathP (λ i → P (push x i)) (finl-0 x) (finl-n 0 (X .map x))
-    fpush-0 x i =
+    pushP-0 :
+        (x : X .obj n)
+      → PathP (λ i → P (push x i)) (inclP-0 x) (inclP-n 0 (X .map x))
+    pushP-0 x i =
       hcomp (λ j → λ
-          { (i = i0) → finl-0 x
-          ; (i = i1) → finl-0-eq j (X .map x) })
-        (finl-0-filler x i)
+          { (i = i0) → inclP-0 x
+          ; (i = i1) → inclP-0-eq j (X .map x) })
+        (inclP-0-filler x i)
 
     elimShiftDataSuc : ElimShiftData n P
-    elimShiftDataSuc .finl  {k = 0} = finl-0
-    elimShiftDataSuc .finl  {k = suc k} = finl-n k
-    elimShiftDataSuc .fpush {k = 0} = fpush-0
-    elimShiftDataSuc .fpush {k = suc k} = fpush-n k
+    elimShiftDataSuc .inclP {k = 0}     = inclP-0
+    elimShiftDataSuc .inclP {k = suc k} = inclP-n k
+    elimShiftDataSuc .pushP {k = 0}     = pushP-0
+    elimShiftDataSuc .pushP {k = suc k} = pushP-n k
 
   -- The eliminators
 
   elim :
-      (P : Lim→ X → Type ℓ')
+      (P : SeqColim X → Type ℓ')
     → ElimData P
-    → (x : Lim→ X) → P x
-  elim P datum (inl x) = datum .finl x
-  elim P datum (push x i) = datum .fpush x i
+    → (x : SeqColim X) → P x
+  elim P datum (incl x)   = datum .inclP x
+  elim P datum (push x i) = datum .pushP x i
 
   elimShift : (n : ℕ)
-    → (P : Lim→ X → Type ℓ')
+    → (P : SeqColim X → Type ℓ')
     → ElimShiftData n P
-    → (x : Lim→ X) → P x
+    → (x : SeqColim X) → P x
   elimShift 0 _ datum = elim _ (ElimShiftData0→ElimData _ datum)
   elimShift (suc n) _ datum = elimShift n _ (elimShiftDataSuc _ _ datum)
 
   elimShiftβ : (n : ℕ)(k : ℕ)
-    → (P : Lim→ X → Type ℓ')
+    → (P : SeqColim X → Type ℓ')
     → (datum : ElimShiftData n P)
-    → elimShift _ _ datum ∘ inl∞ (k + n) ≡ datum .finl
-  elimShiftβ 0 0 _ datum = sym (finl'-0-eq _ datum)
+    → elimShift _ _ datum ∘ incl∞ (k + n) ≡ datum .inclP
+  elimShiftβ 0 0 _ datum = sym (inclP'-0-eq _ datum)
   elimShiftβ 0 (suc k) P datum =
-    transport (λ i → elimShift _ _ datum ∘ inl∞ (+-zero (suc k) (~ i))
-      ≡ finl'-filler P datum (suc k) (~ i)) refl
+    transport (λ i → elimShift _ _ datum ∘ incl∞ (+-zero (suc k) (~ i))
+      ≡ inclP'-filler P datum (suc k) (~ i)) refl
   elimShiftβ (suc n) 0 _ datum =
       elimShiftβ n _ _ (elimShiftDataSuc _ _ datum)
-    ∙ sym (finl-0-eq _ _ datum)
+    ∙ sym (inclP-0-eq _ _ datum)
   elimShiftβ (suc n) (suc k) P datum =
-    transport (λ i → elimShift _ _ datum ∘ inl∞ (alg-path (suc k) n (~ i))
-      ≡ finl-n-filler n P datum (suc k) (~ i))
+    transport (λ i → elimShift _ _ datum ∘ incl∞ (alg-path (suc k) n (~ i))
+      ≡ inclP-n-filler n P datum (suc k) (~ i))
       (elimShiftβ n (suc (suc k)) P (elimShiftDataSuc _ _ datum))
 
   -- Lemma to lift sections
@@ -168,42 +168,42 @@ module _
 
   private
     transpSec :
-      (n : ℕ)(Y : Lim→ X → Type ℓ')
-      (sec : (x : X .space n) → Y (inl x))
-      → (x : X .space n) → Y (inl (X .map x))
+      (n : ℕ)(Y : SeqColim X → Type ℓ')
+      (sec : (x : X .obj n) → Y (incl x))
+      → (x : X .obj n) → Y (incl (X .map x))
     transpSec n Y sec x = transport (λ i → Y (push x i)) (sec x)
 
     module _
       (d : ℕ)(n : ℕ)
       (conn : isConnectedFun d (X .map {n = n}))
-      (Y : Lim→ X → TypeOfHLevel ℓ' d) where
+      (Y : SeqColim X → TypeOfHLevel ℓ' d) where
 
       module _
-        (sec : (x : X .space n) → Y (inl (X .map x)) .fst) where
+        (sec : (x : X .obj n) → Y (incl (X .map x)) .fst) where
 
-        lift-iso = elim.isIsoPrecompose _ d (Y ∘ inl) conn
+        lift-iso = elim.isIsoPrecompose _ d (Y ∘ incl) conn
 
-        liftSec' : (x : X .space (1 + n)) → Y (inl x) .fst
+        liftSec' : (x : X .obj (1 + n)) → Y (incl x) .fst
         liftSec' = lift-iso .inv sec
 
-        liftSecPath' : (x : X .space n) → sec x ≡ liftSec' (X .map x)
+        liftSecPath' : (x : X .obj n) → sec x ≡ liftSec' (X .map x)
         liftSecPath' x i = lift-iso .rightInv sec (~ i) x
 
       module _
-        (sec : (x : X .space n) → Y (inl x) .fst) where
+        (sec : (x : X .obj n) → Y (incl x) .fst) where
 
-        liftSec : (x : X .space (1 + n)) → Y (inl x) .fst
+        liftSec : (x : X .obj (1 + n)) → Y (incl x) .fst
         liftSec = liftSec' (transpSec n (λ x → Y x .fst) sec)
 
         liftSecPath :
-          (x : X .space n)
+          (x : X .obj n)
           → PathP (λ i → Y (push x i) .fst) (sec x) (liftSec (X .map x))
         liftSecPath x i =
           hcomp (λ j → λ
             { (i = i0) → sec x
             ; (i = i1) → liftSecPath'
                 (transpSec n (λ x → Y x .fst) sec) x j })
-          (transport-filler (λ i → Y (push x i) .fst) (sec x) i)
+            (transport-filler (λ i → Y (push x i) .fst) (sec x) i)
 
   module _
     (d : ℕ)(n : ℕ)
@@ -211,27 +211,27 @@ module _
 
     private
       module _
-        (Y : Lim→ X → TypeOfHLevel ℓ' d) where
+        (Y : SeqColim X → TypeOfHLevel ℓ' d) where
 
-        lifting : (k : ℕ)(sec : (x : X .space n) → Y (inl x) .fst)
-          → (x : X .space (k + n)) → Y (inl x) .fst
+        lifting : (k : ℕ)(sec : (x : X .obj n) → Y (incl x) .fst)
+          → (x : X .obj (k + n)) → Y (incl x) .fst
         lifting 0 sec = sec
         lifting (suc k) sec = liftSec d _ (conn _) Y (lifting k sec)
 
-        liftingPath : (k : ℕ)(sec : (x : X .space n) → Y (inl x) .fst)
-          → (x : X .space (k + n))
+        liftingPath : (k : ℕ)(sec : (x : X .obj n) → Y (incl x) .fst)
+          → (x : X .obj (k + n))
           → PathP (λ i → Y (push x i) .fst) (lifting k sec x) (lifting (1 + k) sec (X .map x))
         liftingPath k sec = liftSecPath d _ (conn _) Y (lifting k sec)
 
-        liftingData : ((x : X .space n) → Y (inl x) .fst) → ElimShiftData n (λ x → Y x .fst)
-        liftingData sec .finl  = lifting _ sec
-        liftingData sec .fpush = liftingPath _ sec
+        liftingData : ((x : X .obj n) → Y (incl x) .fst) → ElimShiftData n (λ x → Y x .fst)
+        liftingData sec .inclP = lifting _ sec
+        liftingData sec .pushP = liftingPath _ sec
 
-        hasSectionInl∘ : hasSection (λ (sec : (x : Lim→ X) → Y x .fst) → sec ∘ inl {n = n})
-        hasSectionInl∘ .fst sec = elimShift  _ _   (liftingData sec)
-        hasSectionInl∘ .snd sec = elimShiftβ _ _ _ (liftingData sec)
+        hasSectionIncl∘ : hasSection (λ (sec : (x : SeqColim X) → Y x .fst) → sec ∘ incl {n = n})
+        hasSectionIncl∘ .fst sec = elimShift  _ _   (liftingData sec)
+        hasSectionIncl∘ .snd sec = elimShiftβ _ _ _ (liftingData sec)
 
     -- Connectivity of inclusion map
 
-    isConnectedInl∞ : isConnectedFun d (inl∞ n)
-    isConnectedInl∞ = elim.isConnectedPrecompose _ _ hasSectionInl∘
+    isConnectedIncl∞ : isConnectedFun d (incl∞ n)
+    isConnectedIncl∞ = elim.isConnectedPrecompose _ _ hasSectionIncl∘

--- a/Cubical/HITs/SequentialColimit/Properties.agda
+++ b/Cubical/HITs/SequentialColimit/Properties.agda
@@ -50,7 +50,7 @@ module _
   ElimData→ElimDataShifted n P datum .pushP = datum .pushP
 
   -- Preliminary lemmas
-  -- The difficulty is maincly due to natural numbers having no strict +-commutativity
+  -- The difficulty is mainly due to natural numbers having no strict +-commutativity
 
   private
     alg-path : (a b : ℕ) → a + (1 + b) ≡ 1 + (a + b)
@@ -124,11 +124,11 @@ module _
           ; (i = i1) → inclP-0-eq j (X .map x) })
         (inclP-0-filler x i)
 
-    ElimDataShiftedSuc : ElimDataShifted n P
-    ElimDataShiftedSuc .inclP {k = 0}     = inclP-0
-    ElimDataShiftedSuc .inclP {k = suc k} = inclP-n k
-    ElimDataShiftedSuc .pushP {k = 0}     = pushP-0
-    ElimDataShiftedSuc .pushP {k = suc k} = pushP-n k
+    elimShiftedSuc : ElimDataShifted n P
+    elimShiftedSuc .inclP {k = 0}     = inclP-0
+    elimShiftedSuc .inclP {k = suc k} = inclP-n k
+    elimShiftedSuc .pushP {k = 0}     = pushP-0
+    elimShiftedSuc .pushP {k = suc k} = pushP-n k
 
   -- The eliminators
 
@@ -139,28 +139,28 @@ module _
   elim P datum (incl x)   = datum .inclP x
   elim P datum (push x i) = datum .pushP x i
 
-  elimShift : (n : ℕ)
+  elimShifted : (n : ℕ)
     → (P : SeqColim X → Type ℓ')
     → ElimDataShifted n P
     → (x : SeqColim X) → P x
-  elimShift 0 _ datum = elim _ (ElimDataShifted0→ElimData _ datum)
-  elimShift (suc n) _ datum = elimShift n _ (ElimDataShiftedSuc _ _ datum)
+  elimShifted 0 _ datum = elim _ (ElimDataShifted0→ElimData _ datum)
+  elimShifted (suc n) _ datum = elimShifted n _ (elimShiftedSuc _ _ datum)
 
-  elimShiftβ : (n : ℕ)(k : ℕ)
+  elimShiftedβ : (n : ℕ)(k : ℕ)
     → (P : SeqColim X → Type ℓ')
     → (datum : ElimDataShifted n P)
-    → elimShift _ _ datum ∘ incl∞ (k + n) ≡ datum .inclP
-  elimShiftβ 0 0 _ datum = sym (inclP'-0-eq _ datum)
-  elimShiftβ 0 (suc k) P datum =
-    transport (λ i → elimShift _ _ datum ∘ incl∞ (+-zero (suc k) (~ i))
+    → elimShifted _ _ datum ∘ incl∞ (k + n) ≡ datum .inclP
+  elimShiftedβ 0 0 _ datum = sym (inclP'-0-eq _ datum)
+  elimShiftedβ 0 (suc k) P datum =
+    transport (λ i → elimShifted _ _ datum ∘ incl∞ (+-zero (suc k) (~ i))
       ≡ inclP'-filler P datum (suc k) (~ i)) refl
-  elimShiftβ (suc n) 0 _ datum =
-      elimShiftβ n _ _ (ElimDataShiftedSuc _ _ datum)
+  elimShiftedβ (suc n) 0 _ datum =
+      elimShiftedβ n _ _ (elimShiftedSuc _ _ datum)
     ∙ sym (inclP-0-eq _ _ datum)
-  elimShiftβ (suc n) (suc k) P datum =
-    transport (λ i → elimShift _ _ datum ∘ incl∞ (alg-path (suc k) n (~ i))
+  elimShiftedβ (suc n) (suc k) P datum =
+    transport (λ i → elimShifted _ _ datum ∘ incl∞ (alg-path (suc k) n (~ i))
       ≡ inclP-n-filler n P datum (suc k) (~ i))
-      (elimShiftβ n (suc (suc k)) P (ElimDataShiftedSuc _ _ datum))
+      (elimShiftedβ n (suc (suc k)) P (elimShiftedSuc _ _ datum))
 
   -- Lemma to lift sections
 
@@ -228,8 +228,8 @@ module _
         liftingData sec .pushP = liftingPath _ sec
 
         hasSectionIncl∘ : hasSection (λ (sec : (x : SeqColim X) → Y x .fst) → sec ∘ incl {n = n})
-        hasSectionIncl∘ .fst sec = elimShift  _ _   (liftingData sec)
-        hasSectionIncl∘ .snd sec = elimShiftβ _ _ _ (liftingData sec)
+        hasSectionIncl∘ .fst sec = elimShifted  _ _   (liftingData sec)
+        hasSectionIncl∘ .snd sec = elimShiftedβ _ _ _ (liftingData sec)
 
     -- Connectivity of inclusion map
 

--- a/Cubical/HITs/SequentialColimit/Properties.agda
+++ b/Cubical/HITs/SequentialColimit/Properties.agda
@@ -81,7 +81,7 @@ module _
         PathP (λ i → P (push x i)) (inclP'-filler k i x) (inclP'-filler (1 + k) i (X .map x))) (datum .pushP)
 
     ElimDataShifted0→ElimData : ElimData P
-    ElimDataShifted0→ElimData .inclP = inclP'  _
+    ElimDataShifted0→ElimData .inclP = inclP' _
     ElimDataShifted0→ElimData .pushP = pushP' _
 
   module _


### PR DESCRIPTION
See #1046 .

I also changed some names in `SequentialColimit/Properties.agda` for it being more informative. These names are only used in this one file. Also add some spaces to make them look better.

@felixwellen 