### PR TITLE
Proof of equality that Quo rationals are cubically equal to Rationals

### DIFF
--- a/Cubical/Data/Rationals/Base.agda
+++ b/Cubical/Data/Rationals/Base.agda
@@ -3,11 +3,12 @@ module Cubical.Data.Rationals.Base where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Nat as ℕ using (discreteℕ)
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Sigma
-open import Cubical.Data.Int
+open import Cubical.Data.Int as ℤ
 
 open import Cubical.HITs.SetQuotients as SetQuotient
   using ([_]; eq/; discreteSetQuotients) renaming (_/_ to _//_) public
@@ -25,9 +26,11 @@ open BinaryRelation
 _∼_ : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → Type₀
 (a , b) ∼ (c , d) = a · ℕ₊₁→ℤ d ≡ c · ℕ₊₁→ℤ b
 
+isProp∼ : ∀ (x y : ℤ × ℕ₊₁) → isProp (x ∼ y)
+isProp∼ x@(a , b) y@(c , d) xy xy' = isSetℤ (a ℤ.· (ℕ₊₁→ℤ d)) (c ℤ.· (ℕ₊₁→ℤ b)) xy xy'
+
 ℚ : Type₀
 ℚ = (ℤ × ℕ₊₁) // _∼_
-
 
 isSetℚ : isSet ℚ
 isSetℚ = SetQuotient.squash/
@@ -53,6 +56,12 @@ isEquivRel.transitive isEquivRel∼ (a , b) (c , d) (e , f) p q = ·rCancel _ _ 
 
 eq/⁻¹ : ∀ x y → Path ℚ [ x ] [ y ] → x ∼ y
 eq/⁻¹ = SetQuotient.effective (λ _ _ → isSetℤ _ _) isEquivRel∼
+
+path∼ : ∀ (x  y : ℤ × ℕ₊₁) → Path ℚ [ x ] [ y ] ≡ x ∼ y
+path∼ x y = isoToPath (iso (eq/⁻¹ x y) (eq/ x y)
+            (λ b → isProp∼ x y (eq/⁻¹ x y (eq/ x y b)) b)
+            (λ a → isSetℚ [ x ] [ y ]
+              (eq/ x y (eq/⁻¹ x y a)) a))
 
 discreteℚ : Discrete ℚ
 discreteℚ = discreteSetQuotients isEquivRel∼ (λ _ _ → discreteℤ _ _)

--- a/Cubical/Data/Rationals/MoreRationals/QuoQ.agda
+++ b/Cubical/Data/Rationals/MoreRationals/QuoQ.agda
@@ -3,3 +3,6 @@ module Cubical.Data.Rationals.MoreRationals.QuoQ where
 open import Cubical.Data.Rationals.MoreRationals.QuoQ.Base public
 
 open import Cubical.Data.Rationals.MoreRationals.QuoQ.Properties public
+
+open import Cubical.Data.Rationals.MoreRationals.QuoQ.Extras
+open EqualityQ public

--- a/Cubical/Data/Rationals/MoreRationals/QuoQ/Base.agda
+++ b/Cubical/Data/Rationals/MoreRationals/QuoQ/Base.agda
@@ -2,6 +2,7 @@ module Cubical.Data.Rationals.MoreRationals.QuoQ.Base where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Nat as ℕ using (discreteℕ)
 open import Cubical.Data.NatPlusOne
@@ -35,6 +36,9 @@ _∼_ : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → Type₀
 isSetℚ : isSet ℚ
 isSetℚ = SetQuotient.squash/
 
+isProp∼ : ∀ (x y : ℤ × ℕ₊₁) → isProp (x ∼ y)
+isProp∼ x@(a , b) y@(c , d) xy xy' = isSetℤ (a · ℕ₊₁→ℤ d) (c · ℕ₊₁→ℤ b) xy xy'
+
 [_/_] : ℤ → ℕ₊₁ → ℚ
 [ a / b ] = [ a , b ]
 
@@ -56,6 +60,12 @@ isEquivRel.transitive isEquivRel∼ (a , b) (c , d) (e , f) p q = ·-injʳ _ _ _
 
 eq/⁻¹ : ∀ x y → Path ℚ [ x ] [ y ] → x ∼ y
 eq/⁻¹ = SetQuotient.effective (λ _ _ → isSetℤ _ _) isEquivRel∼
+
+path∼ : ∀ (x  y : ℤ × ℕ₊₁) → Path ℚ [ x ] [ y ] ≡ x ∼ y
+path∼ x y = isoToPath (iso (eq/⁻¹ x y) (eq/ x y)
+            (λ b → isProp∼ x y (eq/⁻¹ x y (eq/ x y b)) b)
+            (λ a → isSetℚ [ x ] [ y ]
+              (eq/ x y (eq/⁻¹ x y a)) a))
 
 discreteℚ : Discrete ℚ
 discreteℚ = discreteSetQuotients isEquivRel∼ (λ _ _ → discreteℤ _ _)

--- a/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
+++ b/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
@@ -6,7 +6,7 @@ open import Cubical.Data.Int.MoreInts.QuoInt renaming (_·_ to _ℤ·_)
 open import Cubical.Data.Int as Int renaming (ℤ to Int)
 open import Cubical.Foundations.Prelude
 
-open import Cubical.HITs.SetQuotients 
+open import Cubical.HITs.SetQuotients
 
 open import Cubical.Relation.Binary.Base
 open BinaryRelation
@@ -22,7 +22,7 @@ iso/rHlp (z , n) = ∼≡-lemma (Int→ℤ (ℤ→Int z)) z n (ℤ→Int→ℤ z
 Int≡Int→ℤ·≡ℤ· : ∀ x y → x Int.· (Rationals.ℕ₊₁→ℤ y) ≡ ℤ→Int ((Int→ℤ x) ℤ· (Quo.ℕ₊₁→ℤ y))
 Int≡Int→ℤ·≡ℤ· x y = (cong₂ (λ u v → u Int.· v) (sym (Int→ℤ→Int x)) refl) ∙
                      sym (ℤ→IntIsHom· (Int→ℤ x) (Quo.ℕ₊₁→ℤ y))
-                     
+
 ∼'→R* : ∀ u v → (u Rationals∼ v) → R* {ER = Quo.isEquivRel∼}
                                 {iso/r = iso/R (λ x → ℤ→Int (fst x) , (snd x))
                                   (λ x → (Int→ℤ (fst x)) , (snd x)) λ u → iso/rHlp u} u v

--- a/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
+++ b/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
@@ -1,0 +1,44 @@
+module Cubical.Data.Rationals.MoreRationals.QuoQ.Extras where
+
+open import Cubical.Data.NatPlusOne
+open import Cubical.Data.Sigma
+open import Cubical.Data.Int.MoreInts.QuoInt renaming (_·_ to _ℤ·_)
+open import Cubical.Data.Int as Int renaming (ℤ to Int)
+open import Cubical.Foundations.Prelude
+
+open import Cubical.HITs.SetQuotients 
+
+open import Cubical.Relation.Binary.Base
+open BinaryRelation
+open import Cubical.Data.Rationals as Rationals renaming (_∼_ to _Rationals∼_)
+open import Cubical.Data.Rationals.MoreRationals.QuoQ.Base as Quo
+
+iso/rHlp : ∀ (zn : ℤ × ℕ₊₁) → (Int→ℤ (ℤ→Int (fst zn)) , snd zn) ∼ (fst zn , snd zn)
+iso/rHlp (z , n) = ∼≡-lemma (Int→ℤ (ℤ→Int z)) z n (ℤ→Int→ℤ z)
+  where
+    ∼≡-lemma : ∀ (a a' : ℤ) → (b : ℕ₊₁) → a ≡ a' → (a , b) ∼ (a' , b)
+    ∼≡-lemma a a' b aa' i = (Quo.isEquivRel∼ .isEquivRel.reflexive) ((aa' i) , b) i
+
+Int≡Int→ℤ·≡ℤ· : ∀ x y → x Int.· (Rationals.ℕ₊₁→ℤ y) ≡ ℤ→Int ((Int→ℤ x) ℤ· (Quo.ℕ₊₁→ℤ y))
+Int≡Int→ℤ·≡ℤ· x y = (cong₂ (λ u v → u Int.· v) (sym (Int→ℤ→Int x)) refl) ∙
+                     sym (ℤ→IntIsHom· (Int→ℤ x) (Quo.ℕ₊₁→ℤ y))
+                     
+∼'→R* : ∀ u v → (u Rationals∼ v) → R* {ER = Quo.isEquivRel∼}
+                                {iso/r = iso/R (λ x → ℤ→Int (fst x) , (snd x))
+                                  (λ x → (Int→ℤ (fst x)) , (snd x)) λ u → iso/rHlp u} u v
+∼'→R* (a , b) (c , d) R =
+  sym (ℤ→Int→ℤ (Int→ℤ a ℤ· Quo.ℕ₊₁→ℤ d)) ∙
+  (cong Int→ℤ (sym (Int≡Int→ℤ·≡ℤ· a d) ∙ R ∙ Int≡Int→ℤ·≡ℤ· c b)) ∙
+  ℤ→Int→ℤ (Int→ℤ c ℤ· Quo.ℕ₊₁→ℤ b)
+
+R*→∼' : ∀ u v → R* {ER = Quo.isEquivRel∼} {iso/r = iso/R (λ x → ℤ→Int (fst x) , (snd x))
+           (λ x → (Int→ℤ (fst x)) , (snd x)) λ u → iso/rHlp u} u v → (u Rationals∼ v)
+R*→∼' (a , b) (c , d) R* = Int≡Int→ℤ·≡ℤ· a d ∙ (cong ℤ→Int R*) ∙ sym (Int≡Int→ℤ·≡ℤ· c b)
+
+module EqualityQ where
+  -- Equality of Quo ℚ and Rationals ℚ
+  Quoℚ≡ℚ : Quo.ℚ ≡ Rationals.ℚ
+  Quoℚ≡ℚ = quotientEqualityLemma {ER = Quo.isEquivRel∼ }
+              {iso/r = iso/R (λ x → ℤ→Int (fst x) , (snd x))
+              (λ x → (Int→ℤ (fst x)) , (snd x)) λ a → iso/rHlp a} ∙
+                sym (A/R≡A/R' ∼'→R* R*→∼')


### PR DESCRIPTION
This proof means that many functions and definitions in Data/Rationals.agda can be transported over more easily not just to Data/Rationals/MoreRationals/QuoQ but also Data/Rationals/MoreRationals/SigmaQ, since there is already a proof of equality bewteen QuoQ and SigmaQ. And vice versa if we wish. 