### PR TITLE
Nat and Int instances of some order structures 

### DIFF
--- a/Cubical/Relation/Binary/Order/Loset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Int.agda
@@ -22,11 +22,11 @@ isLoset (snd ℤ<Loset) = isLosetℤ<
     open IsLoset
     abstract
       isLosetℤ< : IsLoset _<ℤ_
-      isLosetℤ< .is-set           = isSetℤ
-      isLosetℤ< .is-prop-valued   = λ _ _ → isProp<
-      isLosetℤ< .is-irrefl        = λ _ → isIrrefl<
-      isLosetℤ< .is-trans         = λ _ _ _ → isTrans<
-      isLosetℤ< .is-asym          = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
+      isLosetℤ< .is-set         = isSetℤ
+      isLosetℤ< .is-prop-valued = λ _ _ → isProp<
+      isLosetℤ< .is-irrefl      = λ _ → isIrrefl<
+      isLosetℤ< .is-trans       = λ _ _ _ → isTrans<
+      isLosetℤ< .is-asym        = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
       isLosetℤ< .is-weakly-linear a b c a<b with a ≟ c
       ... | lt a<c = ∣ inl a<c ∣₁
       ... | eq a≡c = ∣ inr (subst (_<ℤ b) a≡c a<b) ∣₁

--- a/Cubical/Relation/Binary/Order/Loset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Int.agda
@@ -1,0 +1,37 @@
+module Cubical.Relation.Binary.Order.Loset.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_<_ to _<ℤ_)
+
+open import Cubical.Relation.Binary.Order.Loset
+
+open LosetStr
+
+ℤ<Loset : Loset ℓ-zero ℓ-zero
+fst ℤ<Loset = ℤ
+_<_ (snd ℤ<Loset) = _<ℤ_
+isLoset (snd ℤ<Loset) = isLosetℤ<
+  where
+    open IsLoset
+    abstract
+      isLosetℤ< : IsLoset _<ℤ_
+      isLosetℤ< .is-set           = isSetℤ
+      isLosetℤ< .is-prop-valued   = λ _ _ → isProp<
+      isLosetℤ< .is-irrefl        = λ _ → isIrrefl<
+      isLosetℤ< .is-trans         = λ _ _ _ → isTrans<
+      isLosetℤ< .is-asym          = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
+      isLosetℤ< .is-weakly-linear a b c a<b with a ≟ c
+      ... | lt a<c = ∣ inl a<c ∣₁
+      ... | eq a≡c = ∣ inr (subst (_<ℤ b) a≡c a<b) ∣₁
+      ... | gt c<a = ∣ inr (isTrans< c<a a<b) ∣₁
+      isLosetℤ< .is-connected a b (¬a<b , ¬b<a) with a ≟ b
+      ... | lt a<b = ⊥.rec (¬a<b a<b)
+      ... | eq a≡b = a≡b
+      ... | gt b<a = ⊥.rec (¬b<a b<a)

--- a/Cubical/Relation/Binary/Order/Loset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Nat.agda
@@ -20,11 +20,11 @@ isLoset (snd ℕ<Loset) = isLosetℕ<
     open IsLoset
     abstract
       isLosetℕ< : IsLoset _<ℕ_
-      isLosetℕ< .is-set           = isSetℕ
-      isLosetℕ< .is-prop-valued   = λ _ _ → isProp≤
-      isLosetℕ< .is-irrefl        = λ _ → ¬m<m
-      isLosetℕ< .is-trans         = λ _ _ _ → <-trans
-      isLosetℕ< .is-asym          = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
+      isLosetℕ< .is-set         = isSetℕ
+      isLosetℕ< .is-prop-valued = λ _ _ → isProp≤
+      isLosetℕ< .is-irrefl      = λ _ → ¬m<m
+      isLosetℕ< .is-trans       = λ _ _ _ → <-trans
+      isLosetℕ< .is-asym        = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
       isLosetℕ< .is-weakly-linear a b c a<b with a ≟ c
       ... | lt a<c = ∣ inl a<c ∣₁
       ... | eq a≡c = ∣ inr (subst (_<ℕ b) a≡c a<b) ∣₁

