### PR TITLE
Category/Presheaf notations, univalent displayed categories, Displayed categories in BinProduct and Elements

### DIFF
--- a/Cubical/AlgebraicGeometry/ZariskiLattice/StructureSheaf.agda
+++ b/Cubical/AlgebraicGeometry/ZariskiLattice/StructureSheaf.agda
@@ -69,6 +69,7 @@ open import Cubical.Categories.Limits.RightKan
 open import Cubical.Categories.Instances.CommRings
 open import Cubical.Categories.Instances.CommAlgebras
 open import Cubical.Categories.Instances.DistLattice
+open import Cubical.Categories.Instances.FullSubcategory
 open import Cubical.Categories.Instances.Semilattice
 
 open import Cubical.Categories.DistLatticeSheaf.Diagram

--- a/Cubical/AlgebraicGeometry/ZariskiLattice/StructureSheafPullback.agda
+++ b/Cubical/AlgebraicGeometry/ZariskiLattice/StructureSheafPullback.agda
@@ -67,6 +67,7 @@ open import Cubical.Categories.Limits.Terminal
 open import Cubical.Categories.Limits.Pullback
 open import Cubical.Categories.Instances.CommAlgebras
 open import Cubical.Categories.Instances.DistLattice
+open import Cubical.Categories.Instances.FullSubcategory
 open import Cubical.Categories.Instances.Semilattice
 open import Cubical.Categories.DistLatticeSheaf.Base
 

