### PR TITLE
Do not use idfun for the typing annotation

### DIFF
--- a/Cubical/Foundations/Function.agda
+++ b/Cubical/Foundations/Function.agda
@@ -20,10 +20,14 @@ private
 idfun : (A : Type ℓ) → A → A
 idfun _ x = x
 
-infixr -8 idfun
-
 -- The membership relation (used to clarify the type of a term to Agda when inside a definition, like :: in Haskell)
-syntax idfun A x = x :> A
+-- We introduce the syntax "x :> A" below.
+hasType : (A : Type ℓ) → A → A
+hasType _ x = x
+
+infixr -8 hasType
+
+syntax hasType A x = x :> A
 
 infixr -1 _$_
 


### PR DESCRIPTION
Small correction to #1217 : I think it is better to not use `idfun` to make things more understandable for user. Also, it is a bit weird to give `idfun` this low priority.