### PR TITLE
Reduced homology of CW complexes

### DIFF
--- a/Cubical/Algebra/ChainComplex/Homology.agda
+++ b/Cubical/Algebra/ChainComplex/Homology.agda
@@ -35,42 +35,30 @@ open ChainComplex
 open finChainComplexMap
 open IsGroupHom
 
--- Definition of homology
-homology : (n : ℕ) → ChainComplex ℓ → Group ℓ
-homology n C = ker∂n / img∂+1⊂ker∂n
-  where
-  Cn+2 = AbGroup→Group (chain C (suc (suc n)))
-  ∂n = bdry C n
-  ∂n+1 = bdry C (suc n)
-  ker∂n = kerGroup ∂n
+module _ (n : ℕ) (C : ChainComplex ℓ) where
+  ker∂n = kerGroup (bdry C n)
 
-  -- Restrict ∂n+1 to ker∂n
-  ∂'-fun : Cn+2 .fst → ker∂n .fst
-  fst (∂'-fun x) = ∂n+1 .fst x
-  snd (∂'-fun x) = t
+  ∂ker : GroupHom (AbGroup→Group (chain C (suc (suc n)))) ker∂n
+  ∂ker .fst x = (bdry C (suc n) .fst x) , t
     where
     opaque
-     t : ⟨ fst (kerSubgroup ∂n) (∂n+1 .fst x) ⟩
+     t : ⟨ fst (kerSubgroup (bdry C n)) (bdry C (suc n) .fst x) ⟩
      t = funExt⁻ (cong fst (bdry²=0 C n)) x
-
-  ∂' : GroupHom Cn+2 ker∂n
-  fst ∂' = ∂'-fun
-  snd ∂' = isHom
-    where
-    opaque
-      isHom : IsGroupHom (Cn+2 .snd) ∂'-fun (ker∂n .snd)
-      isHom = makeIsGroupHom λ x y
-        → kerGroup≡ ∂n (∂n+1 .snd .pres· x y)
+  ∂ker .snd = makeIsGroupHom (λ x y → kerGroup≡ (bdry C n) ((bdry C (suc n) .snd .pres· x y)))
 
   img∂+1⊂ker∂n : NormalSubgroup ker∂n
-  fst img∂+1⊂ker∂n = imSubgroup ∂'
+  fst img∂+1⊂ker∂n = imSubgroup ∂ker
   snd img∂+1⊂ker∂n = isNormalImSubGroup
     where
     opaque
       module C1 = AbGroupStr (chain C (suc n)  .snd)
-      isNormalImSubGroup : isNormal (imSubgroup ∂')
-      isNormalImSubGroup = isNormalIm ∂'
-        (λ x y → kerGroup≡ ∂n (C1.+Comm (fst x) (fst y)))
+      isNormalImSubGroup : isNormal (imSubgroup ∂ker)
+      isNormalImSubGroup = isNormalIm ∂ker
+        (λ x y → kerGroup≡ (bdry C n) (C1.+Comm (fst x) (fst y)))
+
+-- Definition of homology
+homology : (n : ℕ) → ChainComplex ℓ → Group ℓ
+homology n C = (ker∂n n C) / (img∂+1⊂ker∂n n C)
 
 -- Induced maps on cohomology by finite chain complex maps/homotopies
 module _ where

--- a/Cubical/CW/ChainComplex.agda
+++ b/Cubical/CW/ChainComplex.agda
@@ -10,14 +10,17 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Function
 
 open import Cubical.Data.Nat
-open import Cubical.Data.Int
+open import Cubical.Data.Nat.Order.Inductive
+open import Cubical.Data.Int renaming (_+_ to _+ℤ_ ; _·_ to _·ℤ_)
 open import Cubical.Data.Bool
+open import Cubical.Data.Empty renaming (rec to emptyrec)
 open import Cubical.Data.Fin.Inductive.Base
 open import Cubical.Data.Fin.Inductive.Properties
 open import Cubical.Data.Sigma
 
 open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
+open import Cubical.HITs.Sn.Degree renaming (degreeConst to degree-const)
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Susp
 open import Cubical.HITs.SphereBouquet
@@ -186,6 +189,26 @@ module _ {ℓ} (C : CWskel ℓ) where
         ∂≡∂↑ : ∂ n ≡ ∂↑
         ∂≡∂↑ = bouquetDegreeSusp (pre∂ n)
 
+  -- alternative description of the boundary for 1-dimensional cells
+  module ∂₀ where
+    src₀ : Fin (C .snd .fst 1) → Fin (C .snd .fst 0)
+    src₀ x = CW₁-discrete C .fst (C .snd .snd .fst 1 (x , true))
+
+    dest₀ : Fin (C .snd .fst 1) → Fin (C .snd .fst 0)
+    dest₀ x = CW₁-discrete C .fst (C .snd .snd .fst 1 (x , false))
+
+    src : AbGroupHom (ℤ[A 1 ]) (ℤ[A 0 ])
+    src = ℤFinFunct src₀
+
+    dest : AbGroupHom (ℤ[A 1 ]) (ℤ[A 0 ])
+    dest = ℤFinFunct dest₀
+
+    ∂₀ : AbGroupHom (ℤ[A 1 ]) (ℤ[A 0 ])
+    ∂₀ = subtrGroupHom (ℤ[A 1 ]) (ℤ[A 0 ]) dest src
+
+    -- ∂₀-alt : ∂ 0 ≡ ∂₀
+    -- ∂₀-alt = agreeOnℤFinGenerator→≡ λ x → funExt λ a → {!!}
+
   -- augmentation map, in order to define reduced homology
   module augmentation where
     ε : Susp (cofibCW 0 C) → SphereBouquet 1 (Fin 1)
@@ -222,6 +245,17 @@ module _ {ℓ} (C : CWskel ℓ) where
 
     ϵ : AbGroupHom (ℤ[A 0 ]) (ℤ[Fin 1 ])
     ϵ = bouquetDegree preϵ
+
+    ϵ-alt : ϵ ≡ sumCoefficients _
+    ϵ-alt = GroupHom≡ (funExt λ (x : ℤ[A 0 ] .fst) → funExt λ y → cong sumFinℤ (funExt (lem1 x y)))
+      where
+        An = snd C .fst 0
+
+        lem0 : (y : Fin 1) (a : Fin An) → (degree _ (pickPetal {k = 1} y ∘ preϵ ∘ inr ∘ (a ,_))) ≡ pos 1
+        lem0 (zero , y₁) a = refl
+
+        lem1 : (x : ℤ[A 0 ] .fst) (y : Fin 1) (a : Fin An) → x a ·ℤ (degree _ (pickPetal {k = 1} y ∘ preϵ ∘ inr ∘ (a ,_))) ≡ x a
+        lem1 x y a = cong (x a ·ℤ_) (lem0 y a) ∙ ·IdR (x a)
 
     opaque
       ϵ∂≡0 : compGroupHom (∂ 0) ϵ ≡ trivGroupHom

--- a/Cubical/CW/ChainComplex.agda
+++ b/Cubical/CW/ChainComplex.agda
@@ -10,10 +10,13 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Function
 
 open import Cubical.Data.Nat
+open import Cubical.Data.Int
+open import Cubical.Data.Bool
 open import Cubical.Data.Fin.Inductive.Base
 open import Cubical.Data.Fin.Inductive.Properties
 open import Cubical.Data.Sigma
 
+open import Cubical.HITs.S1
 open import Cubical.HITs.Sn
 open import Cubical.HITs.Pushout
 open import Cubical.HITs.Susp
@@ -23,6 +26,7 @@ open import Cubical.HITs.SphereBouquet.Degree
 open import Cubical.Algebra.Group.Base
 open import Cubical.Algebra.Group.MorphismProperties
 open import Cubical.Algebra.AbGroup
+open import Cubical.Algebra.AbGroup.Instances.FreeAbGroup
 open import Cubical.Algebra.ChainComplex
 
 
@@ -62,6 +66,9 @@ module _ {ℓ} (C : CWskel ℓ) where
 
     isoCofBouquet : cofibCW n C → SphereBouquet n (Fin An)
     isoCofBouquet = Iso.fun (BouquetIso-gen n An αn (snd C .snd .snd .snd n))
+
+    isoCofBouquetInv : SphereBouquet n (Fin An) → cofibCW n C
+    isoCofBouquetInv = Iso.inv (BouquetIso-gen n An αn (snd C .snd .snd .snd n))
 
     isoCofBouquetInv↑ : SphereBouquet (suc n) (Fin An+1) → cofibCW (suc n) C
     isoCofBouquetInv↑ = Iso.inv (BouquetIso-gen (suc n) An+1 αn+1 (snd C .snd .snd .snd (suc n)))
@@ -179,14 +186,59 @@ module _ {ℓ} (C : CWskel ℓ) where
         ∂≡∂↑ : ∂ n ≡ ∂↑
         ∂≡∂↑ = bouquetDegreeSusp (pre∂ n)
 
+  -- augmentation map, in order to define reduced homology
+  module augmentation where
+    ε : Susp (cofibCW 0 C) → SphereBouquet 1 (Fin 1)
+    ε north = inl tt
+    ε south = inl tt
+    ε (merid (inl tt) i) = inl tt
+    ε (merid (inr x) i) = (push fzero ∙∙ (λ i → inr (fzero , loop i)) ∙∙ (λ i → push fzero (~ i))) i
+    ε (merid (push x i₁) i) with (C .snd .snd .snd .fst x)
+    ε (merid (push x i₁) i) | ()
+
+    εδ : ∀ (x : cofibCW 1 C) → (ε ∘ (suspFun (to_cofibCW 0 C)) ∘ (δ 1 C)) x ≡ inl tt
+    εδ (inl tt) = refl
+    εδ (inr x) i = (push fzero ∙∙ (λ i → inr (fzero , loop i)) ∙∙ (λ i → push fzero (~ i))) (~ i)
+    εδ (push a i) j = (push fzero ∙∙ (λ i → inr (fzero , loop i)) ∙∙ (λ i → push fzero (~ i))) (i ∧ (~ j))
+
+    preϵ : SphereBouquet 1 (Fin (preboundary.An 0)) → SphereBouquet 1 (Fin 1)
+    preϵ = ε ∘ (suspFun isoCofBouquetInv) ∘ isoSuspBouquetInv
+      where
+        open preboundary 0
+
+    opaque
+      preϵpre∂≡0 : ∀ (x : SphereBouquet 1 (Fin (preboundary.An+1 0))) → (preϵ ∘ preboundary.pre∂ 0) x ≡ inl tt
+      preϵpre∂≡0 x = cong (ε ∘ (suspFun isoCofBouquetInv))
+                          (Iso.leftInv sphereBouquetSuspIso
+                                       (((suspFun isoCofBouquet) ∘ (suspFun (to_cofibCW 0 C)) ∘ (δ 1 C) ∘ isoCofBouquetInv↑) x))
+                   ∙ cong ε (aux (((suspFun (to_cofibCW 0 C)) ∘ (δ 1 C) ∘ isoCofBouquetInv↑) x))
+                   ∙ εδ (isoCofBouquetInv↑ x)
+        where
+          open preboundary 0
+          aux : ∀ (x : Susp (cofibCW 0 C)) → (suspFun (isoCofBouquetInv) ∘ (suspFun isoCofBouquet)) x ≡ x
+          aux north = refl
+          aux south = refl
+          aux (merid a i) j = merid (Iso.leftInv (BouquetIso-gen 0 An αn (snd C .snd .snd .snd 0)) a j) i
+
+    ϵ : AbGroupHom (ℤ[A 0 ]) (ℤ[Fin 1 ])
+    ϵ = bouquetDegree preϵ
+
+    opaque
+      ϵ∂≡0 : compGroupHom (∂ 0) ϵ ≡ trivGroupHom
+      ϵ∂≡0 = sym (bouquetDegreeComp (preϵ) (preboundary.pre∂ 0))
+           ∙ cong bouquetDegree (funExt preϵpre∂≡0)
+           ∙ bouquetDegreeConst _ _ _
 
   open ChainComplex
 
-  CW-ChainComplex : ChainComplex ℓ-zero
-  chain CW-ChainComplex n = ℤ[A n ]
-  bdry CW-ChainComplex n = ∂ n
-  bdry²=0 CW-ChainComplex n = ∂∂≡0 n
+  CW-AugChainComplex : ChainComplex ℓ-zero
+  chain CW-AugChainComplex (zero) = ℤ[Fin 1 ]
+  chain CW-AugChainComplex (suc n) = ℤ[A n ]
+  bdry CW-AugChainComplex (zero) = augmentation.ϵ
+  bdry CW-AugChainComplex (suc n) = ∂ n
+  bdry²=0 CW-AugChainComplex (zero) = augmentation.ϵ∂≡0
+  bdry²=0 CW-AugChainComplex (suc n) = ∂∂≡0 n
 
-  -- Cellular homology
-  Hˢᵏᵉˡ : (n : ℕ) → Group₀
-  Hˢᵏᵉˡ n = homology n CW-ChainComplex
+  -- Reduced cellular homology
+  H̃ˢᵏᵉˡ : (n : ℕ) → Group₀
+  H̃ˢᵏᵉˡ n = homology n CW-AugChainComplex

--- a/Cubical/CW/Homology.agda
+++ b/Cubical/CW/Homology.agda
@@ -36,56 +36,56 @@ private
   variable
     ℓ ℓ' ℓ'' : Level
 
------- Part 1. Functoriality of Hˢᵏᵉˡ ------
-Hˢᵏᵉˡ→-pre : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
+------ Part 1. Functoriality of H̃ˢᵏᵉˡ ------
+H̃ˢᵏᵉˡ→-pre : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
   (f : finCellMap (suc (suc (suc m))) C D)
-  → GroupHom (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ D m)
-Hˢᵏᵉˡ→-pre C D m f = finCellMap→HomologyMap m f
+  → GroupHom (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ D m)
+H̃ˢᵏᵉˡ→-pre C D m f = finCellMap→HomologyMap m f
 
 private
-  Hˢᵏᵉˡ→-pre' : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
+  H̃ˢᵏᵉˡ→-pre' : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
     → (f : realise C → realise D)
     → ∥ finCellApprox C D f (suc (suc (suc m))) ∥₁
-    → GroupHom (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ D m)
-  Hˢᵏᵉˡ→-pre' C D m f =
+    → GroupHom (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ D m)
+  H̃ˢᵏᵉˡ→-pre' C D m f =
     rec→Set isSetGroupHom
-    (λ f → Hˢᵏᵉˡ→-pre C D m (f .fst))
+    (λ f → H̃ˢᵏᵉˡ→-pre C D m (f .fst))
     main
     where
-    main : 2-Constant (λ f₁ → Hˢᵏᵉˡ→-pre C D m (f₁ .fst))
+    main : 2-Constant (λ f₁ → H̃ˢᵏᵉˡ→-pre C D m (f₁ .fst))
     main f g = PT.rec (isSetGroupHom _ _)
       (λ q → finChainHomotopy→HomologyPath _ _
         (cellHom-to-ChainHomotopy _ q) flast)
       (pathToCellularHomotopy _ (fst f) (fst g)
         λ x → funExt⁻ (snd f ∙ sym (snd g)) (fincl flast x))
 
-Hˢᵏᵉˡ→ : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
+H̃ˢᵏᵉˡ→ : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
   (f : realise C → realise D)
-  → GroupHom (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ D m)
-Hˢᵏᵉˡ→ {C = C} {D} m f =
-  Hˢᵏᵉˡ→-pre' C D m f
+  → GroupHom (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ D m)
+H̃ˢᵏᵉˡ→ {C = C} {D} m f =
+  H̃ˢᵏᵉˡ→-pre' C D m f
     (CWmap→finCellMap C D f (suc (suc (suc m))))
 
-Hˢᵏᵉˡ→β : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
+H̃ˢᵏᵉˡ→β : (C : CWskel ℓ) (D : CWskel ℓ') (m : ℕ)
   {f : realise C → realise D}
   (ϕ : finCellApprox C D f (suc (suc (suc m))))
-  → Hˢᵏᵉˡ→ {C = C} {D} m f ≡ Hˢᵏᵉˡ→-pre C D m (ϕ .fst)
-Hˢᵏᵉˡ→β C D m {f = f} ϕ =
-  cong (Hˢᵏᵉˡ→-pre' C D m f) (squash₁ _ ∣ ϕ ∣₁)
+  → H̃ˢᵏᵉˡ→ {C = C} {D} m f ≡ H̃ˢᵏᵉˡ→-pre C D m (ϕ .fst)
+H̃ˢᵏᵉˡ→β C D m {f = f} ϕ =
+  cong (H̃ˢᵏᵉˡ→-pre' C D m f) (squash₁ _ ∣ ϕ ∣₁)
 
-Hˢᵏᵉˡ→id : (m : ℕ) {C : CWskel ℓ}
-  → Hˢᵏᵉˡ→ {C = C} m (idfun _) ≡ idGroupHom
-Hˢᵏᵉˡ→id m {C = C} =
-  Hˢᵏᵉˡ→β C C m {idfun _} (idFinCellApprox (suc (suc (suc m))))
+H̃ˢᵏᵉˡ→id : (m : ℕ) {C : CWskel ℓ}
+  → H̃ˢᵏᵉˡ→ {C = C} m (idfun _) ≡ idGroupHom
+H̃ˢᵏᵉˡ→id m {C = C} =
+  H̃ˢᵏᵉˡ→β C C m {idfun _} (idFinCellApprox (suc (suc (suc m))))
   ∙ finCellMap→HomologyMapId _
 
-Hˢᵏᵉˡ→comp : (m : ℕ)
+H̃ˢᵏᵉˡ→comp : (m : ℕ)
   {C : CWskel ℓ} {D : CWskel ℓ'} {E : CWskel ℓ''}
   (g : realise D → realise E)
   (f : realise C → realise D)
-  → Hˢᵏᵉˡ→ m (g ∘ f)
-  ≡ compGroupHom (Hˢᵏᵉˡ→ m f) (Hˢᵏᵉˡ→ m g)
-Hˢᵏᵉˡ→comp m {C = C} {D = D} {E = E} g f =
+  → H̃ˢᵏᵉˡ→ m (g ∘ f)
+  ≡ compGroupHom (H̃ˢᵏᵉˡ→ m f) (H̃ˢᵏᵉˡ→ m g)
+H̃ˢᵏᵉˡ→comp m {C = C} {D = D} {E = E} g f =
   PT.rec2 (isSetGroupHom _ _)
     main
     (CWmap→finCellMap C D f (suc (suc (suc m))))
@@ -97,148 +97,148 @@ Hˢᵏᵉˡ→comp m {C = C} {D = D} {E = E} g f =
     comps : finCellApprox C E (g ∘ f) (suc (suc (suc m)))
     comps = compFinCellApprox _ {g = g} {f} G F
 
-    eq1 : Hˢᵏᵉˡ→ m (g ∘ f)
-        ≡ Hˢᵏᵉˡ→-pre C E m (composeFinCellMap _ (fst G) (fst F))
-    eq1 = Hˢᵏᵉˡ→β C E m {g ∘ f} comps
+    eq1 : H̃ˢᵏᵉˡ→ m (g ∘ f)
+        ≡ H̃ˢᵏᵉˡ→-pre C E m (composeFinCellMap _ (fst G) (fst F))
+    eq1 = H̃ˢᵏᵉˡ→β C E m {g ∘ f} comps
 
-    eq2 : compGroupHom (Hˢᵏᵉˡ→ m f) (Hˢᵏᵉˡ→ m g)
-        ≡ compGroupHom (Hˢᵏᵉˡ→-pre C D m (fst F)) (Hˢᵏᵉˡ→-pre D E m (fst G))
-    eq2 = cong₂ compGroupHom (Hˢᵏᵉˡ→β C D m {f = f} F) (Hˢᵏᵉˡ→β D E m {f = g} G)
+    eq2 : compGroupHom (H̃ˢᵏᵉˡ→ m f) (H̃ˢᵏᵉˡ→ m g)
+        ≡ compGroupHom (H̃ˢᵏᵉˡ→-pre C D m (fst F)) (H̃ˢᵏᵉˡ→-pre D E m (fst G))
+    eq2 = cong₂ compGroupHom (H̃ˢᵏᵉˡ→β C D m {f = f} F) (H̃ˢᵏᵉˡ→β D E m {f = g} G)
 
-    main : Hˢᵏᵉˡ→ m (g ∘ f) ≡ compGroupHom (Hˢᵏᵉˡ→ m f) (Hˢᵏᵉˡ→ m g)
+    main : H̃ˢᵏᵉˡ→ m (g ∘ f) ≡ compGroupHom (H̃ˢᵏᵉˡ→ m f) (H̃ˢᵏᵉˡ→ m g)
     main = eq1 ∙∙ finCellMap→HomologyMapComp _ _ _ ∙∙ sym eq2
 
 -- preservation of equivalence
-Hˢᵏᵉˡ→Iso : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
-  (e : realise C ≃ realise D) → GroupIso (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ D m)
-Iso.fun (fst (Hˢᵏᵉˡ→Iso m e)) = fst (Hˢᵏᵉˡ→ m (fst e))
-Iso.inv (fst (Hˢᵏᵉˡ→Iso m e)) = fst (Hˢᵏᵉˡ→ m (invEq e))
-Iso.rightInv (fst (Hˢᵏᵉˡ→Iso m e)) =
-  funExt⁻ (cong fst (sym (Hˢᵏᵉˡ→comp m (fst e) (invEq e))
-       ∙∙ cong (Hˢᵏᵉˡ→ m) (funExt (secEq e))
-       ∙∙ Hˢᵏᵉˡ→id m))
-Iso.leftInv (fst (Hˢᵏᵉˡ→Iso m e)) =
-  funExt⁻ (cong fst (sym (Hˢᵏᵉˡ→comp m (invEq e) (fst e))
-       ∙∙ cong (Hˢᵏᵉˡ→ m) (funExt (retEq e))
-       ∙∙ Hˢᵏᵉˡ→id m))
-snd (Hˢᵏᵉˡ→Iso m e) = snd (Hˢᵏᵉˡ→ m (fst e))
+H̃ˢᵏᵉˡ→Iso : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
+  (e : realise C ≃ realise D) → GroupIso (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ D m)
+Iso.fun (fst (H̃ˢᵏᵉˡ→Iso m e)) = fst (H̃ˢᵏᵉˡ→ m (fst e))
+Iso.inv (fst (H̃ˢᵏᵉˡ→Iso m e)) = fst (H̃ˢᵏᵉˡ→ m (invEq e))
+Iso.rightInv (fst (H̃ˢᵏᵉˡ→Iso m e)) =
+  funExt⁻ (cong fst (sym (H̃ˢᵏᵉˡ→comp m (fst e) (invEq e))
+       ∙∙ cong (H̃ˢᵏᵉˡ→ m) (funExt (secEq e))
+       ∙∙ H̃ˢᵏᵉˡ→id m))
+Iso.leftInv (fst (H̃ˢᵏᵉˡ→Iso m e)) =
+  funExt⁻ (cong fst (sym (H̃ˢᵏᵉˡ→comp m (invEq e) (fst e))
+       ∙∙ cong (H̃ˢᵏᵉˡ→ m) (funExt (retEq e))
+       ∙∙ H̃ˢᵏᵉˡ→id m))
+snd (H̃ˢᵏᵉˡ→Iso m e) = snd (H̃ˢᵏᵉˡ→ m (fst e))
 
-Hˢᵏᵉˡ→Equiv : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
-  (e : realise C ≃ realise D) → GroupEquiv (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ D m)
-Hˢᵏᵉˡ→Equiv m e = GroupIso→GroupEquiv (Hˢᵏᵉˡ→Iso m e)
+H̃ˢᵏᵉˡ→Equiv : {C : CWskel ℓ} {D : CWskel ℓ'} (m : ℕ)
+  (e : realise C ≃ realise D) → GroupEquiv (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ D m)
+H̃ˢᵏᵉˡ→Equiv m e = GroupIso→GroupEquiv (H̃ˢᵏᵉˡ→Iso m e)
 
 
 ------ Part 2. Definition of cellular homology ------
-Hᶜʷ : ∀ (C : CW ℓ) (n : ℕ) → Group₀
-Hᶜʷ (C , CWstr) n =
+H̃ᶜʷ : ∀ (C : CW ℓ) (n : ℕ) → Group₀
+H̃ᶜʷ (C , CWstr) n =
   PropTrunc→Group
-      (λ Cskel → Hˢᵏᵉˡ (Cskel .fst) n)
+      (λ Cskel → H̃ˢᵏᵉˡ (Cskel .fst) n)
       (λ Cskel Dskel
-        → Hˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Dskel)))
+        → H̃ˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Dskel)))
       coh
       CWstr
   where
-  coh : (Cskel Dskel Eskel : isCW C) (t : fst (Hˢᵏᵉˡ (Cskel .fst) n))
-    → fst (fst (Hˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Dskel)) (snd Eskel))))
-        (fst (fst (Hˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Dskel)))) t)
-    ≡ fst (fst (Hˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Eskel)))) t
+  coh : (Cskel Dskel Eskel : isCW C) (t : fst (H̃ˢᵏᵉˡ (Cskel .fst) n))
+    → fst (fst (H̃ˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Dskel)) (snd Eskel))))
+        (fst (fst (H̃ˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Dskel)))) t)
+    ≡ fst (fst (H̃ˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd Cskel)) (snd Eskel)))) t
   coh (C' , e) (D , f) (E , h) =
     funExt⁻ (cong fst
-          (sym (Hˢᵏᵉˡ→comp n (fst (compEquiv (invEquiv f) h))
+          (sym (H̃ˢᵏᵉˡ→comp n (fst (compEquiv (invEquiv f) h))
                            (fst (compEquiv (invEquiv e) f)))
-          ∙ cong (Hˢᵏᵉˡ→ n) (funExt λ x → cong (fst h) (retEq f _))))
+          ∙ cong (H̃ˢᵏᵉˡ→ n) (funExt λ x → cong (fst h) (retEq f _))))
 
 -- lemmas for functoriality
 private
   module _ {C : Type ℓ} {D : Type ℓ'} (f : C → D) (n : ℕ) where
     right : (cwC : isCW C) (cwD1 : isCW D) (cwD2 : isCW D)
-      → PathP (λ i → GroupHom (Hᶜʷ (C , ∣ cwC ∣₁) n)
-                         (Hᶜʷ (D , squash₁ ∣ cwD1 ∣₁ ∣ cwD2 ∣₁ i) n))
-        (Hˢᵏᵉˡ→ n (λ x → fst (snd cwD1) (f (invEq (snd cwC) x))))
-        (Hˢᵏᵉˡ→ n (λ x → fst (snd cwD2) (f (invEq (snd cwC) x))))
+      → PathP (λ i → GroupHom (H̃ᶜʷ (C , ∣ cwC ∣₁) n)
+                         (H̃ᶜʷ (D , squash₁ ∣ cwD1 ∣₁ ∣ cwD2 ∣₁ i) n))
+        (H̃ˢᵏᵉˡ→ n (λ x → fst (snd cwD1) (f (invEq (snd cwC) x))))
+        (H̃ˢᵏᵉˡ→ n (λ x → fst (snd cwD2) (f (invEq (snd cwC) x))))
     right cwC cwD1 cwD2 =
       PathPGroupHomₗ _
-        (cong (Hˢᵏᵉˡ→ n) (funExt (λ s
+        (cong (H̃ˢᵏᵉˡ→ n) (funExt (λ s
           → cong (fst (snd cwD2)) (sym (retEq (snd cwD1) _))))
-        ∙ Hˢᵏᵉˡ→comp n _ _)
+        ∙ H̃ˢᵏᵉˡ→comp n _ _)
 
     left : (cwC1 : isCW C) (cwC2 : isCW C) (cwD : isCW D)
-      → PathP (λ i → GroupHom (Hᶜʷ (C , squash₁ ∣ cwC1 ∣₁ ∣ cwC2 ∣₁ i) n)
-                                  (Hᶜʷ (D , ∣ cwD ∣₁) n))
-                 (Hˢᵏᵉˡ→ n (λ x → fst (snd cwD) (f (invEq (snd cwC1) x))))
-                 (Hˢᵏᵉˡ→ n (λ x → fst (snd cwD) (f (invEq (snd cwC2) x))))
+      → PathP (λ i → GroupHom (H̃ᶜʷ (C , squash₁ ∣ cwC1 ∣₁ ∣ cwC2 ∣₁ i) n)
+                                  (H̃ᶜʷ (D , ∣ cwD ∣₁) n))
+                 (H̃ˢᵏᵉˡ→ n (λ x → fst (snd cwD) (f (invEq (snd cwC1) x))))
+                 (H̃ˢᵏᵉˡ→ n (λ x → fst (snd cwD) (f (invEq (snd cwC2) x))))
     left cwC1 cwC2 cwD =
-      PathPGroupHomᵣ (Hˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd cwC1)) (snd cwC2)))
-            (sym (Hˢᵏᵉˡ→comp n (λ x → fst (snd cwD) (f (invEq (snd cwC2) x)))
+      PathPGroupHomᵣ (H̃ˢᵏᵉˡ→Equiv n (compEquiv (invEquiv (snd cwC1)) (snd cwC2)))
+            (sym (H̃ˢᵏᵉˡ→comp n (λ x → fst (snd cwD) (f (invEq (snd cwC2) x)))
                              (compEquiv (invEquiv (snd cwC1)) (snd cwC2) .fst))
-           ∙ cong (Hˢᵏᵉˡ→ n) (funExt (λ x
+           ∙ cong (H̃ˢᵏᵉˡ→ n) (funExt (λ x
               → cong (fst (snd cwD) ∘ f)
                   (retEq (snd cwC2) _))))
 
     left-right : (x y : isCW C) (v w : isCW D) →
       SquareP
       (λ i j →
-         GroupHom (Hᶜʷ (C , squash₁ ∣ x ∣₁ ∣ y ∣₁ i) n)
-         (Hᶜʷ (D , squash₁ ∣ v ∣₁ ∣ w ∣₁ j) n))
+         GroupHom (H̃ᶜʷ (C , squash₁ ∣ x ∣₁ ∣ y ∣₁ i) n)
+         (H̃ᶜʷ (D , squash₁ ∣ v ∣₁ ∣ w ∣₁ j) n))
       (right x v w) (right y v w) (left x y v) (left x y w)
     left-right _ _ _ _ = isSet→SquareP
        (λ _ _ → isSetGroupHom) _ _ _ _
 
-    Hᶜʷ→pre : (cwC : ∥ isCW C ∥₁) (cwD : ∥ isCW D ∥₁)
-      → GroupHom (Hᶜʷ (C , cwC) n) (Hᶜʷ (D , cwD) n)
-    Hᶜʷ→pre =
+    H̃ᶜʷ→pre : (cwC : ∥ isCW C ∥₁) (cwD : ∥ isCW D ∥₁)
+      → GroupHom (H̃ᶜʷ (C , cwC) n) (H̃ᶜʷ (D , cwD) n)
+    H̃ᶜʷ→pre =
       elim2→Set (λ _ _ → isSetGroupHom)
-        (λ cwC cwD → Hˢᵏᵉˡ→ n (fst (snd cwD) ∘ f ∘ invEq (snd cwC)))
+        (λ cwC cwD → H̃ˢᵏᵉˡ→ n (fst (snd cwD) ∘ f ∘ invEq (snd cwC)))
         left right
         (λ _ _ _ _ → isSet→SquareP
          (λ _ _ → isSetGroupHom) _ _ _ _)
 
 -- functoriality
-Hᶜʷ→ : {C : CW ℓ} {D : CW ℓ'} (n : ℕ) (f : C →ᶜʷ D)
-    → GroupHom (Hᶜʷ C n) (Hᶜʷ D n)
-Hᶜʷ→ {C = C , cwC} {D = D , cwD} n f = Hᶜʷ→pre f n cwC cwD
+H̃ᶜʷ→ : {C : CW ℓ} {D : CW ℓ'} (n : ℕ) (f : C →ᶜʷ D)
+    → GroupHom (H̃ᶜʷ C n) (H̃ᶜʷ D n)
+H̃ᶜʷ→ {C = C , cwC} {D = D , cwD} n f = H̃ᶜʷ→pre f n cwC cwD
 
-Hᶜʷ→id : {C : CW ℓ} (n : ℕ)
-    → Hᶜʷ→ {C = C} {C} n (idfun (fst C))
+H̃ᶜʷ→id : {C : CW ℓ} (n : ℕ)
+    → H̃ᶜʷ→ {C = C} {C} n (idfun (fst C))
      ≡ idGroupHom
-Hᶜʷ→id {C = C , cwC} n =
+H̃ᶜʷ→id {C = C , cwC} n =
   PT.elim {P = λ cwC
-    → Hᶜʷ→ {C = C , cwC} {C , cwC} n (idfun C) ≡ idGroupHom}
+    → H̃ᶜʷ→ {C = C , cwC} {C , cwC} n (idfun C) ≡ idGroupHom}
     (λ _ → isSetGroupHom _ _)
-    (λ cwC* → cong (Hˢᵏᵉˡ→ n) (funExt (secEq (snd cwC*)))
-              ∙ Hˢᵏᵉˡ→id n) cwC
+    (λ cwC* → cong (H̃ˢᵏᵉˡ→ n) (funExt (secEq (snd cwC*)))
+              ∙ H̃ˢᵏᵉˡ→id n) cwC
 
-Hᶜʷ→comp : {C : CW ℓ} {D : CW ℓ'} {E : CW ℓ''} (n : ℕ)
+H̃ᶜʷ→comp : {C : CW ℓ} {D : CW ℓ'} {E : CW ℓ''} (n : ℕ)
       (g : D →ᶜʷ E) (f : C →ᶜʷ D)
-    → Hᶜʷ→ {C = C} {E} n (g ∘ f)
-     ≡ compGroupHom (Hᶜʷ→ {C = C} {D} n f) (Hᶜʷ→ {C = D} {E} n g)
-Hᶜʷ→comp {C = C , cwC} {D = D , cwD} {E = E , cwE} n g f =
+    → H̃ᶜʷ→ {C = C} {E} n (g ∘ f)
+     ≡ compGroupHom (H̃ᶜʷ→ {C = C} {D} n f) (H̃ᶜʷ→ {C = D} {E} n g)
+H̃ᶜʷ→comp {C = C , cwC} {D = D , cwD} {E = E , cwE} n g f =
   PT.elim3 {P = λ cwC cwD cwE
-    → Hᶜʷ→ {C = C , cwC} {E , cwE} n (g ∘ f)
-     ≡ compGroupHom (Hᶜʷ→ {C = C , cwC} {D , cwD} n f)
-                    (Hᶜʷ→ {C = D , cwD} {E , cwE} n g)}
+    → H̃ᶜʷ→ {C = C , cwC} {E , cwE} n (g ∘ f)
+     ≡ compGroupHom (H̃ᶜʷ→ {C = C , cwC} {D , cwD} n f)
+                    (H̃ᶜʷ→ {C = D , cwD} {E , cwE} n g)}
      (λ _ _ _ → isSetGroupHom _ _)
      (λ cwC cwD cwE
-       → cong (Hˢᵏᵉˡ→ n) (funExt (λ x → cong (fst (snd cwE) ∘ g)
+       → cong (H̃ˢᵏᵉˡ→ n) (funExt (λ x → cong (fst (snd cwE) ∘ g)
                           (sym (retEq (snd cwD) _))))
-       ∙ Hˢᵏᵉˡ→comp n _ _)
+       ∙ H̃ˢᵏᵉˡ→comp n _ _)
      cwC cwD cwE
 
 -- preservation of equivalence
-Hᶜʷ→Iso : {C : CW ℓ} {D : CW ℓ'} (m : ℕ)
-  (e : fst C ≃ fst D) → GroupIso (Hᶜʷ C m) (Hᶜʷ D m)
-Iso.fun (fst (Hᶜʷ→Iso m e)) = fst (Hᶜʷ→ m (fst e))
-Iso.inv (fst (Hᶜʷ→Iso m e)) = fst (Hᶜʷ→ m (invEq e))
-Iso.rightInv (fst (Hᶜʷ→Iso m e)) =
-  funExt⁻ (cong fst (sym (Hᶜʷ→comp m (fst e) (invEq e))
-       ∙∙ cong (Hᶜʷ→ m) (funExt (secEq e))
-       ∙∙ Hᶜʷ→id m))
-Iso.leftInv (fst (Hᶜʷ→Iso m e)) =
-  funExt⁻ (cong fst (sym (Hᶜʷ→comp m (invEq e) (fst e))
-       ∙∙ cong (Hᶜʷ→ m) (funExt (retEq e))
-       ∙∙ Hᶜʷ→id m))
-snd (Hᶜʷ→Iso m e) = snd (Hᶜʷ→ m (fst e))
+H̃ᶜʷ→Iso : {C : CW ℓ} {D : CW ℓ'} (m : ℕ)
+  (e : fst C ≃ fst D) → GroupIso (H̃ᶜʷ C m) (H̃ᶜʷ D m)
+Iso.fun (fst (H̃ᶜʷ→Iso m e)) = fst (H̃ᶜʷ→ m (fst e))
+Iso.inv (fst (H̃ᶜʷ→Iso m e)) = fst (H̃ᶜʷ→ m (invEq e))
+Iso.rightInv (fst (H̃ᶜʷ→Iso m e)) =
+  funExt⁻ (cong fst (sym (H̃ᶜʷ→comp m (fst e) (invEq e))
+       ∙∙ cong (H̃ᶜʷ→ m) (funExt (secEq e))
+       ∙∙ H̃ᶜʷ→id m))
+Iso.leftInv (fst (H̃ᶜʷ→Iso m e)) =
+  funExt⁻ (cong fst (sym (H̃ᶜʷ→comp m (invEq e) (fst e))
+       ∙∙ cong (H̃ᶜʷ→ m) (funExt (retEq e))
+       ∙∙ H̃ᶜʷ→id m))
+snd (H̃ᶜʷ→Iso m e) = snd (H̃ᶜʷ→ m (fst e))
 
-Hᶜʷ→Equiv : {C : CW ℓ} {D : CW ℓ'} (m : ℕ)
-  (e : fst C ≃ fst D) → GroupEquiv (Hᶜʷ C m) (Hᶜʷ D m)
-Hᶜʷ→Equiv m e = GroupIso→GroupEquiv (Hᶜʷ→Iso m e)
+H̃ᶜʷ→Equiv : {C : CW ℓ} {D : CW ℓ'} (m : ℕ)
+  (e : fst C ≃ fst D) → GroupEquiv (H̃ᶜʷ C m) (H̃ᶜʷ D m)
+H̃ᶜʷ→Equiv m e = GroupIso→GroupEquiv (H̃ᶜʷ→Iso m e)

--- a/Cubical/CW/Subcomplex.agda
+++ b/Cubical/CW/Subcomplex.agda
@@ -214,47 +214,38 @@ module _ (C : CWskel ℓ) where
   ... | gt x = ⊥.rec (¬m<ᵗm (<ᵗ-trans x p))
 
 subChainIso : (C : CWskel ℓ) (n : ℕ) (m : Fin n)
-  → AbGroupIso (CWskel-fields.ℤ[A_] C (fst m))
-                (CWskel-fields.ℤ[A_] (subComplex C n) (fst m))
-subChainIso C n (m , p) with (m ≟ᵗ n)
+  → AbGroupIso (CW-AugChainComplex C .ChainComplex.chain (fst m))
+                (CW-AugChainComplex (subComplex C n) .ChainComplex.chain (fst m))
+subChainIso C n (zero , p) = idGroupIso
+subChainIso C n (suc m , p) with (m ≟ᵗ n)
 ... | lt x = idGroupIso
-... | eq x = ⊥.rec (¬m<ᵗm (subst (m <ᵗ_) (sym x) p))
-... | gt x = ⊥.rec (¬m<ᵗm (<ᵗ-trans x p))
+... | eq x = ⊥.rec (¬-suc-n<ᵗn ((subst (suc m <ᵗ_) (sym x) p)))
+... | gt x = ⊥.rec (¬-suc-n<ᵗn ((<ᵗ-trans p x)))
 
 -- main result
 subComplexHomology : (C : CWskel ℓ) (n m : ℕ) (p : suc (suc m) <ᵗ n)
-  → GroupIso (Hˢᵏᵉˡ C m) (Hˢᵏᵉˡ (subComplex C n) m)
+  → GroupIso (H̃ˢᵏᵉˡ C m) (H̃ˢᵏᵉˡ (subComplex C n) m)
 subComplexHomology C n m p =
   homologyIso m _ _
     (subChainIso C n (suc (suc m) , p))
     (subChainIso C n (suc m , <ᵗ-trans <ᵗsucm p))
     (subChainIso C n (m , <ᵗ-trans <ᵗsucm (<ᵗ-trans <ᵗsucm p)))
-    lem₁
-    lem₂
+    (lem₁ m)
+    (lem₁ (suc m))
   where
-  lem₁ : {q : _} {r : _}
-    → Iso.fun (subChainIso C n (m , q) .fst) ∘ ∂ C m .fst
-    ≡ ∂ (subComplex C n) m .fst
+  lem₁ : (m : ℕ) {q : _} {r : _}
+    → Iso.fun (subChainIso C n (m , q) .fst) ∘ CW-AugChainComplex C .ChainComplex.bdry m .fst
+    ≡ CW-AugChainComplex (subComplex C n) .ChainComplex.bdry m .fst
      ∘ Iso.fun (subChainIso C n (suc m , r) .fst)
-  lem₁ {q} {r} with (m ≟ᵗ n) | (suc m ≟ᵗ n) | (suc (suc m) ≟ᵗ n)
+  lem₁ zero with (0 ≟ᵗ n)
+  ... | lt x = refl
+  ... | eq x = ⊥.rec (subst (suc (suc m) <ᵗ_) (sym x) p)
+  ... | gt x = ⊥.rec x
+  lem₁ (suc m) {q} {r} with (m ≟ᵗ n) | (suc m ≟ᵗ n) | (suc (suc m) ≟ᵗ n)
   ... | lt x | lt x₁ | lt x₂ = refl
   ... | lt x | lt x₁ | eq x₂ = refl
   ... | lt x | lt x₁ | gt x₂ = ⊥.rec (¬squeeze (x₁ , x₂))
-  ... | lt x | eq x₁ | t = ⊥.rec (¬m<ᵗm (subst (_<ᵗ n) x₁ r))
-  ... | lt x | gt x₁ | t = ⊥.rec (¬m<ᵗm (<ᵗ-trans x₁ r))
-  ... | eq x | s | t = ⊥.rec (¬-suc-n<ᵗn (subst (suc m <ᵗ_) (sym x) r))
-  ... | gt x | s | t = ⊥.rec (¬-suc-n<ᵗn (<ᵗ-trans r x))
-
-  lem₂ : {q : suc m <ᵗ n} {r : (suc (suc m)) <ᵗ n}
-    → Iso.fun (subChainIso C n (suc m , q) .fst)
-     ∘ ∂ C (suc m) .fst
-     ≡ ∂ (subComplex C n) (suc m) .fst
-     ∘ Iso.fun (subChainIso C n (suc (suc m) , r) .fst)
-  lem₂ {q} with (suc m ≟ᵗ n) | (suc (suc m) ≟ᵗ n) | (suc (suc (suc m)) ≟ᵗ n)
-  ... | lt x | lt x₁ | lt x₂ = refl
-  ... | lt x | lt x₁ | eq x₂ = refl
-  ... | lt x | lt x₁ | gt x₂ = ⊥.rec (¬squeeze (x₁ , x₂))
-  ... | lt x | eq x₁ | t = ⊥.rec (¬m<ᵗm (subst (_<ᵗ n) x₁ p))
-  ... | lt x | gt x₁ | t = ⊥.rec (¬m<ᵗm (<ᵗ-trans x₁ p))
-  ... | eq x | s | t = ⊥.rec (¬m<ᵗm (subst (suc m <ᵗ_) (sym x) q))
-  ... | gt x | s | t = ⊥.rec (¬-suc-n<ᵗn (<ᵗ-trans p x))
+  ... | lt x | eq x₁ | t = ⊥.rec ((¬m<ᵗm (subst (_<ᵗ n) x₁ q)))
+  ... | lt x | gt x₁ | t = ⊥.rec ((¬m<ᵗm (<ᵗ-trans x₁ q)))
+  ... | eq x | s | t = ⊥.rec (¬-suc-n<ᵗn (subst (suc m <ᵗ_) (sym x) q))
+  ... | gt x | s | t = ⊥.rec ((¬-suc-n<ᵗn (<ᵗ-trans q x)))

--- a/Cubical/Data/Fin/Inductive/Properties.agda
+++ b/Cubical/Data/Fin/Inductive/Properties.agda
@@ -25,6 +25,12 @@ open import Cubical.Relation.Nullary
 
 open import Cubical.Algebra.AbGroup.Base using (move4)
 
+Fin≡ : {m : ℕ} (a b : Fin m) → fst a ≡ fst b → a ≡ b
+Fin≡ {m} (a , Ha) (b , Hb) H i =
+  (H i , hcomp (λ j → λ { (i = i0) → Ha
+                        ; (i = i1) → isProp<ᵗ {b}{m} (transp (λ j → H j <ᵗ m) i0 Ha) Hb j })
+               (transp (λ j → H (i ∧ j) <ᵗ m) (~ i) Ha))
+
 fsuc-injectSuc : {m : ℕ} (n : Fin m)
   → injectSuc {n = suc m} (fsuc {n = m} n) ≡ fsuc (injectSuc n)
 fsuc-injectSuc {m = suc m} (x , p) = refl


### PR DESCRIPTION
The current definition for the homology of CW complexes is missing its 0-dimensional component. There are two ways to define 0-dimensional homology: "standard" homology and reduced homology.

This commit defines reduced homology for CW complexes:
- The chain complex associated to a CW presentation is now augmented with Z in dimension -1 [CW/ChainComplex.agda]
- The chain maps and chain homotopies are extended to work in dimension -1 [CW/Map.agda and CW/Homotopy.agda]
- The definition of homology in [CW/Homology.agda] is now fed the augmented chain complex. I changed the name from Hᶜʷ to H̃ᶜʷ to match the standard mathematical notation.