### PR TITLE
Add workflow with Agda master.

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,0 +1,143 @@
+## Adapted from the agda/agda-stdlib workflow
+
+name: Ubuntu build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+########################################################################
+## CONFIGURATION
+##
+## See SETTINGS for the most important configuration variable: AGDA_BRANCH.
+## It has to be defined as a build step because it is potentially branch
+## dependent.
+##
+## As for the rest:
+##
+## Basically do not touch GHC_VERSION and CABAL_VERSION as long as
+## they aren't a problem in the build. If you have time to waste, it
+## could be worth investigating whether newer versions of ghc produce
+## more efficient Agda executable and could cut down the build time.
+## Just be aware that actions are flaky and small variations are to be
+## expected.
+##
+## The CABAL_INSTALL variable only passes `-O1` optimisations to ghc
+## because github actions cannot currently handle a build using `-O2`.
+## To be experimented with again in the future to see if things have
+## gotten better.
+##
+########################################################################
+
+########################################################################
+## SETTINGS
+##
+## AGDA_BRANCH picks the branch of Agda to use to build the library.
+## It doesn't really track the branch, so you have to drop caches to
+## get a new branch version if it changes. This will be fixed in the
+## next PR.
+########################################################################
+
+env:
+  AGDA_BRANCH: master
+  GHC_VERSION: 9.2.5
+  CABAL_VERSION: 3.6.2.0
+  CACHE_PATHS: |
+    ~/.cabal/packages
+    ~/.cabal/store
+    ~/.cabal/bin
+
+jobs:
+  test-cubical:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cabal
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ env.GHC_VERSION }}
+          cabal-version: ${{ env.CABAL_VERSION }}
+          cabal-update: true
+
+      # This caching step allows us to save a lot of building time by only
+      # rebuilding Agda, and re-checking unchanged library files if
+      # absolutely necessary i.e. if we change either the version of Agda,
+      # ghc, or cabal that we want to use for the build.
+      - name: Restore external dependencies cache
+        uses: actions/cache/restore@v3
+        id: cache-external-restore
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}
+
+      ########################################################################
+      ## INSTALLATION STEPS
+      ########################################################################
+
+      - name: Download and install fix-whitespace
+        if: steps.cache-external-restore.outputs.cache-hit != 'true'
+        run: |
+          cabal install fix-whitespace
+
+      - name: Save external dependencies cache
+        if: steps.cache-external-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        id: cache-external-save
+        with:
+          path: ${{ env.CACHE_PATHS }}
+          key: ${{ steps.cache-external-restore.outputs.cache-primary-key }}
+
+      ########################################################################
+      ## INSTALLATION AGDA MASTER
+      ########################################################################
+
+      - name: Get Agda master
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd ~/.local/
+          gh release download --pattern Agda-nightly-linux.tar.xz --repo agda/agda nightly
+          tar -xvf Agda-nightly-linux.tar.xz
+          echo "$PWD/Agda-nightly/bin/" >> "$GITHUB_PATH"
+          echo "Agda_datadir=$PWD/Agda-nightly/data" >> "$GITHUB_ENV"
+
+      ########################################################################
+      ## CHECKOUT
+      ########################################################################
+
+      # By default github actions do not pull the repo
+      - name: Checkout cubical
+        uses: actions/checkout@v3
+
+      ########################################################################
+      ## TESTING
+      ########################################################################
+
+      - name: Restore library cache
+        uses: actions/cache/restore@v3
+        id: cache-library-restore
+        with:
+          path: ./_build
+          key: library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-${{ hashFiles('Cubical/**', 'cubical.agda-lib', 'Everythings.hs') }}
+          restore-keys: |
+            library-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ env.CABAL_VERSION }}-${{ env.AGDA_BRANCH }}-
+
+      - name: Put cabal programs in PATH
+        run: echo "~/.cabal/bin" >> $GITHUB_PATH
+
+      - name: Test cubical
+        run: |
+          make test \
+            AGDA_EXEC='agda -WnoUnsupportedIndexedMatch -W error' \
+            FIX_WHITESPACE='fix-whitespace' \
+            EVERYTHINGS='cabal run Everythings'
+
+      - name: Save library cache
+        if: steps.cache-library-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        id: cache-library-save
+        with:
+          path: ./_build
+          key: ${{ steps.cache-library-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
Hi, this is a first try at adding a CI workflow using Agda master, without rebuilding it ourselves. It simply fetches the nightly release and uses that instead.

This seems to be working fine on my fork, see https://github.com/jpoiret/cubical/actions/runs/6158237986/job/16710596838 (and it has already caught something).

WDYT?