--- a/Cubical/Relation/Binary/Order/Loset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Nat.agda
@@ -1,0 +1,32 @@
+module Cubical.Relation.Binary.Order.Loset.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_<_ to _<ℕ_)
+
+open import Cubical.Relation.Binary.Order.Loset
+
+open LosetStr
+
+ℕ<Loset : Loset ℓ-zero ℓ-zero
+fst ℕ<Loset = ℕ
+_<_ (snd ℕ<Loset) = _<ℕ_
+isLoset (snd ℕ<Loset) = isLosetℕ<
+  where
+    open IsLoset
+    abstract
+      isLosetℕ< : IsLoset _<ℕ_
+      isLosetℕ< .is-set           = isSetℕ
+      isLosetℕ< .is-prop-valued   = λ _ _ → isProp≤
+      isLosetℕ< .is-irrefl        = λ _ → ¬m<m
+      isLosetℕ< .is-trans         = λ _ _ _ → <-trans
+      isLosetℕ< .is-asym          = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
+      isLosetℕ< .is-weakly-linear a b c a<b with a ≟ c
+      ... | lt a<c = ∣ inl a<c ∣₁
+      ... | eq a≡c = ∣ inr (subst (_<ℕ b) a≡c a<b) ∣₁
+      ... | gt c<a = ∣ inr (<-trans c<a a<b) ∣₁
+      isLosetℕ< .is-connected a b (¬a<b , ¬b<a) = ≤-antisym (<-asym' ¬b<a) (<-asym' ¬a<b)

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Int.agda
@@ -2,23 +2,10 @@ module Cubical.Relation.Binary.Order.Poset.Instances.Int where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Int
-open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
-
 open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Toset
 
-open PosetStr
+open import Cubical.Relation.Binary.Order.Toset.Instances.Int
 
 ℤ≤Poset : Poset ℓ-zero ℓ-zero
-fst ℤ≤Poset = ℤ
-_≤_ (snd ℤ≤Poset) = _≤ℤ_
-isPoset (snd ℤ≤Poset) = isPosetℤ≤
-  where
-    open IsPoset
-    abstract
-      isPosetℤ≤ : IsPoset _≤ℤ_
-      isPosetℤ≤ .is-set         = isSetℤ
-      isPosetℤ≤ .is-prop-valued = λ _ _ → isProp≤
-      isPosetℤ≤ .is-refl        = λ _ → isRefl≤
-      isPosetℤ≤ .is-trans       = λ _ _ _ → isTrans≤
-      isPosetℤ≤ .is-antisym     = λ _ _ → isAntisym≤
+ℤ≤Poset = Toset→Poset ℤ≤Toset

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Int.agda
@@ -1,0 +1,24 @@
+module Cubical.Relation.Binary.Order.Poset.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Poset
+
+open PosetStr
+
+ℤ≤Poset : Poset ℓ-zero ℓ-zero
+fst ℤ≤Poset = ℤ
+_≤_ (snd ℤ≤Poset) = _≤ℤ_
+isPoset (snd ℤ≤Poset) = isPosetℤ≤
+  where
+    open IsPoset
+    abstract
+      isPosetℤ≤ : IsPoset _≤ℤ_
+      isPosetℤ≤ .is-set         = isSetℤ
+      isPosetℤ≤ .is-prop-valued = λ _ _ → isProp≤
+      isPosetℤ≤ .is-refl        = λ _ → isRefl≤
+      isPosetℤ≤ .is-trans       = λ _ _ _ → isTrans≤
+      isPosetℤ≤ .is-antisym     = λ _ _ → isAntisym≤

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Nat.agda
@@ -1,0 +1,24 @@
+module Cubical.Relation.Binary.Order.Poset.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
+
+open import Cubical.Relation.Binary.Order.Poset
+
+open PosetStr
+
+ℕ≤Poset : Poset ℓ-zero ℓ-zero
+fst ℕ≤Poset = ℕ
+_≤_ (snd ℕ≤Poset) = _≤ℕ_
+isPoset (snd ℕ≤Poset) = isPosetℕ≤
+  where
+    open IsPoset
+    abstract
+      isPosetℕ≤ : IsPoset _≤ℕ_
+      isPosetℕ≤ .is-set         = isSetℕ
+      isPosetℕ≤ .is-prop-valued = λ _ _   → isProp≤
+      isPosetℕ≤ .is-refl        = λ _     → ≤-refl
+      isPosetℕ≤ .is-trans       = λ _ _ _ → ≤-trans
+      isPosetℕ≤ .is-antisym     = λ _ _   → ≤-antisym

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Nat.agda
@@ -2,23 +2,10 @@ module Cubical.Relation.Binary.Order.Poset.Instances.Nat where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Nat
-open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
-
 open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Toset
 