--- a/Cubical/Categories/Category/Base.agda
+++ b/Cubical/Categories/Category/Base.agda
@@ -130,7 +130,8 @@ pathToIso-refl {C = C} {x} = JRefl (λ z _ → CatIso C x z) (idCatIso)
 eqToIso : {C : Category ℓ ℓ'} {x y : C .ob} (p : x Eq.≡ y) → CatIso C x y
 eqToIso {C = C} Eq.refl = idCatIso
 
--- eqToIso-refl would just be refl
+eqToIso-refl : {C : Category ℓ ℓ'} {x : C .ob} → eqToIso {C = C} {x} Eq.refl ≡ idCatIso
+eqToIso-refl = refl
 
 eqToMorphism : {C : Category ℓ ℓ'} {x y : C .ob} (p : x Eq.≡ y) → C [ x , y ]
 eqToMorphism {C = C} p = eqToIso {C = C} p .fst

--- a/Cubical/Categories/Category/Base.agda
+++ b/Cubical/Categories/Category/Base.agda
@@ -4,7 +4,9 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Powerset
+
 open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
 
 private
   variable
@@ -32,6 +34,14 @@ record Category ℓ ℓ' : Type (ℓ-suc (ℓ-max ℓ ℓ')) where
   ⟨_⟩⋆⟨_⟩ : {x y z : ob} {f f' : Hom[ x , y ]} {g g' : Hom[ y , z ]}
           → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
   ⟨ ≡f ⟩⋆⟨ ≡g ⟩ = cong₂ _⋆_ ≡f ≡g
+
+  ⟨_⟩⋆⟨⟩ : {x y z : ob} {f f' : Hom[ x , y ]} {g : Hom[ y , z ]}
+          → f ≡ f' → f ⋆ g ≡ f' ⋆ g
+  ⟨ ≡f ⟩⋆⟨⟩ = cong (_⋆ _) ≡f
+
+  ⟨⟩⋆⟨_⟩ : {x y z : ob} {f f : Hom[ x , y ]} {g g' : Hom[ y , z ]}
+          → g ≡ g' → f ⋆ g ≡ f ⋆ g'
+  ⟨⟩⋆⟨ ≡g ⟩ = cong (_ ⋆_) ≡g
 
   infixr 9 _⋆_
   infixr 9 _∘_
@@ -108,13 +118,22 @@ idCatIso {C = C} = C .id , isiso (C .id) (C .⋆IdL (C .id)) (C .⋆IdL (C .id))
 isSet-CatIso : {C : Category ℓ ℓ'} → ∀ x y → isSet (CatIso C x y)
 isSet-CatIso {C = C} x y = isOfHLevelΣ 2 (C .isSetHom) (λ f → isProp→isSet (isPropIsIso f))
 
-
 pathToIso : {C : Category ℓ ℓ'} {x y : C .ob} (p : x ≡ y) → CatIso C x y
 pathToIso {C = C} p = J (λ z _ → CatIso C _ z) idCatIso p
+
+pathToMorphism : {C : Category ℓ ℓ'} {x y : C .ob} (p : x ≡ y) → C [ x , y ]
+pathToMorphism {C = C} p = pathToIso {C = C} p .fst
 
 pathToIso-refl : {C : Category ℓ ℓ'} {x : C .ob} → pathToIso {C = C} {x} refl ≡ idCatIso
 pathToIso-refl {C = C} {x} = JRefl (λ z _ → CatIso C x z) (idCatIso)
 
+eqToIso : {C : Category ℓ ℓ'} {x y : C .ob} (p : x Eq.≡ y) → CatIso C x y
+eqToIso {C = C} Eq.refl = idCatIso
+
+-- eqToIso-refl would just be refl
+
+eqToMorphism : {C : Category ℓ ℓ'} {x y : C .ob} (p : x Eq.≡ y) → C [ x , y ]
+eqToMorphism {C = C} p = eqToIso {C = C} p .fst
 
 -- Univalent Categories
 record isUnivalent (C : Category ℓ ℓ') : Type (ℓ-max ℓ ℓ') where
@@ -148,21 +167,3 @@ _⋆_ (C ^op) f g      = g ⋆⟨ C ⟩ f
 ⋆IdR (C ^op)         = C .⋆IdL
 ⋆Assoc (C ^op) f g h = sym (C .⋆Assoc _ _ _)
 isSetHom (C ^op)     = C .isSetHom
-
-ΣPropCat : (C : Category ℓ ℓ') (P : ℙ (ob C)) → Category ℓ ℓ'
-ob (ΣPropCat C P) = Σ[ x ∈ ob C ] x ∈ P
-Hom[_,_] (ΣPropCat C P) x y = C [ fst x , fst y ]
-id (ΣPropCat C P) = id C
-_⋆_ (ΣPropCat C P) = _⋆_ C
-⋆IdL (ΣPropCat C P) = ⋆IdL C
-⋆IdR (ΣPropCat C P) = ⋆IdR C
-⋆Assoc (ΣPropCat C P) = ⋆Assoc C
-isSetHom (ΣPropCat C P) = isSetHom C
-
-isIsoΣPropCat : {C : Category ℓ ℓ'} {P : ℙ (ob C)}
-                {x y : ob C} (p : x ∈ P) (q : y ∈ P)
-                (f : C [ x , y ])
-              → isIso C f → isIso (ΣPropCat C P) {x , p} {y , q} f
-inv (isIsoΣPropCat p q f isIsoF) = isIsoF .inv
-sec (isIsoΣPropCat p q f isIsoF) = isIsoF .sec
-ret (isIsoΣPropCat p q f isIsoF) = isIsoF .ret

--- a/Cubical/Categories/Displayed/Base.agda
+++ b/Cubical/Categories/Displayed/Base.agda
@@ -5,7 +5,12 @@
 module Cubical.Categories.Displayed.Base where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Categories.Category.Base
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Reflection.RecordEquiv
+open import Cubical.Categories.Category.Base renaming (isIso to isCatIso)
 
 private
   variable
@@ -50,22 +55,48 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   open Category C
   open Categoryᴰ Cᴰ
 
-  record isIsoᴰ {a b : ob} {f : C [ a , b ]} (f-isIso : isIso C f)
+  record isIsoᴰ {a b : ob} {f : C [ a , b ]} (f-isIso : isCatIso C f)
     {aᴰ : ob[ a ]} {bᴰ : ob[ b ]} (fᴰ : Hom[ f ][ aᴰ , bᴰ ])
     : Type ℓCᴰ'
     where
     constructor isisoᴰ
-    open isIso f-isIso
+    open isCatIso f-isIso
     field
       invᴰ : Hom[ inv ][ bᴰ , aᴰ ]
       secᴰ : invᴰ ⋆ᴰ fᴰ ≡[ sec ] idᴰ
       retᴰ : fᴰ ⋆ᴰ invᴰ ≡[ ret ] idᴰ
 
+  unquoteDecl isIsoᴰIsoΣ = declareRecordIsoΣ isIsoᴰIsoΣ (quote isIsoᴰ)
+
   CatIsoᴰ : {a b : ob} → CatIso C a b → ob[ a ] → ob[ b ] → Type ℓCᴰ'
   CatIsoᴰ (f , f-isIso) aᴰ bᴰ = Σ[ fᴰ ∈ Hom[ f ][ aᴰ , bᴰ ] ] isIsoᴰ f-isIso fᴰ
 
+  isSetCatIsoᴰ : ∀ {a b : ob} {f : CatIso C a b} {aᴰ : ob[ a ]} {bᴰ : ob[ b ]}
+    → isSet (CatIsoᴰ f aᴰ bᴰ)
+  isSetCatIsoᴰ = isSetΣ isSetHomᴰ (λ fᴰ →
+    isSetRetract (isIsoᴰIsoΣ .Iso.fun) (isIsoᴰIsoΣ .Iso.inv) (isIsoᴰIsoΣ .Iso.ret)
+    (isSetΣSndProp isSetHomᴰ (λ fᴰ⁻ →
+    isProp× (isOfHLevelPathP' 1 isSetHomᴰ _ _)
+            (isOfHLevelPathP' 1 isSetHomᴰ _ _))))
+
+  CatIsoⱽ : {a : ob} → ob[ a ] → ob[ a ] → Type ℓCᴰ'
+  CatIsoⱽ = CatIsoᴰ idCatIso
+
   idᴰCatIsoᴰ : {x : ob} {xᴰ : ob[ x ]} → CatIsoᴰ idCatIso xᴰ xᴰ
   idᴰCatIsoᴰ = idᴰ , isisoᴰ idᴰ (⋆IdLᴰ idᴰ) (⋆IdLᴰ idᴰ)
+
+  pathToIsoᴰ : ∀ {x y : ob} {xᴰ : ob[ x ]}{yᴰ : ob[ y ]}
+    → (p : x ≡ y)
+    → (pᴰ : PathP (λ i → ob[ p i ]) xᴰ yᴰ)
+    → CatIsoᴰ (pathToIso p) xᴰ yᴰ
+  pathToIsoᴰ {x} {y} {xᴰ} {yᴰ} p pᴰ = transport Type≡ idᴰCatIsoᴰ
+    where
+    Type≡ : CatIsoᴰ idCatIso xᴰ xᴰ ≡ CatIsoᴰ (pathToIso p) xᴰ yᴰ
+    Type≡ i = CatIsoᴰ (transp (λ j → CatIso C x (p (i ∧ j))) (~ i) idCatIso) xᴰ (pᴰ i)
+
+  isUnivalentᴰ : Type (ℓ-max (ℓ-max ℓC ℓCᴰ) ℓCᴰ')
+  isUnivalentᴰ = ∀ x y (xᴰ : ob[ x ]) (yᴰ : ob[ y ])
+    → isEquivOver {Q = λ f → CatIsoᴰ f xᴰ yᴰ}{f = pathToIso {C = C}} pathToIsoᴰ
 
 module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   open Category

--- a/Cubical/Categories/Displayed/Functor.agda
+++ b/Cubical/Categories/Displayed/Functor.agda
@@ -9,7 +9,8 @@ open import Cubical.Foundations.Function
 open import Cubical.Foundations.GroupoidLaws
 open import Cubical.Foundations.HLevels
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Functor.Properties
 
 open import Cubical.Categories.Displayed.Base
 
@@ -38,6 +39,10 @@ record Functorᴰ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
       {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]} {zᴰ : Cᴰ.ob[ z ]}
       (fᴰ : Cᴰ [ f ][ xᴰ , yᴰ ]) (gᴰ : Cᴰ [ g ][ yᴰ , zᴰ ])
       → F-homᴰ (fᴰ Cᴰ.⋆ᴰ gᴰ) Dᴰ.≡[ F-seq f g ] F-homᴰ fᴰ Dᴰ.⋆ᴰ F-homᴰ gᴰ
+
+Functorⱽ : {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') (Dᴰ : Categoryᴰ C ℓDᴰ ℓDᴰ')
+  → Type _
+Functorⱽ = Functorᴰ Id
 
 module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F G : Functor C D} {H : F ≡ G}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}

--- a/Cubical/Categories/Displayed/HLevels.agda
+++ b/Cubical/Categories/Displayed/HLevels.agda
@@ -5,9 +5,10 @@ module Cubical.Categories.Displayed.HLevels where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
@@ -33,6 +34,17 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   hasPropHoms =
     ∀ {c c' : C .ob}(f : C [ c , c' ])(cᴰ : Cᴰ.ob[ c ])(cᴰ' : Cᴰ.ob[ c' ])
       → isProp Cᴰ.Hom[ f ][ cᴰ , cᴰ' ]
+
+  hasPropHoms→isPropCatIsoᴰ : hasPropHoms
+    → ∀ {c}{c'}{f : CatIso C c c'}{cᴰ : Cᴰ.ob[ c ]}{cᴰ' : Cᴰ.ob[ c' ]}
+    → isProp (CatIsoᴰ Cᴰ f cᴰ cᴰ')
+  hasPropHoms→isPropCatIsoᴰ propHoms {c} {c'} {f} {cᴰ} {cᴰ'} =
+    isPropΣ (propHoms (f .fst) cᴰ cᴰ') (λ _ →
+    isPropRetract
+      (isIsoᴰIsoΣ Cᴰ .Iso.fun) (isIsoᴰIsoΣ Cᴰ .Iso.inv) (isIsoᴰIsoΣ Cᴰ .Iso.ret)
+      (isPropΣ (propHoms (f .snd .isIso.inv) cᴰ' cᴰ) (λ _ → isProp×
+        (isOfHLevelPathP' 1 Cᴰ.isSetHomᴰ _ _)
+        (isOfHLevelPathP' 1 Cᴰ.isSetHomᴰ _ _))))
 
   hasContrHoms→hasPropHoms : hasContrHoms → hasPropHoms
   hasContrHoms→hasPropHoms contrHoms =

--- a/Cubical/Categories/Displayed/Instances/Element.agda
+++ b/Cubical/Categories/Displayed/Instances/Element.agda
@@ -1,0 +1,89 @@
+module Cubical.Categories.Displayed.Instances.Element where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Instances.BinProduct as BP
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation.Base
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory.Base as TotalCat
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.StructureOver.Base
+open import Cubical.Categories.Displayed.HLevels
+
+private
+  variable
+    ℓ ℓC ℓC' ℓD ℓD' ℓP ℓQ ℓS : Level
+
+open Category
+open StructureOver
+open Functor
+open Functorᴰ
+open Iso
+
+module _ {C : Category ℓC ℓC'} (P : Presheaf C ℓP) where
+  open StructureOver
+  private
+    module P = PresheafNotation P
+  ElementStr : StructureOver C _ _
+  ElementStr .ob[_] = P.p[_]
+  ElementStr .Hom[_][_,_] f p q = (f P.⋆ q) ≡ p
+  ElementStr .idᴰ = P.⋆IdL _
+  ElementStr ._⋆ᴰ_ fy≡x gz≡y = P.⋆Assoc _ _ _ ∙∙ cong (_ P.⋆_) gz≡y ∙∙ fy≡x
+  ElementStr .isPropHomᴰ = P.isSetPsh _ _
+
+  Element : Categoryᴰ C ℓP ℓP
+  Element = StructureOver→Catᴰ ElementStr
+
+  hasPropHomsElement : hasPropHoms Element
+  hasPropHomsElement = hasPropHomsStructureOver ElementStr
+
+  open Categoryᴰ
+  isUnivalentᴰElement : isUnivalentᴰ Element
+  isUnivalentᴰElement x y px py x≡y = propBiimpl→isEquiv
+    (isOfHLevelPathP' 1 P.isSetPsh _ _)
+    (hasPropHoms→isPropCatIsoᴰ Element hasPropHomsElement)
+    (isoᴰ→PathP x≡y py)
+    where
+    isoᴰ→PathP-motive : ∀ y → (x ≡ y) → Type _
+    isoᴰ→PathP-motive y x≡y = ∀ (py : P.p[ y ])
+      → CatIsoᴰ Element (pathToIso x≡y) px py → PathP (λ i → ob[ Element ] (x≡y i)) px py
+
+    isoᴰ→PathP : ∀ {y} (x≡y : x ≡ y) → isoᴰ→PathP-motive y x≡y
+    isoᴰ→PathP = J isoᴰ→PathP-motive λ px' px≅px' →
+      px
+        ≡⟨ (sym $ P.⋆IdL _) ⟩
+      C .id P.⋆ px
+        ≡⟨ P.⟨ sym $ transportRefl (C .id) ⟩⋆⟨⟩ ⟩
+      transport (λ i → C [ x , x ]) (C .id) P.⋆ px
+        ≡⟨ px≅px' .snd .isIsoᴰ.invᴰ ⟩
+      px' ∎
+
+module _ {C : Category ℓC ℓC'} {P Q : Presheaf C ℓP} where
+  open StructureOver
+  open NatTrans
+  private
+    module P = PresheafNotation P
+    module Q = PresheafNotation Q
+
+  ElementF : NatTrans P Q → Functorⱽ (Element P) (Element Q)
+  ElementF α = mkPropHomsFunctor (hasPropHomsElement Q)
+    (α .N-ob _)
+    λ {f = f}{p}{p'} fp'≡p →
+      f Q.⋆ (α .N-ob _ p')
+        ≡[ i ]⟨ α .N-hom f (~ i) p' ⟩
+      α .N-ob _ (f P.⋆ p')
+        ≡[ i ]⟨ α .N-ob _ (fp'≡p i) ⟩
+      α .N-ob _ p ∎

--- a/Cubical/Categories/Displayed/Instances/PropertyOver.agda
+++ b/Cubical/Categories/Displayed/Instances/PropertyOver.agda
@@ -6,7 +6,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category renaming (isIso to isIsoC)
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.HLevels

--- a/Cubical/Categories/Displayed/Instances/StructureOver/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/StructureOver/Base.agda
@@ -7,7 +7,7 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.HLevels

--- a/Cubical/Categories/Displayed/Instances/Weaken/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/Weaken/Base.agda
@@ -1,7 +1,8 @@
 {-
-  Weaken a category to be a displayed category.
+  Weaken a category to be a displayed over an arbitrary other category.
+
+  The total category of this is the ordinary product of categories.
 -}
---
 module Cubical.Categories.Displayed.Instances.Weaken.Base where
 
 open import Cubical.Foundations.Prelude
@@ -9,8 +10,7 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
-open import Cubical.Categories.Instances.BinProduct
+open import Cubical.Categories.Functor.Base
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Section.Base
@@ -42,9 +42,6 @@ module _ (C : Category ℓC ℓC') (D : Category ℓD ℓD') where
   weakenΠ .F-hom = snd
   weakenΠ .F-id = refl
   weakenΠ .F-seq _ _ = refl
-
-  ∫weaken→×C : Functor (∫C weaken) (C ×C D)
-  ∫weaken→×C = TC.Fst ,F weakenΠ
 
 module _ {C : Category ℓC ℓC'}
          {D : Category ℓD ℓD'}

--- a/Cubical/Categories/DistLatticeSheaf/Base.agda
+++ b/Cubical/Categories/DistLatticeSheaf/Base.agda
@@ -24,6 +24,7 @@ open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Limits.Pullback
 open import Cubical.Categories.Limits.Terminal
 open import Cubical.Categories.Limits.Limits
+open import Cubical.Categories.Instances.FullSubcategory
 open import Cubical.Categories.Instances.Poset
 open import Cubical.Categories.Instances.Semilattice
 open import Cubical.Categories.Instances.Lattice

--- a/Cubical/Categories/DistLatticeSheaf/ComparisonLemma.agda
+++ b/Cubical/Categories/DistLatticeSheaf/ComparisonLemma.agda
@@ -45,6 +45,7 @@ open import Cubical.Categories.Limits.Limits
 open import Cubical.Categories.Limits.Pullback
 open import Cubical.Categories.Limits.Terminal
 open import Cubical.Categories.Limits.RightKan
+open import Cubical.Categories.Instances.FullSubcategory
 open import Cubical.Categories.Instances.Poset
 open import Cubical.Categories.Instances.Semilattice
 open import Cubical.Categories.Instances.Lattice

--- a/Cubical/Categories/DistLatticeSheaf/Extension.agda
+++ b/Cubical/Categories/DistLatticeSheaf/Extension.agda
@@ -43,6 +43,7 @@ open import Cubical.Categories.Instances.Poset
 open import Cubical.Categories.Instances.Semilattice
 open import Cubical.Categories.Instances.Lattice
 open import Cubical.Categories.Instances.DistLattice
+open import Cubical.Categories.Instances.FullSubcategory
 
 open import Cubical.Categories.DistLatticeSheaf.Diagram
 open import Cubical.Categories.DistLatticeSheaf.Base

--- a/Cubical/Categories/Equivalence/Properties.agda
+++ b/Cubical/Categories/Equivalence/Properties.agda
@@ -165,36 +165,3 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
     w .invFunc = w-inv
     w .η = pathToNatIso w-η-path
     w .ε = pathToNatIso w-ε-path
-
-
-
--- equivalence on full subcategories defined by propositions
-module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (invF : WeakInverse F) where
-
-  open NatTrans
-  open _≃ᶜ_
-
-  private
-    F⁻¹ = invF .invFunc
-    ηᴱ = invF .η
-    εᴱ = invF .ε
-
-
-  ΣPropCatEquiv : {P : ℙ (ob C)} {Q : ℙ (ob D)}
-                → (presF : ∀ c → c ∈ P → F .F-ob c ∈ Q)
-                → (∀ d → d ∈ Q → F⁻¹ .F-ob d ∈ P)
-                → WeakInverse (ΣPropCatFunc {P = P} {Q = Q} F presF)
-
-  invFunc (ΣPropCatEquiv {P} {Q} _ presF⁻¹) = ΣPropCatFunc {P = Q} {Q = P} F⁻¹ presF⁻¹
-
-  N-ob (trans (η (ΣPropCatEquiv _ _))) (x , _) = ηᴱ .trans .N-ob x
-  N-hom (trans (η (ΣPropCatEquiv _ _))) f = ηᴱ .trans .N-hom f
-  inv (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .inv
-  sec (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .sec
-  ret (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .ret
-
-  N-ob (trans (ε (ΣPropCatEquiv _ _))) (x , _) = εᴱ .trans .N-ob x
-  N-hom (trans (ε (ΣPropCatEquiv _ _))) f = εᴱ .trans .N-hom f
-  inv (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .inv
-  sec (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .sec
-  ret (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .ret

--- a/Cubical/Categories/Functor/Base.agda
+++ b/Cubical/Categories/Functor/Base.agda
@@ -120,12 +120,6 @@ _⟪_⟫ = F-hom
 Id : {C : Category ℓ ℓ'} → Functor C C
 Id = 𝟙⟨ _ ⟩
 
-forgetΣPropCat : (C : Category ℓ ℓ') (prop : ℙ (C .ob)) → Functor (ΣPropCat C prop) C
-forgetΣPropCat _ _ .F-ob x    = x .fst
-forgetΣPropCat _ _ .F-hom f   = f
-forgetΣPropCat _ _ .F-id      = refl
-forgetΣPropCat _ _ .F-seq _ _ = refl
-
 -- functor composition
 funcComp : ∀ (G : Functor D E) (F : Functor C D) → Functor C E
 (funcComp G F) .F-ob c    = G ⟅ F ⟅ c ⟆ ⟆
@@ -176,12 +170,3 @@ Iso^opF .ret F = Functor≡ (λ _ → refl) (λ _ → refl)
 
 ^opFEquiv : Functor C D ≃ Functor (C ^op) (D ^op)
 ^opFEquiv = isoToEquiv Iso^opF
-
--- Functoriality on full subcategories defined by propositions
-ΣPropCatFunc : {P : ℙ (ob C)} {Q : ℙ (ob D)} (F : Functor C D)
-             → (∀ c → c ∈ P → F .F-ob c ∈ Q)
-             → Functor (ΣPropCat C P) (ΣPropCat D Q)
-F-ob (ΣPropCatFunc F FPres) (c , c∈P) = F .F-ob c , FPres c c∈P
-F-hom (ΣPropCatFunc F FPres) = F .F-hom
-F-id (ΣPropCatFunc F FPres) = F .F-id
-F-seq (ΣPropCatFunc F FPres) = F .F-seq

--- a/Cubical/Categories/Functor/Equality.agda
+++ b/Cubical/Categories/Functor/Equality.agda
@@ -8,7 +8,7 @@ module Cubical.Categories.Functor.Equality where
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 import      Cubical.Data.Equality as Eq
 
 private

--- a/Cubical/Categories/Instances/BinProduct.agda
+++ b/Cubical/Categories/Instances/BinProduct.agda
@@ -9,24 +9,20 @@ open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Functors.Constant
 
+open import Cubical.Categories.Instances.TotalCategory.Base
+open import Cubical.Categories.Displayed.Instances.Weaken.Base
+
 private
   variable
     ℓA ℓA' ℓB ℓB' ℓC ℓC' ℓD ℓD' ℓE ℓE' : Level
-
 
 open Category
 
 _×C_ : (C : Category ℓC ℓC') → (D : Category ℓD ℓD')
     → Category (ℓ-max ℓC ℓD) (ℓ-max ℓC' ℓD')
+C ×C D = ∫C (weaken C D)
 
-(C ×C D) .ob = (ob C) × (ob D)
-(C ×C D) .Hom[_,_] (c , d) (c' , d') = (C [ c , c' ]) × (D [ d , d' ])
-(C ×C D) .id = (id C , id D)
-(C ×C D) ._⋆_ _ _ = (_ ⋆⟨ C ⟩ _ , _ ⋆⟨ D ⟩ _)
-(C ×C D) .⋆IdL _ = ≡-× (⋆IdL C _) (⋆IdL D _)
-(C ×C D) .⋆IdR _ = ≡-× (⋆IdR C _) (⋆IdR D _)
-(C ×C D) .⋆Assoc _ _ _ = ≡-× (⋆Assoc C _ _ _) (⋆Assoc D _ _ _)
-(C ×C D) .isSetHom = isSet× (isSetHom C) (isSetHom D)
+{-# DISPLAY ∫C (weaken C D) = C ×C D #-}
 
 infixr 5 _×C_
 

--- a/Cubical/Categories/Instances/CommAlgebras.agda
+++ b/Cubical/Categories/Instances/CommAlgebras.agda
@@ -24,6 +24,7 @@ open import Cubical.Categories.Limits.Pullback
 open import Cubical.Categories.Limits.Limits
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.CommRings
+open import Cubical.Categories.Instances.FullSubcategory
 
 open import Cubical.HITs.PropositionalTruncation
 
@@ -534,9 +535,9 @@ module PreSheafFromUniversalProp (C : Category ℓ ℓ') (P : ob C → Type ℓ)
          where
 
  private
-  ∥P∥ : ℙ (ob C)
-  ∥P∥ x  = ∥ P x ∥₁ , isPropPropTrunc
-  ΣC∥P∥Cat = ΣPropCat C ∥P∥
+  ∥P∥ : (ob C) → Type _
+  ∥P∥ x  = ∥ P x ∥₁
+  ΣC∥P∥Cat = FullSubcategory C ∥P∥
   CommAlgCat = CommAlgebrasCategory {ℓ = ℓ''} R {ℓ' = ℓ''}
 
  𝓕UniqueEquiv : (x : ob C) (p q : P x) → isContr (CommAlgebraEquiv (𝓕 (x , p)) (𝓕 (x , q)))

--- a/Cubical/Categories/Instances/Elements.agda
+++ b/Cubical/Categories/Instances/Elements.agda
@@ -11,93 +11,57 @@ open import Cubical.Data.Sigma
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Opposite
 open import Cubical.Categories.Isomorphism
+open import Cubical.Categories.Instances.TotalCategory as TotalCategory
+open import Cubical.Categories.Displayed.Instances.Element
 
 open Category
 open Functor
 
-module Covariant {ℓ ℓ'} {C : Category ℓ ℓ'} where
-
-  open Category C
-
-  private
-    getIsSet : ∀ {ℓS} (F : Functor C (SET ℓS)) → (c : C .ob) → isSet (fst (F ⟅ c ⟆))
-    getIsSet F c = snd (F ⟅ c ⟆)
-
-  Element : ∀ {ℓS} (F : Functor C (SET ℓS)) → Type (ℓ-max ℓ ℓS)
-  Element F = Σ[ c ∈ C .ob ] fst (F ⟅ c ⟆)
-
-  infix 50 ∫_
-
-  ∫_ : ∀ {ℓS} → Functor C (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
-  -- objects are (c , x) pairs where c ∈ C and x ∈ F c
-  (∫ F) .ob = Element F
-  -- morphisms are f : c → c' which take x to x'
-  (∫ F) .Hom[_,_] (c , x) (c' , x') = fiber (λ (f : C [ c , c' ]) → F .F-hom f x) x'
-  (∫ F) .id     .fst = id C
-  (∫ F) .id {x} .snd = funExt⁻ (F .F-id) (x .snd)
-  (∫ F) ._⋆_ (f , p) (g , q) .fst = f ⋆⟨ C ⟩ g
-  (∫ F) ._⋆_ (f , p) (g , q) .snd = funExt⁻ (F .F-seq _ _) _ ∙∙ cong (F ⟪ g ⟫) p ∙∙ q
-  (∫ F) .⋆IdL _ = Σ≡Prop (λ _ → getIsSet F _ _ _) (⋆IdL C _)
-  (∫ F) .⋆IdR _ = Σ≡Prop (λ _ → getIsSet F _ _ _) (⋆IdR C _)
-  (∫ F) .⋆Assoc _ _ _ = Σ≡Prop (λ _ → getIsSet F _ _ _) (⋆Assoc C _ _ _)
-  (∫ F) .isSetHom {x} {y} = isSetΣSndProp (C .isSetHom) λ _ → (F ⟅ fst y ⟆) .snd _ _
-
-  ElementHom≡ : ∀ {ℓS} (F : Functor C (SET ℓS)) → {x y : Element F}
-              → {f g : (∫ F) [ x , y ]} → fst f ≡ fst g → f ≡ g
-  ElementHom≡ F = Σ≡Prop (λ _ → getIsSet F _ _ _)
-
-  ForgetElements : ∀ {ℓS} → (F : Functor C (SET ℓS)) → Functor (∫ F) C
-  F-ob (ForgetElements F) = fst
-  F-hom (ForgetElements F) = fst
-  F-id (ForgetElements F) = refl
-  F-seq (ForgetElements F) _ _ = refl
-
-  module _ (isUnivC : isUnivalent C) {ℓS} (F : Functor C (SET ℓS)) where
-    open isUnivalent
-    isUnivalent∫ : isUnivalent (∫ F)
-    isUnivalent∫ .univ (c , f) (c' , f') = isIsoToIsEquiv
-      ( isoToPath∫
-      , (λ f≅f' → CatIso≡ _ _
-          (Σ≡Prop (λ _ → (F ⟅ _ ⟆) .snd _ _)
-            (cong fst
-            (secEq (univEquiv isUnivC _ _) (F-Iso {F = ForgetElements F} f≅f')))))
-      , λ f≡f' → ΣSquareSet (λ x → snd (F ⟅ x ⟆))
-        ( cong (CatIsoToPath isUnivC) (F-pathToIso {F = ForgetElements F} f≡f')
-        ∙ retEq (univEquiv isUnivC _ _) (cong fst f≡f'))) where
-
-      isoToPath∫ : ∀ {c c' f f'}
-                 → CatIso (∫ F) (c , f) (c' , f')
-                 → (c , f) ≡ (c' , f')
-      isoToPath∫ {f = f} f≅f' = ΣPathP
-        ( CatIsoToPath isUnivC (F-Iso {F = ForgetElements F} f≅f')
-        , toPathP ( (λ j → transport (λ i → fst
-                    (F-isoToPath isUnivC isUnivalentSET F
-                      (F-Iso {F = ForgetElements F} f≅f') (~ j) i)) f)
-                  ∙ univSetβ (F-Iso {F = F ∘F ForgetElements F} f≅f') f
-                  ∙ f≅f' .fst .snd))
-
 module Contravariant {ℓ ℓ'} {C : Category ℓ ℓ'} where
-  open Covariant {C = C ^op}
-
   -- same thing but for presheaves
-  ∫ᴾ_ : ∀ {ℓS} → Functor (C ^op) (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
-  ∫ᴾ F = (∫ F) ^op
-
-  Elementᴾ : ∀ {ℓS} → Functor (C ^op) (SET ℓS) → Type (ℓ-max ℓ ℓS)
-  Elementᴾ F = (∫ᴾ F) .ob
+  infix 50 ∫_
+  ∫_ : ∀ {ℓS} → Functor (C ^op) (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
+  ∫ P = ∫C (Element P)
 
   -- helpful results
-
   module _ {ℓS} {F : Functor (C ^op) (SET ℓS)} where
+    isUnivalent∫ : isUnivalent C → isUnivalent (∫ F)
+    isUnivalent∫ univC = isUnivalent∫C (Element F) univC (isUnivalentᴰElement F)
 
+  module _ {ℓS} (F : Functor (C ^op) (SET ℓS)) where
     -- morphisms are equal as long as the morphisms in C are equal
-    ∫ᴾhomEq : ∀ {o1 o1' o2 o2'} (f : (∫ᴾ F) [ o1 , o2 ]) (g : (∫ᴾ F) [ o1' , o2' ])
+    ElementHomPathP : ∀ {o1 o1' o2 o2'} (f : (∫ F) [ o1 , o2 ]) (g : (∫ F) [ o1' , o2' ])
             → (p : o1 ≡ o1') (q : o2 ≡ o2')
             → (eqInC : PathP (λ i → C [ fst (p i) , fst (q i) ]) (fst f) (fst g))
-            → PathP (λ i → (∫ᴾ F) [ p i , q i ]) f g
-    ∫ᴾhomEq _ _ _ _ = ΣPathPProp (λ f → snd (F ⟅ _ ⟆) _ _)
+            → PathP (λ i → (∫ F) [ p i , q i ]) f g
+    ElementHomPathP _ _ _ _ = ΣPathPProp (λ f → snd (F ⟅ _ ⟆) _ _)
 
-    ∫ᴾhomEqSimpl : ∀ {o1 o2} (f g : (∫ᴾ F) [ o1 , o2 ])
+    ElementHom≡ : ∀ {o1 o2} {f g : (∫ F) [ o1 , o2 ]}
                  → fst f ≡ fst g → f ≡ g
-    ∫ᴾhomEqSimpl f g p = ∫ᴾhomEq f g refl refl p
+    ElementHom≡ p = ElementHomPathP _ _ refl refl p
+
+module Covariant {ℓ ℓ'} {C : Category ℓ ℓ'} where
+  ∫_ : ∀ {ℓS} → Functor C (SET ℓS) → Category (ℓ-max ℓ ℓS) (ℓ-max ℓ' ℓS)
+  ∫ P = (Contravariant.∫_ {C = C ^op} (P ∘F fromOpOp)) ^op
+
+  ForgetElements : ∀ {ℓS} → (F : Functor C (SET ℓS)) → Functor (∫ F) C
+  ForgetElements F = fromOpOp ∘F (TotalCategory.Fst ^opF)
+
+  module _ {ℓS} {F : Functor C (SET ℓS)} where
+    isUnivalent∫ : (isUnivC : isUnivalent C) → isUnivalent (∫ F)
+    isUnivalent∫ isUnivC = isUnivalentOp (isUnivalent∫C (Element (F ∘F fromOpOp)) (isUnivalentOp isUnivC) (isUnivalentᴰElement (F ∘F fromOpOp)))
+
+  module _ {ℓS} (F : Functor C (SET ℓS)) where
+    -- morphisms are equal as long as the morphisms in C are equal
+    ElementHomPathP : ∀ {o1 o1' o2 o2'} (f : (∫ F) [ o1 , o2 ]) (g : (∫ F) [ o1' , o2' ])
+            → (p : o1 ≡ o1') (q : o2 ≡ o2')
+            → (eqInC : PathP (λ i → C [ fst (p i) , fst (q i) ]) (fst f) (fst g))
+            → PathP (λ i → (∫ F) [ p i , q i ]) f g
+    ElementHomPathP _ _ _ _ = ΣPathPProp (λ f → snd (F ⟅ _ ⟆) _ _)
+
+    ElementHom≡ : ∀ {o1 o2} {f g : (∫ F) [ o1 , o2 ]}
+                 → fst f ≡ fst g → f ≡ g
+    ElementHom≡ p = ElementHomPathP _ _ refl refl p
+

--- a/Cubical/Categories/Instances/Elements/Properties.agda
+++ b/Cubical/Categories/Instances/Elements/Properties.agda
@@ -1,3 +1,4 @@
+module Cubical.Categories.Instances.Elements.Properties where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
@@ -11,13 +12,15 @@ open NatTrans
 open import Cubical.Categories.Instances.Functors
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.Elements
+open import Cubical.Categories.Instances.TotalCategory
 open Covariant
 
 open import Cubical.WildCat.Functor
 open import Cubical.WildCat.Instances.Categories
 open import Cubical.WildCat.Instances.NonWild
 
-module Cubical.Categories.Instances.Elements.Properties where
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Element
 
 variable
   ℓC ℓC' ℓD ℓD' ℓS : Level
@@ -25,16 +28,11 @@ variable
   D : Category ℓD ℓD'
 
 ∫-hom : ∀ {F G : Functor C (SET ℓS)} → NatTrans F G → Functor (∫ F) (∫ G)
-Functor.F-ob (∫-hom ν) (c , f) = c , N-ob ν c f
-Functor.F-hom (∫-hom ν) {c1 , f1} {c2 , f2} (χ , ef) = χ , sym (funExt⁻ (N-hom ν χ) f1) ∙ cong (N-ob ν c2) ef
-Functor.F-id (∫-hom {G = G} ν) {c , f} = ElementHom≡ G refl
-Functor.F-seq (∫-hom {G = G} ν) {c1 , f1} {c2 , f2} {c3 , f3} (χ12 , ef12) (χ23 , ef23) =
-  ElementHom≡ G refl
+∫-hom {F = F}{G = G} α = ∫F {F = Id} (ElementF {P = F ∘F fromOpOp}{Q = G ∘F fromOpOp}
+  (α ∘ˡ fromOpOp)) ^opF
 
 ∫-id : ∀ (F : Functor C (SET ℓS)) → ∫-hom (idTrans F) ≡ Id
-∫-id F = Functor≡
-  (λ _ → refl)
-  λ {(c1 , f1)} {(c2 , f2)} (χ , ef) → ElementHom≡ F refl
+∫-id F = Functor≡ (λ _ → refl) λ f → ElementHom≡ F refl
 
 ∫-seq : ∀ {C : Category ℓC ℓC'} {F G H : Functor C (SET ℓS)} → (μ : NatTrans F G) → (ν : NatTrans G H)
   → ∫-hom (seqTrans μ ν) ≡ funcComp (∫-hom ν) (∫-hom μ)
@@ -43,7 +41,6 @@ Functor.F-seq (∫-hom {G = G} ν) {c1 , f1} {c2 , f2} {c3 , f3} (χ12 , ef12) (
   λ {(c1 , f1)} {(c2 , f2)} (χ , ef) → ElementHom≡ H refl
 
 module _ (C : Category ℓC ℓC') (ℓS : Level) where
-
   ElementsWildFunctor : WildFunctor (AsWildCat (FUNCTOR C (SET ℓS))) (CatWildCat (ℓ-max ℓC ℓS) (ℓ-max ℓC' ℓS))
   WildFunctor.F-ob ElementsWildFunctor = ∫_
   WildFunctor.F-hom ElementsWildFunctor = ∫-hom

--- a/Cubical/Categories/Instances/FullSubcategory.agda
+++ b/Cubical/Categories/Instances/FullSubcategory.agda
@@ -1,22 +1,27 @@
-module Cubical.Categories.Instances.FullSubcategory where
 -- Full subcategory (not necessarily injective on objects)
+module Cubical.Categories.Instances.FullSubcategory where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Equiv.Properties
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Powerset
 
 open import Cubical.Functions.Embedding
 open import Cubical.Data.Sigma
 
-open import Cubical.Categories.Category
+open import Cubical.Categories.Category renaming (isIso to isCatIso)
 open import Cubical.Categories.Isomorphism
 open import Cubical.Categories.Functor renaming (𝟙⟨_⟩ to funcId)
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Equivalence.Base
 
 private
   variable
     ℓC ℓC' ℓD ℓD' ℓE ℓE' ℓP ℓQ ℓR : Level
+
+open isCatIso
 
 module _ (C : Category ℓC ℓC') (P : Category.ob C → Type ℓP) where
   private
@@ -44,8 +49,6 @@ module _ (C : Category ℓC ℓC') (P : Category.ob C → Type ℓP) where
   isFullyFaithfulIncl _ _ = idEquiv _ .snd
 
   module _ (x y : FullSubcategory .ob) where
-
-    open isIso
 
     Incl-Iso = F-Iso {F = FullInclusion} {x = x} {y = y}
 
@@ -158,3 +161,56 @@ module _
   isUnivalentFullSub isUnivC .univ _ _ = isEquiv[equivFunA≃B∘f]→isEquiv[f] _ (Incl-Iso≃ C P _ _)
     (subst isEquiv (sym (F-pathToIso-∘ {F = FullInclusion C P}))
       (compEquiv (_ , isEmbdIncl-ob _ _) (_ , isUnivC .univ _ _) .snd))
+
+open Functor
+ΣPropCat : (C : Category ℓC ℓC') (P : ℙ (ob C)) → Category ℓC ℓC'
+ΣPropCat C P = FullSubcategory C (_∈ P)
+
+forgetΣPropCat : (C : Category ℓC ℓC') (prop : ℙ (C .ob)) → Functor (ΣPropCat C prop) C
+forgetΣPropCat C prop = FullInclusion C _
+
+-- Functoriality on full subcategories defined by propositions
+ΣPropCatFunc : {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
+               {P : ℙ (ob C)} {Q : ℙ (ob D)} (F : Functor C D)
+             → (∀ c → c ∈ P → F .F-ob c ∈ Q)
+             → Functor (ΣPropCat C P) (ΣPropCat D Q)
+ΣPropCatFunc = MapFullSubcategory _ _ _ _
+
+-- equivalence on full subcategories defined by propositions
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D) (invF : WeakInverse F) where
+  open NatTrans
+  open NatIso
+  open WeakInverse
+  open _≃ᶜ_
+
+  private
+    F⁻¹ = invF .invFunc
+    ηᴱ = invF .η
+    εᴱ = invF .ε
+
+  ΣPropCatEquiv : {P : ℙ (ob C)} {Q : ℙ (ob D)}
+                → (presF : ∀ c → c ∈ P → F .F-ob c ∈ Q)
+                → (∀ d → d ∈ Q → F⁻¹ .F-ob d ∈ P)
+                → WeakInverse (ΣPropCatFunc {P = P} {Q = Q} F presF)
+
+  invFunc (ΣPropCatEquiv {P} {Q} _ presF⁻¹) = ΣPropCatFunc {P = Q} {Q = P} F⁻¹ presF⁻¹
+
+  N-ob (trans (η (ΣPropCatEquiv _ _))) (x , _) = ηᴱ .trans .N-ob x
+  N-hom (trans (η (ΣPropCatEquiv _ _))) f = ηᴱ .trans .N-hom f
+  inv (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .inv
+  sec (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .sec
+  ret (nIso (η (ΣPropCatEquiv _ _)) (x , _)) = ηᴱ .nIso x .ret
+
+  N-ob (trans (ε (ΣPropCatEquiv _ _))) (x , _) = εᴱ .trans .N-ob x
+  N-hom (trans (ε (ΣPropCatEquiv _ _))) f = εᴱ .trans .N-hom f
+  inv (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .inv
+  sec (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .sec
+  ret (nIso (ε (ΣPropCatEquiv _ _)) (x , _)) = εᴱ .nIso x .ret
+
+isIsoΣPropCat : {C : Category ℓC ℓC'} {P : ℙ (ob C)}
+                {x y : ob C} (p : x ∈ P) (q : y ∈ P)
+                (f : C [ x , y ])
+              → isCatIso C f → isCatIso (ΣPropCat C P) {x , p} {y , q} f
+inv (isIsoΣPropCat p q f isIsoF) = isIsoF .inv
+sec (isIsoΣPropCat p q f isIsoF) = isIsoF .sec
+ret (isIsoΣPropCat p q f isIsoF) = isIsoF .ret

--- a/Cubical/Categories/Instances/Slice/Properties.agda
+++ b/Cubical/Categories/Instances/Slice/Properties.agda
@@ -28,13 +28,13 @@ open _≃ᶜ_
 open Functor
 open WeakInverse
 
-slice→el : Functor (SliceCat C c) (∫ᴾ (C [-, c ]))
+slice→el : Functor (SliceCat C c) (∫ (C [-, c ]))
 slice→el .F-ob s = s .S-ob , s .S-arr
 slice→el .F-hom f = f .S-hom , f .S-comm
 slice→el .F-id = ΣPathP (refl , (isOfHLevelPath' 1 (C .isSetHom) _ _ _ _))
 slice→el .F-seq _ _ = ΣPathP (refl , (isOfHLevelPath' 1 (C .isSetHom) _ _ _ _))
 
-el→slice : Functor (∫ᴾ (C [-, c ])) (SliceCat C c)
+el→slice : Functor (∫ (C [-, c ])) (SliceCat C c)
 el→slice .F-ob (_ , s) = sliceob s
 el→slice .F-hom (f , comm) = slicehom f comm
 el→slice .F-id = SliceHom-≡-intro C c refl (isOfHLevelPath' 1 (C .isSetHom) _ _ _ _)
@@ -43,7 +43,7 @@ el→slice .F-seq _ _ = SliceHom-≡-intro C c refl (isOfHLevelPath' 1 (C .isSet
 open NatTrans
 open NatIso
 
-sliceIsElementsOfRep : SliceCat C c ≃ᶜ (∫ᴾ (C [-, c ]))
+sliceIsElementsOfRep : SliceCat C c ≃ᶜ (∫ (C [-, c ]))
 sliceIsElementsOfRep .func = slice→el
 sliceIsElementsOfRep .isEquiv  = ∣ w-inv ∣₁
   where
@@ -52,12 +52,8 @@ sliceIsElementsOfRep .isEquiv  = ∣ w-inv ∣₁
     w-inv .η .trans .N-ob s = SliceCat C c .id
     w-inv .η .trans .N-hom f = (SliceCat C c .⋆IdR f)
                              ∙ sym (SliceCat C c .⋆IdL f)
-    w-inv .η .nIso x = isiso (SliceCat C c .id)
-                             (SliceCat C c .⋆IdR _)
-                             (SliceCat C c .⋆IdR _)
-    w-inv .ε .trans .N-ob s = (∫ᴾ (C [-, c ])) .id
-    w-inv .ε .trans .N-hom f = ((∫ᴾ (C [-, c ])) .⋆IdR f)
-                             ∙ sym ((∫ᴾ (C [-, c ])) .⋆IdL f)
-    w-inv .ε .nIso x = isiso ((∫ᴾ (C [-, c ])) .id)
-                             ((∫ᴾ (C [-, c ])) .⋆IdR _)
-                             ((∫ᴾ (C [-, c ])) .⋆IdR _)
+    w-inv .η .nIso x = idCatIso {C = (SliceCat C c)} .snd
+    w-inv .ε .trans .N-ob x = (∫ (C [-, c ])) .id
+    w-inv .ε .trans .N-hom f = ((∫ (C [-, c ])) .⋆IdR f)
+                             ∙ sym ((∫ (C [-, c ])) .⋆IdL f)
+    w-inv .ε .nIso x = idCatIso {C = ∫ (C [-, c ])} .snd

--- a/Cubical/Categories/Instances/SubObject.agda
+++ b/Cubical/Categories/Instances/SubObject.agda
@@ -7,7 +7,8 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.FullSubcategory
 open import Cubical.Categories.Morphism
 
 open import Cubical.Relation.Binary.Order.Proset

--- a/Cubical/Categories/Instances/Terminal.agda
+++ b/Cubical/Categories/Instances/Terminal.agda
@@ -5,7 +5,7 @@ open import Cubical.Foundations.Function
 open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Instances.Discrete
 
 module Cubical.Categories.Instances.Terminal where

--- a/Cubical/Categories/Instances/TotalCategory/Base.agda
+++ b/Cubical/Categories/Instances/TotalCategory/Base.agda
@@ -1,12 +1,16 @@
 module Cubical.Categories.Instances.TotalCategory.Base where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
 
 open import Cubical.Data.Sigma
+open import Cubical.Reflection.StrictEquiv
 
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 
@@ -31,6 +35,57 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   ∫C .⋆IdR _ = ΣPathP (_ , ⋆IdRᴰ _)
   ∫C .⋆Assoc _ _ _ = ΣPathP (_ , ⋆Assocᴰ _ _ _)
   ∫C .isSetHom = isSetΣ C.isSetHom (λ _ → isSetHomᴰ)
+
+
+  ∫CatIso : ∀ {x y}{xᴰ yᴰ}
+    (f : CatIso C x y) (fᴰ : CatIsoᴰ Cᴰ f xᴰ yᴰ)
+    → CatIso ∫C (x , xᴰ) (y , yᴰ)
+  ∫CatIso f fᴰ .fst = f .fst , fᴰ .fst
+  ∫CatIso f fᴰ .snd .isIso.inv = f .snd .isIso.inv , fᴰ .snd .isIsoᴰ.invᴰ
+  ∫CatIso f fᴰ .snd .isIso.sec = ΣPathP (f .snd .isIso.sec , fᴰ .snd .isIsoᴰ.secᴰ)
+  ∫CatIso f fᴰ .snd .isIso.ret = ΣPathP (f .snd .isIso.ret , fᴰ .snd .isIsoᴰ.retᴰ)
+
+  ∫CatIso⁻ : ∀ {x y}{xᴰ yᴰ}
+    → CatIso ∫C (x , xᴰ) (y , yᴰ)
+    → Σ[ f ∈ CatIso C x y ] CatIsoᴰ Cᴰ f xᴰ yᴰ
+  ∫CatIso⁻ ∫f .fst .fst = ∫f .fst .fst
+  ∫CatIso⁻ ∫f .fst .snd .isIso.inv = ∫f .snd .isIso.inv .fst
+  ∫CatIso⁻ ∫f .fst .snd .isIso.sec = PathPΣ (∫f .snd .isIso.sec) .fst
+  ∫CatIso⁻ ∫f .fst .snd .isIso.ret = PathPΣ (∫f .snd .isIso.ret) .fst
+  ∫CatIso⁻ ∫f .snd .fst = ∫f .fst .snd
+  ∫CatIso⁻ ∫f .snd .snd .isIsoᴰ.invᴰ = ∫f .snd .isIso.inv .snd
+  ∫CatIso⁻ ∫f .snd .snd .isIsoᴰ.secᴰ = PathPΣ (∫f .snd .isIso.sec) .snd
+  ∫CatIso⁻ ∫f .snd .snd .isIsoᴰ.retᴰ = PathPΣ (∫f .snd .isIso.ret) .snd
+
+  ∫CatIso-Iso : ∀ {x y}{xᴰ yᴰ}
+    → Iso (Σ[ f ∈ CatIso C x y ] CatIsoᴰ Cᴰ f xᴰ yᴰ)
+          (CatIso ∫C (x , xᴰ) (y , yᴰ))
+  ∫CatIso-Iso .Iso.fun = uncurry ∫CatIso
+  ∫CatIso-Iso .Iso.inv = ∫CatIso⁻
+  ∫CatIso-Iso .Iso.sec = λ _ → refl
+  ∫CatIso-Iso .Iso.ret = λ _ → refl
+
+  module _ {x y}{xᴰ}{yᴰ} where
+    unquoteDecl ∫CatIso-Equiv = declStrictIsoToEquiv ∫CatIso-Equiv (∫CatIso-Iso {x = x}{y = y}{xᴰ = xᴰ}{yᴰ = yᴰ})
+
+  isUnivalent∫C : isUnivalent C → isUnivalentᴰ Cᴰ → isUnivalent ∫C
+  isUnivalent∫C univC univCᴰ .isUnivalent.univ (x , xᴰ) (y , yᴰ) =
+    subst isEquiv fix-up (equiv∫ .snd) where
+    equivΣ : (Σ[ p ∈ x ≡ y ] (PathP (λ i → ob[ p i ]) xᴰ yᴰ))
+           ≃ (Σ[ f ∈ CatIso C x y ] (CatIsoᴰ Cᴰ f xᴰ yᴰ))
+    equivΣ = Σ-cong-equiv
+      (pathToIso , univC .isUnivalent.univ x y)
+      (λ p → pathToIsoᴰ Cᴰ p , univCᴰ x y xᴰ yᴰ p)
+
+    equiv∫ : ((x , xᴰ) ≡ (y , yᴰ)) ≃ CatIso ∫C (x , xᴰ) (y , yᴰ)
+    equiv∫ = compEquiv (invEquiv ΣPath≃PathΣ)
+      (compEquiv equivΣ ∫CatIso-Equiv)
+
+    -- Is it possible to define equiv∫ compositionally in a way
+    -- that makes this refl on proofs?
+    fix-up : equiv∫ .fst ≡ pathToIso
+    fix-up = funExt (λ xxᴰ≡yyᴰ →
+      CatIso≡ (equiv∫ .fst xxᴰ≡yyᴰ) (pathToIso xxᴰ≡yyᴰ) refl)
 
 -- Total functor of a displayed functor
 module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}

--- a/Cubical/Categories/Instances/TotalCategory/Properties.agda
+++ b/Cubical/Categories/Instances/TotalCategory/Properties.agda
@@ -6,7 +6,7 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
-open import Cubical.Categories.Functor
+open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Section.Base

--- a/Cubical/Categories/Presheaf/Base.agda
+++ b/Cubical/Categories/Presheaf/Base.agda
@@ -1,6 +1,7 @@
 module Cubical.Categories.Presheaf.Base where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor.Base
@@ -10,6 +11,8 @@ open import Cubical.Categories.Instances.Sets
 private
   variable
     ℓ ℓ' ℓS : Level
+
+open Functor
 
 Presheaf : Category ℓ ℓ' → (ℓS : Level) → Type (ℓ-max (ℓ-max ℓ ℓ') (ℓ-suc ℓS))
 Presheaf C ℓS = Functor (C ^op) (SET ℓS)
@@ -23,24 +26,58 @@ isUnivalentPresheafCategory : {C : Category ℓ ℓ'}
                             → isUnivalent (PresheafCategory C ℓS)
 isUnivalentPresheafCategory = isUnivalentFUNCTOR _ _ isUnivalentSET
 
-open Category
-open Functor
+module _ where
+  open Category
 
-action : {C : Category ℓ ℓ'} → (P : Presheaf C ℓS)
-       → {a b : C .ob} → C [ a , b ] → fst (P ⟅ b ⟆) → fst (P ⟅ a ⟆)
-action P = P .F-hom
+  action : {C : Category ℓ ℓ'} → (P : Presheaf C ℓS)
+         → {a b : C .ob} → C [ a , b ] → fst (P ⟅ b ⟆) → fst (P ⟅ a ⟆)
+  action P = P .F-hom
 
--- Convenient notation for naturality
-syntax action P f ϕ = ϕ ∘ᴾ⟨ P ⟩ f
+  -- Convenient notation for naturality
+  syntax action P f ϕ = ϕ ∘ᴾ⟨ P ⟩ f
 
-∘ᴾId : ∀ (C : Category ℓ ℓ') → (P : Presheaf C ℓS) → {a : C .ob}
-     → (ϕ : fst (P ⟅ a ⟆))
-     → ϕ ∘ᴾ⟨ P ⟩ C .id ≡ ϕ
-∘ᴾId C P ϕ i = P .F-id i ϕ
+  ∘ᴾId : ∀ (C : Category ℓ ℓ') → (P : Presheaf C ℓS) → {a : C .ob}
+       → (ϕ : fst (P ⟅ a ⟆))
+       → ϕ ∘ᴾ⟨ P ⟩ C .id ≡ ϕ
+  ∘ᴾId C P ϕ i = P .F-id i ϕ
 
-∘ᴾAssoc : ∀ (C : Category ℓ ℓ') → (P : Presheaf C ℓS) → {a b c : C .ob}
-        → (ϕ : fst (P ⟅ c ⟆))
-        → (f : C [ b , c ])
-        → (g : C [ a , b ])
-        → ϕ ∘ᴾ⟨ P ⟩ (f ∘⟨ C ⟩ g) ≡ (ϕ ∘ᴾ⟨ P ⟩ f) ∘ᴾ⟨ P ⟩ g
-∘ᴾAssoc C P ϕ f g i = P .F-seq f g i ϕ
+  ∘ᴾAssoc : ∀ (C : Category ℓ ℓ') → (P : Presheaf C ℓS) → {a b c : C .ob}
+          → (ϕ : fst (P ⟅ c ⟆))
+          → (f : C [ b , c ])
+          → (g : C [ a , b ])
+          → ϕ ∘ᴾ⟨ P ⟩ (f ∘⟨ C ⟩ g) ≡ (ϕ ∘ᴾ⟨ P ⟩ f) ∘ᴾ⟨ P ⟩ g
+  ∘ᴾAssoc C P ϕ f g i = P .F-seq f g i ϕ
+
+module PresheafNotation {ℓo}{ℓh}
+       {C : Category ℓo ℓh} {ℓp} (P : Presheaf C ℓp)
+       where
+  private
+    module C = Category C
+  p[_] : C.ob → Type ℓp
+  p[ x ] = ⟨ P ⟅ x ⟆ ⟩
+
+  infixr 9 _⋆_
+  _⋆_ : ∀ {x y} (f : C [ x , y ]) (g : p[ y ]) → p[ x ]
+  f ⋆ g = P .F-hom f g
+
+  ⋆IdL : ∀ {x} (g : p[ x ]) → C.id ⋆ g ≡ g
+  ⋆IdL = funExt⁻ (P .F-id)
+
+  ⋆Assoc : ∀ {x y z} (f : C [ x , y ])(g : C [ y , z ])(h : p[ z ]) →
+    (f C.⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+  ⋆Assoc f g = funExt⁻ (P .F-seq g f)
+
+  ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
+            → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+  ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
+
+  ⟨⟩⋆⟨_⟩ : ∀ {x y} {f : C [ x , y ]} {g g' : p[ y ]}
+            → g ≡ g' → f ⋆ g ≡ f ⋆ g'
+  ⟨⟩⋆⟨_⟩ = ⟨ refl ⟩⋆⟨_⟩
+
+  ⟨_⟩⋆⟨⟩ : ∀ {x y} {f f' : C [ x , y ]} {g : p[ y ]}
+            → f ≡ f' → f ⋆ g ≡ f' ⋆ g
+  ⟨_⟩⋆⟨⟩ = ⟨_⟩⋆⟨ refl ⟩
+
+  isSetPsh : ∀ {x} → isSet (p[ x ])
+  isSetPsh {x} = (P ⟅ x ⟆) .snd

--- a/Cubical/Categories/Presheaf/Morphism.agda
+++ b/Cubical/Categories/Presheaf/Morphism.agda
@@ -59,15 +59,6 @@ module _ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}
       [ LiftF ℓq ∘F P , LiftF ℓp ∘F Q ∘F (F ^opF) ]
 
   module _ (h : PshHom) where
-    -- -- This should define a functor on the category of elements
-    -- pushElt : Σ[ c ∈ C .ob ] P.p[ c ] → Σ[ d ∈ D .ob ] Q.p[ d ]
-    -- pushElt (A , η) = (F ⟅ A ⟆) , (h .N-ob A (lift η) .lower)
-
-    -- pushEltNat : ∀ {B : C .ob} (η : Σ[ c ∈ C .ob]) (f : C [ B , η .fst ])
-    --               → (pushElt η .snd ∘ᴾ⟨ Q ⟩ F .F-hom f)
-    --                 ≡ pushElt (B , η .snd ∘ᴾ⟨ P ⟩ f) .snd
-    -- pushEltNat η f i = h .N-hom f (~ i) (lift (η .snd)) .lower
-
     pushEltF : Functor (∫ P) (∫ Q)
     pushEltF = ∫F {F = F} (mkPropHomsFunctor (hasPropHomsElement Q)
       (λ {x} z → h .N-ob x (lift z) .lower)

--- a/Cubical/Categories/Presheaf/Morphism.agda
+++ b/Cubical/Categories/Presheaf/Morphism.agda
@@ -9,12 +9,17 @@ open import Cubical.Categories.Instances.Elements
 open import Cubical.Categories.Instances.Lift
 open import Cubical.Categories.Functor
 open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory
 open import Cubical.Categories.Isomorphism
 open import Cubical.Categories.Limits
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.Representable
 
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Element
+open import Cubical.Categories.Displayed.HLevels
 {-
 
   Given two presheaves P and Q on the same category C, a morphism
@@ -45,38 +50,38 @@ module _ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}
          (F : Functor C D)
          (P : Presheaf C ℓp)
          (Q : Presheaf D ℓq) where
+  private
+    module P = PresheafNotation P
+    module Q = PresheafNotation Q
   PshHom : Type (ℓ-max (ℓ-max (ℓ-max ℓc ℓc') ℓp) ℓq)
   PshHom =
     PresheafCategory C (ℓ-max ℓp ℓq)
       [ LiftF ℓq ∘F P , LiftF ℓp ∘F Q ∘F (F ^opF) ]
 
   module _ (h : PshHom) where
-    -- This should define a functor on the category of elements
-    pushElt : Elementᴾ {C = C} P → Elementᴾ {C = D} Q
-    pushElt (A , η) = (F ⟅ A ⟆) , (h .N-ob A (lift η) .lower)
+    -- -- This should define a functor on the category of elements
+    -- pushElt : Σ[ c ∈ C .ob ] P.p[ c ] → Σ[ d ∈ D .ob ] Q.p[ d ]
+    -- pushElt (A , η) = (F ⟅ A ⟆) , (h .N-ob A (lift η) .lower)
 
-    pushEltNat : ∀ {B : C .ob} (η : Elementᴾ {C = C} P) (f : C [ B , η .fst ])
-                  → (pushElt η .snd ∘ᴾ⟨ Q ⟩ F .F-hom f)
-                    ≡ pushElt (B , η .snd ∘ᴾ⟨ P ⟩ f) .snd
-    pushEltNat η f i = h .N-hom f (~ i) (lift (η .snd)) .lower
+    -- pushEltNat : ∀ {B : C .ob} (η : Σ[ c ∈ C .ob]) (f : C [ B , η .fst ])
+    --               → (pushElt η .snd ∘ᴾ⟨ Q ⟩ F .F-hom f)
+    --                 ≡ pushElt (B , η .snd ∘ᴾ⟨ P ⟩ f) .snd
+    -- pushEltNat η f i = h .N-hom f (~ i) (lift (η .snd)) .lower
 
-    pushEltF : Functor (∫ᴾ_ {C = C} P) (∫ᴾ_ {C = D} Q)
-    pushEltF .F-ob = pushElt
-    pushEltF .F-hom {x}{y} (f , commutes) .fst = F .F-hom f
-    pushEltF .F-hom {x}{y} (f , commutes) .snd =
-      pushElt _ .snd ∘ᴾ⟨ Q ⟩ F .F-hom f
-        ≡⟨ pushEltNat y f ⟩
-      pushElt (_ , y .snd ∘ᴾ⟨ P ⟩ f) .snd
-        ≡⟨ cong (λ a → pushElt a .snd) (ΣPathP (refl , commutes)) ⟩
-      pushElt x .snd ∎
-    pushEltF .F-id = Σ≡Prop (λ x → (Q ⟅ _ ⟆) .snd _ _) (F .F-id)
-    pushEltF .F-seq f g =
-      Σ≡Prop ((λ x → (Q ⟅ _ ⟆) .snd _ _)) (F .F-seq (f .fst) (g .fst))
+    pushEltF : Functor (∫ P) (∫ Q)
+    pushEltF = ∫F {F = F} (mkPropHomsFunctor (hasPropHomsElement Q)
+      (λ {x} z → h .N-ob x (lift z) .lower)
+      λ {x} {y} {f} {p} {p'} fp≡p' →
+        F ⟪ f ⟫ Q.⋆ (h .N-ob _ (lift p') .lower)
+          ≡[ i ]⟨ h .N-hom f (~ i) (lift p') .lower ⟩
+        h .N-ob _ (lift (f P.⋆ p')) .lower
+          ≡[ i ]⟨ h .N-ob _ (lift (fp≡p' i)) .lower ⟩
+        h .N-ob _ (lift p) .lower
+          ∎)
 
     preservesRepresentation : ∀ (η : UniversalElement C P)
                             → Type (ℓ-max (ℓ-max ℓd ℓd') ℓq)
-    preservesRepresentation η = isUniversal D Q (η' .fst) (η' .snd)
-      where η' = pushElt (η .vertex , η .element)
+    preservesRepresentation η = isUniversal D Q _ (h .N-ob _ (lift (η .element)) .lower)
 
     preservesRepresentations : Type _
     preservesRepresentations = ∀ η → preservesRepresentation η
@@ -88,8 +93,8 @@ module _ {C : Category ℓc ℓc'}{D : Category ℓd ℓd'}
       ∀ η → preservesRepresentation η → preservesRepresentations
     preservesAnyRepresentation→preservesAllRepresentations η preserves-η η' =
       isTerminalToIsUniversal D Q
-        (preserveAnyTerminal→PreservesTerminals (∫ᴾ_ {C = C} P)
-                                 (∫ᴾ_ {C = D} Q)
+        (preserveAnyTerminal→PreservesTerminals (∫ P)
+                                 (∫ Q)
                                  pushEltF
                                  (universalElementToTerminalElement C P η)
                                  (isUniversalToIsTerminal D Q _ _ preserves-η)

--- a/Cubical/Categories/Presheaf/Properties.agda
+++ b/Cubical/Categories/Presheaf/Properties.agda
@@ -28,8 +28,7 @@ private
     ℓS ℓS' : Level
     e e' : Level
 
-
--- (PresheafCategory C) / F ≃ᶜ PresheafCategory (∫ᴾ F)
+-- (PresheafCategory C) / F ≃ᶜ PresheafCategory (∫ F)
 module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS)) where
   open Category
   open Functor
@@ -54,7 +53,7 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
   -- ========================================
 
   -- action on (slice) objects
-  K-ob : (s : SliceCat .ob) → (PresheafCategory (∫ᴾ F) ℓS .ob)
+  K-ob : (s : SliceCat .ob) → (PresheafCategory (∫ F) ℓS .ob)
   -- we take (c , x) to the fiber in A of ϕ over x
   K-ob (sliceob {A} ϕ) .F-ob (c , x)
     = (fiber (ϕ ⟦ c ⟧) x)
@@ -90,18 +89,18 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
 
       -- just apply the natural transformation (ε) we're given
       -- this ensures that we stay in the fiber over x due to the commutativity given by slicenesss
-      η-ob : (el : (∫ᴾ F) .ob) → (fst (P ⟅ el ⟆) → fst (Q ⟅ el ⟆) )
+      η-ob : (el : (∫ F) .ob) → (fst (P ⟅ el ⟆) → fst (Q ⟅ el ⟆) )
       η-ob (c , x) (a , ϕa≡x) = ((ε ⟦ c ⟧) a) , εψ≡ϕ ∙ ϕa≡x
         where
           εψ≡ϕ : (ψ ⟦ c ⟧) ((ε ⟦ c ⟧) a) ≡ (ϕ ⟦ c ⟧) a
           εψ≡ϕ i = ((com i) ⟦ c ⟧) a
 
-      η-hom : ∀ {el1 el2} (h : (∫ᴾ F) [ el1 , el2 ]) (ae : fst (P ⟅ el2 ⟆)) → η-ob el1 ((P ⟪ h ⟫) ae) ≡ (Q ⟪ h ⟫) (η-ob el2 ae)
+      η-hom : ∀ {el1 el2} (h : (∫ F) [ el1 , el2 ]) (ae : fst (P ⟅ el2 ⟆)) → η-ob el1 ((P ⟪ h ⟫) ae) ≡ (Q ⟪ h ⟫) (η-ob el2 ae)
       η-hom {el1 = (c , x)} {d , y} (h , eqh) (a , eqa)
         = fibersEqIfRepsEqNatTrans ψ (λ i → ε .N-hom h i a)
 
 
-  K : Functor SliceCat (PresheafCategory (∫ᴾ F) ℓS)
+  K : Functor SliceCat (PresheafCategory (∫ F) ℓS)
   K .F-ob = K-ob
   K .F-hom = K-hom
   K .F-id = makeNatTransPath
@@ -120,7 +119,7 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
   -- ========================================
 
   -- action on objects (presheaves)
-  L-ob : (P : PresheafCategory (∫ᴾ F) ℓS .ob)
+  L-ob : (P : PresheafCategory (∫ F) ℓS .ob)
         → SliceCat .ob
   L-ob P = sliceob {S-ob = L-ob-ob} L-ob-hom
     where
@@ -162,7 +161,7 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
                     left : PathP (λ i → fst (P ⟅ c , leftEq i ⟆))
                                   ((P ⟪ C .id , refl ⟫) X)
                                   ((P ⟪ ∫id ⟫) X)
-                    left i = (P ⟪ ∫ᴾhomEq {F = F} (C .id , refl) ∫id (λ i → (c , leftEq i)) refl refl i ⟫) X
+                    left i = (P ⟪ ElementHomPathP F (C .id , refl) ∫id (λ i → (c , leftEq i)) refl refl i ⟫) X
       L-ob-ob .F-seq {x = c} {d} {e} f g
         = funExt seqFunEq
           where
@@ -185,21 +184,21 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
                 rightEq = left ▷ right
                   where
                     -- functoriality of P only gets us to this weird composition on the left
-                    right : (P ⟪ (g , refl) ⋆⟨ (∫ᴾ F) ⟩ (f , refl) ⟫) X ≡ (P ⟪ g , refl ⟫) ((P ⟪ f , refl ⟫) X)
+                    right : (P ⟪ (g , refl) ⋆⟨ (∫ F) ⟩ (f , refl) ⟫) X ≡ (P ⟪ g , refl ⟫) ((P ⟪ f , refl ⟫) X)
                     right i = P .F-seq (f , refl) (g , refl) i X
 
                     -- so we need to show that this composition is actually equal to the one we want
                     left : PathP (λ i → fst (P ⟅ e , leftEq i ⟆))
                                   ((P ⟪ g ⋆⟨ C ⟩ f , refl ⟫) X)
-                                  ((P ⟪ (g , refl) ⋆⟨ (∫ᴾ F) ⟩ (f , refl) ⟫) X)
-                    left i = (P ⟪ ∫ᴾhomEq {F = F} (g ⋆⟨ C ⟩ f , refl) ((g , refl) ⋆⟨ (∫ᴾ F) ⟩ (f , refl)) (λ i → (e , leftEq i)) refl refl i ⟫) X
+                                  ((P ⟪ (g , refl) ⋆⟨ (∫ F) ⟩ (f , refl) ⟫) X)
+                    left i = (P ⟪ ElementHomPathP F (g ⋆⟨ C ⟩ f , refl) ((g , refl) ⋆⟨ (∫ F) ⟩ (f , refl)) (λ i → (e , leftEq i)) refl refl i ⟫) X
       L-ob-hom : L-ob-ob ⇒ F
       L-ob-hom .N-ob c (x , _) = x
       L-ob-hom .N-hom f = funExt λ (x , _) → refl
 
   -- action on morphisms (aka natural transformations between presheaves)
   -- is essentially the identity (plus equality proofs for naturality and slice commutativity)
-  L-hom : ∀ {P Q} → PresheafCategory (∫ᴾ F) ℓS [ P , Q ] →
+  L-hom : ∀ {P Q} → PresheafCategory (∫ F) ℓS [ P , Q ] →
         SliceCat [ L-ob P , L-ob Q ]
   L-hom {P} {Q} η = slicehom arr com
     where
@@ -223,7 +222,7 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
                     → (arr ●ᵛ ψ) ⟦ c ⟧ ≡ ϕ ⟦ c ⟧
           comFunExt c = funExt λ x → refl
 
-  L : Functor (PresheafCategory (∫ᴾ F) ℓS) SliceCat
+  L : Functor (PresheafCategory (∫ F) ℓS) SliceCat
   L .F-ob = L-ob
   L .F-hom = L-hom
   L .F-id {cx} = SliceHom-≡-intro' (makeNatTransPath (funExt λ c → refl))
@@ -300,18 +299,18 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
 
     -- the natural isomorphism
     -- applies typeFiberIso (inv)
-    εTrans : (K ∘F L) ⇒ 𝟙⟨ PresheafCategory (∫ᴾ F) ℓS ⟩
+    εTrans : (K ∘F L) ⇒ 𝟙⟨ PresheafCategory (∫ F) ℓS ⟩
     εTrans .N-ob P = natTrans γ-ob (λ f → funExt (λ a → γ-homFunExt f a))
       where
         KLP = K ⟅ L ⟅ P ⟆ ⟆
 
-        γ-ob : (el : (∫ᴾ F) .ob)
+        γ-ob : (el : (∫ F) .ob)
             → (fst (KLP ⟅ el ⟆) → fst (P ⟅ el ⟆) )
         γ-ob el@(c , _) = typeFiberIso {isSetA = snd (F ⟅ c ⟆)} (λ x → fst (P ⟅ c , x ⟆)) .inv
 
         -- naturality
         -- the annoying part is all the substs
-        γ-homFunExt : ∀ {el2 el1} → (f' : (∫ᴾ F) [ el2 , el1 ])
+        γ-homFunExt : ∀ {el2 el1} → (f' : (∫ F) [ el2 , el1 ])
               → (∀ (a : fst (KLP ⟅ el1 ⟆)) → γ-ob el2 ((KLP ⟪ f' ⟫) a) ≡ (P ⟪ f' ⟫) (γ-ob el1 a))
         γ-homFunExt {d , y} {c , x} f'@(f , comm) a@((x' , X') , eq) i
           = comp (λ j → fst (P ⟅ d , eq' j ⟆)) (λ j → λ { (i = i0) → left j
@@ -340,7 +339,7 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
         KLP = K ⟅ L ⟅ P ⟆ ⟆
 
         -- naturality of the above construction applies a similar argument as in `γ-homFunExt`
-        ε-homFunExt : ∀ (cx@(c , x) : (∫ᴾ F) .ob) (xX'@((x' , X') , eq) : fst (KLP ⟅ cx ⟆))
+        ε-homFunExt : ∀ (cx@(c , x) : (∫ F) .ob) (xX'@((x' , X') , eq) : fst (KLP ⟅ cx ⟆))
                     → subst (λ v → fst (Q ⟅ c , v ⟆)) (snd ((K ⟪ L ⟪ α ⟫ ⟫ ⟦ cx ⟧) xX')) ((α ⟦ c , x' ⟧) X')
                     ≡ (α ⟦ c , x ⟧) (subst _ eq X')
         ε-homFunExt cx@(c , x) xX'@((x' , X') , eq) i
@@ -370,18 +369,18 @@ module _ {ℓS : Level} (C : Category ℓ ℓ') (F : Functor (C ^op) (SET ℓS))
                 eq'≡eq : eq' ≡ eq
                 eq'≡eq = snd (F ⟅ c ⟆) _ _ eq' eq
 
-    εIso : ∀ (P : PresheafCategory (∫ᴾ F) ℓS .ob)
-          → isIsoC (PresheafCategory (∫ᴾ F) ℓS) (εTrans ⟦ P ⟧)
+    εIso : ∀ (P : PresheafCategory (∫ F) ℓS .ob)
+          → isIsoC (PresheafCategory (∫ F) ℓS) (εTrans ⟦ P ⟧)
     εIso P = FUNCTORIso _ _ _ isIsoC'
       where
-        isIsoC' : ∀ (cx : (∫ᴾ F) .ob)
+        isIsoC' : ∀ (cx : (∫ F) .ob)
                 → isIsoC (SET _) ((εTrans ⟦ P ⟧) ⟦ cx ⟧)
         isIsoC' cx@(c , _) = Morphism.CatIso→isIso (Iso→CatIso (invIso (typeFiberIso {isSetA = snd (F ⟅ c ⟆)} _)))
 
 
   -- putting it all together
 
-  preshSlice≃preshElem : SliceCat ≃ᶜ PresheafCategory (∫ᴾ F) ℓS
+  preshSlice≃preshElem : SliceCat ≃ᶜ PresheafCategory (∫ F) ℓS
   preshSlice≃preshElem .func = K
   preshSlice≃preshElem .isEquiv = ∣ w-inv ∣₁
     where

--- a/Cubical/Categories/Presheaf/Representable.agda
+++ b/Cubical/Categories/Presheaf/Representable.agda
@@ -56,6 +56,8 @@ open isIsoC
 -- | Lifts don't appear in practice because we usually use universal
 -- | elements instead
 module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
+  private
+    module P = PresheafNotation P
   Representation : Type (ℓ-max (ℓ-max ℓo (ℓ-suc ℓh)) (ℓ-suc ℓp))
   Representation =
     Σ[ A ∈ C .ob ] PshIso C (C [-, A ]) P
@@ -63,7 +65,7 @@ module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
   Representable : Type (ℓ-max (ℓ-max ℓo (ℓ-suc ℓh)) (ℓ-suc ℓp))
   Representable = ∥ Representation ∥₁
 
-  Elements = ∫ᴾ_ {C = C} P
+  Elements = ∫_ {C = C} P
 
   TerminalElement : Type (ℓ-max (ℓ-max ℓo ℓh) ℓp)
   TerminalElement = Terminal Elements
@@ -145,7 +147,7 @@ module _ {ℓo}{ℓh}{ℓp} (C : Category ℓo ℓh) (P : Presheaf C ℓp) where
     (NatIso≡ (cong NatTrans.N-ob
       (yonedaᴾ* {C = C} P (repr .fst) .Iso.ret (repr .snd .trans)))))
 
-  isTerminalToIsUniversal : ∀ {η : Elementᴾ {C = C} P}
+  isTerminalToIsUniversal : ∀ {η : Σ[ x ∈ C .ob ] P.p[ x ]}
     → isTerminal Elements η → isUniversal (η .fst) (η .snd)
   isTerminalToIsUniversal {η} term A .equiv-proof ϕ .fst .fst =
     term (_ , ϕ) .fst .fst
@@ -201,5 +203,5 @@ module _
   isPropUniversalElement : isProp (UniversalElement C P)
   isPropUniversalElement = isOfHLevelRetractFromIso 1
     (invIso (TerminalElement≅UniversalElement C P))
-    (isPropTerminal (∫ᴾ_ {C = C} P)
-    (isUnivalentOp (Covariant.isUnivalent∫ (isUnivalentOp isUnivC) P)))
+    (isPropTerminal (∫_ {C = C} P)
+    (isUnivalent∫ {F = P} isUnivC))

--- a/Cubical/Categories/Yoneda.agda
+++ b/Cubical/Categories/Yoneda.agda
@@ -224,7 +224,6 @@ module _ {C : Category ℓ ℓ'} where
   YO .F-id = makeNatTransPath λ i _ → λ f → ⋆IdR f i
   YO .F-seq f g = makeNatTransPath λ i _ → λ h → ⋆Assoc h f g (~ i)
 
-
   module _ {x} (F : Functor (C ^op) (SET ℓ')) where
     yonedaToElement : NatTrans (yo x) F → F .F-ob x .fst
     yonedaToElement α = α .N-ob _ id

--- a/Cubical/Categories/Yoneda.agda
+++ b/Cubical/Categories/Yoneda.agda
@@ -224,6 +224,7 @@ module _ {C : Category ℓ ℓ'} where
   YO .F-id = makeNatTransPath λ i _ → λ f → ⋆IdR f i
   YO .F-seq f g = makeNatTransPath λ i _ → λ h → ⋆Assoc h f g (~ i)
 
+
   module _ {x} (F : Functor (C ^op) (SET ℓ')) where
     yonedaToElement : NatTrans (yo x) F → F .F-ob x .fst
     yonedaToElement α = α .N-ob _ id

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -48,12 +48,6 @@ private
   testrefl : test ≡ (2 , 1)
   testrefl = refl
 
-  test' : ℕ ×Σ ℕ
-  test' = transp (λ i → ua (Σ-swap-≃ {A = ℕ} {A' = ℕ}) i) i0 (1 , 2)
-
-  test'refl : test' ≡ (2 , 1)
-  test'refl = refl
-
 -- equivalence between the sigma-based definition and the inductive one
 A×B≃A×ΣB : A × B ≃ A ×Σ B
 A×B≃A×ΣB = isoToEquiv (iso (λ { (a , b) → (a , b)})

--- a/Cubical/Data/Prod/Properties.agda
+++ b/Cubical/Data/Prod/Properties.agda
@@ -48,6 +48,12 @@ private
   testrefl : test ≡ (2 , 1)
   testrefl = refl
 
+  test' : ℕ ×Σ ℕ
+  test' = transp (λ i → ua (Σ-swap-≃ {A = ℕ} {A' = ℕ}) i) i0 (1 , 2)
+
+  test'refl : test' ≡ (2 , 1)
+  test'refl = refl
+
 -- equivalence between the sigma-based definition and the inductive one
 A×B≃A×ΣB : A × B ≃ A ×Σ B
 A×B≃A×ΣB = isoToEquiv (iso (λ { (a , b) → (a , b)})

--- a/Cubical/Data/Quiver/Base.agda
+++ b/Cubical/Data/Quiver/Base.agda
@@ -35,11 +35,9 @@
 module Cubical.Data.Quiver.Base where
 
 open import Cubical.Foundations.Prelude
-
 open import Cubical.Data.Graph.Base
 open import Cubical.Data.Graph.Displayed as DG hiding (Section)
 open import Cubical.Data.Sigma
-
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.UnderlyingGraph
 open import Cubical.Categories.Displayed.Base
@@ -87,7 +85,7 @@ Graph→Quiver g .snd .cod x = x .snd .fst
 -- | The use of ≡ in this definition is the raison d'etre for the
 -- | Quiver-Graph distinction
 -- HetQG Q G ≅ QHom (Quiver→Graph Q) G
-Quiver→Graph : Quiver ℓq ℓq' → Graph ℓq (ℓ-max ℓq ℓq')
+Quiver→Graph : Quiver ℓq ℓq' → Graph _ _
 Quiver→Graph Q .Node = Q .fst
 Quiver→Graph Q .Edge A B =
   Σ[ e ∈ Q .snd .mor ]

--- a/Cubical/Data/Quiver/Base.agda
+++ b/Cubical/Data/Quiver/Base.agda
@@ -35,9 +35,11 @@
 module Cubical.Data.Quiver.Base where
 
 open import Cubical.Foundations.Prelude
+
 open import Cubical.Data.Graph.Base
 open import Cubical.Data.Graph.Displayed as DG hiding (Section)
 open import Cubical.Data.Sigma
+
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.UnderlyingGraph
 open import Cubical.Categories.Displayed.Base
@@ -85,7 +87,7 @@ Graph→Quiver g .snd .cod x = x .snd .fst
 -- | The use of ≡ in this definition is the raison d'etre for the
 -- | Quiver-Graph distinction
 -- HetQG Q G ≅ QHom (Quiver→Graph Q) G
-Quiver→Graph : Quiver ℓq ℓq' → Graph _ _
+Quiver→Graph : Quiver ℓq ℓq' → Graph ℓq (ℓ-max ℓq ℓq')
 Quiver→Graph Q .Node = Q .fst
 Quiver→Graph Q .Edge A B =
   Σ[ e ∈ Q .snd .mor ]

--- a/Cubical/Foundations/Equiv.agda
+++ b/Cubical/Foundations/Equiv.agda
@@ -190,14 +190,18 @@ Lift≃Lift e .snd .equiv-proof b .snd (a , p) i .snd j .lower =
 isContr→Equiv : isContr A → isContr B → A ≃ B
 isContr→Equiv Actr Bctr = isoToEquiv (isContr→Iso Actr Bctr)
 
+propBiimpl→isEquiv
+  : (Aprop : isProp A) (Bprop : isProp B) {f : A → B} (g : B → A) → isEquiv f
+propBiimpl→isEquiv Aprop Bprop {f} g .equiv-proof y .fst =
+  (g y , Bprop (f (g y)) y)
+propBiimpl→isEquiv Aprop Bprop {f} g .equiv-proof y .snd h i .fst =
+  Aprop (g y) (h .fst) i
+propBiimpl→isEquiv Aprop Bprop {f} g .equiv-proof y .snd h i .snd =
+  isProp→isSet' Bprop (Bprop (f (g y)) y) (h .snd)
+                (cong f (Aprop (g y) (h .fst))) refl i
+
 propBiimpl→Equiv : (Aprop : isProp A) (Bprop : isProp B) (f : A → B) (g : B → A) → A ≃ B
-propBiimpl→Equiv Aprop Bprop f g = f , hf
-  where
-  hf : isEquiv f
-  hf .equiv-proof y .fst          = (g y , Bprop (f (g y)) y)
-  hf .equiv-proof y .snd h i .fst = Aprop (g y) (h .fst) i
-  hf .equiv-proof y .snd h i .snd = isProp→isSet' Bprop (Bprop (f (g y)) y) (h .snd)
-                                                  (cong f (Aprop (g y) (h .fst))) refl i
+propBiimpl→Equiv Aprop Bprop f g = f , propBiimpl→isEquiv Aprop Bprop g
 
 isEquivPropBiimpl→Equiv : isProp A → isProp B
                         → ((A → B) × (B → A)) ≃ (A ≃ B)
@@ -322,4 +326,3 @@ isEquiv≃isEquiv' : (f : A → B) → isEquiv f ≃ isEquiv' f
 isEquiv≃isEquiv' f = isoToEquiv (isEquiv-isEquiv'-Iso f)
 
 -- The fact that funExt is an equivalence can be found in Cubical.Functions.FunExtEquiv
-

--- a/Cubical/Foundations/HLevels.agda
+++ b/Cubical/Foundations/HLevels.agda
@@ -643,6 +643,9 @@ isContrDep = isOfHLevelDep 0
 isPropDep : {A : Type ℓ} (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
 isPropDep = isOfHLevelDep 1
 
+isSetDep : {A : Type ℓ} (B : A → Type ℓ') → Type (ℓ-max ℓ ℓ')
+isSetDep = isOfHLevelDep 2
+
 isContrDep∘
   : {A' : Type ℓ} (f : A' → A) → isContrDep B → isContrDep (B ∘ f)
 isContrDep∘ f cB {a} = λ where
@@ -670,6 +673,18 @@ isOfHLevel→isOfHLevelDep (suc (suc n)) {A = A} {B} h {a0} {a1} b0 b1 =
     isOfHLevel (suc n) (PathP (λ i → B (p i)) b0 b1)
   helper p = J (λ a1 p → ∀ b1 → isOfHLevel (suc n) (PathP (λ i → B (p i)) b0 b1))
                      (λ _ → h _ _ _) p b1
+
+isContr→isContrDep :
+ {A : Type ℓ} {B : A → Type ℓ'} (h : (a : A) → isContr (B a)) → isContrDep {A = A} B
+isContr→isContrDep = isOfHLevel→isOfHLevelDep 0
+
+isProp→isPropDep :
+ {A : Type ℓ} {B : A → Type ℓ'} (h : (a : A) → isProp (B a)) → isPropDep {A = A} B
+isProp→isPropDep = isOfHLevel→isOfHLevelDep 1
+
+isSet→isSetDep :
+ {A : Type ℓ} {B : A → Type ℓ'} (h : (a : A) → isSet (B a)) → isSetDep {A = A} B
+isSet→isSetDep = isOfHLevel→isOfHLevelDep 2
 
 isContrDep→isPropDep : isOfHLevelDep 0 B → isOfHLevelDep 1 B
 isContrDep→isPropDep {B = B} Bctr {a0 = a0} b0 b1 p i

--- a/Cubical/Papers/AffineSchemes.agda
+++ b/Cubical/Papers/AffineSchemes.agda
@@ -57,7 +57,7 @@ module ZariskiLatUnivProp = ZLUP.ZarLatUniversalProp
 
 -- 4: Category Theory
 -- background theory not explicitly mentioned
-import Cubical.Categories.Category.Base                            as CatTheory
+import Cubical.Categories.Instances.FullSubcategory                as CatTheory
 import Cubical.Categories.Limits                                   as GeneralLimits
 import Cubical.Categories.Limits.RightKan                          as GeneralKanExtension
 


### PR DESCRIPTION
This looks big but it's mostly a re-org to clean up some redundancies in the category theory library:

1. Merge `ΣPropCat` and `FullSubcategory`
2. Implement the binary product of categories as a total category of a weakened displayed category
3. Implement the category of elements of a presheaf as a total category of a displayed category of elements.
4. In updating that, add a definition of univalent displayed categories and prove that the total category of a univalent displayed category over a univalent category is univalent.
5. Add some congruence notation to Category and add PresheafNotation (that we use heavily downstream in `cubical-categorical-logic`).
6. Some minor definitions we have in `cubical-categorical-logic` like `Functorⱽ` and `isSetDep`...

Changing the definition of binary product looks a bit scary but I put a display pragma on it so that I don't think it should ever leak out. If we didn't have `no-eta-equality` for categories, it would be `refl` equal to the old definition, so no code broke with the change.

The most substantive change is that in porting the category of elements to be defined using a total category, I defined univalent displayed categories.