### PR TITLE
Define transport-reorder.

### DIFF
--- a/Cubical/Foundations/Transport.agda
+++ b/Cubical/Foundations/Transport.agda
@@ -254,3 +254,25 @@ transport-reorder B f g p a =
                  (transport (λ i → B (f (p i))) (g a))
                  (g (transport (λ i → B (p i)) a)))
           (lCancel (cong f p)) composite
+
+resubst : ∀ {ℓ ℓ'} {A : Type ℓ} (B : A → Type ℓ')
+        → (c : (z : A) → B z)
+        → {x y : A} (p : x ≡ y)
+        → c y ≡ subst B p (c x)
+resubst B c {x = x} {y = y} p =
+  let step1 : (λ i → B (p (~ i))) [ c y ≡ c x ]
+      step1 i = c (p (~ i))
+      step2 : (λ i → B (p i))
+            [ c x
+            ≡ subst B p (c x)
+            ]
+      step2 = transport-filler (λ i → B (p i)) (c x)
+      composite : (λ i → B ((sym p ∙ p) i))
+        [ c y
+        ≡ subst B p (c x)
+        ]
+      composite = compPathP' {B = B} step1 step2
+  in subst (λ ○ → PathP (λ i → (B (○ i)))
+                  (c y)
+                  (subst B p (c x)))
+           (lCancel p) composite


### PR DESCRIPTION
This pr adds the utility for showing that we can reorder a `subst` operation with some dependent funciton `g`,

```agda
subst B (cong f p) (g a) ≡ g (subst B p) a)
```

It is defined with type,

```agda
transport-reorder
  : ∀ {ℓ ℓ'} {A : Type ℓ} (B : A → Type ℓ') {x y : A}
  → (f : A → A) (g : {z : A} → B z → B (f z)) (p : x ≡ y) (a : B x)
  → transport (λ i → B (f (p i))) (g a)
  ≡ g (transport (λ i → B (p i)) a)
```