-open PosetStr
+open import Cubical.Relation.Binary.Order.Toset.Instances.Nat
 
 ℕ≤Poset : Poset ℓ-zero ℓ-zero
-fst ℕ≤Poset = ℕ
-_≤_ (snd ℕ≤Poset) = _≤ℕ_
-isPoset (snd ℕ≤Poset) = isPosetℕ≤
-  where
-    open IsPoset
-    abstract
-      isPosetℕ≤ : IsPoset _≤ℕ_
-      isPosetℕ≤ .is-set         = isSetℕ
-      isPosetℕ≤ .is-prop-valued = λ _ _   → isProp≤
-      isPosetℕ≤ .is-refl        = λ _     → ≤-refl
-      isPosetℕ≤ .is-trans       = λ _ _ _ → ≤-trans
-      isPosetℕ≤ .is-antisym     = λ _ _   → ≤-antisym
+ℕ≤Poset = Toset→Poset ℕ≤Toset

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Int.agda
@@ -2,22 +2,10 @@ module Cubical.Relation.Binary.Order.Proset.Instances.Int where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Int
-open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
-
+open import Cubical.Relation.Binary.Order.Poset
 open import Cubical.Relation.Binary.Order.Proset
 
-open ProsetStr
+open import Cubical.Relation.Binary.Order.Poset.Instances.Int
 
 ℤ≤Proset : Proset ℓ-zero ℓ-zero
-fst ℤ≤Proset = ℤ
-_≲_ (snd ℤ≤Proset) = _≤ℤ_
-isProset (snd ℤ≤Proset) = isProsetℤ≤
-  where
-    open IsProset
-    abstract
-      isProsetℤ≤ : IsProset _≤ℤ_
-      isProsetℤ≤ .is-set         = isSetℤ
-      isProsetℤ≤ .is-prop-valued = λ _ _   → isProp≤
-      isProsetℤ≤ .is-refl        = λ _     → isRefl≤
-      isProsetℤ≤ .is-trans       = λ _ _ _ → isTrans≤
+ℤ≤Proset = Poset→Proset ℤ≤Poset

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Int.agda
@@ -1,0 +1,23 @@
+module Cubical.Relation.Binary.Order.Proset.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Proset
+
+open ProsetStr
+
+ℤ≤Proset : Proset ℓ-zero ℓ-zero
+fst ℤ≤Proset = ℤ
+_≲_ (snd ℤ≤Proset) = _≤ℤ_
+isProset (snd ℤ≤Proset) = isProsetℤ≤
+  where
+    open IsProset
+    abstract
+      isProsetℤ≤ : IsProset _≤ℤ_
+      isProsetℤ≤ .is-set         = isSetℤ
+      isProsetℤ≤ .is-prop-valued = λ _ _   → isProp≤
+      isProsetℤ≤ .is-refl        = λ _     → isRefl≤
+      isProsetℤ≤ .is-trans       = λ _ _ _ → isTrans≤

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Nat.agda
@@ -2,22 +2,10 @@ module Cubical.Relation.Binary.Order.Proset.Instances.Nat where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Nat
-open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
-
+open import Cubical.Relation.Binary.Order.Poset
 open import Cubical.Relation.Binary.Order.Proset
 
-open ProsetStr
+open import Cubical.Relation.Binary.Order.Poset.Instances.Nat
 
 ℕ≤Proset : Proset ℓ-zero ℓ-zero
