### PR TITLE
Nix flake: pin agda version to 2.8.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,12 @@ Start by making a branch for the release. Change the following things:
 
 * If needed, Increment the `version` field in `flake.nix`.
 
+* If needed, increment the version in the url of the Agda flake input.
+
+  ```diff
+  -url = "github:agda/agda/v2.8.0";
+  +url = "github:agda/agda/v2.9.0";
+  ```
 * Update flake inputs by running `nix flake update`.
 
 * Increment the version number in the name field in the library file

--- a/flake.lock
+++ b/flake.lock
@@ -8,15 +8,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1753260234,
-        "narHash": "sha256-5b1XH3thCrnYSKIJPaz1MtnNPSYRQtd0BYE3HIoQEeg=",
+        "lastModified": 1751745194,
+        "narHash": "sha256-ysvgf0sum3eH5GwSYYv8kUbJ38x8LZ9UdUaDbVzqAQg=",
         "owner": "agda",
         "repo": "agda",
-        "rev": "93f736936ab6d695adf1cea81e6df2ff7e52ac0f",
+        "rev": "3d04bacca842729f9c0869b9287256321b5f450f",
         "type": "github"
       },
       "original": {
         "owner": "agda",
+        "ref": "v2.8.0",
         "repo": "agda",
         "type": "github"
       }
@@ -24,11 +25,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -75,11 +76,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747426788,
-        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
+        "lastModified": 1770015011,
+        "narHash": "sha256-7vUo0qWCl/rip+fzr6lcMlz9I0tN/8m7d5Bla/rS2kk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
+        "rev": "f08e6b11a5ed43637a8ac444dd44118bc7d273b9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake = false;
   };
   inputs.agda = {
-    url = "github:agda/agda";
+    url = "github:agda/agda/v2.8.0";
     inputs = {
       nixpkgs.follows = "nixpkgs";
     };


### PR DESCRIPTION
Right now, the nix flake is tracking the `master` branch of the Agda repo as of July 30, 2025. This pull request pins the used Agda version specifically to the `v2.8.0` tag instead.

The current setup actually builds Agda version `2.9.0` (at least in name), which confuses my Emacs agda-mode and makes it complain about mismatched Agda versions. I suspect that this is due to the fact that after the 2.8.0 release (on July 5) the upstream Agda team increased the version identifier on their master branch before our lock file was updated.