### PR TITLE
[chore] remove unnecessary --safe --cubical and --no-import-sort flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,13 +39,6 @@ When preparing a PR here are some general guidelines:
 - Use `Type ℓ` for universes (so `Set ℓ` is not allowed in order to
   avoid confusion with the type of h-sets).
 
-- All files should start with
-
-  `{-# OPTIONS --safe #-}`
-
-  unless there is a good reason for it not to. The `--cubical` and
-  `--no-import-sorts` flags are added in the `cubical.agda-lib` file.
-
 - It is much easier for us to review and merge smaller and
   self-contained PRs. If a PR changes a lot of files all over the
   library then they will conflict with other PRs making it harder for

--- a/Cubical/Algebra/BooleanRing/Initial.agda
+++ b/Cubical/Algebra/BooleanRing/Initial.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Algebra.BooleanRing.Initial where
 

--- a/Cubical/Algebra/BooleanRing/Instances/Bool.agda
+++ b/Cubical/Algebra/BooleanRing/Instances/Bool.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Algebra.BooleanRing.Instances.Bool where
 

--- a/Cubical/Algebra/CommRing/Instances/Bool.agda
+++ b/Cubical/Algebra/CommRing/Instances/Bool.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Algebra.CommRing.Instances.Bool where
 

--- a/Cubical/Algebra/CommRing/Quotient/ImageQuotient.agda
+++ b/Cubical/Algebra/CommRing/Quotient/ImageQuotient.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Algebra.CommRing.Quotient.ImageQuotient where
 

--- a/Cubical/Axiom/Omniscience.agda
+++ b/Cubical/Axiom/Omniscience.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 
 module Cubical.Axiom.Omniscience where
 

--- a/Cubical/Categories/Dagger.agda
+++ b/Cubical/Categories/Dagger.agda
@@ -1,5 +1,4 @@
 -- Dagger categories