-fst ℕ≤Proset = ℕ
-_≲_ (snd ℕ≤Proset) = _≤ℕ_
-isProset (snd ℕ≤Proset) = isProsetℕ≤
-  where
-    open IsProset
-    abstract
-      isProsetℕ≤ : IsProset _≤ℕ_
-      isProsetℕ≤ .is-set         = isSetℕ
-      isProsetℕ≤ .is-prop-valued = λ _ _   → isProp≤
-      isProsetℕ≤ .is-refl        = λ _     → ≤-refl
-      isProsetℕ≤ .is-trans       = λ _ _ _ → ≤-trans
+ℕ≤Proset = Poset→Proset ℕ≤Poset

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Nat.agda
@@ -1,0 +1,23 @@
+module Cubical.Relation.Binary.Order.Proset.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
+
+open import Cubical.Relation.Binary.Order.Proset
+
+open ProsetStr
+
+ℕ≤Proset : Proset ℓ-zero ℓ-zero
+fst ℕ≤Proset = ℕ
+_≲_ (snd ℕ≤Proset) = _≤ℕ_
+isProset (snd ℕ≤Proset) = isProsetℕ≤
+  where
+    open IsProset
+    abstract
+      isProsetℕ≤ : IsProset _≤ℕ_
+      isProsetℕ≤ .is-set         = isSetℕ
+      isProsetℕ≤ .is-prop-valued = λ _ _   → isProp≤
+      isProsetℕ≤ .is-refl        = λ _     → ≤-refl
+      isProsetℕ≤ .is-trans       = λ _ _ _ → ≤-trans

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Int.agda
@@ -2,23 +2,10 @@ module Cubical.Relation.Binary.Order.Quoset.Instances.Int where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Int
-open import Cubical.Data.Int.Order renaming (_<_ to _<ℤ_)
+open import Cubical.Relation.Binary.Order.Quoset
+open import Cubical.Relation.Binary.Order.StrictOrder
 
-open import Cubical.Relation.Binary.Order.Quoset.Base
-
-open QuosetStr
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Int
 
 ℤ<Quoset : Quoset ℓ-zero ℓ-zero
-fst ℤ<Quoset = ℤ
-_<_ (snd ℤ<Quoset) = _<ℤ_
-isQuoset (snd ℤ<Quoset) = isQuosetℤ<
-  where
-    open IsQuoset
-    abstract
-      isQuosetℤ< : IsQuoset _<ℤ_
-      isQuosetℤ< .is-set         = isSetℤ
-      isQuosetℤ< .is-prop-valued = λ _ _ → isProp<
-      isQuosetℤ< .is-irrefl      = λ _ → isIrrefl<
-      isQuosetℤ< .is-trans       = λ _ _ _ → isTrans<
-      isQuosetℤ< .is-asym        = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
+ℤ<Quoset = StrictOrder→Quoset ℤ<StrictOrder

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Int.agda
@@ -1,0 +1,24 @@
+module Cubical.Relation.Binary.Order.Quoset.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_<_ to _<ℤ_)
+
+open import Cubical.Relation.Binary.Order.Quoset.Base
+
+open QuosetStr
+
+ℤ<Quoset : Quoset ℓ-zero ℓ-zero
+fst ℤ<Quoset = ℤ
+_<_ (snd ℤ<Quoset) = _<ℤ_
+isQuoset (snd ℤ<Quoset) = isQuosetℤ<
+  where
+    open IsQuoset
+    abstract
+      isQuosetℤ< : IsQuoset _<ℤ_
+      isQuosetℤ< .is-set         = isSetℤ
+      isQuosetℤ< .is-prop-valued = λ _ _ → isProp<
+      isQuosetℤ< .is-irrefl      = λ _ → isIrrefl<
+      isQuosetℤ< .is-trans       = λ _ _ _ → isTrans<
+      isQuosetℤ< .is-asym        = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Nat.agda
@@ -1,0 +1,24 @@
+module Cubical.Relation.Binary.Order.Quoset.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_<_ to _<ℕ_)
+
+open import Cubical.Relation.Binary.Order.Quoset.Base
+
+open QuosetStr
+
+ℕ<Quoset : Quoset ℓ-zero ℓ-zero
+fst ℕ<Quoset = ℕ
+_<_ (snd ℕ<Quoset) = _<ℕ_
+isQuoset (snd ℕ<Quoset) = isQuosetℕ<
+  where
+    open IsQuoset
+    abstract
+      isQuosetℕ< : IsQuoset _<ℕ_
+      isQuosetℕ< .is-set         = isSetℕ
+      isQuosetℕ< .is-prop-valued = λ _ _ → isProp≤
+      isQuosetℕ< .is-irrefl      = λ _ → ¬m<m
+      isQuosetℕ< .is-trans       = λ _ _ _ → <-trans
+      isQuosetℕ< .is-asym        = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Nat.agda
@@ -2,23 +2,10 @@ module Cubical.Relation.Binary.Order.Quoset.Instances.Nat where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Nat
-open import Cubical.Data.Nat.Order renaming (_<_ to _<ℕ_)
+open import Cubical.Relation.Binary.Order.Quoset
+open import Cubical.Relation.Binary.Order.StrictOrder
 
