### PR TITLE
Initial Boolean Algebra

### DIFF
--- a/Cubical/Algebra/BooleanRing/Base.agda
+++ b/Cubical/Algebra/BooleanRing/Base.agda
@@ -57,13 +57,18 @@ BooleanRing→Ring (carrier , structure ) = carrier , BooleanStr→RingStr struc
 isIdemRing : {ℓ : Level} → CommRing ℓ → Type ℓ
 isIdemRing R = ∀ (r : ⟨ R ⟩) → (str R) .CommRingStr._·_ r r ≡ r
 
-idemCommRing→BR : {ℓ : Level} (R : CommRing ℓ) → isIdemRing R → BooleanRing ℓ
-idemCommRing→BR R idem = ⟨ R ⟩ ,
-  record
-   { 𝟘 = _ ; 𝟙 = _ ; _+_ = _ ; _·_ = _ ; -_ = _
-   ; isBooleanRing = record
-   { isCommRing = (str R) .CommRingStr.isCommRing
-   ; ·Idem = idem } }
+module _ {ℓ : Level} (R : CommRing ℓ) (idem : isIdemRing R) where
+  open BooleanStr
+  open IsBooleanRing
+  idemCommRing→BR : BooleanRing ℓ
+  fst idemCommRing→BR = ⟨ R ⟩
+  𝟘 (snd idemCommRing→BR)   = _
+  𝟙 (snd idemCommRing→BR)   = _
+  _+_ (snd idemCommRing→BR) = _
+  _·_ (snd idemCommRing→BR) = _
+  - snd idemCommRing→BR     = _
+  isCommRing (isBooleanRing (snd idemCommRing→BR)) = (str R) .CommRingStr.isCommRing
+  ·Idem (isBooleanRing (snd idemCommRing→BR))      = idem
 
 BoolHom : {ℓ ℓ' : Level} → (A : BooleanRing ℓ) → (B : BooleanRing ℓ') → Type _
 BoolHom A B = CommRingHom (BooleanRing→CommRing A) (BooleanRing→CommRing B)

--- a/Cubical/Algebra/BooleanRing/Base.agda
+++ b/Cubical/Algebra/BooleanRing/Base.agda
@@ -42,8 +42,16 @@ record BooleanRingStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
 BooleanRing : ∀ ℓ → Type (ℓ-suc ℓ)
 BooleanRing ℓ = TypeWithStr ℓ BooleanRingStr
 
-BooleanRingStr→CommRingStr : { A : Type ℓ } →  BooleanRingStr A  → CommRingStr A
-BooleanRingStr→CommRingStr x = record { isCommRing = IsBooleanRing.isCommRing (BooleanRingStr.isBooleanRing x) }
+module _ {A : Type ℓ} (BRStr : BooleanRingStr A) where
+  open CommRingStr
+  open BooleanRingStr( BRStr)
+  BooleanRingStr→CommRingStr : CommRingStr A
+  0r  BooleanRingStr→CommRingStr = _
+  1r  BooleanRingStr→CommRingStr = _
+  _+_ BooleanRingStr→CommRingStr = _
+  _·_ BooleanRingStr→CommRingStr = _
+  -   BooleanRingStr→CommRingStr = _
+  isCommRing BooleanRingStr→CommRingStr = isCommRing BRStr
 
 BooleanRing→CommRing : BooleanRing ℓ → CommRing ℓ
 BooleanRing→CommRing (carrier , structure ) = carrier , BooleanRingStr→CommRingStr structure
@@ -277,3 +285,4 @@ module BooleanAlgebraStr (A : BooleanRing ℓ)  where
     ((𝟙 + x)  + (𝟙 + x)) + (y + y)  + 𝟙 + x · y
       ≡⟨ solve! (BooleanRing→CommRing A) ⟩
     ¬ x ∨ ¬ y ∎
+

--- a/Cubical/Algebra/BooleanRing/Base.agda
+++ b/Cubical/Algebra/BooleanRing/Base.agda
@@ -54,6 +54,20 @@ BooleanStr→RingStr S = CommRingStr→RingStr (BooleanStr→CommRingStr S)
 BooleanRing→Ring : BooleanRing ℓ → Ring ℓ
 BooleanRing→Ring (carrier , structure ) = carrier , BooleanStr→RingStr structure
 
