### PR TITLE
Update to `Int.Fast`

### DIFF
--- a/Cubical/Algebra/AbGroup/Instances/Int/Fast.agda
+++ b/Cubical/Algebra/AbGroup/Instances/Int/Fast.agda
@@ -1,0 +1,9 @@
+module Cubical.Algebra.AbGroup.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Data.Int.Fast
+open import Cubical.Algebra.AbGroup.Base
+open import Cubical.Algebra.Group.Instances.Int.Fast
+
+ℤAbGroup : AbGroup ℓ-zero
+ℤAbGroup = Group→AbGroup ℤGroup +Comm

--- a/Cubical/Algebra/CommRing/Instances/Int/Fast.agda
+++ b/Cubical/Algebra/CommRing/Instances/Int/Fast.agda
@@ -1,0 +1,23 @@
+module Cubical.Algebra.CommRing.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Data.Int.Fast as Int renaming (_+_ to _+ℤ_; _·_ to _·ℤ_ ; -_ to -ℤ_)
+
+open CommRingStr using (0r ; 1r ; _+_ ; _·_ ; -_ ; isCommRing)
+
+ℤCommRing : CommRing ℓ-zero
+fst ℤCommRing = ℤ
+0r (snd ℤCommRing) = pos 0
+1r (snd ℤCommRing) = pos 1
+_+_ (snd ℤCommRing) = _+ℤ_
+_·_ (snd ℤCommRing) = _·ℤ_
+- snd ℤCommRing = -ℤ_
+isCommRing (snd ℤCommRing) = isCommRingℤ
+  where
+  abstract
+    isCommRingℤ : IsCommRing (pos 0) (pos 1) _+ℤ_ _·ℤ_ -ℤ_
+    isCommRingℤ = makeIsCommRing isSetℤ Int.+Assoc +IdR
+                                 -Cancel Int.+Comm Int.·Assoc
+                                 Int.·IdR ·DistR+ Int.·Comm

--- a/Cubical/Algebra/Group/Instances/Int/Fast.agda
+++ b/Cubical/Algebra/Group/Instances/Int/Fast.agda
@@ -1,0 +1,56 @@
+module Cubical.Algebra.Group.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Int.Fast renaming (_+_ to _+ℤ_ ; _-_ to _-ℤ_ ; _·_ to _·ℤ_ ; -_ to -ℤ_)
+
+open import Cubical.Data.Nat using (ℕ ; zero ; suc)
+open import Cubical.Data.Fin.Inductive.Base
+
+open import Cubical.Algebra.Group.Base
+open import Cubical.Algebra.Group.Properties
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+
+
+open GroupStr
+
+ℤGroup : Group₀
+fst ℤGroup = ℤ
+1g (snd ℤGroup) = 0
+_·_ (snd ℤGroup) = _+ℤ_
+inv (snd ℤGroup) = -ℤ_
+isGroup (snd ℤGroup) = isGroupℤ
+  where
+  abstract
+    isGroupℤ : IsGroup (pos 0) (_+ℤ_) (-ℤ_)
+    isGroupℤ = makeIsGroup isSetℤ
+                           +Assoc +IdR +IdL
+                           -Cancel -Cancel'
+
+ℤHom : (n : ℤ) → GroupHom ℤGroup ℤGroup
+fst (ℤHom n) x = n ·ℤ x
+snd (ℤHom n) =
+  makeIsGroupHom λ x y → ·DistR+ n x y
+
+negEquivℤ : GroupEquiv ℤGroup ℤGroup
+fst negEquivℤ =
+  isoToEquiv
+    (iso (GroupStr.inv (snd ℤGroup))
+         (GroupStr.inv (snd ℤGroup))
+         (GroupTheory.invInv ℤGroup)
+         (GroupTheory.invInv ℤGroup))
+snd negEquivℤ =
+  makeIsGroupHom -Dist+
+
+sumFinGroupℤComm : (G : Group₀) (h : GroupIso G ℤGroup) {n : ℕ}
+  (f : Fin n → fst G) → sumFinℤ {n = n} (λ a → Iso.fun (fst h) (f a))
+  ≡ Iso.fun (fst h) (sumFinGroup G {n = n} f)
+sumFinGroupℤComm G h {n = zero} f = sym (IsGroupHom.pres1 (snd h))
+sumFinGroupℤComm G h {n = suc n} f =
+    cong₂ _+ℤ_ (λ _ → Iso.fun (fst h) (f flast))
+      (sumFinGroupℤComm G h {n = n} (f ∘ injectSuc {n = n}))
+  ∙ sym (IsGroupHom.pres· (snd h) (f flast)
+    (sumFinGroup G {n = n} (λ x → f (injectSuc {n = n} x))))

--- a/Cubical/Algebra/OrderedCommRing/Base.agda
+++ b/Cubical/Algebra/OrderedCommRing/Base.agda
@@ -1,6 +1,6 @@
 module Cubical.Algebra.OrderedCommRing.Base where
 {-
-  Definition of an commutative ordered ring.
+  Definition of an ordered commutative ring.
 -}
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Algebra/OrderedCommRing/Instances/Int.agda
+++ b/Cubical/Algebra/OrderedCommRing/Instances/Int.agda
@@ -1,0 +1,66 @@
+module Cubical.Algebra.OrderedCommRing.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Int as ℤ
+  renaming (_+_ to _+ℤ_ ; _-_ to _-ℤ_; -_ to -ℤ_ ; _·_ to _·ℤ_)
+open import Cubical.Data.Int.Order
+  renaming (_<_ to _<ℤ_ ; _≤_ to _≤ℤ_)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.Instances.Int
+
+open import Cubical.Algebra.OrderedCommRing
+
+open import Cubical.Relation.Nullary
+
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Int
+
+open import Cubical.Relation.Binary.Order.Pseudolattice
+open import Cubical.Relation.Binary.Order.Pseudolattice.Instances.Int
+
+open CommRingStr
+open OrderedCommRingStr
+open PseudolatticeStr
+open StrictOrderStr
+
+ℤOrderedCommRing : OrderedCommRing ℓ-zero ℓ-zero
+fst ℤOrderedCommRing = ℤ
+0r  (snd ℤOrderedCommRing) = 0
+1r  (snd ℤOrderedCommRing) = 1
+_+_ (snd ℤOrderedCommRing) = _+ℤ_
+_·_ (snd ℤOrderedCommRing) = _·ℤ_
+-_  (snd ℤOrderedCommRing) = -ℤ_
+_<_ (snd ℤOrderedCommRing) = _<ℤ_
+_≤_ (snd ℤOrderedCommRing) = _≤ℤ_
+isOrderedCommRing (snd ℤOrderedCommRing) = isOrderedCommRingℤ
+  where
+    open IsOrderedCommRing
+
+    isOrderedCommRingℤ : IsOrderedCommRing 0 1 _+ℤ_ _·ℤ_ -ℤ_ _<ℤ_ _≤ℤ_
+    isOrderedCommRingℤ .isCommRing      = ℤCommRing .snd .isCommRing
+    isOrderedCommRingℤ .isPseudolattice = ℤ≤Pseudolattice .snd .is-pseudolattice
+    isOrderedCommRingℤ .isStrictOrder   = ℤ<StrictOrder .snd .isStrictOrder
+    isOrderedCommRingℤ .<-≤-weaken      = λ _ _ → <-weaken
+    isOrderedCommRingℤ .≤≃¬>            = λ x y →
+      propBiimpl→Equiv isProp≤ (isProp¬ (y <ℤ x))
+        (λ x≤y y<x → isIrrefl< (≤<-trans x≤y y<x))
+        (λ ¬y<x → case x ≟ y return (λ _ → x ≤ℤ y) of λ {
+          (lt x<y) → <-weaken x<y ;
+          (eq x≡y) → subst (x ≤ℤ_) x≡y isRefl≤ ;
+          (gt y<z) → ⊥.rec (¬y<x y<z) })
+    isOrderedCommRingℤ .+MonoR≤         = λ _ _ z → ≤-+o {o = z}
+    isOrderedCommRingℤ .+MonoR<         = λ _ _ z → <-+o {o = z}
+    isOrderedCommRingℤ .posSum→pos∨pos  = λ _ _ → ∣_∣₁ ∘ 0<+ _ _
+    isOrderedCommRingℤ .<-≤-trans       = λ _ _ _ → <≤-trans
+    isOrderedCommRingℤ .≤-<-trans       = λ _ _ _ → ≤<-trans
+    isOrderedCommRingℤ .·MonoR≤         = λ _ _ _ → 0≤o→≤-·o
+    isOrderedCommRingℤ .·MonoR<         = λ _ _ _ → 0<o→<-·o
+    isOrderedCommRingℤ .0<1             = isRefl≤

--- a/Cubical/Algebra/OrderedCommRing/Instances/Int/Fast.agda
+++ b/Cubical/Algebra/OrderedCommRing/Instances/Int/Fast.agda
@@ -1,0 +1,69 @@
+module Cubical.Algebra.OrderedCommRing.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Int.Fast as ℤ
+  renaming (_+_ to _+ℤ_ ; _-_ to _-ℤ_; -_ to -ℤ_ ; _·_ to _·ℤ_)
+open import Cubical.Data.Int.Fast.Order
+  renaming (_<_ to _<ℤ_ ; _≤_ to _≤ℤ_)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.Instances.Int.Fast
+
+open import Cubical.Algebra.OrderedCommRing
+
+open import Cubical.Relation.Nullary
+
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Int.Fast
+
+open import Cubical.Relation.Binary.Order.Pseudolattice
+open import Cubical.Relation.Binary.Order.Pseudolattice.Instances.Int.Fast
+
+open import Cubical.Relation.Binary
+open BinaryRelation
+
+open CommRingStr
+open OrderedCommRingStr
+open PseudolatticeStr
+open StrictOrderStr
+
+ℤOrderedCommRing : OrderedCommRing ℓ-zero ℓ-zero
+fst ℤOrderedCommRing = ℤ
+0r  (snd ℤOrderedCommRing) = 0
+1r  (snd ℤOrderedCommRing) = 1
+_+_ (snd ℤOrderedCommRing) = _+ℤ_
+_·_ (snd ℤOrderedCommRing) = _·ℤ_
+-_  (snd ℤOrderedCommRing) = -ℤ_
+_<_ (snd ℤOrderedCommRing) = _<ℤ_
+_≤_ (snd ℤOrderedCommRing) = _≤ℤ_
+isOrderedCommRing (snd ℤOrderedCommRing) = isOrderedCommRingℤ
+  where
+    open IsOrderedCommRing
+
+    isOrderedCommRingℤ : IsOrderedCommRing 0 1 _+ℤ_ _·ℤ_ -ℤ_ _<ℤ_ _≤ℤ_
+    isOrderedCommRingℤ .isCommRing      = ℤCommRing .snd .isCommRing
+    isOrderedCommRingℤ .isPseudolattice = ℤ≤Pseudolattice .snd .is-pseudolattice
+    isOrderedCommRingℤ .isStrictOrder   = ℤ<StrictOrder .snd .isStrictOrder
+    isOrderedCommRingℤ .<-≤-weaken      = λ x y → <-weaken {x} {y}
+    isOrderedCommRingℤ .≤≃¬>            = λ x y →
+      propBiimpl→Equiv (isProp≤ {x} {y}) (isProp¬ (y <ℤ x))
+        (λ x≤y y<x → isIrrefl< (≤<-trans {x} {y} x≤y y<x))
+        (λ ¬y<x → case x ≟ y return (λ _ → x ≤ℤ y) of λ {
+          (lt x<y) → <-weaken {x} {y} x<y ;
+          (eq x≡y) → subst (x ≤ℤ_) x≡y isRefl≤ ;
+          (gt y<z) → ⊥.rec (¬y<x y<z) })
+    isOrderedCommRingℤ .+MonoR≤         = λ x y z → ≤-+o {x} {y} {z}
+    isOrderedCommRingℤ .+MonoR<         = λ x y z → <-+o {x} {y} {z}
+    isOrderedCommRingℤ .posSum→pos∨pos  = λ _ _ → ∣_∣₁ ∘ 0<+ _ _
+    isOrderedCommRingℤ .<-≤-trans       = λ x y z → <≤-trans {x} {y} {z}
+    isOrderedCommRingℤ .≤-<-trans       = λ x y z → ≤<-trans {x} {y} {z}
+    isOrderedCommRingℤ .·MonoR≤         = λ x y z → 0≤o→≤-·o {z} {x} {y}
+    isOrderedCommRingℤ .·MonoR<         = λ x y z → 0<o→<-·o {z} {x} {y}
+    isOrderedCommRingℤ .0<1             = isRefl≤

--- a/Cubical/Data/Int/Base.agda
+++ b/Cubical/Data/Int/Base.agda
@@ -42,6 +42,11 @@ abs : ℤ → ℕ
 abs (pos n) = n
 abs (negsuc n) = suc n
 
+sign : ℤ → ℤ
+sign (pos zero) = pos zero
+sign (pos (suc n)) = pos (suc zero)
+sign (negsuc n) = negsuc zero
+
 _ℕ-_ : ℕ → ℕ → ℤ
 a ℕ- 0 = pos a
 0 ℕ- suc b = negsuc b

--- a/Cubical/Data/Int/Fast.agda
+++ b/Cubical/Data/Int/Fast.agda
@@ -1,0 +1,6 @@
+-- This is the fast version of the integers.
+-- It uses the preferred version of the integers, but with more efficient operations.
+module Cubical.Data.Int.Fast where
+
+open import Cubical.Data.Int.Fast.Base public
+open import Cubical.Data.Int.Fast.Properties public

--- a/Cubical/Data/Int/Fast/Base.agda
+++ b/Cubical/Data/Int/Fast/Base.agda
@@ -2,7 +2,8 @@ module Cubical.Data.Int.Fast.Base where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Data.Nat as ℕ hiding (_+_ ; _·_)
-open import Cubical.Data.Int.Base hiding (_ℕ-_ ; _+_ ; _-_ ; _·_) public
+open import Cubical.Data.Int.Base hiding (_ℕ-_ ; _+_ ; _-_ ; _·_ ; sumFinℤ ; sumFinℤId) public
+open import Cubical.Data.Fin.Inductive.Base
 
 infixl 7 _·_
 infixl 6 _+_ _-_
@@ -15,18 +16,25 @@ _ℕ-_ : ℕ → ℕ → ℤ
 m ℕ- n = ℕ-hlp (m ℕ.∸ n) (n ℕ.∸ m)
 
 _+_ : ℤ → ℤ → ℤ
-pos n + pos n₁ = pos (n ℕ.+ n₁)
-negsuc n + negsuc n₁ = negsuc (suc (n ℕ.+ n₁))
-pos n + negsuc n₁ = n ℕ- (suc n₁)
-negsuc n + pos n₁ = n₁ ℕ- (suc n)
+pos m    + pos n    = pos (m ℕ.+ n)
+negsuc m + negsuc n = negsuc (suc (m ℕ.+ n))
+pos m    + negsuc n = m ℕ- (suc n)
+negsuc m + pos n    = n ℕ- (suc m)
 
 _-_ : ℤ → ℤ → ℤ
 m - n = m + (- n)
 
 _·_ : ℤ → ℤ → ℤ
-pos n · pos n₁ = pos (n ℕ.· n₁)
-pos zero · negsuc n₁ = pos zero
-pos (suc n) · negsuc n₁ = negsuc (predℕ (suc n ℕ.· suc n₁))
-negsuc n · pos zero = pos zero
-negsuc n · pos (suc n₁) = negsuc (predℕ (suc n ℕ.· suc n₁))
-negsuc n · negsuc n₁ = pos (suc n ℕ.· suc n₁)
+pos m       · pos n       = pos (m ℕ.· n)
+pos zero    · negsuc n    = pos zero
+pos (suc m) · negsuc n    = negsuc (predℕ (suc m ℕ.· suc n))
+negsuc m    · pos zero    = pos zero
+negsuc m    · pos (suc n) = negsuc (predℕ (suc m ℕ.· suc n))
+negsuc m    · negsuc n    = pos (suc m ℕ.· suc n)
+
+sumFinℤ : {n : ℕ} (f : Fin n → ℤ) → ℤ
+sumFinℤ {n = n} f = sumFinGen {n = n} _+_ 0 f
+
+sumFinℤId : (n : ℕ) {f g : Fin n → ℤ}
+  → ((x : _) → f x ≡ g x) → sumFinℤ {n = n} f ≡ sumFinℤ {n = n} g
+sumFinℤId n t i = sumFinℤ {n = n} λ x → t x i