-open import Cubical.Relation.Binary.Order.Quoset.Base
-
-open QuosetStr
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Nat
 
 ℕ<Quoset : Quoset ℓ-zero ℓ-zero
-fst ℕ<Quoset = ℕ
-_<_ (snd ℕ<Quoset) = _<ℕ_
-isQuoset (snd ℕ<Quoset) = isQuosetℕ<
-  where
-    open IsQuoset
-    abstract
-      isQuosetℕ< : IsQuoset _<ℕ_
-      isQuosetℕ< .is-set         = isSetℕ
-      isQuosetℕ< .is-prop-valued = λ _ _ → isProp≤
-      isQuosetℕ< .is-irrefl      = λ _ → ¬m<m
-      isQuosetℕ< .is-trans       = λ _ _ _ → <-trans
-      isQuosetℕ< .is-asym        = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
+ℕ<Quoset = StrictOrder→Quoset ℕ<StrictOrder

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int.agda
@@ -2,30 +2,10 @@ module Cubical.Relation.Binary.Order.StrictOrder.Instances.Int where
 
 open import Cubical.Foundations.Prelude
 
-open import Cubical.Data.Sum
-open import Cubical.HITs.PropositionalTruncation
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.Loset
 
-open import Cubical.Data.Int
-open import Cubical.Data.Int.Order renaming (_<_ to _<ℤ_)
-
-open import Cubical.Relation.Binary.Order.StrictOrder.Base
-
-open StrictOrderStr
+open import Cubical.Relation.Binary.Order.Loset.Instances.Int
 
 ℤ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
-fst ℤ<StrictOrder = ℤ
-_<_ (snd ℤ<StrictOrder) = _<ℤ_
-isStrictOrder (snd ℤ<StrictOrder) = isStrictOrderℤ<
-  where
-    open IsStrictOrder
-    abstract
-      isStrictOrderℤ< : IsStrictOrder _<ℤ_
-      isStrictOrderℤ< .is-set           = isSetℤ
-      isStrictOrderℤ< .is-prop-valued   = λ _ _ → isProp<
-      isStrictOrderℤ< .is-irrefl        = λ _ → isIrrefl<
-      isStrictOrderℤ< .is-trans         = λ _ _ _ → isTrans<
-      isStrictOrderℤ< .is-asym          = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
-      isStrictOrderℤ< .is-weakly-linear a b c a<b with a ≟ c
-      ... | lt a<c = ∣ inl a<c ∣₁
-      ... | eq a≡c = ∣ inr (subst (_<ℤ b) a≡c a<b) ∣₁
-      ... | gt c<a = ∣ inr (isTrans< c<a a<b) ∣₁
+ℤ<StrictOrder = Loset→StrictOrder ℤ<Loset

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int.agda
@@ -1,0 +1,31 @@
+module Cubical.Relation.Binary.Order.StrictOrder.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_<_ to _<ℤ_)
+
+open import Cubical.Relation.Binary.Order.StrictOrder.Base
+
+open StrictOrderStr
+
+ℤ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
+fst ℤ<StrictOrder = ℤ
+_<_ (snd ℤ<StrictOrder) = _<ℤ_
+isStrictOrder (snd ℤ<StrictOrder) = isStrictOrderℤ<
+  where
+    open IsStrictOrder
+    abstract
+      isStrictOrderℤ< : IsStrictOrder _<ℤ_
+      isStrictOrderℤ< .is-set           = isSetℤ
+      isStrictOrderℤ< .is-prop-valued   = λ _ _ → isProp<
+      isStrictOrderℤ< .is-irrefl        = λ _ → isIrrefl<
+      isStrictOrderℤ< .is-trans         = λ _ _ _ → isTrans<
+      isStrictOrderℤ< .is-asym          = λ a b a<b b<a → isIrrefl< (isTrans< a<b b<a)
+      isStrictOrderℤ< .is-weakly-linear a b c a<b with a ≟ c
+      ... | lt a<c = ∣ inl a<c ∣₁
+      ... | eq a≡c = ∣ inr (subst (_<ℤ b) a≡c a<b) ∣₁
+      ... | gt c<a = ∣ inr (isTrans< c<a a<b) ∣₁

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Nat.agda
@@ -1,32 +1,11 @@
 module Cubical.Relation.Binary.Order.StrictOrder.Instances.Nat where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Function
 