+isIdemRing : {ℓ : Level} → CommRing ℓ → Type ℓ
+isIdemRing R = ∀ (r : ⟨ R ⟩) → (str R) .CommRingStr._·_ r r ≡ r
+
+idemCommRing→BR : {ℓ : Level} (R : CommRing ℓ) → isIdemRing R → BooleanRing ℓ
+idemCommRing→BR R idem = ⟨ R ⟩ ,
+  record
+   { 𝟘 = _ ; 𝟙 = _ ; _+_ = _ ; _·_ = _ ; -_ = _
+   ; isBooleanRing = record
+   { isCommRing = (str R) .CommRingStr.isCommRing
+   ; ·Idem = idem } }
+
+BoolHom : {ℓ ℓ' : Level} → (A : BooleanRing ℓ) → (B : BooleanRing ℓ') → Type _
+BoolHom A B = CommRingHom (BooleanRing→CommRing A) (BooleanRing→CommRing B)
+
 module BooleanAlgebraStr (A : BooleanRing ℓ)  where
   open BooleanStr (A . snd)
   _∨_ : ⟨ A ⟩ → ⟨ A ⟩ → ⟨ A ⟩

--- a/Cubical/Algebra/BooleanRing/Base.agda
+++ b/Cubical/Algebra/BooleanRing/Base.agda
@@ -24,7 +24,7 @@ record IsBooleanRing {B : Type ℓ}
 
   open IsCommRing isCommRing public
 
-record BooleanStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
+record BooleanRingStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
   field
     𝟘          : A
     𝟙          : A
@@ -40,25 +40,25 @@ record BooleanStr (A : Type ℓ) : Type (ℓ-suc ℓ) where
   open IsBooleanRing isBooleanRing public
 
 BooleanRing : ∀ ℓ → Type (ℓ-suc ℓ)
-BooleanRing ℓ = TypeWithStr ℓ BooleanStr
+BooleanRing ℓ = TypeWithStr ℓ BooleanRingStr
 
-BooleanStr→CommRingStr : { A : Type ℓ } →  BooleanStr A  → CommRingStr A
-BooleanStr→CommRingStr x = record { isCommRing = IsBooleanRing.isCommRing (BooleanStr.isBooleanRing x) }
+BooleanRingStr→CommRingStr : { A : Type ℓ } →  BooleanRingStr A  → CommRingStr A
+BooleanRingStr→CommRingStr x = record { isCommRing = IsBooleanRing.isCommRing (BooleanRingStr.isBooleanRing x) }
 
 BooleanRing→CommRing : BooleanRing ℓ → CommRing ℓ
-BooleanRing→CommRing (carrier , structure ) = carrier , BooleanStr→CommRingStr structure
+BooleanRing→CommRing (carrier , structure ) = carrier , BooleanRingStr→CommRingStr structure
 
-BooleanStr→RingStr : { A : Type ℓ } → BooleanStr A → RingStr A
-BooleanStr→RingStr S = CommRingStr→RingStr (BooleanStr→CommRingStr S)
+BooleanRingStr→RingStr : { A : Type ℓ } → BooleanRingStr A → RingStr A
+BooleanRingStr→RingStr S = CommRingStr→RingStr (BooleanRingStr→CommRingStr S)
 
 BooleanRing→Ring : BooleanRing ℓ → Ring ℓ
-BooleanRing→Ring (carrier , structure ) = carrier , BooleanStr→RingStr structure
+BooleanRing→Ring (carrier , structure ) = carrier , BooleanRingStr→RingStr structure
 
 isIdemRing : {ℓ : Level} → CommRing ℓ → Type ℓ
 isIdemRing R = ∀ (r : ⟨ R ⟩) → (str R) .CommRingStr._·_ r r ≡ r
 
 module _ {ℓ : Level} (R : CommRing ℓ) (idem : isIdemRing R) where
-  open BooleanStr
+  open BooleanRingStr
   open IsBooleanRing
   idemCommRing→BR : BooleanRing ℓ
   fst idemCommRing→BR = ⟨ R ⟩
