### PR TITLE
Some recursive Fin functions

### DIFF
--- a/Cubical/Data/Fin/Recursive/Base.agda
+++ b/Cubical/Data/Fin/Recursive/Base.agda
@@ -32,3 +32,7 @@ elim
   → (fn : Fin k) → P fn
 elim {k = suc k} P fz fs zero = fz
 elim {k = suc k} P fz fs (suc x) = fs x (elim P fz fs x)
+
+toℕ : Fin k → ℕ
+toℕ {suc k}   zero  = zero
+toℕ {suc k} (suc n) = suc (toℕ n)

--- a/Cubical/Data/Fin/Recursive/Properties.agda
+++ b/Cubical/Data/Fin/Recursive/Properties.agda
@@ -179,6 +179,10 @@ toFin : (n : ℕ) → Fin (suc n)
 toFin zero = zero
 toFin (suc n) = suc (toFin n)
 
+toFin< : (m : ℕ) → m < n → Fin n
+toFin< {suc n} zero 0<sn = zero
+toFin< {suc n} (suc m) m<n = suc (toFin< m m<n)
+
 inject<#toFin : ∀(i : Fin n) → inject< (≤-refl (suc n)) i # toFin n
 inject<#toFin {suc n} zero = _
 inject<#toFin {suc n} (suc i) = inject<#toFin {n} i


### PR DESCRIPTION
Adds `Fin` to `ℕ` and a generalized version of `ℕ` to `Fin` (using `_<_` rather than just successor).

I found myself needing these when using these as variables in well-scoped lambda terms.