-{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Dagger where
 

--- a/Cubical/Categories/Dagger/Base.agda
+++ b/Cubical/Categories/Dagger/Base.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Dagger.Base where
 

--- a/Cubical/Categories/Instances/Posets.agda
+++ b/Cubical/Categories/Instances/Posets.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.Categories.Instances.Posets where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Categories/Monoidal/Cartesian.agda
+++ b/Cubical/Categories/Monoidal/Cartesian.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Categories.Monoidal.Cartesian where
 

--- a/Cubical/Categories/Morphism.agda
+++ b/Cubical/Categories/Morphism.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.Categories.Morphism where
 
 open import Cubical.Foundations.HLevels

--- a/Cubical/Codata/Conat/Bounded.agda
+++ b/Cubical/Codata/Conat/Bounded.agda
@@ -1,4 +1,4 @@
-{-# OPTIONS --cubical --no-import-sorts --guardedness #-}
+{-# OPTIONS --guardedness #-}
 module Cubical.Codata.Conat.Bounded where
 
 open import Cubical.Foundations.Equiv

--- a/Cubical/Data/Fin/Arithmetic.agda
+++ b/Cubical/Data/Fin/Arithmetic.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical #-}
 module Cubical.Data.Fin.Arithmetic where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/Data/Nat/Lower.agda
+++ b/Cubical/Data/Nat/Lower.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 
 module Cubical.Data.Nat.Lower where
 

--- a/Cubical/Data/Nat/Mod.agda
+++ b/Cubical/Data/Nat/Mod.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical #-}
 module Cubical.Data.Nat.Mod where
 
 open import Agda.Builtin.Nat using () renaming (

--- a/Cubical/Data/Nat/Omniscience.agda
+++ b/Cubical/Data/Nat/Omniscience.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts #-}
 
 module Cubical.Data.Nat.Omniscience where
 

--- a/Cubical/Data/W/Indexed.agda
+++ b/Cubical/Data/W/Indexed.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical #-}
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function

--- a/Cubical/Foundations/Pointed/Fiber.agda
+++ b/Cubical/Foundations/Pointed/Fiber.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.Foundations.Pointed.Fiber where
 
 open import Cubical.Data.Sigma

--- a/Cubical/HITs/AbPath.agda
+++ b/Cubical/HITs/AbPath.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.HITs.AbPath where
 
 open import Cubical.HITs.AbPath.Base public

--- a/Cubical/HITs/EilenbergMacLane1.agda
+++ b/Cubical/HITs/EilenbergMacLane1.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts  #-}
 module Cubical.HITs.EilenbergMacLane1 where
 
 open import Cubical.HITs.EilenbergMacLane1.Base public

--- a/Cubical/HITs/EilenbergMacLane1/Base.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Base.agda
@@ -10,7 +10,6 @@ between Ω EM₁ and G is in
 Cubical.Homotopy.EilenbergMacLane.Properties
 
 -}
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.HITs.EilenbergMacLane1.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/EilenbergMacLane1/Properties.agda
+++ b/Cubical/HITs/EilenbergMacLane1/Properties.agda
@@ -4,7 +4,7 @@ Eilenberg–Mac Lane type K(G, 1)
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts  --lossy-unification #-}
+{-# OPTIONS --lossy-unification #-}
 module Cubical.HITs.EilenbergMacLane1.Properties where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/GroupoidQuotients.agda
+++ b/Cubical/HITs/GroupoidQuotients.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical --no-import-sorts  #-}
 module Cubical.HITs.GroupoidQuotients where
 
 open import Cubical.HITs.GroupoidQuotients.Base public

--- a/Cubical/HITs/GroupoidQuotients/Base.agda
+++ b/Cubical/HITs/GroupoidQuotients/Base.agda
@@ -5,7 +5,6 @@ This file contains:
 - Definition of groupoid quotients
 
 -}
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.HITs.GroupoidQuotients.Base where
 
 open import Cubical.Foundations.Prelude

--- a/Cubical/HITs/GroupoidQuotients/Properties.agda
+++ b/Cubical/HITs/GroupoidQuotients/Properties.agda
@@ -4,7 +4,6 @@ Groupoid quotients:
 
 -}
 
-{-# OPTIONS --cubical --no-import-sorts #-}
 module Cubical.HITs.GroupoidQuotients.Properties where
 
 open import Cubical.HITs.GroupoidQuotients.Base

--- a/Cubical/Homotopy/Spectrum/Fiber.agda
+++ b/Cubical/Homotopy/Spectrum/Fiber.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.Homotopy.Spectrum.Fiber where
 
 open import Cubical.Data.Int

--- a/Cubical/Homotopy/Spectrum/Truncation.agda
+++ b/Cubical/Homotopy/Spectrum/Truncation.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 module Cubical.Homotopy.Spectrum.Truncation where
 
 open import Cubical.Data.Int

--- a/Cubical/Papers/Pi4S3-JournalVersion.agda
+++ b/Cubical/Papers/Pi4S3-JournalVersion.agda
@@ -10,7 +10,6 @@ the paper:
 
 -- The "--safe" flag ensures that there are no postulates or
 -- unfinished goals
-{-# OPTIONS --cubical #-}
 
 module Cubical.Papers.Pi4S3-JournalVersion where
 

--- a/Cubical/Papers/Pi4S3.agda
+++ b/Cubical/Papers/Pi4S3.agda
@@ -11,7 +11,6 @@ Formalizing π₄(S³) ≅ ℤ/2ℤ and Computing a Brunerie Number in Cubical A
 
 -- The "--safe" flag ensures that there are no postulates or
 -- unfinished goals
-{-# OPTIONS --cubical #-}
 
 module Cubical.Papers.Pi4S3 where
 

--- a/Cubical/Relation/Binary/Order/Poset/Covering.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Covering.agda
@@ -1,5 +1,4 @@
 -- The covering relation
-{-# OPTIONS --safe #-}
 
 module Cubical.Relation.Binary.Order.Poset.Covering where
 

--- a/Cubical/Relation/Binary/Order/Poset/Instances/PosetalReflection.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/PosetalReflection.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --cubical #-}
 
 -- The posetal reflection is the universal way to turn a preorder into a poset
 -- In abstract-nonsense terms, the posetal reflection exhibits Pos as a reflective subcategory of preorders.

--- a/Cubical/Relation/Binary/Order/Poset/Interval.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Interval.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --safe #-}
 
 module Cubical.Relation.Binary.Order.Poset.Interval where
 


### PR DESCRIPTION
These flags are included in the agda-lib file so they aren't needed. I also removed a related outdated comment in the CONTRIBUTING.md file.

The `--guardedness` flag is used extensively in the `Cubical/Codata` modules even though it is also included in the `agda-lib` flag, but I left those in because it says in `RELEASE.md` that this is intended to be removed from `agda-lib` eventually.