@@ -74,7 +74,7 @@ BoolHom : {ℓ ℓ' : Level} → (A : BooleanRing ℓ) → (B : BooleanRing ℓ'
 BoolHom A B = CommRingHom (BooleanRing→CommRing A) (BooleanRing→CommRing B)
 
 module BooleanAlgebraStr (A : BooleanRing ℓ)  where
-  open BooleanStr (A . snd)
+  open BooleanRingStr (A . snd)
   _∨_ : ⟨ A ⟩ → ⟨ A ⟩ → ⟨ A ⟩
   a ∨ b = (a + b) + (a · b)
   _∧_ : ⟨ A ⟩ → ⟨ A ⟩ → ⟨ A ⟩

--- a/Cubical/Algebra/BooleanRing/Initial.agda
+++ b/Cubical/Algebra/BooleanRing/Initial.agda
@@ -1,0 +1,69 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Algebra.BooleanRing.Initial where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Function
+
+open import Cubical.Algebra.BooleanRing.Base
+open import Cubical.Data.Bool renaming (elim to bool-ind)
+open import Cubical.Algebra.CommRing
+open import Cubical.Tactics.CommRingSolver
+
+module _ where
+  open BooleanStr
+
+  BoolBRStr : BooleanStr Bool
+  BoolBRStr .𝟘 = false
+  BoolBRStr .𝟙 = true
+  BoolBRStr ._+_ = _⊕_
+  BoolBRStr ._·_ = _and_
+  BoolBRStr .-_ x = x
+  BoolBRStr .isBooleanRing = record
+    { isCommRing = makeIsCommRing isSetBool ⊕-assoc ⊕-identityʳ
+              (bool-ind refl refl) ⊕-comm and-assoc and-identityʳ
+              (bool-ind (λ _ _ → refl) λ _ _ → refl) and-comm
+    ; ·Idem = bool-ind refl refl
+    }
+
+BoolBR : BooleanRing ℓ-zero
+BoolBR = Bool , BoolBRStr
+
+BoolCR : CommRing ℓ-zero
+BoolCR = BooleanRing→CommRing BoolBR
+
+module _ {ℓ : Level} (B : BooleanRing ℓ) where
+  private
+    B' = BooleanRing→CommRing B
+
+  open CommRingStr (snd B')
+  open BooleanAlgebraStr B
+  open IsCommRingHom
+
+  BoolBR→BAMap : Bool → ⟨ B ⟩
+  BoolBR→BAMap = bool-ind 1r 0r
+
+  BoolBR→BAIsCommRingHom : IsCommRingHom (snd BoolCR) BoolBR→BAMap (snd B')
+  pres0 BoolBR→BAIsCommRingHom = refl
+  pres1 BoolBR→BAIsCommRingHom = refl
+  pres+ BoolBR→BAIsCommRingHom =
+    λ { false false → solve! B'
+    ; false true  → solve! B'
+    ; true  false → solve! B'
+    ; true  true  → sym characteristic2
+    }
+  pres· BoolBR→BAIsCommRingHom =
+    λ { false false → solve! B'
+    ; false true  → solve! B'
+    ; true  false → solve! B'
+    ; true  true  → solve! B'
+    }
+  pres- BoolBR→BAIsCommRingHom false = solve! B'
+  pres- BoolBR→BAIsCommRingHom true  = -IsId :> 1r ≡ - 1r
+
+  BoolBR→ : BoolHom BoolBR B
+  BoolBR→ = BoolBR→BAMap , BoolBR→BAIsCommRingHom
+
+  BoolBR→IsUnique : (f : BoolHom BoolBR B) → (fst f) ≡ fst (BoolBR→)
+  BoolBR→IsUnique f =  funExt (bool-ind (pres1 (snd f)) (pres0 (snd f)))

--- a/Cubical/Algebra/BooleanRing/Initial.agda
+++ b/Cubical/Algebra/BooleanRing/Initial.agda
@@ -13,19 +13,20 @@ open import Cubical.Tactics.CommRingSolver
 
 module _ where
   open BooleanStr
+  open IsBooleanRing
 
   BoolBRStr : BooleanStr Bool
-  BoolBRStr .𝟘 = false
-  BoolBRStr .𝟙 = true
-  BoolBRStr ._+_ = _⊕_
-  BoolBRStr ._·_ = _and_
-  BoolBRStr .-_ x = x
-  BoolBRStr .isBooleanRing = record
-    { isCommRing = makeIsCommRing isSetBool ⊕-assoc ⊕-identityʳ
-              (bool-ind refl refl) ⊕-comm and-assoc and-identityʳ
-              (bool-ind (λ _ _ → refl) λ _ _ → refl) and-comm
-    ; ·Idem = bool-ind refl refl
-    }
+  𝟘 BoolBRStr   = false
+  𝟙 BoolBRStr   = true
+  _+_ BoolBRStr = _⊕_
+  _·_ BoolBRStr = _and_
+  - BoolBRStr   = λ x → x
+  isCommRing (isBooleanRing BoolBRStr) = makeIsCommRing
+    isSetBool ⊕-assoc ⊕-identityʳ
+    (bool-ind refl refl) ⊕-comm and-assoc
+    and-identityʳ (bool-ind (λ _ _ → refl)
+    (λ _ _ → refl)) and-comm
+  ·Idem (isBooleanRing BoolBRStr) = bool-ind refl refl
 
 BoolBR : BooleanRing ℓ-zero
 BoolBR = Bool , BoolBRStr

--- a/Cubical/Algebra/BooleanRing/Initial.agda
+++ b/Cubical/Algebra/BooleanRing/Initial.agda
@@ -11,28 +11,8 @@ open import Cubical.Data.Bool renaming (elim to bool-ind)
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver
 
-module _ where
-  open BooleanStr
-  open IsBooleanRing
-
-  BoolBRStr : BooleanStr Bool
-  𝟘 BoolBRStr   = false
-  𝟙 BoolBRStr   = true
-  _+_ BoolBRStr = _⊕_
-  _·_ BoolBRStr = _and_
-  - BoolBRStr   = λ x → x
-  isCommRing (isBooleanRing BoolBRStr) = makeIsCommRing
-    isSetBool ⊕-assoc ⊕-identityʳ
-    (bool-ind refl refl) ⊕-comm and-assoc
-    and-identityʳ (bool-ind (λ _ _ → refl)
-    (λ _ _ → refl)) and-comm
-  ·Idem (isBooleanRing BoolBRStr) = bool-ind refl refl
-
-BoolBR : BooleanRing ℓ-zero
-BoolBR = Bool , BoolBRStr
-
-BoolCR : CommRing ℓ-zero
-BoolCR = BooleanRing→CommRing BoolBR
+open import Cubical.Algebra.BooleanRing.Instances.Bool
+open import Cubical.Algebra.CommRing.Instances.Bool
 
 module _ {ℓ : Level} (B : BooleanRing ℓ) where
   private

--- a/Cubical/Algebra/BooleanRing/Instances/Bool.agda
+++ b/Cubical/Algebra/BooleanRing/Instances/Bool.agda
@@ -1,0 +1,28 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Algebra.BooleanRing.Instances.Bool where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Algebra.BooleanRing.Base
+open import Cubical.Data.Bool renaming (elim to bool-ind)
+open import Cubical.Algebra.CommRing
+
+open BooleanStr
+open IsBooleanRing
+
+BoolBRStr : BooleanStr Bool
+𝟘 BoolBRStr   = false
+𝟙 BoolBRStr   = true
+_+_ BoolBRStr = _⊕_
+_·_ BoolBRStr = _and_
+- BoolBRStr   = λ x → x
+isCommRing (isBooleanRing BoolBRStr) = makeIsCommRing
+  isSetBool ⊕-assoc ⊕-identityʳ
+  (bool-ind refl refl) ⊕-comm and-assoc
+  and-identityʳ (bool-ind (λ _ _ → refl)
+  (λ _ _ → refl)) and-comm
+·Idem (isBooleanRing BoolBRStr) = bool-ind refl refl
+
+BoolBR : BooleanRing ℓ-zero
+BoolBR = Bool , BoolBRStr
+

--- a/Cubical/Algebra/BooleanRing/Instances/Bool.agda
+++ b/Cubical/Algebra/BooleanRing/Instances/Bool.agda
@@ -7,10 +7,10 @@ open import Cubical.Algebra.BooleanRing.Base
 open import Cubical.Data.Bool renaming (elim to bool-ind)
 open import Cubical.Algebra.CommRing
 
-open BooleanStr
+open BooleanRingStr
 open IsBooleanRing
 
-BoolBRStr : BooleanStr Bool
+BoolBRStr : BooleanRingStr Bool
 𝟘 BoolBRStr   = false
 𝟙 BoolBRStr   = true
 _+_ BoolBRStr = _⊕_

--- a/Cubical/Algebra/CommRing/Instances/Bool.agda
+++ b/Cubical/Algebra/CommRing/Instances/Bool.agda
@@ -1,0 +1,12 @@
+{-# OPTIONS --safe #-}
+
+module Cubical.Algebra.CommRing.Instances.Bool where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Algebra.BooleanRing.Base
+open import Cubical.Algebra.CommRing
+
+open import Cubical.Algebra.BooleanRing.Instances.Bool
+
+BoolCR : CommRing ℓ-zero
+BoolCR = BooleanRing→CommRing BoolBR


### PR DESCRIPTION
Replaces #1234

- Add an easy constructor for Boolean algebras
- Add Boolean morphisms
- Show the standard Booleans form a Boolean algebra
- Show that the above Boolean algebra is initial