-open import Cubical.Data.Sum
-open import Cubical.HITs.PropositionalTruncation
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.Loset
 
-open import Cubical.Data.Nat
-open import Cubical.Data.Nat.Order renaming (_<_ to _<ℕ_)
-
-open import Cubical.Relation.Binary.Order.StrictOrder.Base
-
-open StrictOrderStr
+open import Cubical.Relation.Binary.Order.Loset.Instances.Nat
 
 ℕ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
-fst ℕ<StrictOrder = ℕ
-_<_ (snd ℕ<StrictOrder) = _<ℕ_
-isStrictOrder (snd ℕ<StrictOrder) = isStrictOrderℕ<
-  where
-    open IsStrictOrder
-    abstract
-      isStrictOrderℕ< : IsStrictOrder _<ℕ_
-      isStrictOrderℕ< .is-set           = isSetℕ
-      isStrictOrderℕ< .is-prop-valued   = λ _ _ → isProp≤
-      isStrictOrderℕ< .is-irrefl        = λ _ → ¬m<m
-      isStrictOrderℕ< .is-trans         = λ _ _ _ → <-trans
-      isStrictOrderℕ< .is-asym          = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
-      isStrictOrderℕ< .is-weakly-linear a b c a<b with a ≟ c
-      ... | lt a<c = ∣ inl a<c ∣₁
-      ... | eq a≡c = ∣ inr (subst (_<ℕ b) a≡c a<b) ∣₁
-      ... | gt c<a = ∣ inr (<-trans c<a a<b) ∣₁
+ℕ<StrictOrder = Loset→StrictOrder ℕ<Loset

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Nat.agda
@@ -1,0 +1,32 @@
+module Cubical.Relation.Binary.Order.StrictOrder.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_<_ to _<ℕ_)
+
+open import Cubical.Relation.Binary.Order.StrictOrder.Base
+
+open StrictOrderStr
+
+ℕ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
+fst ℕ<StrictOrder = ℕ
+_<_ (snd ℕ<StrictOrder) = _<ℕ_
+isStrictOrder (snd ℕ<StrictOrder) = isStrictOrderℕ<
+  where
+    open IsStrictOrder
+    abstract
+      isStrictOrderℕ< : IsStrictOrder _<ℕ_
+      isStrictOrderℕ< .is-set           = isSetℕ
+      isStrictOrderℕ< .is-prop-valued   = λ _ _ → isProp≤
+      isStrictOrderℕ< .is-irrefl        = λ _ → ¬m<m
+      isStrictOrderℕ< .is-trans         = λ _ _ _ → <-trans
+      isStrictOrderℕ< .is-asym          = λ a b a<b b<a → ¬m<m (<-trans a<b b<a)
+      isStrictOrderℕ< .is-weakly-linear a b c a<b with a ≟ c
+      ... | lt a<c = ∣ inl a<c ∣₁
+      ... | eq a≡c = ∣ inr (subst (_<ℕ b) a≡c a<b) ∣₁
+      ... | gt c<a = ∣ inr (<-trans c<a a<b) ∣₁

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Int.agda
@@ -24,7 +24,7 @@ isToset (snd ℤ≤Toset) = isTosetℤ≤
       isTosetℤ≤ .is-prop-valued = λ _ _ → isProp≤
       isTosetℤ≤ .is-refl        = λ _ → isRefl≤
       isTosetℤ≤ .is-trans       = λ _ _ _ → isTrans≤
