### PR TITLE
Remove redundant clause for agda/agda#7496

### DIFF
--- a/Cubical/HITs/SmashProduct/SymmetricMonoidal.agda
+++ b/Cubical/HITs/SmashProduct/SymmetricMonoidal.agda
@@ -230,7 +230,6 @@ Bool⋀→ {A = A} (push (inr x) i) = pt A
 Bool⋀→ {A = A} (push (push a i₁) i) = pt A
 
 ⋀lIdIso : Iso (Bool*∙ {ℓ} ⋀ A) (typ A)
-Iso.fun (⋀lIdIso {A = A}) (inl x) = pt A
 Iso.fun ⋀lIdIso = Bool⋀→
 Iso.inv ⋀lIdIso a = inr (false* , a)
 Iso.rightInv ⋀lIdIso a = refl


### PR DESCRIPTION
`⋀lIdIso` relied on a bug to pass termination check, which will be fixed in agda/agda#7496.