### PR TITLE
Generalized Universe Levels in 'substInPaths'

### DIFF
--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -174,7 +174,7 @@ overPathFunct p q =
 
 -- substition over families of paths
 -- theorem 2.11.3 in The Book
-substInPaths : ∀ {ℓ} {A B : Type ℓ} {a a' : A}
+substInPaths : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}  {a a' : A}
                  → (f g : A → B) → (p : a ≡ a') (q : f a ≡ g a)
                  → subst (λ x → f x ≡ g x) p q ≡ sym (cong f p) ∙ q ∙ cong g p
 substInPaths {a = a} f g p q =


### PR DESCRIPTION
Made `substInPaths` slightly more general by allowing A and B to be Types with different levels. Suggested by #1022.