-      isTosetℤ≤ .is-antisym     = λ _ _   → isAntisym≤
+      isTosetℤ≤ .is-antisym     = λ _ _ → isAntisym≤
       isTosetℤ≤ .is-total a b with a ≟ b
       ... | lt a<b = ∣ inl (<-weaken a<b) ∣₁
       ... | eq a≡b = ∣ inl (subst (a ≤ℤ_) a≡b isRefl≤) ∣₁

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Int.agda
@@ -1,0 +1,31 @@
+module Cubical.Relation.Binary.Order.Toset.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Toset
+
+open TosetStr
+
+ℤ≤Toset : Toset ℓ-zero ℓ-zero
+fst ℤ≤Toset = ℤ
+_≤_ (snd ℤ≤Toset) = _≤ℤ_
+isToset (snd ℤ≤Toset) = isTosetℤ≤
+  where
+    open IsToset
+    abstract
+      isTosetℤ≤ : IsToset _≤ℤ_
+      isTosetℤ≤ .is-set         = isSetℤ
+      isTosetℤ≤ .is-prop-valued = λ _ _ → isProp≤
+      isTosetℤ≤ .is-refl        = λ _ → isRefl≤
+      isTosetℤ≤ .is-trans       = λ _ _ _ → isTrans≤
+      isTosetℤ≤ .is-antisym     = λ _ _   → isAntisym≤
+      isTosetℤ≤ .is-total a b with a ≟ b
+      ... | lt a<b = ∣ inl (<-weaken a<b) ∣₁
+      ... | eq a≡b = ∣ inl (subst (a ≤ℤ_) a≡b isRefl≤) ∣₁
+      ... | gt b<a = ∣ inr (<-weaken b<a) ∣₁

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Nat.agda
@@ -1,0 +1,30 @@
+module Cubical.Relation.Binary.Order.Toset.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
+
+open import Cubical.Relation.Binary.Order.Toset
+
+open TosetStr
+
+ℕ≤Toset : Toset ℓ-zero ℓ-zero
+fst ℕ≤Toset = ℕ
+_≤_ (snd ℕ≤Toset) = _≤ℕ_
+isToset (snd ℕ≤Toset) = isTosetℕ≤
+  where
+    open IsToset
+    abstract
+      isTosetℕ≤ : IsToset _≤ℕ_
+      isTosetℕ≤ .is-set = isSetℕ
+      isTosetℕ≤ .is-prop-valued = λ _ _ → isProp≤
+      isTosetℕ≤ .is-refl = λ _ → ≤-refl
+      isTosetℕ≤ .is-trans = λ _ _ _ → ≤-trans
+      isTosetℕ≤ .is-antisym = λ _ _ → ≤-antisym
+      isTosetℕ≤ .is-total a b with splitℕ-≤ a b
+      ... | inl a≤b = ∣ inl a≤b ∣₁
+      ... | inr b<a = ∣ inr (<-weaken b<a) ∣₁

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Nat.agda
@@ -20,11 +20,11 @@ isToset (snd ℕ≤Toset) = isTosetℕ≤
     open IsToset
     abstract
       isTosetℕ≤ : IsToset _≤ℕ_
-      isTosetℕ≤ .is-set = isSetℕ
+      isTosetℕ≤ .is-set         = isSetℕ
       isTosetℕ≤ .is-prop-valued = λ _ _ → isProp≤
-      isTosetℕ≤ .is-refl = λ _ → ≤-refl
-      isTosetℕ≤ .is-trans = λ _ _ _ → ≤-trans
-      isTosetℕ≤ .is-antisym = λ _ _ → ≤-antisym
+      isTosetℕ≤ .is-refl        = λ _ → ≤-refl
+      isTosetℕ≤ .is-trans       = λ _ _ _ → ≤-trans
+      isTosetℕ≤ .is-antisym     = λ _ _ → ≤-antisym
       isTosetℕ≤ .is-total a b with splitℕ-≤ a b
       ... | inl a≤b = ∣ inl a≤b ∣₁
       ... | inr b<a = ∣ inr (<-weaken b<a) ∣₁


### PR DESCRIPTION
This PR adds some missing instances of order structures for `Nat` and `Int`.
These instances are derived for simpler orders from more complex ones. For example, I defined `ℤ≤Poset = Toset→Poset ℤ≤Toset`, rather than manually constructing all the fields.

I am not sure if this is the preferred approach. If not, I also have a version ready where all instances are explicitly constructed.

Please let me know what you think.