--- a/Cubical/Data/Int/Fast/Divisibility.agda
+++ b/Cubical/Data/Int/Fast/Divisibility.agda
@@ -1,0 +1,441 @@
+{-
+
+Base facts about that the ring ℤ is Bézout domain
+
+-}
+module Cubical.Data.Int.Fast.Divisibility where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Nat
+  hiding   (+-assoc ; +-comm ; ·-comm)
+  renaming (_·_ to _·ℕ_; _+_ to _+ℕ_ ; ·-assoc to ·ℕ-assoc)
+open import Cubical.Data.Nat.Order
+open import Cubical.Data.Nat.Divisibility
+  using    (m∣n→m≤n)
+  renaming (_∣_ to _∣ℕ_ ; isProp∣ to isProp∣ℕ ; stDivIneq to stDivIneqℕ)
+open import Cubical.Data.Nat.Mod renaming (
+  quotient'_/_ to quotient_/_ ; remainder'_/_ to remainder_/_ ;
+  ≡remainder'+quotient' to ≡remainder+quotient ; mod'< to mod<
+  ) hiding (quotient_/_ ; remainder_/_ ; ≡remainder+quotient ; mod<)
+open import Cubical.Data.Int.Base as ℤ
+  hiding   (_+_ ; _·_ ; _-_ ; -_)
+open import Cubical.Data.Int.Fast.Properties as ℤ
+  hiding (addEq ; ·Comm ; ·Assoc ; +Comm ; +Assoc ; ·DistL+)
+
+open import Cubical.Data.Empty as Empty
+open import Cubical.Data.Sum
+open import Cubical.Data.Sigma
+
+open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.Relation.Nullary
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.Instances.Int.Fast
+open import Cubical.Tactics.CommRingSolver
+
+private
+  variable
+    m n k : ℤ
+
+
+open CommRingStr      (ℤCommRing .snd)
+
+-- The Divisibility Relation
+-- Most definitions are the same as in Cubical.Data.Nat.Divisibility
+
+_∣_ : ℤ → ℤ → Type
+m ∣ n = ∃[ c ∈ ℤ ] c · m ≡ n
+
+isProp∣ : isProp (m ∣ n)
+isProp∣ = squash₁
+
+-- Untruncated divisiblility relation
+
+_∣'_ : ℤ → ℤ → Type
+pos 0  ∣' n = 0 ≡ n
+pos (suc m) ∣' n = Σ[ c ∈ ℤ ] c · (pos (suc m)) ≡ n
+(negsuc m)  ∣' n = Σ[ c ∈ ℤ ] c · (negsuc m)    ≡ n
+
+isProp∣' : isProp (m ∣' n)
+isProp∣' {m = pos 0} {n = n} = isSetℤ 0 n
+isProp∣' {m = pos (suc m)} {n = n} p q =
+  Σ≡Prop (λ _ → isSetℤ _ _) (·rCancel (pos (suc m)) _ _ (p .snd ∙ sym (q .snd)) (λ r → snotz (injPos r)))
+isProp∣' {m = negsuc m} {n = n} p q =
+  Σ≡Prop (λ _ → isSetℤ _ _) (·rCancel (negsuc m) _ _ (p .snd ∙ sym (q .snd)) (negsucNotpos _ 0))
+
+∣→∣' : (m n : ℤ) → m ∣ n → m ∣' n
+∣→∣' (pos 0) n ∣ c , p ∣₁   =  sym (·AnnihilR c) ∙ p
+∣→∣' (pos (suc m)) n ∣ p ∣₁ = p
+∣→∣' (negsuc m) n ∣ p ∣₁    = p
+∣→∣' m n (squash₁ p q i)    = isProp∣' (∣→∣' _ _ p) (∣→∣' _ _ q) i
+
+∣'→∣ : (m n : ℤ) → m ∣' n → m ∣ n
+∣'→∣ (pos 0) n p = ∣ 0 , p ∣₁
+∣'→∣ (pos (suc m)) n p = ∣ p ∣₁
+∣'→∣ (negsuc m) n p = ∣ p ∣₁
+
+∣≃∣' : (m n : ℤ) → (m ∣ n) ≃ (m ∣' n)
+∣≃∣' m n = propBiimpl→Equiv isProp∣ isProp∣' (∣→∣' _ _) (∣'→∣ _ _)
+
+-- Properties of divisibility
+
+∣-left : m ∣ (m · k)
+∣-left {k = k} = ∣ k , ·Comm k _ ∣₁
+
+∣-right : m ∣ (k · m)
+∣-right {k = k} =  ∣ k , refl ∣₁
+
+∣-refl : m ≡ n → m ∣ n
+∣-refl p = ∣ 1 ,  ℤ.·IdL _ ∙ p ∣₁
+
+∣-zeroˡ : 0 ∣ m → 0 ≡ m
+∣-zeroˡ = ∣→∣' _ _
+
+∣-zeroʳ : m ∣ 0
+∣-zeroʳ = ∣ 0 , ·AnnihilL _ ∣₁
+
+∣-+ : k ∣ m → k ∣ n → k ∣ (m + n)
+∣-+ =
+  Prop.map2
+    λ {(c₁ , p) (c₂ , q) → (c₁ + c₂ , ·DistL+ c₁ c₂ _ ∙ (λ t → p t + q t))}
+
+∣-trans : k ∣ m → m ∣ n → k ∣ n
+∣-trans =
+  Prop.map2
+    λ {(c₁ , p) (c₂ , q) → (c₂ · c₁ , sym (·Assoc c₂ c₁ _) ∙ cong (c₂ ·_) p ∙ q)}
+
+∣-left· : k ∣ n → k ∣ (n · m)
+∣-left· {k = k} {m = m} p = ∣-trans p (∣-left {k = m})
+
+∣-right· : k ∣ m → k ∣ (n · m)
+∣-right· {k = k} {n = n} p = ∣-trans p (∣-right {k = n})
+
+
+-- Natural numbers back and forth (using abs)
+
+∣→∣ℕ : m ∣ n → abs m ∣ℕ abs n
+∣→∣ℕ {m = m} = Prop.rec isProp∣ℕ (λ (c , h) → ∣ abs c , sym (abs· c m) ∙ cong abs h ∣₁)
+
+private
+  ∣ℕ→∣-helper : (m n : ℤ)
+    → (c : ℕ)(h : c ·ℕ abs m ≡ abs n)
+    → (m ≡ pos (abs m)) ⊎ (m ≡ - pos (abs m))
+    → (n ≡ pos (abs n)) ⊎ (n ≡ - pos (abs n))
+    → Σ[ d ∈ ℤ ] d · m ≡ n
+  ∣ℕ→∣-helper _ _ c _ (inl _) (inl _) .fst = pos c
+  ∣ℕ→∣-helper m n c h (inl p) (inl q) .snd =
+      (λ t → pos c · p t)
+    ∙ cong pos h
+    ∙ sym q
+  ∣ℕ→∣-helper _ _ c _ (inl _) (inr _) .fst = - pos c
+  ∣ℕ→∣-helper m n c h (inl p) (inr q) .snd =
+      (λ t → - pos c · p t)
+    ∙ sym (-DistL· (pos c) (pos (abs m)))
+    ∙ (λ t → - pos·pos c (abs m) (~ t))
+    ∙ cong (-_) (cong pos h)
+    ∙ sym q
+  ∣ℕ→∣-helper _ _ c _ (inr _) (inl _) .fst = - pos c
+  ∣ℕ→∣-helper m n c h (inr p) (inl q) .snd =
+      (λ t → - pos c · p t)
+    ∙ sym (-DistLR· (pos c) (pos (abs m)))
+    ∙ sym (pos·pos c (abs m))
+    ∙ cong pos h
+    ∙ sym q
+  ∣ℕ→∣-helper _ _ c _ (inr _) (inr _) .fst = pos c
+  ∣ℕ→∣-helper m n c h (inr p) (inr q) .snd =
+      (λ t → pos c · p t)
+    ∙ sym (-DistR· (pos c) (pos (abs m)))
+    ∙ (λ t → - pos·pos c (abs m) (~ t))
+    ∙ cong (-_) (cong pos h)
+    ∙ sym q
+
+∣ℕ→∣ : abs m ∣ℕ abs n → m ∣ n
+∣ℕ→∣ = Prop.rec isProp∣ (λ (c , h) → ∣ ∣ℕ→∣-helper _ _ c h (abs→⊎ _ _ refl) (abs→⊎ _ _ refl) ∣₁)
+
+¬∣→¬∣ℕ : ¬ m ∣ n → ¬ abs m ∣ℕ abs n
+¬∣→¬∣ℕ p q = p (∣ℕ→∣ q)
+
+
+-- Inequality for strict divisibility
+
+stDivIneq : ¬ m ≡ 0 → ¬ m ∣ n → k ∣ m → k ∣ n → abs k < abs m
+stDivIneq p q h h' = stDivIneqℕ (¬x≡0→¬abs≡0 p) (¬∣→¬∣ℕ q) (∣→∣ℕ h) (∣→∣ℕ h')
+
+
+-- Exact division
+
+divide : m ∣ n → ℤ
+divide {m = pos 0} _ = 0
+divide {m = pos (suc m)} p = ∣→∣' _ _ p .fst
+divide {m = negsuc m} p = ∣→∣' _ _ p .fst
+
+divideEq : (p : m ∣ n) → divide p · m ≡ n
+divideEq {m = pos 0} = ∣→∣' _ _
+divideEq {m = pos (suc m)} p = ∣→∣' _ _ p .snd
+divideEq {m = negsuc m} p = ∣→∣' _ _ p .snd
+
+
+-- Bézout and Euclidean Domain
+
+record Bézout (m n : ℤ) : Type where
+  constructor bezout
+  field
+    coef₁ : ℤ
+    coef₂ : ℤ
+    gcd   : ℤ
+    identity : coef₁ · m + coef₂ · n ≡ gcd
+    isCD  : (gcd ∣ m) × (gcd ∣ n)
+
+open Bézout
+
+Bézout0 : (n : ℤ) → Bézout 0 n
+Bézout0 n .coef₁ = 0
+Bézout0 n .coef₂ = 1
+Bézout0 n .gcd   = n
+Bézout0 n .identity = ℤ.+IdL _ ∙ ℤ.·IdL n
+Bézout0 n .isCD  = ∣-zeroʳ , ∣-refl refl
+
+bézoutReduction : (m d r : ℤ) → Bézout r m → Bézout m (d · m + r)
+bézoutReduction m d r b .coef₁ = - b .coef₁ · d + b .coef₂
+bézoutReduction m d r b .coef₂ = b .coef₁
+bézoutReduction m d r b .gcd   = b .gcd
+bézoutReduction m d r b .identity =
+   solve! ℤCommRing ∙ b .identity
+bézoutReduction m d r b .isCD .fst = b .isCD .snd
+bézoutReduction m d r b .isCD .snd = ∣-+ (∣-right· {n = d} (b .isCD .snd)) (b .isCD .fst)
+
+-- Properties of Bézout identity
+
+module _
+  (b : Bézout m n) where
+
+  private
+    g = b .gcd
+
+  gcdIsGCD : k ∣ m → k ∣ n → k ∣ g
+  gcdIsGCD {k = k} p q =
+    subst (k ∣_) (b .identity) (∣-+ (∣-right· {n = b .coef₁} p) (∣-right· {n = b .coef₂} q))
+
+  gcd≡0 : g ≡ 0 → (m ≡ 0) × (n ≡ 0)
+  gcd≡0 p .fst = sym (∣-zeroˡ (subst (λ a → a ∣ _) p (b .isCD .fst)))
+  gcd≡0 p .snd = sym (∣-zeroˡ (subst (λ a → a ∣ _) p (b .isCD .snd)))
+
+  ¬m≡0→¬gcd≡0 : ¬ m ≡ 0 → ¬ g ≡ 0
+  ¬m≡0→¬gcd≡0 p q = p (gcd≡0 q .fst)
+
+  div₁ div₂ : ℤ
+  div₁ = divide (b .isCD .fst)
+  div₂ = divide (b .isCD .snd)
+
+  div·-helper : g · (div₁ · n) ≡ g · (div₂ · m)
+  div·-helper =
+      ·Assoc g div₁ n
+    ∙ (λ i → ·Comm g div₁ i · n)
+    ∙ (λ i → divideEq (b .isCD .fst) i · n)
+    ∙ ·Comm m n
+    ∙ (λ i → divideEq (b .isCD .snd) (~ i) · m)
+    ∙ (λ i → ·Comm div₂ g i · m)
+    ∙ sym (·Assoc g div₂ m)
+
+  div·-g≠0 : ¬ g ≡ 0 → div₁ · n ≡ div₂ · m
+  div·-g≠0 p = ·lCancel _ _ _ div·-helper p
+
+  div·-g≡0 : g ≡ 0 → div₁ · n ≡ div₂ · m
+  div·-g≡0 p =
+      (λ i → div₁ · gcd≡0 p .snd i)
+    ∙ ·AnnihilR div₁
+    ∙ sym (·AnnihilR div₂)
+    ∙ λ i → div₂ · gcd≡0 p .fst (~ i)
+
+  div·-case : Dec (g ≡ 0) → div₁ · n ≡ div₂ · m
+  div·-case (yes p) = div·-g≡0  p
+  div·-case (no ¬p) = div·-g≠0 ¬p
+
+  div· : div₁ · n ≡ div₂ · m
+  div· = div·-case (discreteℤ g 0)
+
+  div·- : - div₂ · m + div₁ · n ≡ 0
+  div·- =  (λ i → -DistL· div₂ m (~ i) + div₁ · n)
+          ∙ subst (λ a → - a + div₁ · n ≡ 0) div· (-Cancel' (div₁ · n))
+
+-- Quotient and Remainder
+
+record QuotRem (m n : ℤ) : Type where
+  constructor quotrem
+  field
+    div : ℤ
+    rem : ℤ
+    quotEq : n ≡ div · m + rem
+    normIneq : (rem ≡ 0) ⊎ ((¬ rem ≡ 0) × (abs rem < abs m))
+
+open QuotRem
+
+-- Using remainder to decide divisibility
+
+module _
+  (m n : ℤ)(qr : QuotRem m n) where
+
+  rem≡0→m∣n : qr .rem ≡ 0 → m ∣ n
+  rem≡0→m∣n p = ∣ qr .div ,  sym (ℤ.+IdR _) ∙∙ cong (qr .div · m +_) (sym p) ∙∙ sym (qr .quotEq) ∣₁
+
+  m∣n→rem≡0 : m ∣ n → qr .rem ≡ 0
+  m∣n→rem≡0 p =
+    case qr .normIneq
+    return _ of λ
+    { (inl q) → q
+    ; (inr q) →
+        let ∣+  = ∣-+ p (∣-right {m = m} {k = - qr .div})
+            m∣r = subst {x = n + - qr .div · m} {y = qr .rem}
+                (m ∣_) (cong (_+ _) (qr .quotEq) ∙ solve! ℤCommRing) ∣+
+            m≤r = m∣n→m≤n (¬x≡0→¬abs≡0 (q .fst)) (∣→∣ℕ m∣r)
+        in  Empty.rec (<-asym (q .snd) m≤r) }
+
+  m∣n→rem≡0' : (p : m ∣ n) → qr .normIneq ≡ inl (m∣n→rem≡0 p)
+  m∣n→rem≡0' p =
+    case (qr .normIneq)
+    return (λ x → x ≡ inl (m∣n→rem≡0 p)) of λ
+    { (inl q) → cong inl (isSet→SquareP (λ i j → isSetℤ) q (m∣n→rem≡0 p) refl refl)
+    ; (inr q) → Empty.rec (q .fst (m∣n→rem≡0 p)) }
+
+  rem≢0→m∤n : ¬ qr .rem ≡ 0 → ¬ m ∣ n
+  rem≢0→m∤n p q = p (m∣n→rem≡0 q)
+
+-- The Euclidean Algorithm
+module _
+  (decEq0  : (n : ℤ) → Dec (n ≡ 0))
+  (quotRem : (m n : ℤ)(¬z : ¬ m ≡ 0) → QuotRem m n) where
+
+  euclidStep : (norm : ℕ)
+    → (m n : ℤ)(h : abs m < norm)
+    → (b : QuotRem m n)
+    → Bézout m n
+  euclidStep 0 _ _ h _ = Empty.rec (¬-<-zero h)
+  euclidStep (suc N) m n h (quotrem div rem quotEq (inl p)) =
+    let q = subst (λ r → n ≡ div · m + r) p quotEq
+    in  bezout 1 0 m (
+      1 · m + 0 · n ≡⟨ cong (1 · m +_) (·AnnihilL n) ⟩
+      1 · m + 0     ≡⟨ ℤ.+IdR (1 · m) ⟩
+      1 · m         ≡⟨ ℤ.·IdL m ⟩
+      m             ∎ )
+      (∣-refl refl , subst (λ k → m ∣ k) (sym q) (subst (m ∣_) (sym (ℤ.+IdR (div · m))) (∣-right {k = div})) )
+  euclidStep (suc N) m n h (quotrem div rem quotEq (inr p)) =
+    let b = euclidStep N rem m (<≤-trans (p .snd) (pred-≤-pred h)) (quotRem _ _ (p .fst))
+    in  subst (λ x → Bézout m x) (sym quotEq) (bézoutReduction _ div _ b)
+
+  private
+    euclid-helper : (m n : ℤ)(dec : Dec (m ≡ 0)) → Bézout m n
+    euclid-helper m n (yes z) = subst (λ x → Bézout x n) (sym z) (Bézout0 n)
+    euclid-helper m n (no ¬z) = euclidStep (suc (abs m)) m n ≤-refl (quotRem m n ¬z)
+
+  euclid : (m n : ℤ) → Bézout m n
+  euclid m n = euclid-helper m n (decEq0 _)
+
+  -- Euclid algorithm when divisibility holds
+  euclid∣ : (m n : ℤ) → ¬ m ≡ 0 → m ∣ n → (euclid m n .coef₁ ≡ 1) × (euclid m n .coef₂ ≡ 0)
+  euclid∣ _ _ = euclid∣-helper _ _ (decEq0 _)
+    where
+    euclid∣-helper : (m n : ℤ)(dec : Dec (m ≡ 0)) → ¬ m ≡ 0 → m ∣ n
+      → (euclid-helper m n dec .coef₁ ≡ 1) × (euclid-helper m n dec .coef₂ ≡ 0)
+    euclid∣-helper _ _ (yes z) q = Empty.rec (q z)
+    euclid∣-helper m n (no ¬z) _ q =
+      let qr = quotRem m n ¬z
+          path : qr ≡ quotrem _ _ _ _
+          path t = record qr { normIneq = m∣n→rem≡0' _ _ qr q t }
+      in  (λ t → euclidStep (suc (abs m)) m n ≤-refl (path t) .coef₁) ,
+          (λ t → euclidStep (suc (abs m)) m n ≤-refl (path t) .coef₂)
+
+
+-- The ring ℤ is an Euclidean domain
+
+private
+  dec-helper : {ℓ ℓ' : Level}{A : Type ℓ}{B : Type ℓ'} → Dec A → B → A ⊎ ((¬ A) × B)
+  dec-helper (yes p) _ = inl p
+  dec-helper (no ¬p) b = inr (¬p , b)
+
+quotRemPosPos : (m n : ℕ)(¬z : ¬ pos m ≡ 0) → QuotRem (pos m) (pos n)
+quotRemPosPos m n _ .div = pos (quotient  n / m)
+quotRemPosPos m n _ .rem = pos (remainder n / m)
+quotRemPosPos m n _ .quotEq =
+    (λ t → pos (≡remainder+quotient m n (~ t)))
+  ∙ pos+ (remainder n / m) (m ·ℕ (quotient n / m))
+  ∙ +Comm (pos (remainder n / m)) (pos (m ·ℕ (quotient n / m)))
+  ∙ (λ t → pos·pos m (quotient n / m) t + pos (remainder n / m))
+  ∙ (λ t → ·Comm (pos m) (pos (quotient n / m)) t + pos (remainder n / m))
+quotRemPosPos 0       n ¬z .normIneq = Empty.rec (¬z refl)
+quotRemPosPos (suc m) n ¬z .normIneq = dec-helper (discreteℤ _ 0) (mod< m n)
+
+quotRemNegPos : (m n : ℕ)(¬z : ¬ - pos m ≡ 0) → QuotRem (- pos m) (pos n)
+quotRemNegPos m n ¬z .div = - (quotRemPosPos m n (λ p → ¬z (λ t → - p t)) .div)
+quotRemNegPos m n ¬z .rem = quotRemPosPos m n (λ p → ¬z (λ t → - p t)) .rem
+quotRemNegPos m n ¬z .quotEq =
+    quotRemPosPos m n (λ p → ¬z (λ t → - p t)) .quotEq
+  ∙ (λ t → -DistLR· (pos (quotient n / m)) (pos m) t + (pos (remainder n / m)))
+quotRemNegPos 0       n ¬z .normIneq = Empty.rec (¬z refl)
+quotRemNegPos (suc m) n ¬z .normIneq = quotRemPosPos (suc m) n (λ p → ¬z (λ t → - p t)) .normIneq
+
+private
+  quotRemPos-helper : (m : ℤ)(k n : ℕ)(¬z : ¬ m ≡ 0) → (m ≡ pos k) ⊎ (m ≡ - pos k) → QuotRem m (pos n)
+  quotRemPos-helper m k n ¬z (inl p) =
+    subst (λ l → QuotRem l (pos n)) (sym p) (quotRemPosPos k n (λ r → ¬z (p ∙ r)))
+  quotRemPos-helper m k n ¬z (inr p) =
+    subst (λ l → QuotRem l (pos n)) (sym p) (quotRemNegPos k n (λ r → ¬z (p ∙ r)))
+
+quotRemPos : (m : ℤ)(n : ℕ)(¬z : ¬ m ≡ 0) → QuotRem m (pos n)
+quotRemPos m n ¬z = quotRemPos-helper m (abs m) n ¬z (abs→⊎ _ _ refl)
+
+private
+  sum-helper : (m r : ℤ)
+    → (r ≡ 0)   ⊎ ((¬ r ≡ 0)   × (abs r < abs m))
+    → (- r ≡ 0) ⊎ ((¬ - r ≡ 0) × (abs (- r) < abs m))
+  sum-helper m r (inl p) = inl (λ t → - p t)
+  sum-helper m r (inr p) =
+    inr ((λ q → p .fst (sym (-Involutive r) ∙ (λ t → - q t)))
+      , subst (λ k → k < abs m) (sym (abs- r)) (p .snd))
+
+quotRemNeg : (m : ℤ)(n : ℕ)(¬z : ¬ m ≡ 0) → QuotRem m (- pos n)
+quotRemNeg m n ¬z .div = - (quotRemPos m n ¬z .div)
+quotRemNeg m n ¬z .rem = - (quotRemPos m n ¬z .rem)
+quotRemNeg m n ¬z .quotEq =
+    (λ t → - quotRemPos m n ¬z .quotEq t)
+  ∙ -Dist+ (quotRemPos m n ¬z .div · m) (quotRemPos m n ¬z .rem)
+  ∙ (λ t → -DistL· (quotRemPos m n ¬z .div) m t + - quotRemPos m n ¬z .rem)
+quotRemNeg m n ¬z .normIneq = sum-helper m _ (quotRemPos m n ¬z .normIneq)
+
+private
+  quotRem-helper : (m n : ℤ)(k : ℕ)(¬z : ¬ m ≡ 0) → (n ≡ pos k) ⊎ (n ≡ - pos k) → QuotRem m n
+  quotRem-helper m n k ¬z (inl p) = subst (λ l → QuotRem m l) (sym p) (quotRemPos m k ¬z)
+  quotRem-helper m n k ¬z (inr p) = subst (λ l → QuotRem m l) (sym p) (quotRemNeg m k ¬z)
+
+
+-- The quotient-remainder Theorem and the Bézout identity
+
+quotRem : (m n : ℤ)(¬z : ¬ m ≡ 0) → QuotRem m n
+quotRem m n ¬z = quotRem-helper m n (abs n) ¬z (abs→⊎ _ _ refl)
+
+bézout : (m n : ℤ) → Bézout m n
+bézout = euclid (λ m → discreteℤ m 0) quotRem
+
+bézout∣ : (m n : ℤ) → ¬ m ≡ 0 → m ∣ n → (bézout m n .coef₁ ≡ 1) × (bézout m n .coef₂ ≡ 0)
+bézout∣ = euclid∣ (λ m → discreteℤ m 0) quotRem
+
+
+-- Divisibility is decidable
+dec∣ : (m n : ℤ) → Dec (m ∣ n)
+dec∣ m n =
+  case discreteℤ m 0
+  return (λ _ → Dec (m ∣ n)) of λ
+  { (yes p) →
+      case discreteℤ n 0
+      return (λ _ → Dec (m ∣ n)) of λ
+      { (yes p) → yes (subst (m ∣_) (sym p) ∣-zeroʳ)
+      ; (no ¬p) → no  (λ r → ¬p (sym (∣-zeroˡ (subst (_∣ n) p r)))) }
+  ; (no ¬p) →
+      let qr = quotRem m n ¬p in
+      case discreteℤ (qr .rem) 0
+      return (λ _ → Dec (m ∣ n)) of λ
+      { (yes p) → yes (rem≡0→m∣n _ _ qr  p)
+      ; (no ¬p) → no  (rem≢0→m∤n _ _ qr ¬p) }}

--- a/Cubical/Data/Int/Fast/IsEven.agda
+++ b/Cubical/Data/Int/Fast/IsEven.agda
@@ -1,0 +1,137 @@
+module Cubical.Data.Int.Fast.IsEven where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Nullary
+
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.Bool
+open import Cubical.Data.Nat
+  using (ℕ ; zero ;  suc ; +-zero ; +-suc ; injSuc ; +-comm ; snotz ; znots ; ·-distribˡ)
+  renaming
+  (_+_    to _+ℕ_ ;
+   _·_    to _·ℕ_ ;
+   isEven to isEvenℕ ;
+   isOdd  to isOddℕ)
+import Cubical.Data.Nat.IsEven as ℕeven
+
+open import Cubical.Data.Int.Base as ℤ
+  hiding (_+_ ; _·_ ; _-_ ; _ℕ-_ ; sumFinℤ ; sumFinℤId)
+open import Cubical.Data.Int.Fast.Base as ℤ
+open import Cubical.Data.Int.Fast.Properties
+open import Cubical.Data.Sum
+
+open import Cubical.Algebra.Group
+open import Cubical.Algebra.Group.Morphisms
+open import Cubical.Algebra.Group.MorphismProperties
+open import Cubical.Algebra.Group.Instances.Bool
+open import Cubical.Algebra.Group.Instances.Int.Fast
+
+open GroupStr (snd BoolGroup) using ()
+  renaming ( _·_ to _+Bool_ )
+
+-----------------------------------------------------------------------------
+-- Lemma over ℤ
+
+2negsuc : (k : ℕ) → 2 · negsuc k ≡ negsuc (1 +ℕ 2 ·ℕ k)
+2negsuc k = cong negsuc (+-suc k (k +ℕ zero))
+
+1+2kNegsuc : (k : ℕ) → 1 + 2 · negsuc k ≡ negsuc (2 ·ℕ k)
+1+2kNegsuc k = cong (λ X → 1 + X)
+                    ( 2negsuc k
+                    ∙ cong negsuc (+-comm 1 (2 ·ℕ k))
+                    ∙ negsuc+ (2 ·ℕ k) 1
+                    ∙ +Comm (negsuc (2 ·ℕ k)) (- 1))
+               ∙ sym (pos0+ (negsuc (2 ·ℕ k)))
+
+1+2kPos : (k : ℕ) → pos (1 +ℕ 2 ·ℕ k) ≡ 1 + 2 · (pos k)
+1+2kPos k = refl
+
+-- isEven → 2k / isOdd → 1 + 2k
+isEvenTrue : (a : ℤ) → (isEven a ≡ true) → Σ[ m ∈ ℤ ] a ≡ (2 · m)
+isEvenTrue (pos n) p = (pos k) , cong pos pp
+  where
+  k = fst (ℕeven.isEvenTrue n p)
+  pp = snd (ℕeven.isEvenTrue n p)
+isEvenTrue (negsuc n) p = (negsuc k) , cong negsuc pp ∙ sym (2negsuc k)
+  where
+  k = fst (ℕeven.isOddTrue n p)
+  pp = snd (ℕeven.isOddTrue n p)
+
+isEvenFalse : (a : ℤ) → (isEven a ≡ false) → Σ[ m ∈ ℤ ] a ≡ 1 + (2 · m)
+isEvenFalse (pos n) p = (pos k) , (cong pos pp)
+  where
+  k = fst (ℕeven.isEvenFalse n p)
+  pp = snd (ℕeven.isEvenFalse n p)
+isEvenFalse (negsuc n) p = (negsuc k) , (cong negsuc pp ∙ sym (1+2kNegsuc k))
+  where
+  k = fst (ℕeven.isOddFalse n p)
+  pp = snd (ℕeven.isOddFalse n p)
+
+
+-- 2k → isEven / 1 + 2k → isOdd
+trueIsEven : (a : ℤ)  → Σ[ m ∈ ℤ ] a ≡ (2 · m) → (isEven a ≡ true)
+trueIsEven (pos n) (pos m , p) = ℕeven.trueIsEven n (m , injPos p)
+trueIsEven (pos n) (negsuc m , p) = ⊥.rec (posNotnegsuc n (1 +ℕ 2 ·ℕ m) (p ∙ 2negsuc m))
+trueIsEven (negsuc n) (pos m , p) = ⊥.rec (negsucNotpos n (2 ·ℕ m) p)
+trueIsEven (negsuc n) (negsuc m , p) = ℕeven.¬IsEvenFalse n (ℕeven.falseIsEven n
+                                       (m , (injNegsuc (p ∙ 2negsuc m))))
+
+falseIsEven : (a : ℤ) → Σ[ m ∈ ℤ ] a ≡ 1 + (2 · m) → isEven a ≡ false
+falseIsEven (pos n) (pos m , p) = ℕeven.falseIsEven n (m , injPos p)
+falseIsEven (pos n) (negsuc m , p) = ⊥.rec (posNotnegsuc n (2 ·ℕ m) (p ∙ 1+2kNegsuc m))
+falseIsEven (negsuc n) (pos m , p) = ⊥.rec (negsucNotpos n (1 +ℕ 2 ·ℕ m) (p ∙ sym (1+2kPos m)))
+falseIsEven (negsuc n) (negsuc m , p) = ℕeven.¬IsEvenTrue n (ℕeven.trueIsEven n (m , (injNegsuc (p ∙ 1+2kNegsuc m ))))
+
+
+-- Value of isEven (x + y)  depending on IsEven x, IsEven y
+isOddIsOdd→IsEven : (x y : ℤ) → isEven x ≡ false → isEven y ≡ false → isEven (x + y) ≡ true
+isOddIsOdd→IsEven x y px py = trueIsEven (x + y) ((1 + k + l) , cong₂ _+_ qk ql ∙ sym helper)
+  where
+  k  = fst (isEvenFalse x px)
+  qk = snd (isEvenFalse x px)
+  l  = fst (isEvenFalse y py)
+  ql = snd (isEvenFalse y py)
+  helper : 2 · ((1 + k) + l) ≡ (1 + 2 · k) + (1 + 2 · l)
+  helper = 2 · ((1 + k) + l)         ≡⟨ ·DistR+ 2 (1 + k) l ⟩
+           2 · (1 + k) + 2 · l       ≡⟨ cong (_+ 2 · l) (·DistR+ 2 1 k) ⟩
+           (1 + 1 + 2 · k) + 2 · l   ≡⟨ cong (_+ 2 · l) (sym (+Assoc 1 1 (2 · k))) ⟩
+           1 + (1 + 2 · k) + 2 · l   ≡⟨ cong (λ r → 1 + r + 2 · l) (+Comm 1 (2 · k)) ⟩
+           1 + (2 · k + 1) + 2 · l   ≡⟨ cong (_+ 2 · l) (+Assoc 1 (2 · k) 1) ⟩
+           ((1 + 2 · k) + 1) + 2 · l ≡⟨ sym (+Assoc (1 + 2 · k) 1 (2 · l)) ⟩
+           (1 + 2 · k) + (1 + 2 · l) ∎
+
+isOddIsEven→IsOdd : (x y : ℤ) → isEven x ≡ false → isEven y ≡ true → isEven (x + y) ≡ false
+isOddIsEven→IsOdd x y px py = falseIsEven (x + y) ((k + l) , ( cong₂ _+_ qk ql ∙ helper))
+  where
+  k  = fst (isEvenFalse x px)
+  qk = snd (isEvenFalse x px)
+  l  = fst (isEvenTrue y py)
+  ql = snd (isEvenTrue y py)
+  helper : _
+  helper = (1 + 2 · k) + 2 · l ≡⟨ sym (+Assoc 1 (2 · k) (2 · l)) ⟩
+           1 + (2 · k + 2 · l) ≡⟨ cong (1 +_) ( sym (·DistR+ 2 k l)) ⟩
+           1 + 2 · (k + l)     ∎
+
+isEvenIsOdd→IsOdd : (x y : ℤ) → isEven x ≡ true → isEven y ≡ false → isEven (x + y) ≡ false
+isEvenIsOdd→IsOdd x y px py = cong isEven (+Comm x y) ∙ isOddIsEven→IsOdd y x py px
+
+isEvenIsEven→IsEven : (x y : ℤ) → isEven x ≡ true → isEven y ≡ true → isEven (x + y) ≡ true
+isEvenIsEven→IsEven x y px py = trueIsEven (x + y) ((k + l) , cong₂ _+_ qk ql ∙ sym (·DistR+ 2 k l))
+  where
+  k =  fst (isEvenTrue x px)
+  qk = snd (isEvenTrue x px)
+  l = fst (isEvenTrue y py)
+  ql = snd (isEvenTrue y py)
+
+
+-- Proof that isEven is morphism
+isEven-pres+ : (x y : ℤ) → isEven (x + y) ≡ isEven x +Bool isEven y
+isEven-pres+ x y with (dichotomyBoolSym (isEven x)) | dichotomyBoolSym (isEven y)
+... | inl xf | inl yf = isOddIsOdd→IsEven x y xf yf ∙ sym (cong₂ _+Bool_ xf yf)
+... | inl xf | inr yt = isOddIsEven→IsOdd x y xf yt ∙ sym (cong₂ _+Bool_ xf yt)
+... | inr xt | inl yf = isEvenIsOdd→IsOdd x y xt yf ∙ sym (cong₂ _+Bool_ xt yf)
+... | inr xt | inr yt = isEvenIsEven→IsEven x y xt yt ∙ sym (cong₂ _+Bool_ xt yt)
+
+isEven-GroupMorphism : IsGroupHom (snd ℤGroup) isEven (snd BoolGroup)
+isEven-GroupMorphism = makeIsGroupHom isEven-pres+

--- a/Cubical/Data/Int/Fast/Order.agda
+++ b/Cubical/Data/Int/Fast/Order.agda
@@ -113,8 +113,12 @@ isProp≤ {m} {n} (k , p) (l , q)
 isProp< : isProp (m < n)
 isProp< {m} = isProp≤ {sucℤ m}
 
+-- this proof warrants the particular order of summands in the definition of order
 zero-≤pos : 0 ≤ pos l
-zero-≤pos {l} = l , (sym (pos0+ (pos l)))
+zero-≤pos {l} = l , refl
+
+zero-<possuc : 0 < pos (suc l)
+zero-<possuc {l} = l , refl
 
 negsuc≤-zero : negsuc k ≤ 0
 negsuc≤-zero {k} = suc k , nℕ-n≡0 k

--- a/Cubical/Data/Int/Fast/Order.agda
+++ b/Cubical/Data/Int/Fast/Order.agda
@@ -1,0 +1,609 @@
+module Cubical.Data.Int.Fast.Order where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Function
+
+open import Cubical.Relation.Binary.Order.Pseudolattice
+open import Cubical.Relation.Binary.Order.Pseudolattice.Instances.Nat renaming (
+  ℕ≤Pseudolattice to ℕ≤)
+
+open import Cubical.Data.Empty as ⊥ using (⊥)
+
+open import Cubical.Data.Bool.Base hiding (_≟_)
+
+open import Cubical.Data.Int.Fast.Base as ℤ
+open import Cubical.Data.Int.Fast.Properties as ℤ
+open import Cubical.Data.Nat as ℕ hiding (_<ᵇ_)
+import Cubical.Data.Nat.Order as ℕ
+open import Cubical.Data.Nat.Order.Recursive as ℕrec using ()
+open import Cubical.Data.NatPlusOne.Base as ℕ₊₁
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
+
+open import Cubical.Relation.Nullary
+open import Cubical.Relation.Binary
+
+infix 4 _≤_ _<_ _≥_ _>_
+
+_≤_ : ℤ → ℤ → Type₀
+m ≤ n = Σ[ k ∈ ℕ ] m ℤ.+ pos k ≡ n
+
+_<_ : ℤ → ℤ → Type₀
+m < n = sucℤ m ≤ n
+
+_≥_ : ℤ → ℤ → Type₀
+m ≥ n = n ≤ m
+
+_>_ : ℤ → ℤ → Type₀
+m > n = n < m
+
+-- Recursive order
+
+_≤ᵗ_ : ℤ → ℤ → Type₀
+pos m    ≤ᵗ pos n    = m ℕrec.≤ n
+pos m    ≤ᵗ negsuc n = ⊥
+negsuc m ≤ᵗ pos n    = Unit
+negsuc m ≤ᵗ negsuc n = n ℕrec.≤ m
+
+_<ᵗ_ : ℤ → ℤ → Type₀
+pos m    <ᵗ pos n    = m ℕrec.< n
+pos m    <ᵗ negsuc n = ⊥
+negsuc m <ᵗ pos n    = Unit
+negsuc m <ᵗ negsuc n = n ℕrec.< m
+
+_≥ᵗ_ : ℤ → ℤ → Type₀
+m ≥ᵗ n = n ≤ᵗ m
+
+_>ᵗ_ : ℤ → ℤ → Type₀
+m >ᵗ n = n <ᵗ m
+
+-- Boolen order
+
+_<ᵇ_ : ℤ → ℤ → Bool
+pos m    <ᵇ pos n    = m ℕ.<ᵇ n
+pos m    <ᵇ negsuc n = false
+negsuc m <ᵇ pos n    = true
+negsuc m <ᵇ negsuc n = n ℕ.<ᵇ m
+
+_≤ᵇ_ : ℤ → ℤ → Bool
+pos m    ≤ᵇ pos n    = m ℕ.≤ᵇ n
+pos m    ≤ᵇ negsuc n = false
+negsuc m ≤ᵇ pos n    = true
+negsuc m ≤ᵇ negsuc n = n ℕ.≤ᵇ m
+
+_>ᵇ_ : ℤ → ℤ → Bool
+m >ᵇ n = n <ᵇ m
+
+_≥ᵇ_ : ℤ → ℤ → Bool
+m ≥ᵇ n = n ≤ᵇ m
+
+-- The recursive and boolean order normalize in the same way:
+≤ᵗ≡≤ᵇ : ∀ x y → x ≤ᵗ y ≡ Bool→Type (x ≤ᵇ y)
+≤ᵗ≡≤ᵇ (pos zero)       (pos n)          = refl
+≤ᵗ≡≤ᵇ (pos (suc m))    (pos zero)       = refl
+≤ᵗ≡≤ᵇ (pos (suc m))    (pos (suc n))    = ≤ᵗ≡≤ᵇ (pos m) (pos n)
+≤ᵗ≡≤ᵇ (pos m)          (negsuc n)       = refl
+≤ᵗ≡≤ᵇ (negsuc m)       (pos n)          = refl
+≤ᵗ≡≤ᵇ (negsuc m)       (negsuc zero)    = refl
+≤ᵗ≡≤ᵇ (negsuc zero)    (negsuc (suc n)) = refl
+≤ᵗ≡≤ᵇ (negsuc (suc m)) (negsuc (suc n)) = ≤ᵗ≡≤ᵇ (negsuc m) (negsuc n)
+
+data Trichotomy (m n : ℤ) : Type₀ where
+  lt : m < n → Trichotomy m n
+  eq : m ≡ n → Trichotomy m n
+  gt : n < m → Trichotomy m n
+
+private
+  variable
+    m n o s : ℤ
+    k l : ℕ
+
+private
+  witness-prop : ∀ j → isProp (m ℤ.+ pos j ≡ n)
+  witness-prop {m} {n} j = isSetℤ (m ℤ.+ pos j) n
+
+isProp≤ : isProp (m ≤ n)
+isProp≤ {m} {n} (k , p) (l , q)
+  = Σ≡Prop (witness-prop {m} {n}) lemma
+  where
+    lemma : k ≡ l
+    lemma = injPos (inj-z+ {m} {pos k} {pos l} (p ∙ sym q))
+
+isProp< : isProp (m < n)
+isProp< {m} = isProp≤ {sucℤ m}
+
+zero-≤pos : 0 ≤ pos l
+zero-≤pos {l} = l , (sym (pos0+ (pos l)))
+
+negsuc≤-zero : negsuc k ≤ 0
+negsuc≤-zero {k} = suc k , nℕ-n≡0 k
+
+¬-pos<-zero : ¬ (pos k) < 0
+¬-pos<-zero {k} (i , p) = snotz (injPos (pos+ (suc k) i ∙ p))
+
+negsuc<-zero : negsuc k < 0
+negsuc<-zero {k} .fst = k
+negsuc<-zero {k} .snd =
+  sucℤ (negsuc k) ℤ.+ pos k    ≡⟨ sym (sucℤ+ (negsuc k) (pos k)) ⟩
+  sucℤ (negsuc k ℤ.+ pos k)    ≡⟨ +sucℤ (negsuc k) (pos k) ⟩
+  neg (suc k) ℤ.+ pos (suc k)  ≡⟨ -Cancel' (pos (suc k)) ⟩
+  pos zero                     ∎
+
+¬pos≤negsuc : ¬ (pos k) ≤ negsuc l
+¬pos≤negsuc {k} {l} (i , p) = posNotnegsuc (k ℕ.+ i) l (pos+ k i ∙ p)
+
+negsuc≤pos : negsuc k ≤ pos l
+negsuc≤pos {k} {l} .fst = l ℕ.+ suc k
+negsuc≤pos {k} {l} .snd = plusMinus (pos (suc k)) (pos l)
+
+negsuc<pos : negsuc k < pos l
+negsuc<pos {zero} {zero}   = 0 , refl
+negsuc<pos {zero} {suc l}  = suc l , sym (pos0+ (pos (suc l)))
+negsuc<pos {suc k} {zero}  = suc k , -Cancel' (pos (suc k))
+negsuc<pos {suc k} {suc l} = suc k ℕ.+ suc l
+                           , cong (negsuc k ℤ.+_) (pos+ (suc k) (suc l)) ∙
+                             +Assoc (negsuc k) (pos (suc k)) (pos (suc l)) ∙
+                             cong (ℤ._+ pos (suc l)) (-Cancel' (pos (suc k))) ∙
+                             sym (pos0+ (pos (suc l)))
+
+suc-≤-suc : m ≤ n → sucℤ m ≤ sucℤ n
+suc-≤-suc {m} {n} (k , p) = k , (sym (sucℤ+pos k m) ∙ cong sucℤ p)
+
+negsuc-≤-negsuc : pos k ≤ pos l → negsuc l ≤ negsuc k
+negsuc-≤-negsuc {k} {l} (i , p) .fst = i
+negsuc-≤-negsuc {k} {l} (i , p) .snd =
+  negsuc l ℤ.+ pos i                ≡⟨ +Comm (negsuc l) (pos i) ⟩
+  pos i ℤ.+ negsuc l                ≡⟨ -AntiComm (pos i) (pos (suc l)) ⟩
+  - (pos (suc l) - pos i)           ≡⟨ sym $ cong (-_ ∘ (_- pos i) ∘ sucℤ) p ⟩
+  - (pos (suc k) ℤ.+ pos i - pos i) ≡⟨ cong -_ (plusMinus (pos i) _) ⟩
+  negsuc k                          ∎
+
+pos-≤-pos : negsuc k ≤ negsuc l → pos l ≤ pos k
+pos-≤-pos {k} {l} (i , p) .fst = i
+pos-≤-pos {k} {l} (i , p) .snd =
+  pos l ℤ.+ pos i                       ≡⟨ sym $ -Involutive _ ⟩
+  - (- (pos l ℤ.+ pos i))               ≡⟨ cong -_ (-Dist+ (pos l) (pos i)) ⟩
+  - (- pos l - pos i)                   ≡⟨ sym $ cong (-_ ∘ (_- _)) (sucℤ[negsuc]-pos l) ⟩
+  - (sucℤ (negsuc l) - pos i)           ≡⟨ sym $ cong (-_ ∘ (_- _) ∘ sucℤ) p ⟩
+  - (sucℤ (negsuc k ℤ.+ pos i) - pos i) ≡⟨ cong (-_ ∘ (_- _)) (sucℤ+ (negsuc k) _) ⟩
+  - (sucℤ (negsuc k) ℤ.+ pos i - pos i) ≡⟨ cong -_ (plusMinus (pos i) (sucℤ (negsuc k))) ⟩
+  - sucℤ (negsuc k)                     ≡⟨ cong -_ (sucℤ[negsuc]-pos k) ⟩
+  - (- pos k)                           ≡⟨ -Involutive _ ⟩
+  pos k                                 ∎
+
+-- Conversions between natural, integer and boolean orders
+
+ℕ≤→≤ : ∀ {m n} → m ℕ.≤ n → pos m ≤ pos n
+ℕ≤→≤ {m} (i , p) = i , cong pos (+-comm m i ∙ p)
+
+ℕ≤→negsuc≥negsuc : ∀ {m n} → m ℕ.≤ n → negsuc m ≥ negsuc n
+ℕ≤→negsuc≥negsuc = negsuc-≤-negsuc ∘ ℕ≤→≤
+
+≤→ℕ≤ : ∀ {m n} → pos m ≤ pos n → m ℕ.≤ n
+≤→ℕ≤ {m} (i , p) = i , injPos (+Comm (pos i) (pos m) ∙ p)
+
+negsuc≥negsuc→ℕ≤ : ∀ {m n} → negsuc m ≥ negsuc n → m ℕ.≤ n
+negsuc≥negsuc→ℕ≤ = ≤→ℕ≤ ∘ pos-≤-pos
+
+<ᵇ→< : Bool→Type (m <ᵇ n) → m < n
+<ᵇ→< {pos m}          {pos n}          t = ℕ≤→≤ (ℕ.<ᵇ→< t)
+<ᵇ→< {negsuc m}       {pos n}          t = negsuc<pos {m} {n}
+<ᵇ→< {negsuc (suc m)} {negsuc zero}    t = negsuc-≤-negsuc zero-≤pos
+<ᵇ→< {negsuc (suc m)} {negsuc (suc n)} t = ℕ≤→negsuc≥negsuc (ℕ.<ᵇ→< t)
+
+<→<ᵇ : m < n → Bool→Type (m <ᵇ n)
+<→<ᵇ {pos m}          {pos n}    = ℕ.≤→≤ᵇ ∘ ≤→ℕ≤
+<→<ᵇ {pos m}          {negsuc n} = ¬pos≤negsuc
+<→<ᵇ {negsuc m}       {pos n}    = λ _ → tt
+<→<ᵇ {negsuc zero}    {negsuc n} = ¬pos≤negsuc
+<→<ᵇ {negsuc (suc m)} {negsuc n} = ℕ.≤→≤ᵇ ∘ negsuc≥negsuc→ℕ≤
+
+≤ᵇ→≤ : Bool→Type (m ≤ᵇ n) → m ≤ n
+≤ᵇ→≤ {pos m}    {pos n}    t = ℕ≤→≤ (ℕ.≤ᵇ→≤ t)
+≤ᵇ→≤ {negsuc m} {pos n}    t = negsuc≤pos
+≤ᵇ→≤ {negsuc m} {negsuc n} t = ℕ≤→negsuc≥negsuc (ℕ.≤ᵇ→≤ t)
+
+≤→≤ᵇ : m ≤ n → Bool→Type (m ≤ᵇ n)
+≤→≤ᵇ {pos m}    {pos n}    = ℕ.≤→≤ᵇ ∘ ≤→ℕ≤
+≤→≤ᵇ {pos m}    {negsuc n} = ¬pos≤negsuc
+≤→≤ᵇ {negsuc m} {pos n}    = λ _ → tt
+≤→≤ᵇ {negsuc m} {negsuc n} = ℕ.≤→≤ᵇ ∘ negsuc≥negsuc→ℕ≤
+
+≤-+o : m ≤ n → m ℤ.+ o ≤ n ℤ.+ o
+≤-+o {m} {n} {o} (i , p) .fst = i
+≤-+o {m} {n} {o} (i , p) .snd =
+  (m ℤ.+ o) ℤ.+ pos i  ≡⟨ sym (+Assoc m o (pos i)) ⟩
+  m ℤ.+ (o ℤ.+ pos i)  ≡⟨ cong (m ℤ.+_) (+Comm o (pos i)) ⟩
+  m ℤ.+ (pos i ℤ.+ o)  ≡⟨ +Assoc m (pos i) o ⟩
+  (m ℤ.+ pos i) ℤ.+ o  ≡⟨ cong (ℤ._+ o) p ⟩
+  n ℤ.+ o              ∎
+
+≤SumRightPos : n ≤ pos k ℤ.+ n
+≤SumRightPos {n} {k} = k , +Comm n (pos k)
+
+≤-o+ : m ≤ n → o ℤ.+ m ≤ o ℤ.+ n
+≤-o+ {m} {n} {o} = subst2 (_≤_) (+Comm m o) (+Comm n o) ∘ ≤-+o {m} {o = o}
+
+≤SumLeftPos : n ≤ n ℤ.+ pos k
+≤SumLeftPos {n} {k} = k , refl
+
+pred-≤-pred : sucℤ m ≤ sucℤ n → m ≤ n
+pred-≤-pred {m} {n} (k , p) .fst = k
+pred-≤-pred {m} {n} (k , p) .snd =
+  m ℤ.+ pos k              ≡⟨ sym $ cong (ℤ._+ pos k) (predSuc m) ⟩
+  predℤ (sucℤ m) ℤ.+ pos k ≡⟨ sym $ predℤ+ (sucℤ m) (pos k) ⟩
+  predℤ (sucℤ m ℤ.+ pos k) ≡⟨ cong predℤ p ⟩
+  predℤ (sucℤ n)           ≡⟨ predSuc n ⟩
+  n                        ∎
+
+isRefl≤ : m ≤ m
+isRefl≤ = 0 , +IdR _
+
+≤-suc : m ≤ n → m ≤ sucℤ n
+≤-suc {m} {n} (k , p) = suc k , sym (+sucℤ m (pos k)) ∙ cong sucℤ p
+
+suc-< : sucℤ m < n → m < n
+suc-< {m} {n} p = pred-≤-pred {sucℤ m} (≤-suc {sucℤ (sucℤ m)} p)
+
+≤-sucℤ : n ≤ sucℤ n
+≤-sucℤ {n} = ≤-suc {n} isRefl≤
+
+≤-predℤ : predℤ n ≤ n
+≤-predℤ {n} = 1 , sym (predℤ+ n 1) ∙ cong predℤ (+Comm n 1 ∙ sym (sucℤ≡1+ _)) ∙ predSuc n
+
+isTrans≤ : m ≤ n → n ≤ o → m ≤ o
+isTrans≤ {m} {n} {o} (i , p) (j , q) .fst = i ℕ.+ j
+isTrans≤ {m} {n} {o} (i , p) (j , q) .snd =
+  m ℤ.+ (pos i ℤ.+ pos j) ≡⟨ +Assoc m (pos i) (pos j) ⟩
+  (m ℤ.+ pos i) ℤ.+ pos j ≡⟨ cong (ℤ._+ pos j) p ⟩
+  n ℤ.+ pos j             ≡⟨ q ⟩
+  o                       ∎
+
+isAntisym≤ : m ≤ n → n ≤ m → m ≡ n
+isAntisym≤ {m} {n} (i , p) (j , q) =
+  sym (+IdR _) ∙ cong ((m ℤ.+_) ∘ pos) (injPos lemma₂) ∙ p
+  where lemma₀ : pos (j ℕ.+ i) ℤ.+ m ≡ m
+        lemma₀ = pos (j ℕ.+ i) ℤ.+ m    ≡⟨ sym (+Assoc (pos j) (pos i) m) ⟩
+                 pos j ℤ.+ (pos i ℤ.+ m) ≡⟨ cong (pos j ℤ.+_) (+Comm (pos i) m) ⟩
+                 pos j ℤ.+ (m ℤ.+ pos i) ≡⟨ cong (pos j ℤ.+_) p ⟩
+                 pos j ℤ.+ n             ≡⟨ +Comm (pos j) n ⟩
+                 n ℤ.+ pos j             ≡⟨ q ⟩
+                 m                       ∎
+        lemma₁ : pos (j ℕ.+ i) ≡ 0
+        lemma₁ = n+z≡z→n≡0 (pos (j ℕ.+ i)) m lemma₀
+
+        lemma₂ : 0 ≡ pos i
+        lemma₂ = cong pos (sym (snd (m+n≡0→m≡0×n≡0 (injPos lemma₁))))
+
+≤Monotone+ : m ≤ n → o ≤ s → m ℤ.+ o ≤ n ℤ.+ s
+≤Monotone+ {m} {n} {o} p q = isTrans≤ {m ℤ.+ o} (≤-+o {m} {o = o} p) (≤-o+ {o = n} q)
+
+≤-o+-cancel : o ℤ.+ m ≤ o ℤ.+ n → m ≤ n
+≤-o+-cancel {o} {m} (i , p) = i , inj-z+ {z = o} (+Assoc o m (pos i) ∙ p)
+
+≤-+o-cancel : m ℤ.+ o ≤ n ℤ.+ o → m ≤ n
+≤-+o-cancel {m} {o} {n} (i , p) .fst = i
+≤-+o-cancel {m} {o} {n} (i , p) .snd = inj-+z {z = o} $
+  (m ℤ.+  pos i) ℤ.+ o  ≡⟨ sym (+Assoc m (pos i) o) ⟩
+   m ℤ.+ (pos i  ℤ.+ o) ≡⟨ cong (m ℤ.+_) (+Comm (pos i) o) ⟩
+   m ℤ.+ (o  ℤ.+ pos i) ≡⟨ +Assoc m o (pos i) ⟩
+  (m ℤ.+  o) ℤ.+ pos i  ≡⟨ p ⟩
+  n ℤ.+ o               ∎
+
+≤-+pos-trans : m ℤ.+ pos k ≤ n → m ≤ n
+≤-+pos-trans {m} {k} {n} p = isTrans≤ {m} (≤SumRightPos {m}) (subst (_≤ n) (+Comm m _) p)
+
+≤-pos+-trans : pos k ℤ.+ m ≤ n → m ≤ n
+≤-pos+-trans {k} {m} p = isTrans≤ {m} (≤SumRightPos {m}) p
+
+≤-·o : m ≤ n → m ℤ.· (pos k) ≤ n ℤ.· (pos k)
+≤-·o {m} {n} {k} (i , p) .fst = i ℕ.· k
+≤-·o {m} {n} {k} (i , p) .snd =
+  m ℤ.· pos k ℤ.+ pos i ℤ.· pos k ≡⟨ sym (·DistL+ m (pos i) (pos k)) ⟩
+  (m ℤ.+ pos i) ℤ.· pos k         ≡⟨ cong (ℤ._· pos k) p ⟩
+  n ℤ.· pos k                     ∎
+
+0≤o→≤-·o : 0 ≤ o → m ≤ n → m ℤ.· o ≤ n ℤ.· o
+0≤o→≤-·o {pos o}    {m} 0≤o m≤n = ≤-·o {m} {k = o} m≤n
+0≤o→≤-·o {negsuc o} {m} 0≤o _   = ⊥.rec (¬pos≤negsuc 0≤o)
+
+<-·o : m < n → m ℤ.· (pos (suc k)) < n ℤ.· (pos (suc k))
+<-·o {m} {n} {k} (i , p) .fst = i ℕ.· suc k ℕ.+ k
+<-·o {m} {n} {k} (i , p) .snd =
+  sucℤ (m ℤ.· pos (suc k)) ℤ.+
+    (pos i ℤ.· pos (suc k) ℤ.+ pos k)       ≡⟨ cong (sucℤ (m ℤ.· pos (suc k)) ℤ.+_)
+                                               (+Comm (pos _) (pos k)) ⟩
+  sucℤ (m ℤ.· pos (suc k)) ℤ.+
+    (pos k ℤ.+ pos i ℤ.· pos (suc k))       ≡⟨ +Assoc (sucℤ (m ℤ.· pos _)) _ _ ⟩
+  (sucℤ (m ℤ.· pos (suc k)) ℤ.+ pos k) ℤ.+
+    pos i ℤ.· pos (suc k)                   ≡⟨ sym $ cong (ℤ._+ pos _)
+                                                     (sucℤ+ (m ℤ.· pos _) _) ⟩
+  sucℤ (m ℤ.· pos (suc k) ℤ.+ pos k) ℤ.+
+    pos i ℤ.· pos (suc k)                   ≡⟨ cong (ℤ._+ pos _) (+sucℤ (m ℤ.· pos _) _) ⟩
+  (m ℤ.· pos (suc k) ℤ.+ pos (suc k)) ℤ.+
+    pos i ℤ.· pos (suc k)                   ≡⟨ cong (ℤ._+ pos _)
+                                                (+Comm (m ℤ.· pos (suc k)) _) ⟩
+  (pos (suc k) ℤ.+ m ℤ.· pos (suc k)) ℤ.+
+    pos i ℤ.· pos (suc k)                   ≡⟨ sym $ cong (ℤ._+ pos _) (sucℤ· m _) ⟩
+  (sucℤ m ℤ.· pos (suc k)) ℤ.+
+    pos i ℤ.· pos (suc k)                   ≡⟨ sym $ ·DistL+ (sucℤ m) (pos i) _ ⟩
+  ((sucℤ m) ℤ.+ pos i) ℤ.· pos (suc k)      ≡⟨ cong (ℤ._· pos _) p ⟩
+  n ℤ.· pos (suc k)                                              ∎
+
+<-o+-cancel : o ℤ.+ m < o ℤ.+ n → m < n
+<-o+-cancel {o} {m} {n} = ≤-o+-cancel {o} ∘ subst (_≤ o ℤ.+ n) (+sucℤ o m)
+
+<-weaken : m < n → m ≤ n
+<-weaken {m} (i , p) = (suc i) , sym (+sucℤ m (pos i)) ∙ sucℤ+ m (pos i) ∙ p
+
+isIrrefl< : ¬ m < m
+isIrrefl< {pos zero}       (i , p) = snotz (injPos p)
+isIrrefl< {pos (suc n)}    (i , p) = isIrrefl< {pos n} (i , cong predℤ p)
+isIrrefl< {negsuc zero}    (i , p) = posNotnegsuc i 0 p
+isIrrefl< {negsuc (suc n)} (i , p) = isIrrefl< {negsuc n} (i ,
+                                     sym (sucℤ+ (negsuc n) _) ∙ cong sucℤ p)
+
+0<o→<-·o : 0 < o → m < n → m ℤ.· o < n ℤ.· o
+0<o→<-·o {pos zero}        0<o _   = ⊥.rec (isIrrefl< 0<o)
+0<o→<-·o {pos (suc o)} {m} _   m<n = <-·o {m} {k = o} m<n
+0<o→<-·o {negsuc o}        0<o _   = ⊥.rec (¬pos≤negsuc (<-weaken {0} {negsuc o} 0<o))
+
+pos≤0→≡0 : pos k ≤ 0 → pos k ≡ 0
+pos≤0→≡0 {zero} _ = refl
+pos≤0→≡0 {suc k} p = ⊥.rec (¬-pos<-zero {k = k} p)
+
+predℤ-≤-predℤ : m ≤ n → predℤ m ≤ predℤ n
+predℤ-≤-predℤ {m} {n} (i , p) .fst = i
+predℤ-≤-predℤ {m} {n} (i , p) .snd =
+  predℤ m ℤ.+ pos i   ≡⟨ sym (predℤ+ m _) ⟩
+  predℤ (m ℤ.+ pos i) ≡⟨ cong predℤ p ⟩
+  predℤ n             ∎
+
+¬m+posk<m : ¬ m ℤ.+ pos k < m
+¬m+posk<m {m} {k} = ¬-pos<-zero ∘ <-o+-cancel {o = m} {m = pos k} {n = 0}
+                  ∘ subst (m ℤ.+ pos k <_) (+pos0 m)
+
+≤<-trans : o ≤ m → m < n → o < n
+≤<-trans {o} p = isTrans≤ {sucℤ o} (suc-≤-suc {o} p)
+
+<≤-trans : o < m → m ≤ n → o < n
+<≤-trans {o} = isTrans≤ {sucℤ o}
+
+isTrans< : o < m → m < n → o < n
+isTrans< {o} p = ≤<-trans {o} (<-weaken {o} p)
+
+isAsym< : m < n → ¬ n ≤ m
+isAsym< {m} m<n = isIrrefl< ∘ <≤-trans {m} m<n
+
+<-+o : m < n → m ℤ.+ o < n ℤ.+ o
+<-+o {m} {n} {o} = subst (_≤ n ℤ.+ o) (sym (sucℤ+ m o)) ∘ ≤-+o {sucℤ m} {o = o}
+
+<-o+ : m < n → o ℤ.+ m < o ℤ.+ n
+<-o+ {m} {n} {o} = subst (_≤ o ℤ.+ n) (sym (+sucℤ o m)) ∘ ≤-o+ {o = o}
+
+<-+pos-trans : m ℤ.+ pos k < n → m < n
+<-+pos-trans {m} {k} = ≤<-trans {m} (k , refl)
+
+<-pos+-trans : pos k ℤ.+ m < n → m < n
+<-pos+-trans {k} {m} = ≤<-trans {m} (k , (+Comm m (pos k)))
+
+<Monotone+ : m < n → o < s → m ℤ.+ o < n ℤ.+ s
+<Monotone+ {m} {n} {o} m<n o<s = isTrans< {m ℤ.+ o} (<-+o {m} m<n) (<-o+ {o} {o = n} o<s)
+
+<-+-≤ : m < n → o ≤ s → m ℤ.+ o < n ℤ.+ s
+<-+-≤ {m} {n} {o} m<n o≤s = <≤-trans {m ℤ.+ o} (<-+o {m} m<n) (≤-o+ {o = n} o≤s)
+
+-pos≤ : m - (pos k) ≤ m
+-pos≤ {m} {k} = k , minusPlus (pos k) m
+
+·suc≤0 : m ℤ.· (pos (suc k)) ≤ 0 → m ≤ 0
+·suc≤0 {pos n} {k} (i , p) .fst = n ℕ.· k ℕ.+ i
+·suc≤0 {pos n} {k} (i , p) .snd =
+  pos (n ℕ.+ (n ℕ.· k ℕ.+ i))  ≡⟨ +Assoc (pos n) (pos n ℤ.· pos k) (pos i) ⟩
+  pos (n ℕ.+ n ℕ.· k ℕ.+ i)    ≡⟨ sym $ cong (pos ∘ (ℕ._+ i)) (·-suc n k) ⟩
+  pos (n ℕ.· suc k ℕ.+ i)      ≡⟨ p ⟩
+  0                             ∎
+·suc≤0 {negsuc n} {k} _ = negsuc≤-zero
+
+·suc<0 : m ℤ.· (pos (suc k)) < 0 → m < 0
+·suc<0 {pos n}    = ⊥.rec ∘ ¬-pos<-zero
+·suc<0 {negsuc n} = λ _ → negsuc<-zero {n}
+
+≤-·o-cancel : m ℤ.· (pos (suc k)) ≤ n ℤ.· (pos (suc k)) → m ≤ n
+≤-·o-cancel {m} {k} {n} mk≤nk = subst2 _≤_ (minusPlus n m) (+IdL n) $
+  ≤-+o {m - n} $ ·suc≤0 {m - n} $ subst2 (_≤_)
+    (sym (·DistL+ m (- n) (pos (suc k))))
+    (cong (n ℤ.· pos _ ℤ.+_) (sym (-DistL· n (pos _))) ∙ -Cancel (n ℤ.· pos _))
+    (≤-+o {m ℤ.· pos (suc k)} {n ℤ.· pos (suc k)} {(- n) ℤ.· pos (suc k)} mk≤nk)
+
+0<o→≤-·o-cancel : 0 < o → m ℤ.· o ≤ n ℤ.· o → m ≤ n
+0<o→≤-·o-cancel {pos zero}        0<o _     = ⊥.rec (isIrrefl< 0<o)
+0<o→≤-·o-cancel {pos (suc o)} {m} _   mo≤no = ≤-·o-cancel {m} {o} mo≤no
+0<o→≤-·o-cancel {negsuc o}        0<o _     = ⊥.rec (¬pos≤negsuc 0<o)
+
+≤-o·-cancel : (pos (suc k)) ℤ.· m ≤ (pos (suc k)) ℤ.· n → m ≤ n
+≤-o·-cancel {k} {m} {n} = ≤-·o-cancel {m} {k} {n} ∘ (subst2 _≤_ (·Comm _ m) (·Comm _ n))
+
+<-·o-cancel : m ℤ.· (pos (suc k)) < n ℤ.· (pos (suc k)) → m < n
+<-·o-cancel {m} {k} {n} mk<nk = subst2 _<_ (minusPlus n m) (+IdL n) $
+  <-+o {m - n} $ ·suc<0 {m - n} $ subst2 _<_
+    (sym (·DistL+ m (- n) (pos (suc k))))
+    (cong (n ℤ.· pos _ ℤ.+_) (sym (-DistL· n (pos _))) ∙ -Cancel (n ℤ.· pos _))
+    (<-+o {m ℤ.· pos (suc k)} {n ℤ.· pos (suc k)} {(- n) ℤ.· pos (suc k)} mk<nk)
+
+0<o→<-·o-cancel : 0 < o → m ℤ.· o < n ℤ.· o → m < n
+0<o→<-·o-cancel {pos zero}        0<o _     = ⊥.rec (isIrrefl< 0<o)
+0<o→<-·o-cancel {pos (suc o)} {m} _   mo<no = <-·o-cancel {m} {o} mo<no
+0<o→<-·o-cancel {negsuc o}        0<o _     = ⊥.rec (¬pos≤negsuc 0<o)
+
+<-o·-cancel : (pos (suc k)) ℤ.· m < (pos (suc k)) ℤ.· n → m < n
+<-o·-cancel {k} {m} {n} = <-·o-cancel {m} ∘ (subst2 _<_ (·Comm (pos (suc k)) m) (·Comm (pos (suc k)) n))
+
+-Dist≤ : m ≤ n → (- n) ≤ (- m)
+-Dist≤ {pos zero}       {pos zero}    = λ _ → isRefl≤
+-Dist≤ {pos zero}       {pos (suc n)} = λ _ → negsuc≤-zero
+-Dist≤ {pos (suc m)}    {pos zero}    = ⊥.rec ∘ snotz ∘ injPos ∘ pos≤0→≡0
+-Dist≤ {pos (suc m)}    {pos (suc n)} = negsuc-≤-negsuc ∘ pred-≤-pred {pos m} {pos n}
+-Dist≤ {pos m}          {negsuc n}    = ⊥.rec ∘ ¬pos≤negsuc
+-Dist≤ {negsuc zero}    {pos zero}    = λ _ → zero-≤pos
+-Dist≤ {negsuc zero}    {pos (suc n)} = λ _ → negsuc≤pos
+-Dist≤ {negsuc (suc m)} {pos zero}    = λ _ → zero-≤pos
+-Dist≤ {negsuc (suc m)} {pos (suc n)} = λ _ → negsuc≤pos
+-Dist≤ {negsuc m}       {negsuc n}    = suc-≤-suc {pos n} {pos m} ∘ pos-≤-pos
+
+-Dist< : m < n → (- n) < (- m)
+-Dist< {m} {n} = subst (- n <_) (cong sucℤ (-sucℤ m) ∙ sucPred (- m))
+               ∘ suc-≤-suc { - n} { - sucℤ m}
+               ∘ -Dist≤ {sucℤ m} {n}
+
+≤max : m ≤ ℤ.max m n
+≤max {pos m}    {pos n}     = ℕ≤→≤ ℕ.left-≤-max
+≤max {pos m}    {negsuc n}  = isRefl≤
+≤max {negsuc m} {pos n}     = negsuc≤pos
+≤max {negsuc m} {negsuc n}  = ℕ≤→negsuc≥negsuc ℕ.min-≤-left
+
+≤→max : m ≤ n → ℤ.max m n ≡ n
+≤→max {pos m}    {pos n}    = cong pos ∘ ∨Comm ℕ≤ {m} {n} ∙_ ∘ sym ∘ ≤→∨ ℕ≤ ∘ ≤→ℕ≤
+≤→max {pos m}    {negsuc n} = ⊥.rec ∘ ¬pos≤negsuc
+≤→max {negsuc m} {pos n}    = λ _ → refl
+≤→max {negsuc m} {negsuc n} = cong negsuc ∘ ∧Comm ℕ≤ {m} {n} ∙_
+                            ∘ sym ∘ ≤→∧ ℕ≤ ∘ negsuc≥negsuc→ℕ≤
+
+min≤ : ℤ.min m n ≤ m
+min≤ {pos m}    {pos n}    = ℕ≤→≤ ℕ.min-≤-left
+min≤ {pos m}    {negsuc n} = negsuc≤pos
+min≤ {negsuc m} {pos n}    = isRefl≤
+min≤ {negsuc m} {negsuc n} = ℕ≤→negsuc≥negsuc ℕ.left-≤-max
+
+≤→min : m ≤ n → ℤ.min m n ≡ m
+≤→min {pos m}    {pos n}    = cong pos ∘ sym ∘ ≤→∧ ℕ≤ ∘ ≤→ℕ≤
+≤→min {pos m}    {negsuc n} = ⊥.rec ∘ ¬pos≤negsuc
+≤→min {negsuc m} {pos n}    = λ _ → refl
+≤→min {negsuc m} {negsuc n} = cong negsuc ∘ sym ∘ ≤→∨ ℕ≤ ∘ negsuc≥negsuc→ℕ≤
+
+≤MonotoneMin : m ≤ n → o ≤ s → ℤ.min m o ≤ ℤ.min n s
+≤MonotoneMin {m} {n} {o} {s} m≤n o≤s
+  = subst (_≤ ℤ.min n s)
+          (sym (minAssoc n s (ℤ.min m o)) ∙
+           cong (ℤ.min n) (minAssoc s m o ∙
+                           cong (λ a → ℤ.min a o) (ℤ.minComm s m) ∙
+                                 sym (minAssoc m s o)) ∙
+                           minAssoc n m (ℤ.min s o) ∙
+           cong₂ ℤ.min (ℤ.minComm n m ∙ ≤→min m≤n)
+                       (ℤ.minComm s o ∙ ≤→min o≤s))
+           (min≤ {m = ℤ.min n s} {n = ℤ.min m o})
+
+≤MonotoneMax : m ≤ n → o ≤ s → ℤ.max m o ≤ ℤ.max n s
+≤MonotoneMax {m} {n} {o} {s} m≤n o≤s
+  = subst (ℤ.max m o ≤_)
+          (sym (maxAssoc m o (ℤ.max n s)) ∙
+           cong (ℤ.max m) (maxAssoc o n s ∙
+                           cong (λ a → ℤ.max a s) (ℤ.maxComm o n) ∙
+                                 sym (maxAssoc n o s)) ∙
+                           maxAssoc m n (ℤ.max o s) ∙
+           cong₂ ℤ.max (≤→max m≤n) (≤→max o≤s))
+          (≤max {m = ℤ.max m o} {n = ℤ.max n s})
+
+0<+ : ∀ m n → 0 < m ℤ.+ n → (0 < m) ⊎ (0 < n)
+0<+ (pos zero)    (pos zero)    = ⊥.rec ∘ isIrrefl<
+0<+ (pos zero)    (pos (suc n)) = inr
+0<+ (pos (suc m)) (pos n)       = λ _ → inl (suc-≤-suc {0} zero-≤pos)
+0<+ (pos zero)    (negsuc n)    = ⊥.rec ∘ ¬pos≤negsuc
+0<+ (pos (suc m)) (negsuc n)    = λ _ → inl (suc-≤-suc {0} zero-≤pos)
+0<+ (negsuc m)    (pos zero)    = ⊥.rec ∘ ¬pos≤negsuc
+0<+ (negsuc m)    (pos (suc n)) = λ _ → inr (suc-≤-suc {0} zero-≤pos)
+0<+ (negsuc m)    (negsuc n)    = ⊥.rec ∘ ¬pos≤negsuc
+
+≤Dec : ∀ m n → Dec (m ≤ n)
+≤Dec (pos m)    (pos n)    with ℕ.≤Dec m n
+... | yes p = yes (ℕ≤→≤ p)
+... | no ¬p = no (¬p ∘ ≤→ℕ≤)
+≤Dec (pos m)    (negsuc n) = no ¬pos≤negsuc
+≤Dec (negsuc m) (pos n)    = yes negsuc≤pos
+≤Dec (negsuc m) (negsuc n) with ℕ.≤Dec n m
+... | yes p = yes (-Dist≤ (suc-≤-suc {pos n} (ℕ≤→≤ p)))
+... | no ¬p = no (¬p ∘ negsuc≥negsuc→ℕ≤)
+
+≤Stable : ∀ m n → Stable (m ≤ n)
+≤Stable m n = Dec→Stable (≤Dec m n)
+
+<Dec : ∀ m n → Dec (m < n)
+<Dec m n = ≤Dec (sucℤ m) n
+
+<Stable : ∀ m n → Stable (m < n)
+<Stable m n = Dec→Stable (<Dec m n)
+
+Trichotomy-suc : Trichotomy m n → Trichotomy (sucℤ m) (sucℤ n)
+Trichotomy-suc {m}     (lt m<n) = lt (suc-≤-suc {sucℤ m} m<n)
+Trichotomy-suc         (eq m≡n) = eq (cong sucℤ m≡n)
+Trichotomy-suc {n = n} (gt n<m) = gt (suc-≤-suc {sucℤ n} n<m)
+
+Trichotomy-pred : Trichotomy (sucℤ m) (sucℤ n) → Trichotomy m n
+Trichotomy-pred {m}     (lt m<n) = lt (pred-≤-pred {sucℤ m} m<n)
+Trichotomy-pred {m} {n} (eq m≡n) = eq (sym (predSuc m)
+                                      ∙ cong predℤ m≡n
+                                      ∙ predSuc n)
+Trichotomy-pred {n = n} (gt n<m) = gt (pred-≤-pred {sucℤ n} n<m)
+
+_≟_ : ∀ m n → Trichotomy m n
+pos m    ≟ pos n    with m ℕ.≟ n
+... | ℕ.lt m<n = lt (ℕ≤→≤ m<n)
+... | ℕ.eq m≡n = eq (cong pos m≡n)
+... | ℕ.gt m>n = gt (ℕ≤→≤ m>n)
+pos m    ≟ negsuc n = gt (negsuc<pos {n})
+negsuc m ≟ pos n    = lt (negsuc<pos {m})
+negsuc m ≟ negsuc n with n ℕ.≟ m
+... | ℕ.lt n<m = lt (-Dist< (suc-≤-suc {pos (suc n)} (ℕ≤→≤ n<m)))
+... | ℕ.eq n≡m = eq (cong negsuc (sym n≡m))
+... | ℕ.gt n>m = gt (-Dist< (suc-≤-suc {pos (suc m)} (ℕ≤→≤ n>m)))
+
+-- alternative proof
+_≟'_ : ∀ m n → Trichotomy m n
+pos zero ≟' pos zero = eq refl
+pos zero ≟' pos (suc n) = lt (suc-≤-suc {0} {pos n} zero-≤pos)
+pos (suc m) ≟' pos zero = gt (suc-≤-suc {0} {pos m} zero-≤pos)
+pos (suc m) ≟' pos (suc n) = Trichotomy-suc (pos m ≟' pos n)
+pos m ≟' negsuc n = gt (negsuc<pos {n})
+negsuc m ≟' pos n = lt (negsuc<pos {m})
+negsuc zero ≟' negsuc zero = eq refl
+negsuc zero ≟' negsuc (suc n) = gt (negsuc-≤-negsuc zero-≤pos)
+negsuc (suc m) ≟' negsuc zero = lt (negsuc-≤-negsuc zero-≤pos)
+negsuc (suc m) ≟' negsuc (suc n) = Trichotomy-pred (negsuc m ≟' negsuc n)
+
+-- Raw comparisons, without the proof terms
+compare : ℤ → ℤ → Ordering
+compare m n with m ≟ n
+... | lt _ = LT
+... | eq _ = EQ
+... | gt _ = GT
+
+compare' : ℤ → ℤ → Ordering
+compare' m n with m ≟' n
+... | lt _ = LT
+... | eq _ = EQ
+... | gt _ = GT
+
+private
+
+  test₀ : compare -4294967296  4295967296 ≡ LT
+  test₀ = refl
+
+  test₁ : compare -4294967296 -4294967296 ≡ EQ
+  test₁ = refl
+
+  test₂ : compare -4294967296 -4295967296 ≡ GT
+  test₂ = refl
+
+  test₀' : compare' -4294967296  4295967296 ≡ LT
+  test₀' = refl
+
+  {- This would take much longer to typecheck:
+
+  test₁' : compare' -4294967296 -4295967296 ≡ GT
+  test₁' = refl
+
+  test₂' : compare' -4294967296 -4295967296 ≡ GT
+  test₂' = refl
+
+  -}

--- a/Cubical/Data/Int/Fast/Properties.agda
+++ b/Cubical/Data/Int/Fast/Properties.agda
@@ -1,0 +1,1163 @@
+module Cubical.Data.Int.Fast.Properties where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Equiv
+
+open import Cubical.Relation.Nullary
+
+open import Cubical.Relation.Binary.Order.Pseudolattice
+open import Cubical.Relation.Binary.Order.Pseudolattice.Instances.Nat renaming (
+  ℕ≤Pseudolattice to ℕ≤)
+
+open import Cubical.Data.Bool
+
+open import Cubical.Data.Empty as ⊥
+open import Cubical.Data.NatPlusOne.Base as ℕ₊₁
+open import Cubical.Data.Nat as ℕ hiding (
+    +-assoc ; +-comm ; min ; max ; minComm ; maxComm)
+  renaming (_·_ to _·ℕ_; _+_ to _+ℕ_)
+open import Cubical.Data.Nat.Order as ℕ using ()
+open import Cubical.Data.Sum
+open import Cubical.Data.Fin.Inductive.Base
+open import Cubical.Data.Fin.Inductive.Properties
+
+open import Cubical.Data.Int.Base as ℤ
+  hiding (_+_ ; _·_ ; _-_ ; _ℕ-_ ; sumFinℤ ; sumFinℤId)
+open import Cubical.Data.Int.Properties as P public using (
+    sucPred ; predSuc ; injPos ; injNegsuc ; posNotnegsuc ; negsucNotpos ; injNeg
+  ; discreteℤ ; isSetℤ ; -pos ; -neg ; sucℤnegsucneg ; -sucℤ ; -predℤ
+  ; -Involutive ; isEquiv- ; predℤ+negsuc ; sucℤ+negsuc ; predℤ-pos
+  ; ind-assoc ; ind-comm ; sucPathℤ ; addEq ; predPathℤ ; subEq ; _+'_ ; isEquivAddℤ'
+  ; abs→⊎ ; ⊎→abs ; abs≡0 ; ¬x≡0→¬abs≡0 ; abs- ; 0≢1-ℤ ; clamp)
+
+open import Cubical.Data.Int.Fast.Base
+
+private
+  ℕ-lem : ∀ n m → (pos n +negsuc m) ≡ (n ℕ- suc m)
+  ℕ-lem zero          zero    = refl
+  ℕ-lem (suc zero)    zero    = refl
+  ℕ-lem (suc (suc n)) zero    = refl
+  ℕ-lem zero          (suc m) = cong predℤ (P.+Comm 0 (negsuc m))
+  ℕ-lem (suc n)       (suc m) = predℤ+negsuc m (pos (suc n)) ∙ ℕ-lem n m
+
++≡+f : ∀ n m → n ℤ.+ m ≡ n + m
++≡+f (pos n)    (pos m)    = sym (P.pos+ n m)
++≡+f (pos n)    (negsuc m) = ℕ-lem n m
++≡+f (negsuc n) (pos m)    = P.+Comm (negsuc n) (pos m) ∙ ℕ-lem m n
++≡+f (negsuc n) (negsuc m) = sym (P.neg+ (suc n) (suc m))
+                            ∙ cong negsuc (ℕ.+-suc _ _)
+
+·≡·f : ∀ n m → n ℤ.· m ≡ n · m
+·≡·f (pos n)       (pos m)       = sym (P.pos·pos n m)
+·≡·f (pos zero)    (negsuc m)    = refl
+·≡·f (pos (suc n)) (negsuc m)    = P.pos·negsuc (suc n) m
+                                  ∙ cong -_ (sym (P.pos·pos (suc n) (suc m)))
+·≡·f (negsuc n)    (pos zero)    = P.·AnnihilR (negsuc n)
+·≡·f (negsuc n)    (pos (suc m)) = P.negsuc·pos n (suc m)
+                                  ∙ cong -_ (sym (P.pos·pos (suc n) (suc m)))
+·≡·f (negsuc n)    (negsuc m)    = P.negsuc·negsuc n m
+                                  ∙ sym (P.pos·pos (suc n) (suc m))
+
+subst-f : (A : (ℤ → ℤ → ℤ) → (ℤ → ℤ → ℤ) → Type) → A ℤ._+_ ℤ._·_ → A _+_ _·_
+subst-f A = subst2 A (λ i x y → +≡+f x y i) (λ i x y → ·≡·f x y i)
+
+-- `subst-f` can be used to transport proofs from the standard to the fast operations:
+private
+  ·Assoc' : (x y z : ℤ) → x · (y · z) ≡ x · y · z
+  ·Assoc' x y z = subst-f (λ _+_ _·_ → (x · (y · z)) ≡ ((x · y) · z)) (P.·Assoc x y z)
+
+sucℤ[negsuc]-pos : ∀ k → sucℤ (negsuc k) ≡ - pos k
+sucℤ[negsuc]-pos zero    = refl
+sucℤ[negsuc]-pos (suc k) = refl
+
++IdL : ∀ z → 0 + z ≡ z
++IdL (pos n)    = refl
++IdL (negsuc n) = refl
+
++IdR : ∀ z → z + 0 ≡ z
++IdR (pos n)    = cong pos (+-zero n)
++IdR (negsuc n) = refl
+
+min : ℤ → ℤ → ℤ
+min (pos m)    (pos n)    = pos (ℕ.min m n)
+min (pos m)    (negsuc n) = negsuc n
+min (negsuc m) (pos n)    = negsuc m
+min (negsuc m) (negsuc n) = negsuc (ℕ.max m n)
+
+minComm : ∀ n m → min n m ≡ min m n
+minComm (pos m)    (pos n)    = cong pos (ℕ.minComm m n)
+minComm (pos m)    (negsuc n) = refl
+minComm (negsuc m) (pos n)    = refl
+minComm (negsuc m) (negsuc n) = cong negsuc (ℕ.maxComm m n)
+
+minIdem : ∀ n → min n n ≡ n
+minIdem (pos n)    = cong pos (∧Idem ℕ≤)
+minIdem (negsuc n) = cong negsuc (∨Idem ℕ≤)
+
+max : ℤ → ℤ → ℤ
+max (pos m)    (pos n)    = pos (ℕ.max m n )
+max (pos m)    (negsuc n) = pos m
+max (negsuc m) (pos n)    = pos n
+max (negsuc m) (negsuc n) = negsuc (ℕ.min m n)
+
+maxComm : ∀ m n → max m n ≡ max n m
+maxComm (pos m)    (pos n)    = cong pos (ℕ.maxComm m n)
+maxComm (pos m)    (negsuc n) = refl
+maxComm (negsuc m) (pos n)    = refl
+maxComm (negsuc m) (negsuc n) = cong negsuc (ℕ.minComm m n)
+
+maxIdem : ∀ n → max n n ≡ n
+maxIdem (pos n)    = cong pos (∨Idem ℕ≤)
+maxIdem (negsuc n) = cong negsuc (∧Idem ℕ≤)
+
+sucDistMin : ∀ m n → sucℤ (min m n) ≡ min (sucℤ m) (sucℤ n)
+sucDistMin (pos m)          (pos n)          = cong pos (sym minSuc)
+sucDistMin (pos m)          (negsuc zero)    = refl
+sucDistMin (pos m)          (negsuc (suc n)) = refl
+sucDistMin (negsuc zero)    (pos n)          = refl
+sucDistMin (negsuc (suc m)) (pos n)          = refl
+sucDistMin (negsuc zero)    (negsuc zero)    = refl
+sucDistMin (negsuc zero)    (negsuc (suc n)) = refl
+sucDistMin (negsuc (suc m)) (negsuc zero)    = refl
+sucDistMin (negsuc (suc m)) (negsuc (suc n)) = cong (sucℤ ∘ negsuc) maxSuc
+
+predDistMin : ∀ m n → predℤ (min m n) ≡ min (predℤ m) (predℤ n)
+predDistMin (pos zero)    (pos zero)    = refl
+predDistMin (pos zero)    (pos (suc n)) = refl
+predDistMin (pos (suc m)) (pos zero)    = refl
+predDistMin (pos (suc m)) (pos (suc n)) = cong (predℤ ∘ pos) minSuc
+predDistMin (pos zero)    (negsuc n)    = refl
+predDistMin (pos (suc m)) (negsuc n)    = refl
+predDistMin (negsuc m) (pos zero)       = refl
+predDistMin (negsuc m) (pos (suc n))    = refl
+predDistMin (negsuc m)    (negsuc n)    = cong negsuc (sym maxSuc)
+
+minSucL : ∀ m → min (sucℤ m) m ≡ m
+minSucL (pos m)          = cong pos (ℕ.minComm (suc m) m ∙ sym (≤→∧ ℕ≤ ℕ.≤-sucℕ))
+minSucL (negsuc zero)    = refl
+minSucL (negsuc (suc m)) = cong negsuc (ℕ.maxComm m (suc m) ∙ sym (≤→∨ ℕ≤ ℕ.≤-sucℕ))
+
+minSucR : ∀ m → min m (sucℤ m)  ≡ m
+minSucR m = minComm m (sucℤ m) ∙ minSucL m
+
+minPredL : ∀ m → min (predℤ m) m ≡ predℤ m
+minPredL (pos zero)    = refl
+minPredL (pos (suc m)) = cong pos (sym (≤→∧ ℕ≤ ℕ.≤-sucℕ))
+minPredL (negsuc m)    = cong negsuc (sym (≤→∨ ℕ≤ ℕ.≤-sucℕ))
+
+minPredR : ∀ m → min m (predℤ m) ≡ predℤ m
+minPredR m = minComm m (predℤ m) ∙ minPredL m
+
+sucDistMax : ∀ m n → sucℤ (max m n) ≡ max (sucℤ m) (sucℤ n)
+sucDistMax (pos m)          (pos n)          = cong pos (sym maxSuc)
+sucDistMax (pos m)          (negsuc zero)    = refl
+sucDistMax (pos m)          (negsuc (suc n)) = refl
+sucDistMax (negsuc zero)    (pos n)          = refl
+sucDistMax (negsuc (suc m)) (pos n)          = refl
+sucDistMax (negsuc zero)    (negsuc zero)    = refl
+sucDistMax (negsuc zero)    (negsuc (suc n)) = refl
+sucDistMax (negsuc (suc m)) (negsuc zero)    = refl
+sucDistMax (negsuc (suc m)) (negsuc (suc n)) = cong (sucℤ ∘ negsuc) minSuc
+
+predDistMax : ∀ m n → predℤ (max m n) ≡ max (predℤ m) (predℤ n)
+predDistMax (pos zero)    (pos zero)    = refl
+predDistMax (pos zero)    (pos (suc n)) = refl
+predDistMax (pos (suc m)) (pos zero)    = refl
+predDistMax (pos (suc m)) (pos (suc n)) = cong (predℤ ∘ pos) maxSuc
+predDistMax (pos zero)    (negsuc n)    = refl
+predDistMax (pos (suc m)) (negsuc n)    = refl
+predDistMax (negsuc m)    (pos zero)    = refl
+predDistMax (negsuc m)    (pos (suc n)) = refl
+predDistMax (negsuc m)    (negsuc n)    = cong negsuc (sym minSuc)
+
+maxSucL : ∀ m → max (sucℤ m) m ≡ sucℤ m
+maxSucL (pos m)          = cong pos (sym (≤→∨ ℕ≤ ℕ.≤-sucℕ))
+maxSucL (negsuc zero)    = refl
+maxSucL (negsuc (suc m)) = cong negsuc (sym (≤→∧ ℕ≤ ℕ.≤-sucℕ))
+
+maxSucR : ∀ m → max m (sucℤ m) ≡ sucℤ m
+maxSucR m = maxComm m (sucℤ m) ∙ maxSucL m
+
+maxPredL : ∀ m → max (predℤ m) m ≡ m
+maxPredL (pos zero)    = refl
+maxPredL (pos (suc m)) = cong pos (ℕ.maxComm m (suc m) ∙ sym (≤→∨ ℕ≤ ℕ.≤-sucℕ))
+maxPredL (negsuc m)    = cong negsuc (ℕ.minComm (suc m) m ∙ sym (≤→∧ ℕ≤ ℕ.≤-sucℕ))
+
+maxPredR : ∀ m → max m (predℤ m) ≡ m
+maxPredR m = maxComm m (predℤ m) ∙ maxPredL m
+
+minAssoc : ∀ x y z → min x (min y z) ≡ min (min x y) z
+minAssoc (pos m)    (pos n)    (pos k)    = cong pos $ ∧Assoc ℕ≤ {m} {n} {k}
+minAssoc (pos m)    (pos n)    (negsuc k) = refl
+minAssoc (pos m)    (negsuc n) (pos k)    = refl
+minAssoc (pos m)    (negsuc n) (negsuc k) = refl
+minAssoc (negsuc m) (pos n)    (pos k)    = refl
+minAssoc (negsuc m) (pos n)    (negsuc k) = refl
+minAssoc (negsuc m) (negsuc n) (pos k)    = refl
+minAssoc (negsuc m) (negsuc n) (negsuc k) = cong negsuc $ ∨Assoc ℕ≤ {m} {n} {k}
+
+maxAssoc : ∀ x y z → max x (max y z) ≡ max (max x y) z
+maxAssoc (pos m)    (pos n)    (pos k)    = cong pos $ ∨Assoc ℕ≤ {m} {n} {k}
+maxAssoc (pos m)    (pos n)    (negsuc k) = refl
+maxAssoc (pos m)    (negsuc n) (pos k)    = refl
+maxAssoc (pos m)    (negsuc n) (negsuc k) = refl
+maxAssoc (negsuc m) (pos n)    (pos k)    = refl
+maxAssoc (negsuc m) (pos n)    (negsuc k) = refl
+maxAssoc (negsuc m) (negsuc n) (pos k)    = refl
+maxAssoc (negsuc m) (negsuc n) (negsuc k) = cong negsuc $ ∧Assoc ℕ≤ {m} {n} {k}
+
+minAbsorbLMax : ∀ x y → min x (max x y) ≡ x
+minAbsorbLMax (pos zero) (pos n) = refl
+minAbsorbLMax (pos (suc m)) (pos zero) = cong pos (∧Idem ℕ≤)
+minAbsorbLMax (pos (suc m)) (pos (suc n)) with m <ᵇ n UsingEq
+... | false , _ = cong pos (∧Idem ℕ≤)
+... | true  , p  with m <ᵇ n UsingEq
+... | false , ¬p = ⊥.rec (true≢false (sym p ∙ ¬p))
+... | true  , _  = refl
+minAbsorbLMax (pos m)    (negsuc n) = cong pos (∧Idem ℕ≤)
+minAbsorbLMax (negsuc m) (pos n)    = refl
+minAbsorbLMax (negsuc zero) (negsuc n) = refl
+minAbsorbLMax (negsuc (suc m)) (negsuc zero) = refl
+minAbsorbLMax (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ n UsingEq
+... | true  , _ = cong negsuc (∨Idem ℕ≤)
+... | false , ¬p with m <ᵇ n UsingEq
+... | false , _ = refl
+... | true  , p = ⊥.rec (true≢false (sym p ∙ ¬p))
+
+maxAbsorbLMin : ∀ x y → max x (min x y) ≡ x
+maxAbsorbLMin (pos zero) (pos n) = refl
+maxAbsorbLMin (pos (suc m)) (pos zero) = refl
+maxAbsorbLMin (pos (suc m)) (pos (suc n)) with m <ᵇ n UsingEq
+... | true  , _ = cong pos (∨Idem ℕ≤)
+... | false , ¬p with m <ᵇ n UsingEq
+... | false , _ = refl
+... | true  , p = ⊥.rec (true≢false (sym p ∙ ¬p))
+maxAbsorbLMin (pos m) (negsuc n) = refl
+maxAbsorbLMin (negsuc m) (pos n) = cong negsuc (∧Idem ℕ≤)
+maxAbsorbLMin (negsuc zero) (negsuc n) = refl
+maxAbsorbLMin (negsuc (suc m)) (negsuc zero) = cong negsuc (∧Idem ℕ≤)
+maxAbsorbLMin (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ n UsingEq
+... | false , _ = cong negsuc (∧Idem ℕ≤)
+... | true  , p  with m <ᵇ n UsingEq
+... | false , ¬p = ⊥.rec (true≢false (sym p ∙ ¬p))
+... | true  , _  = refl
+
+predℤ+pos : ∀ n m → predℤ (m +pos n) ≡ (predℤ m) +pos n
+predℤ+pos zero m = refl
+predℤ+pos (suc n) m =
+  predℤ (sucℤ (m +pos n))   ≡⟨ predSuc _ ⟩
+  m +pos n                  ≡[ i ]⟨ sucPred m (~ i) +pos n ⟩
+  (sucℤ (predℤ m)) +pos n   ≡⟨ sym (P.sucℤ+pos n (predℤ m))⟩
+  (predℤ m) +pos (suc n)    ∎
+
+predℕ-≡ℕ-suc : ∀ m n → predℤ (m ℕ- n) ≡ m ℕ- (suc n)
+predℕ-≡ℕ-suc zero          zero    = refl
+predℕ-≡ℕ-suc zero          (suc n) = refl
+predℕ-≡ℕ-suc (suc zero)    zero    = refl
+predℕ-≡ℕ-suc (suc (suc m)) zero    = refl
+predℕ-≡ℕ-suc (suc m)       (suc n) = predℕ-≡ℕ-suc m n
+
+predℤ+ : ∀ m n → predℤ (m + n) ≡ (predℤ m) + n
+predℤ+ (pos zero)    (pos zero)          = refl
+predℤ+ (pos zero)    (pos (suc zero))    = refl
+predℤ+ (pos zero)    (pos (suc (suc n))) = refl
+predℤ+ (pos (suc m)) (pos n)             = refl
+predℤ+ (pos zero)    (negsuc n)          = refl
+predℤ+ (pos (suc m)) (negsuc n)          = predℕ-≡ℕ-suc m n
+predℤ+ (negsuc m)    (pos n)             = predℕ-≡ℕ-suc n (suc m)
+predℤ+ (negsuc m)    (negsuc n)          = refl
+
++predℤ : ∀ m n → predℤ (m + n) ≡ m + (predℤ n)
++predℤ (pos zero)          (pos zero)    = refl
++predℤ (pos (suc zero))    (pos zero)    = refl
++predℤ (pos (suc (suc m))) (pos zero)    = cong (pos ∘ suc) (ℕ.+-zero m)
++predℤ (pos m)             (pos (suc n)) = cong (predℤ ∘ pos) (ℕ.+-comm m (suc n)) ∙ cong pos (ℕ.+-comm n m)
++predℤ (pos m)             (negsuc n)    = predℕ-≡ℕ-suc m (suc n)
++predℤ (negsuc m)          (pos zero)    = cong (negsuc ∘ suc) (sym (ℕ.+-zero m))
++predℤ (negsuc m)          (pos (suc n)) = predℕ-≡ℕ-suc n m
++predℤ (negsuc m)          (negsuc n)    = cong (negsuc ∘ suc ∘ suc ) (ℕ.+-comm m n)
+                                         ∙ cong (negsuc ∘ suc) (ℕ.+-comm (suc n) m)
+
+sucℕ-suc≡ℕ- : ∀ m n → sucℤ (m ℕ- suc n) ≡ m ℕ- n
+sucℕ-suc≡ℕ- zero          zero    = refl
+sucℕ-suc≡ℕ- zero          (suc n) = refl
+sucℕ-suc≡ℕ- (suc zero)    zero    = refl
+sucℕ-suc≡ℕ- (suc (suc m)) zero    = refl
+sucℕ-suc≡ℕ- (suc m)       (suc n) = sucℕ-suc≡ℕ- m n
+
+sucℤ+pos : ∀ n m → sucℤ (m + pos n) ≡ (sucℤ m) + pos n
+sucℤ+pos n (pos m)                   = refl
+sucℤ+pos zero (negsuc m)             = sym (+IdR (sucℤ (negsuc m + pos zero)))
+sucℤ+pos (suc zero) (negsuc zero)    = refl
+sucℤ+pos (suc (suc n)) (negsuc zero) = cong (sucℤ ∘ (ℕ-hlp (suc n))) (zero∸ (suc n))
+sucℤ+pos (suc n) (negsuc (suc m))    = w n m where
+  w : ∀ n m → sucℤ (ℕ-hlp (n ∸ suc m) (suc m ∸ n)) ≡ ℕ-hlp (n ∸ m) (m ∸ n)
+  w zero zero          = refl
+  w zero (suc m)       = refl
+  w (suc zero) zero    = refl
+  w (suc (suc n)) zero = cong (sucℤ ∘ (ℕ-hlp (suc n))) (zero∸ (suc n))
+  w (suc n) (suc m)    = w n m
+
+sucℤ+ : ∀ m n → sucℤ (m + n) ≡ (sucℤ m) + n
+sucℤ+ (pos m)          (pos n)             = refl
+sucℤ+ (pos m)          (negsuc n)          = sucℕ-suc≡ℕ- m n
+sucℤ+ (negsuc zero)    (pos zero)          = refl
+sucℤ+ (negsuc zero)    (pos (suc zero))    = refl
+sucℤ+ (negsuc zero)    (pos (suc (suc n))) = refl
+sucℤ+ (negsuc (suc m)) (pos n)             = sucℕ-suc≡ℕ- n (suc m)
+sucℤ+ (negsuc zero)    (negsuc n)          = refl
+sucℤ+ (negsuc (suc m)) (negsuc n)          = refl
+
++sucℤ : ∀ m n → sucℤ (m + n) ≡ m + (sucℤ n)
++sucℤ (pos m)             (pos n)          = cong (pos ∘ suc) (ℕ.+-comm m n) ∙ cong pos (ℕ.+-comm (suc n) m)
++sucℤ (pos zero)          (negsuc zero)    = refl
++sucℤ (pos (suc zero))    (negsuc zero)    = refl
++sucℤ (pos (suc (suc m))) (negsuc zero)    = cong (pos ∘ suc) (sym (ℕ.+-zero (suc m)))
++sucℤ (pos m)             (negsuc (suc n)) = sucℕ-suc≡ℕ- m (suc n)
++sucℤ (negsuc m)          (pos n)          = sucℕ-suc≡ℕ- n m
++sucℤ (negsuc m)          (negsuc zero)    = cong negsuc (ℕ.+-zero m)
++sucℤ (negsuc m)          (negsuc (suc n)) = cong negsuc (ℕ.+-comm m (suc n) ∙ cong suc (ℕ.+-comm n m))
+
+pos0+ : ∀ z → z ≡ pos 0 + z
+pos0+ (pos n)    = refl
+pos0+ (negsuc n) = refl
+
++pos0 : ∀ z → z ≡ z + pos 0
++pos0 (pos n)    = cong pos $ sym (ℕ.+-zero n)
++pos0 (negsuc n) = refl
+
+
+negsuc0+ : ∀ z → predℤ z ≡ negsuc 0 + z
+negsuc0+ (pos zero)          = refl
+negsuc0+ (pos (suc zero))    = refl
+negsuc0+ (pos (suc (suc n))) = refl
+negsuc0+ (negsuc n)          = refl
+
++negsuc0 : ∀ z → predℤ z ≡ z + negsuc 0
++negsuc0 (pos zero)          = refl
++negsuc0 (pos (suc zero))    = refl
++negsuc0 (pos (suc (suc n))) = refl
++negsuc0 (negsuc n)          = cong (negsuc ∘ suc) $ sym (ℕ.+-zero n)
+
++Comm : ∀ m n → m + n ≡ n + m
++Comm (pos m)    (pos n)     = cong pos (ℕ.+-comm m n)
++Comm (negsuc m) (pos n)     = refl
++Comm (pos m)    (negsuc n)  = refl
++Comm (negsuc m) (negsuc n)  = cong (negsuc ∘ suc) (ℕ.+-comm m n)
+
++Comm' : ∀ m n → m + n ≡ n + m
++Comm' m (pos n)    = ind-comm _+_ pos    sucℤ  refl sucℤ+  +sucℤ (λ n → sym (+pos0 n) ∙ pos0+ n) m n
++Comm' m (negsuc n) = ind-comm _+_ negsuc predℤ refl predℤ+ +predℤ (λ n → sym (+negsuc0 n) ∙ negsuc0+ n) m n
+
++Assoc' : ∀ m n o → m + (n + o) ≡ (m + n) + o
++Assoc' m n (pos o)    = ind-assoc _+_ pos    sucℤ  +sucℤ  refl (λ m n → sym (+pos0 (m + n)) ∙ cong (m +_) (+pos0 n) ) m n o
++Assoc' m n (negsuc o) = ind-assoc _+_ negsuc predℤ +predℤ refl (λ m n → sym (+negsuc0 (m + n))
+                                                                      ∙∙ +predℤ m n
+                                                                      ∙∙ cong (m +_) (+negsuc0 n) ) m n o
+
+nℕ-n≡0 : ∀ n → n ℕ- n ≡ pos 0
+nℕ-n≡0 zero    = refl
+nℕ-n≡0 (suc n) = nℕ-n≡0 n
+
++PosDistLℕ- : ∀ m n k → (n ℕ- k) + (pos m) ≡ (n ℕ.+ m) ℕ- k
++PosDistLℕ- zero    zero    zero    = refl
++PosDistLℕ- (suc m) zero    zero    = refl
++PosDistLℕ- m       zero    (suc k) = refl
++PosDistLℕ- m       (suc n) zero    = refl
++PosDistLℕ- m       (suc n) (suc k) = +PosDistLℕ- m n k
+
++PosDistRℕ- : ∀ m n k → (pos m) + (n ℕ- k) ≡ (m ℕ.+ n) ℕ- k
++PosDistRℕ- m n k = +Comm (pos m) (n ℕ- k)
+                 ∙∙ +PosDistLℕ- m n k
+                 ∙∙ cong (_ℕ- k) (ℕ.+-comm n m)
+
++NegsucDistLℕ- : ∀ m n k → (n ℕ- k) + negsuc m ≡ n ℕ- (suc k ℕ.+ m)
++NegsucDistLℕ- m zero zero       = refl
++NegsucDistLℕ- m zero (suc k)    = refl
++NegsucDistLℕ- m (suc n) zero    = refl
++NegsucDistLℕ- m (suc n) (suc k) = +NegsucDistLℕ- m n k
+
++NegsucDistRℕ- : ∀ m n k → negsuc m + (n ℕ- k) ≡ n ℕ- (suc m ℕ.+ k)
++NegsucDistRℕ- m n k = +Comm (negsuc m) (n ℕ- k)
+                    ∙∙ +NegsucDistLℕ- m n k
+                    ∙∙ cong (n ℕ-_ ∘ suc) (ℕ.+-comm k m)
+
++Assoc : ∀ m n k → m + (n + k) ≡ (m + n) + k
++Assoc (pos m)    (pos n)    (pos k)    = cong pos (ℕ.+-assoc m n k)
++Assoc (pos m)    (pos n)    (negsuc k) = +PosDistRℕ- m n (suc k)
++Assoc (pos m)    (negsuc n) (pos k)    =
+  pos m + k ℕ- suc n ≡⟨ +PosDistRℕ- m k (suc n) ⟩
+  (m +ℕ k) ℕ- suc n  ≡⟨ sym (+PosDistLℕ- k m (suc n)) ⟩
+  m ℕ- suc n + pos k ∎
++Assoc (pos m)    (negsuc n) (negsuc k) = sym $ +NegsucDistLℕ- k m (suc n)
++Assoc (negsuc m) (pos n)    (pos k)    = sym $ +PosDistLℕ- k n (suc m)
++Assoc (negsuc m) (pos n)    (negsuc k) =
+  negsuc m + n ℕ- suc k   ≡⟨ +NegsucDistRℕ- m n (suc k) ⟩
+  n ℕ- (suc m +ℕ suc k)   ≡⟨ cong (n ℕ-_ ∘ suc) (ℕ.+-suc m k) ⟩
+  n ℕ- (suc (suc m) +ℕ k) ≡⟨ sym $ +NegsucDistLℕ- k n (suc m) ⟩
+  n ℕ- suc m + negsuc k   ∎
++Assoc (negsuc m) (negsuc n) (pos k)    = +NegsucDistRℕ- m k (suc n) ∙ cong (k ℕ-_ ∘ suc) (ℕ.+-suc m n)
++Assoc (negsuc m) (negsuc n) (negsuc k) = cong (negsuc ∘ suc) $
+  m +ℕ suc (n +ℕ k)   ≡⟨ ℕ.+-suc m (n +ℕ k) ⟩
+  suc (m +ℕ (n +ℕ k)) ≡⟨ cong suc (ℕ.+-assoc m n k)  ⟩
+  suc (m +ℕ n +ℕ k)   ∎
+
++'≡+ : _+'_ ≡ _+_
++'≡+ =  P.+'≡+ ∙ (λ i x y → +≡+f x y i)
+
+isEquivAddℤ : (m : ℤ) → isEquiv (λ n → n + m)
+isEquivAddℤ = subst (λ add → (m : ℤ) → isEquiv (λ n → add n m)) +'≡+ P.isEquivAddℤ'
+
+-- below is an alternate proof of isEquivAddℤ for comparison
+-- We also have two useful lemma here.
+
+-Cancel : ∀ z → z - z ≡ 0
+-Cancel (pos zero) = refl
+-Cancel (pos (suc n)) = nℕ-n≡0 n
+-Cancel (negsuc n) = nℕ-n≡0 n
+
+-Cancel' : ∀ z → - z + z ≡ 0
+-Cancel' z = +Comm (- z) z ∙ -Cancel z
+
+minusPlus : ∀ m n → (n - m) + m ≡ n
+minusPlus m n = (sym (+Assoc n (- m) m))
+             ∙∙ cong (n +_) (-Cancel' m)
+             ∙∙ sym (+pos0 n)
+
+plusMinus : ∀ m n → (n + m) - m ≡ n
+plusMinus m n = sym (+Assoc n m (- m))
+             ∙∙ cong (n +_) (-Cancel m)
+             ∙∙ sym (+pos0 n)
+
+private
+  alternateProof : (m : ℤ) → isEquiv (λ n → n + m)
+  alternateProof m = isoToIsEquiv (iso (λ n → n + m)
+                                       (λ n → n - m)
+                                       (minusPlus m)
+                                       (plusMinus m))
+
+-≡0 : (m n : ℤ) → m - n ≡ 0 → m ≡ n
+-≡0 m n p =
+  m         ≡⟨ sym (minusPlus n m) ⟩
+  m - n + n ≡⟨ cong (_+ n) p  ⟩
+  pos 0 + n ≡⟨ sym (pos0+ n) ⟩
+  n         ∎
+
+pos+ : ∀ m n → pos (m +ℕ n) ≡ pos m + pos n
+pos+ m n = refl
+
+negsuc+ : ∀ m n → negsuc (m +ℕ n) ≡ negsuc m - pos n
+negsuc+ m zero    = cong negsuc (ℕ.+-zero m)
+negsuc+ m (suc n) = cong negsuc (ℕ.+-suc m n)
+
+neg+ : ∀ m n → neg (m +ℕ n) ≡ neg m + neg n
+neg+ zero    zero    = refl
+neg+ zero    (suc n) = refl
+neg+ (suc m) zero    = cong negsuc (ℕ.+-zero m)
+neg+ (suc m) (suc n) = cong negsuc (ℕ.+-suc m n)
+
+ℕ-AntiComm : ∀ m n → m ℕ- n ≡ -(n ℕ- m)
+ℕ-AntiComm zero    zero    = refl
+ℕ-AntiComm zero    (suc n) = refl
+ℕ-AntiComm (suc m) zero    = refl
+ℕ-AntiComm (suc m) (suc n) = ℕ-AntiComm m n
+
+pos- : ∀ m n → m ℕ- n ≡ pos m - pos n
+pos- zero    zero    = refl
+pos- (suc m) zero    = cong (pos ∘ suc) (sym (ℕ.+-zero m))
+pos- m       (suc n) = refl
+
+-AntiComm : ∀ m n → m - n ≡ - (n - m)
+-AntiComm (pos m)       (pos n)       = sym (pos- m n) ∙∙ ℕ-AntiComm m n ∙∙ cong -_ (pos- n m)
+-AntiComm (pos zero)    (negsuc n)    = refl
+-AntiComm (pos (suc m)) (negsuc n)    = cong (pos ∘ suc) (ℕ.+-comm m (suc n))
+-AntiComm (negsuc m)    (pos zero)    = refl
+-AntiComm (negsuc m)    (pos (suc n)) = cong negsuc (ℕ.+-comm (suc m) n)
+-AntiComm (negsuc m)    (negsuc n)    = ℕ-AntiComm n m
+
+-Dist+ : ∀ m n → - (m + n) ≡ (- m) + (- n)
+-Dist+ (pos zero)    (pos zero)    = refl
+-Dist+ (pos zero)    (pos (suc n)) = refl
+-Dist+ (pos (suc m)) (pos zero)    = cong negsuc (ℕ.+-zero m)
+-Dist+ (pos (suc m)) (pos (suc n)) = cong negsuc (ℕ.+-suc m n)
+-Dist+ (pos zero)    (negsuc n)    = refl
+-Dist+ (pos (suc m)) (negsuc n)    = sym (ℕ-AntiComm n m)
+-Dist+ (negsuc m)    (pos zero)    = cong (pos ∘ suc) $ sym $ ℕ.+-zero m
+-Dist+ (negsuc m)    (pos (suc n)) = sym (ℕ-AntiComm m n)
+-Dist+ (negsuc m)    (negsuc n)    = cong (pos ∘ suc) $ sym $ ℕ.+-suc m n
+
+-DistMin : ∀ m n → - min m n ≡ max (- m) (- n)
+-DistMin (pos zero)    (pos zero)    = refl
+-DistMin (pos zero)    (pos (suc n)) = refl
+-DistMin (pos (suc m)) (pos zero)    = refl
+-DistMin (pos (suc m)) (pos (suc n)) = cong (-_ ∘ pos) minSuc
+-DistMin (pos zero)    (negsuc n)    = refl
+-DistMin (pos (suc m)) (negsuc n)    = refl
+-DistMin (negsuc m)    (pos zero)    = refl
+-DistMin (negsuc m)    (pos (suc n)) = refl
+-DistMin (negsuc m)    (negsuc n)    = cong pos (sym $ ℕ.maxSuc)
+
+-DistMax : ∀ m n → - max m n ≡ min (- m ) (- n)
+-DistMax m n = sym (cong₂ (λ x y → - (max x y)) (-Involutive m) (-Involutive n))
+            ∙∙ (sym $ cong -_ (-DistMin (- m) (- n)))
+            ∙∙ -Involutive (min (- m) (- n))
+
+min- : ∀ x y → min (pos x) (- (pos y)) ≡ - (pos y)
+min- zero    zero    = refl
+min- zero    (suc y) = refl
+min- (suc x) zero    = refl
+min- (suc x) (suc y) = refl
+
+-min : ∀ x y → min (- (pos x)) (pos y) ≡ - (pos x)
+-min x y = minComm (- (pos x)) (pos y) ∙ min- y x
+
+max- : ∀ x y → max (pos x) (- (pos y)) ≡ pos x
+max- zero    zero    = refl
+max- zero    (suc y) = refl
+max- (suc x) zero    = refl
+max- (suc x) (suc y) = refl
+
+-max : ∀ x y → max (- (pos x)) (pos y) ≡ pos y
+-max x y = maxComm (- (pos x)) (pos y) ∙ max- y x
+
+inj-z+ : ∀ {z l n} → z + l ≡ z + n → l ≡ n
+inj-z+ {z} {l} {n} p =
+  l             ≡⟨ pos0+ l ⟩
+  0 + l         ≡⟨ cong (_+ l) (sym (-Cancel' z)) ⟩
+  - z + z + l   ≡⟨ sym (+Assoc (- z) z l)  ⟩
+  - z + (z + l) ≡⟨ cong (- z +_) p ⟩
+  - z + (z + n) ≡⟨ +Assoc (- z) z n ⟩
+  - z + z + n   ≡⟨ cong (_+ n) (-Cancel' z) ⟩
+  0 + n         ≡⟨ sym (pos0+ n) ⟩
+  n             ∎
+
+inj-+z : ∀ {z l n} → l + z ≡ n + z → l ≡ n
+inj-+z {z} {l} {n} p = inj-z+ {z = z} {l} {n} (+Comm z l ∙∙ p ∙∙ +Comm n z)
+
+n+z≡z→n≡0 : ∀ n z → n + z ≡ z → n ≡ 0
+n+z≡z→n≡0 n z p = inj-z+ {z = z} {l = n} {n = 0} (+Comm z n ∙∙ p ∙∙ +pos0 z)
+
+pos+posLposMin : ∀ x y → min (pos (x +ℕ y)) (pos x) ≡ pos x
+pos+posLposMin zero y = minComm (pos y) (pos zero)
+pos+posLposMin (suc x) y = cong pos minSuc ∙ cong sucℤ (pos+posLposMin x y)
+
+pos+posRposMin : ∀ x y → min (pos x) (pos (x +ℕ y)) ≡ pos x
+pos+posRposMin x y = minComm (pos x) (pos (x +ℕ y)) ∙ pos+posLposMin x y
+
+pos+posLposMax : ∀ x y → max (pos (x +ℕ y)) (pos x) ≡ pos (x +ℕ y)
+pos+posLposMax zero y = maxComm (pos y) (pos zero)
+pos+posLposMax (suc x) y = cong pos maxSuc ∙ cong sucℤ (pos+posLposMax x y)
+
+pos+posRposMax : ∀ x y → max (pos x) (pos (x +ℕ y)) ≡ pos (x +ℕ y)
+pos+posRposMax x y = maxComm (pos x) (pos (x +ℕ y)) ∙ pos+posLposMax x y
+
+negsuc+posLnegsucMin : ∀ x y → min (negsuc x + pos y) (negsuc x) ≡ negsuc x
+negsuc+posLnegsucMin zero    zero          = refl
+negsuc+posLnegsucMin zero    (suc zero)    = refl
+negsuc+posLnegsucMin zero    (suc (suc y)) = refl
+negsuc+posLnegsucMin (suc x) zero          = minIdem (negsuc (suc x))
+negsuc+posLnegsucMin (suc x) (suc y)
+  = cong (flip min _)
+         (sym $ predℤ+ (negsuc x) (pos (suc y))) ∙∙
+    sym (predDistMin (negsuc x + pos (suc y)) (negsuc x)) ∙∙
+    cong predℤ (negsuc+posLnegsucMin x (suc y))
+
+negsuc+posRnegsucMin : ∀ x y → min (negsuc x) (negsuc x + pos y) ≡ negsuc x
+negsuc+posRnegsucMin x y = minComm (negsuc x) (negsuc x + pos y) ∙ negsuc+posLnegsucMin x y
+
+negsuc+posLnegsucMax : ∀ x y → max (negsuc x + pos y) (negsuc x) ≡ negsuc x + pos y
+negsuc+posLnegsucMax zero    zero          = refl
+negsuc+posLnegsucMax zero    (suc zero)    = refl
+negsuc+posLnegsucMax zero    (suc (suc y)) = refl
+negsuc+posLnegsucMax (suc x) zero          = maxIdem (negsuc (suc x))
+negsuc+posLnegsucMax (suc x) (suc y)
+  = cong (flip max _)
+         (sym $ predℤ+ (negsuc x) (pos (suc y))) ∙
+    sym (predDistMax (negsuc x + pos (suc y)) (negsuc x)) ∙
+    cong predℤ (negsuc+posLnegsucMax x (suc y)) ∙
+    predℤ+ (negsuc x) (pos (suc y))
+
+negsuc+posRnegsucMax : ∀ x y → max (negsuc x) (negsuc x + pos y) ≡ negsuc x + pos y
+negsuc+posRnegsucMax x y = maxComm (negsuc x) (negsuc x + pos y) ∙ negsuc+posLnegsucMax x y
+
+--  the following hold definitionally:
+
+negsuc+negsucLposMin : ∀ x y z → min (negsuc x + negsuc y) (pos z) ≡ negsuc x + negsuc y
+negsuc+negsucLposMin x y z = refl
+
+negsuc+negsucRposMin : ∀ x y z → min (pos x) (negsuc y + negsuc z) ≡ negsuc y + negsuc z
+negsuc+negsucRposMin z x y = refl
+
+negsuc+negsucLposMax : ∀ x y z → max (negsuc x + negsuc y) (pos z) ≡ pos z
+negsuc+negsucLposMax x y z = refl
+
+negsuc+negsucRposMax : ∀ x y z → max (pos x) (negsuc y + negsuc z) ≡ pos x
+negsuc+negsucRposMax z x y = refl
+
+
+negsuc+negsucLnegsucMin : ∀ x y → min (negsuc x + negsuc y) (negsuc x) ≡ negsuc x + negsuc y
+negsuc+negsucLnegsucMin zero    y = refl
+negsuc+negsucLnegsucMin (suc x) y = cong negsuc maxSuc ∙ cong predℤ (negsuc+negsucLnegsucMin x y)
+
+negsuc+negsucRnegsucMin : ∀ x y → min (negsuc x) (negsuc x + negsuc y) ≡ negsuc x + negsuc y
+negsuc+negsucRnegsucMin x y = minComm (negsuc x) (negsuc x + negsuc y) ∙ negsuc+negsucLnegsucMin x y
+
+negsuc+negsucLnegsucMax : ∀ x y → max (negsuc x + negsuc y) (negsuc x) ≡ negsuc x
+negsuc+negsucLnegsucMax zero zero    = refl
+negsuc+negsucLnegsucMax zero (suc y) = refl
+negsuc+negsucLnegsucMax (suc x) zero
+  = cong (flip max (negsuc (suc x)) ∘ negsuc ∘ suc ∘ suc) (+-zero x) ∙
+    maxPredL (negsuc (suc x))
+negsuc+negsucLnegsucMax (suc x) (suc y)
+  = cong (flip max _)
+         (sym $ predℤ+ (negsuc x) (negsuc (suc y))) ∙∙
+    sym (predDistMax (negsuc x + negsuc (suc y)) (negsuc x)) ∙∙
+    cong predℤ (negsuc+negsucLnegsucMax x (suc y))
+
+negsuc+negsucRnegsucMax : ∀ x y → max (negsuc x) (negsuc x + negsuc y) ≡ negsuc x
+negsuc+negsucRnegsucMax x y = maxComm (negsuc x) (negsuc x + negsuc y) ∙ negsuc+negsucLnegsucMax x y
+
+pos+pospos+negsucMin : ∀ x y z → min (pos x + pos y) (pos x + negsuc z) ≡ pos x + negsuc z
+pos+pospos+negsucMin zero x y = refl
+pos+pospos+negsucMin (suc x) y z
+  = cong₂ min (sym (sucℤ+ (pos x) (pos y)))
+              (sym (sucℤ+ (pos x) (negsuc z))) ∙
+    sym (sucDistMin (pos x + pos y) (pos x + negsuc z)) ∙
+    cong sucℤ (pos+pospos+negsucMin x y z) ∙
+    sucℤ+ (pos x) (negsuc z)
+
+pos+pospos+negsucMax : ∀ x y z → max (pos x + pos y) (pos x + negsuc z) ≡ pos x + pos y
+pos+pospos+negsucMax zero y z = refl
+pos+pospos+negsucMax (suc x) y z
+  = cong₂ max (sym (sucℤ+ (pos x) (pos y)))
+              (sym (sucℤ+ (pos x) (negsuc z))) ∙
+    sym (sucDistMax (pos x + pos y) (pos x + negsuc z)) ∙
+    cong sucℤ (pos+pospos+negsucMax x y z) ∙ sucℤ+ (pos x) (pos y)
+
+negsuc+negsucnegsuc+posMin : ∀ x y z → min (negsuc x + negsuc y) (negsuc x + pos z)
+                           ≡ negsuc x + negsuc y
+negsuc+negsucnegsuc+posMin zero zero    zero          = refl
+negsuc+negsucnegsuc+posMin zero zero    (suc zero)    = refl
+negsuc+negsucnegsuc+posMin zero zero    (suc (suc z)) = refl
+negsuc+negsucnegsuc+posMin zero (suc y) zero          = refl
+negsuc+negsucnegsuc+posMin zero (suc y) (suc zero)    = refl
+negsuc+negsucnegsuc+posMin zero (suc y) (suc (suc z)) = refl
+negsuc+negsucnegsuc+posMin (suc x) y z
+  = cong₂ min (sym (predℤ+ (negsuc x) (negsuc y)))
+              (sym (predℤ+ (negsuc x) (pos z))) ∙
+    sym (predDistMin (negsuc x + negsuc y) (negsuc x + pos z)) ∙
+    cong predℤ (negsuc+negsucnegsuc+posMin x y z) ∙
+    predℤ+ (negsuc x) (negsuc y)
+
+negsuc+negsucnegsuc+posMax : ∀ x y z → max (negsuc x + negsuc y) (negsuc x + pos z)
+                           ≡ negsuc x + pos z
+negsuc+negsucnegsuc+posMax zero zero    zero          = refl
+negsuc+negsucnegsuc+posMax zero zero    (suc zero)    = refl
+negsuc+negsucnegsuc+posMax zero zero    (suc (suc z)) = refl
+negsuc+negsucnegsuc+posMax zero (suc y) zero          = refl
+negsuc+negsucnegsuc+posMax zero (suc y) (suc zero)    = refl
+negsuc+negsucnegsuc+posMax zero (suc y) (suc (suc z)) = refl
+negsuc+negsucnegsuc+posMax (suc x) y z
+  = cong₂ max (sym (predℤ+ (negsuc x) (negsuc y)))
+              (sym (predℤ+ (negsuc x) (pos z))) ∙
+    sym (predDistMax (negsuc x + negsuc y) (negsuc x + pos z)) ∙
+    cong predℤ (negsuc+negsucnegsuc+posMax x y z) ∙
+    predℤ+ (negsuc x) (pos z)
+
++DistRMin : ∀ x y z → x + min y z ≡ min (x + y) (x + z)
++DistRMin (pos zero) y z = +IdL _ ∙ cong₂ min (pos0+ y) (pos0+ z)
++DistRMin (pos (suc x)) (pos zero) (pos zero)
+  = +IdR _ ∙∙ sym (minIdem (pos (suc x))) ∙∙ cong₂ min (sym $ +IdR _) (sym $ +IdR _)
++DistRMin (pos (suc x)) (pos zero) (pos (suc z))
+  = +IdR _ ∙∙ sym (pos+posRposMin _ _) ∙∙ cong (flip min _) (sym $ +IdR _)
++DistRMin (pos (suc x)) (pos (suc y)) (pos zero)
+  = +IdR _ ∙∙ sym (pos+posLposMin _ _) ∙∙ cong (min _) (sym $ +IdR _)
++DistRMin (pos (suc x)) (pos (suc y)) (pos (suc z))
+  = cong ((pos (suc x) +_) ∘ pos) minSuc ∙
+    (cong pos $ +-suc _ (ℕ.min y z)) ∙
+    (cong (sucℤ ∘ sucℤ) $ +DistRMin (pos x) (pos y) (pos z)) ∙
+    sym (cong (sucℤ ∘ pos) minSuc) ∙ sym (cong pos minSuc) ∙
+    sym (cong₂ (λ p q → min (pos p) (pos q)) (+-suc (suc x) y) (+-suc (suc x) z))
++DistRMin (pos (suc x)) (pos y) (negsuc z)
+  = cong (pos (suc x) +_) (minComm (pos y) (negsuc z)) ∙
+    sym (pos+pospos+negsucMin (suc x) y z)
++DistRMin (pos (suc x)) (negsuc y) (pos z)
+  = sym (minComm _ _ ∙ pos+pospos+negsucMin (suc x) z y)
++DistRMin (pos (suc x)) (negsuc zero) (negsuc zero) = sym (minIdem _)
++DistRMin (pos (suc zero)) (negsuc zero) (negsuc (suc zero)) = refl
++DistRMin (pos (suc zero)) (negsuc zero) (negsuc (suc (suc z))) = refl
++DistRMin (pos (suc (suc x))) (negsuc zero) (negsuc (suc z))
+  = sym (pos+pospos+negsucMin (suc x) 0 z) ∙ cong (flip min _) (+IdR _)
++DistRMin (pos (suc zero)) (negsuc (suc y)) (negsuc zero) = refl
++DistRMin (pos (suc (suc x))) (negsuc (suc y)) (negsuc zero)
+  = sym (pos+pospos+negsucMin (suc x) 0 y) ∙ cong (flip min _) (+IdR _) ∙ minComm _ _
++DistRMin (pos (suc x)) (negsuc (suc y)) (negsuc (suc z))
+  = sym (sucℤ+ (pos x) (min (negsuc (suc y)) (negsuc (suc z)))) ∙
+    +sucℤ (pos x) (min (negsuc (suc y)) (negsuc (suc z))) ∙
+    cong (pos x +_) (sucDistMin (negsuc (suc y)) (negsuc (suc z))) ∙
+    +DistRMin (pos x) (negsuc y) (negsuc z)
++DistRMin (negsuc x) (pos zero) (pos zero) = sym (minIdem (negsuc x))
++DistRMin (negsuc x) (pos zero) (pos (suc z)) = sym (negsuc+posRnegsucMin x (suc z))
++DistRMin (negsuc x) (pos (suc y)) (pos zero) = sym (negsuc+posLnegsucMin x (suc y))
++DistRMin (negsuc zero) (pos (suc zero)) (pos (suc zero)) = refl
++DistRMin (negsuc zero) (pos (suc zero)) (pos (suc (suc z))) = refl
++DistRMin (negsuc zero) (pos (suc (suc y))) (pos (suc zero)) = refl
++DistRMin (negsuc zero) (pos (suc (suc y))) (pos (suc (suc z)))
+  = cong (_ℕ- 1) (minSuc {suc y} {suc z}) ∙
+    cong ((_ℕ- 1) ∘ suc) (minSuc {y} {z}) ∙ sym (cong pos minSuc)
++DistRMin (negsuc (suc x)) (pos (suc y)) (pos (suc z))
+  = cong ((negsuc (suc x) +_) ∘ pos) (minSuc {y} {z}) ∙
+    sym (+sucℤ (negsuc (suc x)) (min (pos y) (pos z))) ∙
+    cong sucℤ (+DistRMin (negsuc (suc x)) (pos y) (pos z)) ∙
+    sucDistMin (negsuc (suc x) + pos y) (negsuc (suc x) + pos z) ∙
+    cong₂ min (sucℕ-suc≡ℕ- y (suc x)) (sucℕ-suc≡ℕ- z (suc x))
++DistRMin (negsuc x) (pos y) (negsuc z)
+  = cong (negsuc x +_) (minComm (pos y) (negsuc z)) ∙
+    sym (negsuc+negsucnegsuc+posMin x z y) ∙
+    minComm (negsuc x + negsuc z) (negsuc x + pos y)
++DistRMin (negsuc x) (negsuc y) (pos z) = sym (negsuc+negsucnegsuc+posMin x y z)
++DistRMin (negsuc zero) (negsuc zero) (negsuc zero) = refl
++DistRMin (negsuc zero) (negsuc zero) (negsuc (suc z)) = refl
++DistRMin (negsuc zero) (negsuc (suc y)) (negsuc zero) = refl
++DistRMin (negsuc zero) (negsuc (suc y)) (negsuc (suc z)) = cong negsuc (sym maxSuc)
++DistRMin (negsuc (suc x)) (negsuc zero) (negsuc zero) = sym (minIdem _)
++DistRMin (negsuc (suc x)) (negsuc zero) (negsuc (suc z))
+  = cong -_ (
+    sym (pos+posRposMax ((suc ∘ suc ∘ suc) x) (suc z)) ∙
+    cong pos (maxSuc ∙ cong (suc ∘ flip ℕ.max (suc (suc (x +ℕ suc z))))
+                            (sym (+-zero _))))
++DistRMin (negsuc (suc x)) (negsuc (suc y)) (negsuc zero)
+  = cong negsuc (+-suc _ y) ∙
+    sym (cong predℤ (negsuc+negsucLnegsucMin (suc x) y)) ∙
+    predDistMin (negsuc (suc x) + negsuc y) (negsuc (suc x)) ∙
+    sym (cong₂ (λ p q → min (negsuc p) (negsuc q))
+    (+-suc _ y) (+-zero (suc (suc x))))
++DistRMin (negsuc (suc x)) (negsuc (suc y)) (negsuc (suc z))
+  = cong ((negsuc (suc x) +_) ∘ negsuc) maxSuc ∙
+    sym (+predℤ (negsuc (suc x)) (min (negsuc y) (negsuc z))) ∙
+    cong predℤ (+DistRMin (negsuc (suc x)) (negsuc y) (negsuc z)) ∙
+    predDistMin (negsuc (suc x) + negsuc y) (negsuc (suc x) + negsuc z) ∙
+    sym (cong₂ (λ p q → min (negsuc p) (negsuc q)) (+-suc _ y) (+-suc _ z))
+
++DistLMin : ∀ x y z → min x y + z ≡ min (x + z) (y + z)
++DistLMin x y z
+  = +Comm (min x y) z ∙
+    +DistRMin z x y ∙
+    cong₂ min (+Comm z x)
+              (+Comm z y)
+
++DistRMax : ∀ x y z → x + max y z ≡ max (x + y) (x + z)
++DistRMax x y z
+  = sym (-Involutive (x + max y z)) ∙
+    cong -_ (-Dist+ x (max y z) ∙
+             cong (- x +_) (-DistMax y z) ∙
+                  +DistRMin (- x) (- y) (- z)) ∙
+             -DistMin (- x - y) (- x - z) ∙
+    cong₂ max (-Dist+ (- x) (- y) ∙
+               cong₂ _+_ (-Involutive x)
+                         (-Involutive y))
+              (-Dist+ (- x) (- z) ∙
+               cong₂ _+_ (-Involutive x)
+                         (-Involutive z))
+
++DistLMax : ∀ x y z → max x y + z ≡ max (x + z) (y + z)
++DistLMax x y z
+  = +Comm (max x y) z ∙
+    +DistRMax z x y ∙
+    cong₂ max (+Comm z x)
+              (+Comm z y)
+
+pos·pos : (n m : ℕ) → pos (n ·ℕ m) ≡ pos n · pos m
+pos·pos n m = refl
+
+pos·negsuc : (n m : ℕ) → pos n · negsuc m ≡ - (pos n · pos (suc m))
+pos·negsuc zero    m = refl
+pos·negsuc (suc n) m = refl
+
+negsuc·pos : (n m : ℕ) → negsuc n · pos m ≡ - (pos (suc n) · pos m)
+negsuc·pos n zero    = cong (-_ ∘ pos) (ℕ.0≡m·0 n)
+negsuc·pos n (suc m) = refl
+
+negsuc·negsuc : (n m : ℕ) → negsuc n · negsuc m ≡ pos (suc n) · pos (suc m)
+negsuc·negsuc n m = refl
+
+negsuc·ℤ : (n : ℕ) → (m : ℤ) → negsuc n · m ≡ - (pos (suc n) · m)
+negsuc·ℤ n (pos m)    = negsuc·pos n m
+negsuc·ℤ n (negsuc m) = refl
+
+·Comm : (x y : ℤ) → x · y ≡ y · x
+·Comm (pos m)       (pos n)       = cong pos (ℕ.·-comm m n)
+·Comm (pos zero)    (negsuc n)    = refl
+·Comm (pos (suc m)) (negsuc n)    = cong neg $ ℕ.·-comm (suc m) (suc n)
+·Comm (negsuc m)    (pos zero)    = refl
+·Comm (negsuc m)    (pos (suc n)) = cong neg $ ℕ.·-comm (suc m) (suc n)
+·Comm (negsuc m)    (negsuc n)    = cong pos $ ℕ.·-comm (suc m) (suc n)
+
+·IdR : (x : ℤ) → x · 1 ≡ x
+·IdR (pos n)    = cong pos (ℕ.·-identityʳ n)
+·IdR (negsuc n) = cong negsuc (ℕ.·-identityʳ n)
+
+·IdL : (x : ℤ) → 1 · x ≡ x
+·IdL (pos n)    = cong pos (ℕ.+-zero n)
+·IdL (negsuc n) = cong negsuc (ℕ.+-zero n)
+
+·AnnihilR : (x : ℤ) → x · 0 ≡ 0
+·AnnihilR (pos n)    = cong pos $ sym $ ℕ.0≡m·0 n
+·AnnihilR (negsuc n) = refl
+
+·AnnihilL : (x : ℤ) → 0 · x ≡ 0
+·AnnihilL (pos n)    = refl
+·AnnihilL (negsuc n) = refl
+
+-1·x≡-x : ∀ x → -1 · x ≡ - x
+-1·x≡-x (pos zero)    = refl
+-1·x≡-x (pos (suc n)) = cong negsuc (+-zero n)
+-1·x≡-x (negsuc n)    = cong (pos ∘ suc) (+-zero n)
+
+private
+  distrHelper : (x y z w : ℤ) → (x + y) + (z + w) ≡ ((x + z) + (y + w))
+  distrHelper x y z w =
+      +Assoc (x + y) z w
+   ∙∙ cong (_+ w) (sym (+Assoc x y z) ∙∙ cong (x +_) (+Comm y z) ∙∙ +Assoc x z y)
+   ∙∙ sym (+Assoc (x + z) y w)
+
+ℕ-Cancel+ : ∀ m n l → (m +ℕ n) ℕ- (m +ℕ l) ≡ n ℕ- l
+ℕ-Cancel+ zero    n l = refl
+ℕ-Cancel+ (suc m) n l = ℕ-Cancel+ m n l
+
+Pos·DistRℕ- : ∀ x y z → pos x · y ℕ- z ≡ (x ·ℕ y ) ℕ- (x ·ℕ z)
+Pos·DistRℕ- zero y z = ·AnnihilL (y ℕ- z)
+Pos·DistRℕ- (suc x) zero zero =
+  pos (x ·ℕ zero)            ≡⟨ cong pos $ sym $ ℕ.0≡m·0 x ⟩
+  pos 0                      ≡⟨ cong₂ _ℕ-_ (ℕ.0≡m·0 x) (ℕ.0≡m·0 x) ⟩
+  (x ·ℕ zero) ℕ- (x ·ℕ zero) ∎
+Pos·DistRℕ- (suc x) zero    (suc z) = cong (_ℕ- (suc x ·ℕ suc z)) (ℕ.0≡m·0 x)
+Pos·DistRℕ- (suc x) (suc y) zero    = cong ((suc x ·ℕ suc y) ℕ-_) (ℕ.0≡m·0 x)
+Pos·DistRℕ- (suc x) (suc y) (suc z) =
+  pos (suc x) · (y ℕ- z)                         ≡⟨ Pos·DistRℕ- (suc x) y z ⟩
+  (suc x ·ℕ y) ℕ- (suc x ·ℕ z)                   ≡⟨ sym $ ℕ-Cancel+ (suc x) (suc x ·ℕ y) (suc x ·ℕ z) ⟩
+  (suc x +ℕ suc x ·ℕ y) ℕ- (suc x +ℕ suc x ·ℕ z) ≡⟨ sym $ cong₂ _ℕ-_ (ℕ.·-suc (suc x) y) (ℕ.·-suc (suc x) z) ⟩
+  (suc x ·ℕ suc y) ℕ- (suc x ·ℕ suc z)           ∎
+
+Negsuc·DistRℕ- : ∀ x y z → negsuc x · y ℕ- z ≡ (suc x ·ℕ suc z) ℕ- (suc x ·ℕ suc y)
+Negsuc·DistRℕ- m n l =
+  negsuc m · (suc n ℕ- suc l)                  ≡⟨ negsuc·ℤ m (n ℕ- l) ⟩
+  - (pos (suc m) · (suc n ℕ- suc l))           ≡⟨ cong -_ (Pos·DistRℕ- (suc m) (suc n) (suc l)) ⟩
+  - ((suc m ·ℕ suc n) ℕ- (suc m ·ℕ suc l))     ≡⟨ sym $ ℕ-AntiComm (suc m ·ℕ suc l) (suc m ·ℕ suc n) ⟩
+  negsuc m · pos (suc n) + negsuc m · negsuc l ∎
+
+·DistR+ : (x y z : ℤ) → x · (y + z) ≡ x · y + x · z
+·DistR+ (pos m)       (pos n)    (pos l)    = cong pos $ sym $ ℕ.·-distribˡ m n l
+·DistR+ (pos zero)    (pos n)    (negsuc l) = ·AnnihilL (n ℕ- suc l)
+·DistR+ (pos (suc m)) (pos n)    (negsuc l) = Pos·DistRℕ- (suc m) n (suc l)
+·DistR+ (pos zero)    (negsuc n) (pos l)    = ·AnnihilL (l ℕ- suc n)
+·DistR+ (pos (suc m)) (negsuc n) (pos l)    = Pos·DistRℕ- (suc m) l (suc n)
+·DistR+ (pos zero)    (negsuc n) (negsuc l) = refl
+·DistR+ (pos (suc m)) (negsuc n) (negsuc l) = cong neg $
+  suc m ·ℕ suc (suc (n +ℕ l))               ≡⟨ cong (suc m ·ℕ_) (sym (ℕ.+-suc (suc n) l)) ⟩
+  suc m ·ℕ (suc n +ℕ suc l)                 ≡⟨ sym (ℕ.·-distribˡ (suc m) (suc n) (suc l)) ⟩
+  suc m ·ℕ suc n +ℕ suc m ·ℕ suc l          ≡⟨⟩
+  suc m ·ℕ suc n +ℕ suc (l +ℕ m ·ℕ suc l)   ≡⟨ ℕ.+-suc (suc m ·ℕ suc n) (l +ℕ m ·ℕ suc l) ⟩
+  suc (suc m ·ℕ suc n) +ℕ (l +ℕ m ·ℕ suc l) ∎
+·DistR+ (negsuc m) (pos zero)    (pos zero)    = refl
+·DistR+ (negsuc m) (pos zero)    (pos (suc l)) = refl
+·DistR+ (negsuc m) (pos (suc n)) (pos zero)    = λ i → negsuc $ (ℕ.+-zero n i) +ℕ m ·ℕ suc (ℕ.+-zero n i)
+·DistR+ (negsuc m) (pos (suc n)) (pos (suc l)) = cong neg $
+  suc m ·ℕ suc (n +ℕ suc l)                      ≡⟨ (sym $ ℕ.·-distribˡ (suc m) (suc n) (suc l) ) ⟩
+  suc m ·ℕ suc n +ℕ suc m ·ℕ suc l               ≡⟨⟩
+  suc n +ℕ m ·ℕ suc n +ℕ suc (l +ℕ m ·ℕ suc l)   ≡⟨ ℕ.+-suc ((suc n) +ℕ m ·ℕ suc n) (l +ℕ m ·ℕ suc l)  ⟩
+  suc (suc n) +ℕ m ·ℕ suc n +ℕ (l +ℕ m ·ℕ suc l) ∎
+·DistR+ (negsuc m) (pos zero)    (negsuc l)    = refl
+·DistR+ (negsuc m) (pos (suc n)) (negsuc l)    = Negsuc·DistRℕ- m n l
+·DistR+ (negsuc m) (negsuc n)    (pos zero)    = cong pos $ sym $ ℕ.+-zero (suc m ·ℕ suc n)
+·DistR+ (negsuc m) (negsuc n)    (pos (suc l)) = Negsuc·DistRℕ- m l n
+·DistR+ (negsuc m) (negsuc n)    (negsuc l)    = cong pos $
+  suc m ·ℕ suc (suc (n +ℕ l))      ≡⟨ cong (suc m ·ℕ_) (sym (ℕ.+-suc (suc n) l)) ⟩
+  suc m ·ℕ (suc n +ℕ suc l)        ≡⟨ sym (ℕ.·-distribˡ (suc m) (suc n) (suc l)) ⟩
+  suc m ·ℕ suc n +ℕ suc m ·ℕ suc l ∎
+
+·DistL+ : (x y z : ℤ) → (x + y) · z ≡ x · z + y · z
+·DistL+ x y z = ·Comm (x + y) z ∙∙ ·DistR+ z x y ∙∙ cong₂ _+_ (·Comm z x) (·Comm z y)
+
+-DistL· : (b c : ℤ) → - (b · c) ≡ - b · c
+-DistL· (pos zero)    (pos n)       = refl
+-DistL· (pos (suc m)) (pos zero)    = cong (-_ ∘ pos) $ sym $ ℕ.0≡m·0 m
+-DistL· (pos (suc m)) (pos (suc n)) = refl
+-DistL· (pos zero)    (negsuc n)    = refl
+-DistL· (pos (suc m)) (negsuc n)    = refl
+-DistL· (negsuc m)    (pos zero)    = cong pos (ℕ.0≡m·0 m)
+-DistL· (negsuc m)    (pos (suc n)) = refl
+-DistL· (negsuc m)    (negsuc n)    = refl
+
+-DistR· : (b c : ℤ) → - (b · c) ≡ b · - c
+-DistR· b c = cong (-_) (·Comm b c) ∙∙ -DistL· c b ∙∙ ·Comm (- c) b
+
+-DistLR· : (b c : ℤ) → b · c ≡ - b · - c
+-DistLR· b c = sym (-Involutive (b · c)) ∙ (λ i → - -DistL· b c i) ∙ -DistR· (- b) c
+
+ℤ·negsuc : (n : ℤ) (m : ℕ) → n · negsuc m ≡ - (n · pos (suc m))
+ℤ·negsuc (pos zero)    zero    = refl
+ℤ·negsuc (pos (suc n)) zero    = refl
+ℤ·negsuc (pos zero)    (suc m) = refl
+ℤ·negsuc (pos (suc n)) (suc m) = refl
+ℤ·negsuc (negsuc n)    zero    = refl
+ℤ·negsuc (negsuc n)    (suc m) = refl
+
+private
+  neg·Assoc : ∀ m n l → negsuc m · (negsuc n · negsuc l) ≡ (negsuc m · negsuc n) · negsuc l
+  neg·Assoc m n l = cong neg (ℕ.·-assoc (suc m) (suc n) (suc l))
+  pos·Assoc : ∀ m n l → pos m · (pos n · pos l) ≡ (pos m · pos n) · pos l
+  pos·Assoc m n l = cong pos (ℕ.·-assoc m n l)
+
+·Assoc : (a b c : ℤ) → (a · (b · c)) ≡ ((a · b) · c)
+·Assoc (pos m)       (pos n)       (pos l)       = pos·Assoc m n l
+·Assoc (pos m)       (pos (zero))  (negsuc l)    =
+  pos (suc m ·ℕ 0)           ≡⟨ cong pos $ sym $ ℕ.0≡m·0 m ⟩
+  0                          ≡⟨ sym $ ·AnnihilL (negsuc l) ⟩
+  0 · negsuc l               ≡⟨ cong (_· negsuc l) (cong pos (ℕ.0≡m·0 m)) ⟩
+  pos (m ·ℕ zero) · negsuc l ∎
+·Assoc (pos zero)    (pos (suc n)) (negsuc l)    = refl
+·Assoc (pos (suc m)) (pos (suc n)) (negsuc l)    = neg·Assoc m n l
+·Assoc (pos zero)    (negsuc n)    (pos zero)    = refl
+·Assoc (pos zero)    (negsuc n)    (pos (suc l)) = refl
+·Assoc (pos (suc m)) (negsuc n)    (pos zero)    = cong pos $ sym $ ℕ.0≡m·0 m
+·Assoc (pos (suc m)) (negsuc n)    (pos (suc l)) = neg·Assoc m n l
+·Assoc (pos zero)    (negsuc n)    (negsuc l)    = refl
+·Assoc (pos (suc m)) (negsuc n)    (negsuc l)    = pos·Assoc (suc m) (suc n) (suc l)
+·Assoc (negsuc m)    (pos zero)    (pos l)       = refl
+·Assoc (negsuc m)    (pos (suc n)) (pos zero)    =
+  negsuc m · pos (n ·ℕ 0) ≡⟨ cong ((negsuc m ·_) ∘ pos) $ sym $ ℕ.0≡m·0 n ⟩
+  negsuc m · 0            ≡⟨ ·AnnihilR (negsuc m) ⟩
+  0                       ∎
+·Assoc (negsuc m)    (pos (suc n)) (pos (suc l)) = neg·Assoc m n l
+·Assoc (negsuc m)    (pos zero)    (negsuc l)    = refl
+·Assoc (negsuc m)    (pos (suc n)) (negsuc l)    = pos·Assoc (suc m) (suc n) (suc l)
+·Assoc (negsuc m)    (negsuc n)    (pos zero)    = cong pos $ ℕ.0≡m·0 (suc m ·ℕ suc n)
+·Assoc (negsuc m)    (negsuc n)    (pos (suc l)) = pos·Assoc (suc m) (suc n) (suc l)
+·Assoc (negsuc m)    (negsuc n)    (negsuc l)    = neg·Assoc m n l
+
+·suc→0 : (a : ℤ) (b : ℕ) → a · pos (suc b) ≡ 0 → a ≡ 0
+·suc→0 (pos n) b n·b≡0 = cong pos (sym (0≡n·sm→0≡n (sym (injPos (pos·pos n (suc b) ∙ n·b≡0)))))
+·suc→0 (negsuc n) b n·b≡0 = ⊥.rec (snotz
+                                     (injNeg
+                                      (cong -_ (pos·pos (suc n) (suc b)) ∙
+                                       sym (negsuc·pos n (suc b)) ∙
+                                       n·b≡0)))
+
+sucℤ≡1+ : ∀ a → sucℤ a ≡ 1 + a
+sucℤ≡1+ (pos n)          = refl
+sucℤ≡1+ (negsuc zero)    = refl
+sucℤ≡1+ (negsuc (suc n)) = refl
+
+sucℤ· : (a b : ℤ) → sucℤ a · b ≡ b + a · b
+sucℤ· a b =
+  sucℤ a · b    ≡⟨ cong (_· b) (sucℤ≡1+ a) ⟩
+  (1 + a) · b   ≡⟨ ·DistL+ 1 a b ⟩
+  1 · b + a · b ≡⟨ cong (_+ a · b) (·IdL b) ⟩
+  b + a · b     ∎
+
+·sucℤ : (a b : ℤ) → a · sucℤ b ≡ a · b + a
+·sucℤ a b = ·Comm a (sucℤ b) ∙ sucℤ· b a ∙ cong (a +_) (·Comm b a) ∙ +Comm a (a · b)
+
+predℤ≡-1 : ∀ a → predℤ a ≡ a - 1
+predℤ≡-1 (pos zero)          = refl
+predℤ≡-1 (pos (suc zero))    = refl
+predℤ≡-1 (pos (suc (suc n))) = refl
+predℤ≡-1 (negsuc n)          = cong (negsuc ∘ suc) $ sym $ ℕ.+-zero n
+
+predℤ· : (a  b : ℤ) → predℤ a · b ≡ - b + a · b
+predℤ· a b =
+  predℤ a · b       ≡⟨ cong (_· b) (predℤ≡-1 a) ⟩
+  (a - 1) · b       ≡⟨ cong (_· b) (+Comm a -1) ⟩
+  (-1 + a) · b      ≡⟨ ·DistL+ -1 a b ⟩
+  -1 · b + a · b    ≡⟨ cong (_+ a · b) (negsuc·ℤ 0 b) ⟩
+  - (1 · b) + a · b ≡⟨ cong ((_+ a · b) ∘ -_) (·IdL b) ⟩
+  - b + a · b       ∎
+
+·predℤ : ∀ a b → a · predℤ b ≡ a · b - a
+·predℤ a b = ·Comm a (predℤ b) ∙ predℤ· b a ∙ cong ((- a) +_) (·Comm b a) ∙ +Comm (- a) (a · b)
+
+·DistPosRMin : (x : ℕ) (y z : ℤ) → pos x · min y z ≡ min (pos x · y) (pos x · z)
+·DistPosRMin zero y z = ·AnnihilL _ ∙ sym (cong₂ min (·AnnihilL _) (·AnnihilL _))
+·DistPosRMin (suc x) (pos zero) (pos zero)
+  = ·AnnihilR (pos (suc x)) ∙
+    sym (cong₂ min (·AnnihilR (pos (suc x))) (·AnnihilR (pos (suc x))))
+·DistPosRMin (suc x) (pos zero) (pos (suc z))
+  = ·AnnihilR (pos (suc x)) ∙
+    sym (cong (flip min _) (·AnnihilR (pos (suc x))))
+·DistPosRMin (suc x) (pos (suc y)) (pos zero)
+  = ·AnnihilR (pos (suc x)) ∙
+    sym (cong₂ min (·Comm (pos (suc x)) (pos (suc y))) (·AnnihilR (pos (suc x))))
+·DistPosRMin (suc x) (pos (suc y)) (pos (suc z))
+  = cong (pos ∘ (suc x ·ℕ_)) minSuc ∙
+    ·sucℤ (pos (suc x)) (min (pos y) (pos z)) ∙
+    cong (_+ pos (suc x)) (·DistPosRMin (suc x) (pos y) (pos z)) ∙
+    +DistLMin (pos (suc x) · pos y) (pos (suc x) · pos z) (pos (suc x)) ∙
+    cong₂ min (sym (·sucℤ (pos (suc x)) (pos y)))
+              (sym (·sucℤ (pos (suc x)) (pos z)))
+·DistPosRMin (suc x) (pos y) (negsuc z)
+  = cong (pos (suc x) ·_) (minComm (pos y) (negsuc z)) ∙
+    sym (cong₂ min (sym (pos·pos (suc x) y))
+                   (pos·negsuc (suc x) z ∙
+                    cong -_ (sym (pos·pos (suc x) (suc z)))) ∙
+         min- (suc x ·ℕ y) (suc x ·ℕ suc z) ∙
+         cong -_ (pos·pos (suc x) (suc z)) ∙
+         sym (pos·negsuc (suc x) z))
+·DistPosRMin (suc x) (negsuc y) (pos z)
+  = sym (cong₂ min (pos·negsuc (suc x) y ∙
+                    cong -_ (sym (pos·pos (suc x) (suc y))))
+                   (sym (pos·pos (suc x) z)) ∙
+         -min (suc x ·ℕ suc y) (suc x ·ℕ z) ∙
+         cong -_ (pos·pos (suc x) (suc y)) ∙
+         sym (pos·negsuc (suc x) y))
+·DistPosRMin (suc x) (negsuc zero) (negsuc zero)
+  = sym (minIdem (pos (suc x) · negsuc zero))
+·DistPosRMin (suc x) (negsuc zero) (negsuc (suc z))
+  = ·Comm (pos (suc x)) (negsuc (suc z)) ∙
+    cong negsuc (+-suc x _) ∙
+    sym (negsuc+negsucRnegsucMin x (x +ℕ z ·ℕ suc x)) ∙
+    sym (cong₂ min (cong negsuc (·-identityʳ x))
+                   (·Comm (pos (suc x)) (negsuc (suc z)) ∙
+                     cong negsuc (+-suc x _)))
+·DistPosRMin (suc x) (negsuc (suc y)) (negsuc zero)
+  = ·Comm (pos (suc x)) (negsuc (suc y)) ∙
+    cong negsuc (+-suc x _) ∙
+    sym (negsuc+negsucLnegsucMin x (x +ℕ y ·ℕ suc x)) ∙
+    sym (cong₂ min (·Comm (pos (suc x)) (negsuc (suc y)) ∙ cong negsuc (+-suc x _))
+                   (cong negsuc (·-identityʳ x)))
+·DistPosRMin (suc x) (negsuc (suc y)) (negsuc (suc z))
+  = cong ((pos (suc x) ·_) ∘ negsuc) maxSuc ∙
+    ·predℤ (pos (suc x)) (min (negsuc y) (negsuc z)) ∙
+    cong (_- pos (suc x)) (·DistPosRMin (suc x) (negsuc y) (negsuc z)) ∙
+    +DistLMin (pos (suc x) · negsuc y) (pos (suc x) · negsuc z) (- pos (suc x)) ∙
+    cong₂ min (sym (·predℤ (pos (suc x)) (negsuc y)))
+              (sym (·predℤ (pos (suc x)) (negsuc z)))
+
+·DistPosLMin : (x y : ℤ) (z : ℕ) → min x y · pos z ≡ min (x · pos z) (y · pos z)
+·DistPosLMin y z x = ·Comm (min y z) (pos x) ∙
+                     ·DistPosRMin x y z ∙
+                     cong₂ min (·Comm (pos x) y)
+                               (·Comm (pos x) z)
+
+·DistPosRMax : (x : ℕ) (y z : ℤ) → pos x · max y z ≡ max (pos x · y) (pos x · z)
+·DistPosRMax x y z
+  = sym (-Involutive (pos x · max y z)) ∙
+    cong -_ (-DistR· (pos x) (max y z) ∙
+             cong (pos x ·_) (-DistMax y z) ∙
+             ·DistPosRMin x (- y) (- z)) ∙
+    -DistMin (pos x · - y) (pos x · - z) ∙
+    cong₂ max (-DistR· (pos x) (- y) ∙
+               cong (pos x ·_) (-Involutive y))
+              (-DistR· (pos x) (- z) ∙
+               cong (pos x ·_) (-Involutive z))
+
+·DistPosLMax : (x y : ℤ) (z : ℕ) → max x y · pos z ≡ max (x · pos z) (y · pos z)
+·DistPosLMax y z x = ·Comm (max y z) (pos x) ∙
+                     ·DistPosRMax x y z ∙
+                     cong₂ max (·Comm (pos x) y)
+                               (·Comm (pos x) z)
+
+·DistNegsucRMin : (x : ℕ) (y z : ℤ) → negsuc x · min y z ≡ max (negsuc x · y) (negsuc x · z)
+·DistNegsucRMin x y z
+  = -DistLR· (negsuc x) (min y z) ∙
+    cong (pos (suc x) ·_) (-DistMin y z) ∙
+    ·DistPosRMax (suc x) (- y) (- z) ∙
+    cong₂ max (sym (-DistR· (pos (suc x)) y) ∙
+               -DistL· (pos (suc x)) y)
+              (sym (-DistR· (pos (suc x)) z) ∙
+               -DistL· (pos (suc x)) z)
+
+·DistNegsucLMin : (x y : ℤ) (z : ℕ) → min x y · negsuc z ≡ max (x · negsuc z) (y · negsuc z)
+·DistNegsucLMin y z x = ·Comm (min y z) (negsuc x) ∙
+                        ·DistNegsucRMin x y z ∙
+                        cong₂ max (·Comm (negsuc x) y)
+                                  (·Comm (negsuc x) z)
+
+·DistNegsucRMax : (x : ℕ) (y z : ℤ) → negsuc x · max y z ≡ min (negsuc x · y) (negsuc x · z)
+·DistNegsucRMax x y z
+  = -DistLR· (negsuc x) (max y z) ∙
+    cong (pos (suc x) ·_) (-DistMax y z) ∙
+    ·DistPosRMin (suc x) (- y) (- z) ∙
+    cong₂ min (sym (-DistR· (pos (suc x)) y) ∙
+               -DistL· (pos (suc x)) y)
+              (sym (-DistR· (pos (suc x)) z) ∙
+               -DistL· (pos (suc x)) z)
+
+·DistNegsucLMax : (x y : ℤ) (z : ℕ) → max x y · negsuc z ≡ min (x · negsuc z) (y · negsuc z)
+·DistNegsucLMax y z x = ·Comm (max y z) (negsuc x) ∙
+                        ·DistNegsucRMax x y z ∙
+                        cong₂ min (·Comm (negsuc x) y)
+                                  (·Comm (negsuc x) z)
+
+minus≡0- : (x : ℤ) → - x ≡ (0 - x)
+minus≡0- (pos zero)    = refl
+minus≡0- (pos (suc n)) = refl
+minus≡0- (negsuc n)    = refl
+
+absPos·Pos : (m n : ℕ) → abs (pos m · pos n) ≡ abs (pos m) ·ℕ abs (pos n)
+absPos·Pos m n = refl
+
+abs· : (m n : ℤ) → abs (m · n) ≡ abs m ·ℕ abs n
+abs· (pos m)       (pos n)       = refl
+abs· (pos zero)    (negsuc n)    = refl
+abs· (pos (suc m)) (negsuc n)    = refl
+abs· (negsuc m)    (pos zero)    = 0≡m·0 m
+abs· (negsuc m)    (pos (suc n)) = refl
+abs· (negsuc m)    (negsuc n)    = refl
+
+sign·abs : ∀ m → sign m · pos (abs m) ≡ m
+sign·abs (pos zero)    = refl
+sign·abs (pos (suc n)) = cong (pos ∘ suc) (ℕ.+-zero n)
+sign·abs (negsuc n)    = cong negsuc (ℕ.+-zero n)
+
+-- ℤ is integral domain
+
+isIntegralℤPosPos : (c m : ℕ) → pos c · pos m ≡ 0 → ¬ c ≡ 0 → m ≡ 0
+isIntegralℤPosPos zero    m p c≠0 =  ⊥.rec (c≠0 refl)
+isIntegralℤPosPos (suc c) m p _   = sym $ ℕ.0≡n·sm→0≡n $ injPos $
+  pos 0               ≡⟨ sym p ⟩
+  pos (suc c) · pos m ≡⟨ ·Comm (pos (suc c)) (pos m)  ⟩
+  pos m · pos (suc c) ∎
+
+isIntegralℤ : (c m : ℤ) → c · m ≡ 0 → ¬ c ≡ 0 → m ≡ 0
+isIntegralℤ (pos zero)    (pos m)       p h = ⊥.rec (h refl)
+isIntegralℤ (pos (suc c)) (pos m)       p h = cong pos (isIntegralℤPosPos (suc c) m p ℕ.snotz)
+isIntegralℤ (pos zero)    (negsuc m)    p h = ⊥.rec (h refl)
+isIntegralℤ (pos (suc c)) (negsuc m)    p h = ⊥.rec (negsucNotpos (predℕ (suc c ·ℕ suc m)) 0 p )
+isIntegralℤ (negsuc c)    (pos zero)    p h = refl
+isIntegralℤ (negsuc c)    (pos (suc m)) p h = ⊥.rec (negsucNotpos (predℕ (suc c ·ℕ suc m)) 0 p )
+isIntegralℤ (negsuc c)    (negsuc m)    p h = ⊥.rec (ℕ.snotz (injPos p))
+
+private
+  ·lCancel-helper : (c m n : ℤ) → c · m ≡ c · n → c · (m - n) ≡ 0
+  ·lCancel-helper c m n p =
+      ·DistR+ c m (- n)
+    ∙ (λ i → c · m + -DistR· c n (~ i))
+    ∙ subst (λ a → c · m - a ≡ 0) p (-Cancel (c · m))
+
+·lCancel : (c m n : ℤ) → c · m ≡ c · n → ¬ c ≡ 0 → m ≡ n
+·lCancel c m n p h = -≡0 _ _ (isIntegralℤ c (m - n) (·lCancel-helper c m n p) h)
+
+·rCancel : (c m n : ℤ) → m · c ≡ n · c → ¬ c ≡ 0 → m ≡ n
+·rCancel c m n p h = ·lCancel c m n (·Comm c m ∙ p ∙ ·Comm n c) h
+
+-Cancel'' : ∀ z → z ≡ - z → z ≡ 0
+-Cancel'' z r = isIntegralℤ 2 z (
+    2 · z         ≡⟨ ·DistL+ 1 1 z ⟩
+    1 · z + 1 · z ≡⟨ cong₂ _+_ (·IdL z) (·IdL z) ⟩
+    z + z         ≡⟨ cong (z +_) r ⟩
+    z + - z       ≡⟨ -Cancel z ⟩
+    0             ∎)
+  λ r → ⊥.rec (snotz (injPos r))
+
+-- some lemmas about finite sums
+
+sumFinℤ0 : (n : ℕ) → sumFinℤ {n = n} (λ (x : Fin n) → 0) ≡ 0
+sumFinℤ0 n = sumFinGen0 _+_ 0 +IdR n (λ _ → 0) λ _ → refl
+
+sumFinℤHom : {n : ℕ} (f g : Fin n → ℤ)
+  → sumFinℤ {n = n} (λ x → f x + g x) ≡ sumFinℤ {n = n} f + sumFinℤ {n = n} g
+sumFinℤHom {n = n} = sumFinGenHom _+_ 0 +IdR +Comm +Assoc n

--- a/Cubical/Data/Int/Order.agda
+++ b/Cubical/Data/Int/Order.agda
@@ -10,6 +10,7 @@ open import Cubical.Data.Int.Properties as ℤ
 open import Cubical.Data.Nat as ℕ
 open import Cubical.Data.NatPlusOne.Base as ℕ₊₁
 open import Cubical.Data.Sigma
+open import Cubical.Data.Sum
 
 open import Cubical.Relation.Nullary
 
@@ -449,6 +450,18 @@ min≤ {negsuc (suc m)} {negsuc (suc n)} = pred-≤-pred (subst (_≤ negsuc m)
                            maxAssoc m n (ℤ.max o s) ∙
            cong₂ ℤ.max (≤→max m≤n) (≤→max o≤s))
           (≤max {m = ℤ.max m o} {n = ℤ.max n s})
+
+0<+ : ∀ m n → 0 < m ℤ.+ n → (0 < m) ⊎ (0 < n)
+0<+ (pos zero)    (pos zero)    = ⊥.rec ∘ isIrrefl<
+0<+ (pos zero)    (pos (suc n)) = inr ∘ subst (0 <_) (sym $ pos0+ _)
+0<+ (pos (suc m)) (pos n)       = λ _ → inl (suc-≤-suc zero-≤pos)
+0<+ (pos zero)    (negsuc n)    = ⊥.rec ∘ ¬pos≤negsuc ∘ subst (0 <_)
+                                  (sym $ pos0+ (negsuc n))
+0<+ (pos (suc m)) (negsuc n)    = λ _ → inl (suc-≤-suc zero-≤pos)
+0<+ (negsuc m)    (pos zero)    = ⊥.rec ∘ ¬pos≤negsuc
+0<+ (negsuc m)    (pos (suc n)) = λ _ → inr (suc-≤-suc zero-≤pos)
+0<+ (negsuc m)    (negsuc n)    = ⊥.rec ∘ ¬pos≤negsuc ∘ subst (0 <_)
+                                  (sym $ neg+ (suc m) (suc n))
 
 ≤Dec : ∀ m n → Dec (m ≤ n)
 ≤Dec (pos zero) (pos n) = yes zero-≤pos

--- a/Cubical/Data/Int/Properties.agda
+++ b/Cubical/Data/Int/Properties.agda
@@ -1454,6 +1454,11 @@ abs· (negsuc m) (pos n) =
   cong abs (negsuc·pos m n) ∙ abs- (pos (suc m) · pos n) ∙ absPos·Pos (suc m) n
 abs· (negsuc m) (negsuc n) = cong abs (negsuc·negsuc m n) ∙ absPos·Pos (suc m) (suc n)
 
+sign·abs : ∀ m → sign m · pos (abs m) ≡ m
+sign·abs (pos zero) = refl
+sign·abs (pos (suc n)) = refl
+sign·abs (negsuc n) = refl
+
 -- ℤ is integral domain
 
 isIntegralℤPosPos : (c m : ℕ) → pos c · pos m ≡ 0 → ¬ c ≡ 0 → m ≡ 0

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -277,6 +277,20 @@ min-≤-right {zero} {n} = zero-≤
 min-≤-right {suc m} {zero} = ≤-refl
 min-≤-right {suc m} {suc n} = subst (_≤ _) (sym minSuc) $ suc-≤-suc $ min-≤-right {m} {n}
 
+maxLUB : ∀ {x} → m ≤ x → n ≤ x → max m n ≤ x
+maxLUB {zero}  {n}     _    n≤x  = n≤x
+maxLUB {suc m} {zero}  sm≤x _    = sm≤x
+maxLUB {suc m} {suc n} sm≤x sn≤x with m <ᵇ n
+... | false = sm≤x
+... | true  = sn≤x
+
+minGLB : ∀ {x} → x ≤ m → x ≤ n → x ≤ min m n
+minGLB {zero}  {n}     x≤0 _     = x≤0
+minGLB {suc m} {zero}  _   x≤0   = x≤0
+minGLB {suc m} {suc n} x≤sm x≤sn with m <ᵇ n
+... | false = x≤sn
+... | true  = x≤sm
+
 -- Boolean order relations and their conversions to/from ≤ and <
 
 _≤ᵇ_ : ℕ → ℕ → Bool

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -23,9 +23,9 @@ private
 min : ℕ → ℕ → ℕ
 min zero m = zero
 min (suc n) zero = zero
-min (suc n) (suc m) with n <ᵇ m
-... | false = suc m
-... | true  = suc n
+min (suc n) (suc m) with n <ᵇ m UsingEq
+... | false , _ = suc m
+... | true  , _ = suc n
 
 minSuc : min (suc n) (suc m) ≡ suc (min n m)
 minSuc {zero} {zero} = refl
@@ -44,9 +44,9 @@ minComm (suc n) (suc m) = minSuc ∙∙ cong suc (minComm n m) ∙∙ sym minSuc
 max : ℕ → ℕ → ℕ
 max zero m = m
 max (suc n) zero = suc n
-max (suc n) (suc m) with n <ᵇ m
-... | false = suc n
-... | true  = suc m
+max (suc n) (suc m) with n <ᵇ m UsingEq
+... | false , _ = suc n
+... | true  , _ = suc m
 
 maxSuc : max (suc n) (suc m) ≡ suc (max n m)
 maxSuc {zero} {zero} = refl

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -506,6 +506,9 @@ infixl 0 _i0:>_UsingEqP
 
 -- Similar to `inspect`, but more convenient when `a` is not a function
 -- application, or when the applied function is not relevant
+-- Note: when defining a term with `UsingEq`, it's still possible to prove its properties
+-- using a with-abstraction without `UsingEq`, but not the other way around.
+-- See `min`/`max` and their properties in Data.Nat.Properties for examples of this.
 _UsingEq : (a : A) → singl a
 a UsingEq = isContrSingl a .fst
 

--- a/Cubical/Relation/Binary/Base.agda
+++ b/Cubical/Relation/Binary/Base.agda
@@ -45,6 +45,11 @@ compPropRel R S .snd _ _ = squash₁
 graphRel : ∀ {ℓ} {A B : Type ℓ} → (A → B) → Rel A B ℓ
 graphRel f a b = f a ≡ b
 
+data Ordering : Type where
+  LT : Ordering
+  EQ : Ordering
+  GT : Ordering
+
 module HeterogenousRelation {ℓ ℓ' : Level} {A B : Type ℓ} (R : Rel A B ℓ') where
   isUniversalRel : Type (ℓ-max ℓ ℓ')
   isUniversalRel = (a : A) (b : B) → R a b

--- a/Cubical/Relation/Binary/Order/Loset/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Int/Fast.agda
@@ -1,0 +1,40 @@
+module Cubical.Relation.Binary.Order.Loset.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.Data.Int.Fast
+open import Cubical.Data.Int.Fast.Order renaming (_<_ to _<ℤ_)
+
+open import Cubical.Relation.Binary.Order.Loset
+
+open import Cubical.Relation.Binary
+open BinaryRelation
+
+open LosetStr
+
+ℤ<Loset : Loset ℓ-zero ℓ-zero
+fst ℤ<Loset = ℤ
+_<_ (snd ℤ<Loset) = _<ℤ_
+isLoset (snd ℤ<Loset) = isLosetℤ<
+  where
+    open IsLoset
+    abstract
+      isLosetℤ< : IsLoset _<ℤ_
+      isLosetℤ< .is-set         = isSetℤ
+      isLosetℤ< .is-prop-valued = λ a b → isProp< {a} {b}
+      isLosetℤ< .is-irrefl      = λ _ → isIrrefl<
+      isLosetℤ< .is-trans       = λ a b c → isTrans< {a} {b} {c}
+      isLosetℤ< .is-asym        = λ a b a<b b<a → isIrrefl< (isTrans< {a} {b} {a} a<b b<a)
+      isLosetℤ< .is-weakly-linear a b c a<b with a ≟ c
+      ... | lt a<c = ∣ inl a<c ∣₁
+      ... | eq a≡c = ∣ inr (subst (_<ℤ b) a≡c a<b) ∣₁
+      ... | gt c<a = ∣ inr (isTrans< {c} {a} {b} c<a a<b) ∣₁
+      isLosetℤ< .is-connected a b (¬a<b , ¬b<a) with a ≟ b
+      ... | lt a<b = ⊥.rec (¬a<b a<b)
+      ... | eq a≡b = a≡b
+      ... | gt b<a = ⊥.rec (¬b<a b<a)

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Int/Fast.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Poset.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Toset
+
+open import Cubical.Relation.Binary.Order.Toset.Instances.Int.Fast
+
+ℤ≤Poset : Poset ℓ-zero ℓ-zero
+ℤ≤Poset = Toset→Poset ℤ≤Toset

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Int/Fast.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Proset.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Proset
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Int.Fast
+
+ℤ≤Proset : Proset ℓ-zero ℓ-zero
+ℤ≤Proset = Poset→Proset ℤ≤Poset

--- a/Cubical/Relation/Binary/Order/Pseudolattice.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice.agda
@@ -1,3 +1,4 @@
 module Cubical.Relation.Binary.Order.Pseudolattice where
 
 open import Cubical.Relation.Binary.Order.Pseudolattice.Base public
+open import Cubical.Relation.Binary.Order.Pseudolattice.Properties public

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Base.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Base.agda
@@ -1,6 +1,9 @@
 module Cubical.Relation.Binary.Order.Pseudolattice.Base where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.SIP
 
 open import Cubical.Relation.Binary.Base
@@ -38,6 +41,8 @@ record PseudolatticeStr (ℓ' : Level) (L : Type ℓ) : Type (ℓ-suc (ℓ-max �
     _≤_ : L → L → Type ℓ'
     is-pseudolattice : IsPseudolattice _≤_
 
+  infix 5 _≤_
+
   open IsPseudolattice is-pseudolattice public
 
 Pseudolattice : ∀ ℓ ℓ' → Type (ℓ-suc (ℓ-max ℓ ℓ'))
@@ -57,3 +62,33 @@ makeIsPseudolattice {_≤_ = _≤_} is-setL is-prop-valued is-refl is-trans is-a
     PS : IsPseudolattice _≤_
     PS .IsPseudolattice.isPoset = isposet is-setL is-prop-valued is-refl is-trans is-antisym
     PS .IsPseudolattice.isPseudolattice = is-meet-semipseudolattice , is-join-semipseudolattice
+
+module _
+  (P : Poset ℓ ℓ') (_∧_ _∨_ : ⟨ P ⟩ → ⟨ P ⟩ → ⟨ P ⟩) where
+  open PosetStr (str P) renaming (_≤_ to infix 8 _≤_)
+  module _
+    (π₁ : ∀ {a b}   → a ∧ b ≤ a)
+    (π₂ : ∀ {a b}   → a ∧ b ≤ b)
+    (ϕ  : ∀ {a b x} → x ≤ a → x ≤ b → x ≤ a ∧ b)
+    (ι₁ : ∀ {a b}   → a ≤ a ∨ b)
+    (ι₂ : ∀ {a b}   → b ≤ a ∨ b)
+    (ψ  : ∀ {a b x} → a ≤ x → b ≤ x → a ∨ b ≤ x) where
+
+    makePseudolatticeFromPoset : Pseudolattice ℓ ℓ'
+    makePseudolatticeFromPoset .fst = ⟨ P ⟩
+    makePseudolatticeFromPoset .snd .PseudolatticeStr._≤_ = (str P) .PosetStr._≤_
+    makePseudolatticeFromPoset .snd .PseudolatticeStr.is-pseudolattice = isPL where
+      isPL : IsPseudolattice _≤_
+      isPL .IsPseudolattice.isPoset = isPoset
+      isPL .IsPseudolattice.isPseudolattice .fst a b .fst = a ∧ b
+      isPL .IsPseudolattice.isPseudolattice .fst a b .snd x = propBiimpl→Equiv
+        (is-prop-valued _ _)
+        (isProp× (is-prop-valued _ _) (is-prop-valued _ _))
+        (λ x≤a∧b → is-trans _ _ _ x≤a∧b π₁ , is-trans _ _ _ x≤a∧b π₂)
+        (uncurry ϕ)
+      isPL .IsPseudolattice.isPseudolattice .snd a b .fst = a ∨ b
+      isPL .IsPseudolattice.isPseudolattice .snd a b .snd x = propBiimpl→Equiv
+        (is-prop-valued _ _)
+        (isProp× (is-prop-valued _ _) (is-prop-valued _ _))
+        (λ a∨b≤x → is-trans _ _ _ ι₁ a∨b≤x , is-trans _ _ _ ι₂ a∨b≤x)
+        (uncurry ψ)

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Int.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Int.agda
@@ -1,0 +1,18 @@
+module Cubical.Relation.Binary.Order.Pseudolattice.Instances.Int where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Int
+open import Cubical.Data.Int.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Int
+open import Cubical.Relation.Binary.Order.Pseudolattice
+
+ℤ≤Pseudolattice : Pseudolattice ℓ-zero ℓ-zero
+ℤ≤Pseudolattice = makePseudolatticeFromPoset ℤ≤Poset min max
+  min≤
+  (λ {a b} → subst (_≤ℤ b) (minComm b a) min≤)
+  (λ {a b} x≤a x≤b → subst (_≤ℤ min a b) (minIdem _) (≤MonotoneMin x≤a x≤b))
+  ≤max
+  (λ {a b} → subst (b ≤ℤ_) (maxComm b a) ≤max)
+  (λ {a b} a≤x b≤x → subst (max a b ≤ℤ_) (maxIdem _) (≤MonotoneMax a≤x b≤x))

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Int/Fast.agda
@@ -1,0 +1,18 @@
+module Cubical.Relation.Binary.Order.Pseudolattice.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Int.Fast
+open import Cubical.Data.Int.Fast.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Int.Fast
+open import Cubical.Relation.Binary.Order.Pseudolattice
+
+ℤ≤Pseudolattice : Pseudolattice ℓ-zero ℓ-zero
+ℤ≤Pseudolattice = makePseudolatticeFromPoset ℤ≤Poset min max
+  min≤
+  (λ {a b} → subst (_≤ℤ b) (minComm b a) min≤)
+  (λ {a b x} x≤a x≤b → subst (_≤ℤ min a b) (minIdem x) (≤MonotoneMin {x} x≤a x≤b))
+  ≤max
+  (λ {a b} → subst (b ≤ℤ_) (maxComm b a) ≤max)
+  (λ {a b x} a≤x b≤x → subst (max a b ≤ℤ_) (maxIdem x) (≤MonotoneMax {a} {x} {b} a≤x b≤x))

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Nat.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Nat.agda
@@ -1,0 +1,18 @@
+module Cubical.Relation.Binary.Order.Pseudolattice.Instances.Nat where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Nat
+open import Cubical.Data.Nat.Order renaming (_≤_ to _≤ℕ_)
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Nat
+open import Cubical.Relation.Binary.Order.Pseudolattice
+
+ℕ≤Pseudolattice : Pseudolattice ℓ-zero ℓ-zero
+ℕ≤Pseudolattice = makePseudolatticeFromPoset ℕ≤Poset min max
+  min-≤-left
+  (λ {a b} → min-≤-right {a} {b})
+  minGLB
+  left-≤-max
+  (λ {a b} → right-≤-max {b} {a})
+  maxLUB

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Properties.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Properties.agda
@@ -1,0 +1,93 @@
+module Cubical.Relation.Binary.Order.Pseudolattice.Properties where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Relation.Binary.Base
+open import Cubical.Relation.Binary.Order.Poset renaming (isPseudolattice to pseudolattice)
+
+open import Cubical.Relation.Binary.Order.Pseudolattice.Base
+
+open import Cubical.Algebra.Semigroup
+
+open BinaryRelation
+
+private
+  variable
+    ℓ ℓ' : Level
+
+DualPseudolattice : Pseudolattice ℓ ℓ' → Pseudolattice ℓ ℓ'
+DualPseudolattice L .fst = L .fst
+DualPseudolattice L .snd .PseudolatticeStr._≤_ = Dual (L .snd .PseudolatticeStr._≤_)
+DualPseudolattice L .snd .PseudolatticeStr.is-pseudolattice = isPL
+  where
+    open module L≤ = PseudolatticeStr (L .snd)
+    open IsPseudolattice
+    isPL : IsPseudolattice _
+    isPL .isPoset              = isPosetDual L≤.isPoset
+    isPL .isPseudolattice .fst = L≤.isPseudolattice .snd
+    isPL .isPseudolattice .snd = L≤.isPseudolattice .fst
+
+module MeetProperties (L≤ : Pseudolattice ℓ ℓ') where
+  private
+    L = L≤ .fst
+    open PseudolatticeStr (L≤ .snd)
+    variable
+      a b c x : L
+
+  isMeet∧ : ∀ {a b x} → x ≤ (a ∧l b) ≃ (x ≤ a) × (x ≤ b)
+  isMeet∧ {a} {b} {x} = isPseudolattice .fst a b .snd x
+
+  ∧≤L : (a ∧l b) ≤ a
+  ∧≤L = equivFun isMeet∧ (is-refl _) .fst
+
+  ∧≤R : (a ∧l b) ≤ b
+  ∧≤R = equivFun isMeet∧ (is-refl _) .snd
+
+  ∧GLB : ∀ {a b x} → x ≤ a → x ≤ b → x ≤ a ∧l b
+  ∧GLB {a} {b} {x} = curry (invEq isMeet∧)
+
+  isMeet→≡∧ : ∀ m
+              → (∀ {x} → x ≤ m → x ≤ a)
+              → (∀ {x} → x ≤ m → x ≤ b)
+              → (∀ {x} → x ≤ a → x ≤ b → x ≤ m)
+              → a ∧l b ≡ m
+  isMeet→≡∧ {a = a} {b = b} m l r u =
+    fst $ PathPΣ $ MeetUnique isPoset a b (isPseudolattice .fst a b) $
+    m , λ x → propBiimpl→Equiv (is-prop-valued _ _)
+                               (isProp× (is-prop-valued _ _) (is-prop-valued _ _))
+    (λ x≤m → l x≤m , r x≤m)
+    (uncurry u)
+
+  ∧Idem : a ∧l a ≡ a
+  ∧Idem = meetIdemp isPoset (isPseudolattice .fst) _
+
+  ∧Comm : a ∧l b ≡ b ∧l a
+  ∧Comm = meetComm isPoset (isPseudolattice .fst) _ _
+
+  ∧Assoc : a ∧l (b ∧l c) ≡ (a ∧l b) ∧l c
+  ∧Assoc = meetAssoc isPoset (isPseudolattice .fst) _ _ _
+
+  ≤≃∧ : (a ≤ b) ≃ (a ≡ a ∧l b)
+  ≤≃∧ = order≃meet isPoset _ _ _ λ _ → isMeet∧
+
+  ≤→∧ : a ≤ b → a ≡ a ∧l b
+  ≤→∧ {a} {b} = equivFun ≤≃∧
+
+  Pseudolattice→Semigroup∧ : Semigroup ℓ
+  Pseudolattice→Semigroup∧ .fst = L
+  Pseudolattice→Semigroup∧ .snd .SemigroupStr._·_ = _∧l_
+  Pseudolattice→Semigroup∧ .snd .SemigroupStr.isSemigroup =
+    issemigroup is-set (λ _ _ _ → ∧Assoc)
+
+open MeetProperties public
+
+module _ (L≤ : Pseudolattice ℓ ℓ') where
+  open MeetProperties (DualPseudolattice L≤) public renaming (
+      isMeet∧ to isJoin∨ ; ∧≤L to L≤∨ ; ∧≤R to R≤∨ ; ∧GLB to ∨LUB
+    ; isMeet→≡∧ to isJoin→≡∨ ; ∧Comm to ∨Comm ; ∧Idem to ∨Idem ; ∧Assoc to ∨Assoc
+    ; ≤≃∧ to ≤≃∨ ; ≤→∧ to ≤→∨ ; Pseudolattice→Semigroup∧ to Pseudolattice→Semigroup∨)

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Int/Fast.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Quoset.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Quoset
+open import Cubical.Relation.Binary.Order.StrictOrder
+
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Int.Fast
+
+ℤ<Quoset : Quoset ℓ-zero ℓ-zero
+ℤ<Quoset = StrictOrder→Quoset ℤ<StrictOrder

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Int/Fast.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.StrictOrder.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.Loset
+
+open import Cubical.Relation.Binary.Order.Loset.Instances.Int.Fast
+
+ℤ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
+ℤ<StrictOrder = Loset→StrictOrder ℤ<Loset

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Int/Fast.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Int/Fast.agda
@@ -1,0 +1,34 @@
+module Cubical.Relation.Binary.Order.Toset.Instances.Int.Fast where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Int.Fast
+open import Cubical.Data.Int.Fast.Order renaming (_≤_ to _≤ℤ_)
+
+open import Cubical.Relation.Binary.Order.Toset
+
+open import Cubical.Relation.Binary
+open BinaryRelation
+
+open TosetStr
+
+ℤ≤Toset : Toset ℓ-zero ℓ-zero
+fst ℤ≤Toset = ℤ
+_≤_ (snd ℤ≤Toset) = _≤ℤ_
+isToset (snd ℤ≤Toset) = isTosetℤ≤
+  where
+    open IsToset
+    abstract
+      isTosetℤ≤ : IsToset _≤ℤ_
+      isTosetℤ≤ .is-set         = isSetℤ
+      isTosetℤ≤ .is-prop-valued = λ a b → isProp≤ {a} {b}
+      isTosetℤ≤ .is-refl        = λ _ → isRefl≤
+      isTosetℤ≤ .is-trans       = λ a b c → isTrans≤ {a} {b} {c}
+      isTosetℤ≤ .is-antisym     = λ _ _ → isAntisym≤
+      isTosetℤ≤ .is-total a b with a ≟ b
+      ... | lt a<b = ∣ inl (<-weaken {a} {b} a<b) ∣₁
+      ... | eq a≡b = ∣ inl (subst (a ≤ℤ_) a≡b isRefl≤) ∣₁
+      ... | gt b<a = ∣ inr (<-weaken {b} {a} b<a) ∣₁


### PR DESCRIPTION
This PR introduces the `Fast` counterparts of the modules in `Cubical.Data.Int`, together with the relevant order and algebraic instances.
The code is complete and typechecks, but I'm marking it as _draft_ until a few design questions are clarified:
- **Folder organization**: currently the `Fast` modules live inside the `Int` directory, but placing a `Fast` folder directly under `Cubical.Data` is also an option, and the same question applies to the instances.  
- **Upcoming PR for fast rationals**: I plan to submit a follow-up PR implementing fast rationals. Since rationals have fewer dependencies than integers, with little effort I should be able to _replace_ the current implementation so that it uses the fast integer operations. Would such a replacement be welcome, or would you prefer a separate `Fast` namespace? In the latter case, I could also experiment with defining rational operations that prenormalize their arguments.
- **Implicit arguments in `Int.Fast.Order`**: I noticed that many properties in `Int.Fast.Order` have implicit variables that are harder for Agda to infer compared to their non-fast counterparts. Should I make these arguments explicit, or keep the signatures identical for better drop-in compatibility when switching between `Int` and `Int.Fast`?

I should also note that this PR depends on #1270, #1271, and #1272.

I would greatly appreciate the maintainers' perspectives on these points. @mortberg @felixwellen @ecavallo
                