### PR TITLE
Fix to the definitions of `min` and `max`

### DIFF
--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -23,9 +23,9 @@ private
 min : ℕ → ℕ → ℕ
 min zero m = zero
 min (suc n) zero = zero
-min (suc n) (suc m) with n <ᵇ m
-... | false = suc m
-... | true  = suc n
+min (suc n) (suc m) with n <ᵇ m UsingEq
+... | false , _ = suc m
+... | true  , _ = suc n
 
 minSuc : min (suc n) (suc m) ≡ suc (min n m)
 minSuc {zero} {zero} = refl
@@ -44,9 +44,9 @@ minComm (suc n) (suc m) = minSuc ∙∙ cong suc (minComm n m) ∙∙ sym minSuc
 max : ℕ → ℕ → ℕ
 max zero m = m
 max (suc n) zero = suc n
-max (suc n) (suc m) with n <ᵇ m
-... | false = suc n
-... | true  = suc m
+max (suc n) (suc m) with n <ᵇ m UsingEq
+... | false , _ = suc n
+... | true  , _ = suc m
 
 maxSuc : max (suc n) (suc m) ≡ suc (max n m)
 maxSuc {zero} {zero} = refl

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -506,6 +506,9 @@ infixl 0 _i0:>_UsingEqP
 
 -- Similar to `inspect`, but more convenient when `a` is not a function
 -- application, or when the applied function is not relevant
+-- Note: when defining a term with `UsingEq`, it's still possible to prove its properties
+-- using a with-abstraction without `UsingEq`, but not the other way around.
+-- See `min`/`max` and their properties in Data.Nat.Properties for examples of this.
 _UsingEq : (a : A) → singl a
 a UsingEq = isContrSingl a .fst
 


### PR DESCRIPTION
While working on a future PR, I noticed that when performing a "with-abstraction with `UsingEq`" on `n <ᵇ m`, each case was not normalizing to the expected term. 
This issue is resolved by adding `UsingEq` into the definitions of `min` and `max`. Interestingly, all proofs that relied on "with-abstraction *withot* `UsingEq`" still works unchanged. 

I added a comment about this limitation above the definition of `UsingEq`, but I'm not entirely sure how clear it is, so I also referenced its use in `min` and `max` over ℕ. 
Please let me know if there is a clearer way to explain this behavior.