### PR TITLE
Add `Π-contractDom`

### DIFF
--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -25,6 +25,8 @@ open import Cubical.Foundations.Univalence using (ua ; univalenceIso)
 open import Cubical.Data.Sigma
 open import Cubical.Data.Nat   using (ℕ; zero; suc; _+_; +-zero; +-comm)
 
+open Iso
+
 HLevel : Type₀
 HLevel = ℕ
 
@@ -839,3 +841,13 @@ module _ (B : (i j k : I) → Type ℓ)
   isGroupoid→CubeP : isGroupoid (B i1 i1 i1) → CubeP
   isGroupoid→CubeP grpd =
     isOfHLevelPathP' 0 (isOfHLevelPathP' 1 (isOfHLevelPathP' 2 grpd _ _) _ _) _ _ .fst
+
+
+Π-contractDomIso : (c : isContr A) → Iso ((x : A) → B x) (B (c .fst))
+Π-contractDomIso {B = B} c .fun f = f (c .fst)
+Π-contractDomIso {B = B} c .inv b x = subst B (c .snd x) b
+Π-contractDomIso {B = B} c .rightInv b i = transp (λ j → B (isProp→isSet (isContr→isProp c) _ _ (c .snd (c .fst)) refl i j)) i b
+Π-contractDomIso {B = B} c .leftInv f = funExt λ x → fromPathP (cong f (c .snd x))
+
+Π-contractDom : (c : isContr A) → ((x : A) → B x) ≃ B (c .fst)
+Π-contractDom c = isoToEquiv (Π-contractDomIso c)


### PR DESCRIPTION
Analogous to [`Σ-contractFst`](https://github.com/agda/cubical/blob/60f18987bb1819a15fccc325343ef7b469bb2eeb/Cubical/Data/Sigma/Properties.agda#L318-L328). Not sure where this should live; can't go in `Cubical.Foundations.Function` because of cyclic imports.