### PR TITLE
Fix makefile race condition

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -57,7 +57,7 @@ timings: clean gen-everythings
 	$(AGDA) -v profile.modules:10 Cubical/README.agda
 
 .PHONY : listings
-listings: $(wildcard Cubical/**/*.agda)
+listings: gen-everythings $(wildcard Cubical/**/*.agda)
 	$(AGDA) -i. -isrc --html Cubical/README.agda -v0
 
 .PHONY : clean


### PR DESCRIPTION
If you use `make -j gen-everythings listings`, currently there is a near-certainty that the `listings` task will fail because the Everythings modules haven't been generated yet.  This PR enforces the dependency.

This was found during the investigation of #1209.