### PR TITLE
Add union of iterative sets

### DIFF
--- a/Cubical/Data/IterativeSets/Base.agda
+++ b/Cubical/Data/IterativeSets/Base.agda
@@ -3,9 +3,12 @@ module Cubical.Data.IterativeSets.Base where
 open import Cubical.Foundations.Prelude
 
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Smallness
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Data.W.W
 open import Cubical.Functions.Embedding
+open import Cubical.Functions.FunExtEquiv
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.Relation.Nullary using (¬_)
@@ -185,3 +188,25 @@ isProp-∈⁰-Equiv x y = isPropΠ λ z → isOfHLevel≃ 1 (isProp∈⁰ {x = x
         g : sup-∞ z γ ∈∞ sup-∞ x α → (sup-∞ z γ , itsetz) ∈⁰ (sup-∞ x α , itsetx)
         g (a , p) .fst = a
         g (a , p) .snd = Σ≡Prop isPropIsIterativeSet p
+
+-- Some results about smallness of iterative sets
+isSmallEl⁰ : ∀ {ℓ} (x : V⁰ {ℓ}) → is[ ℓ ]Small (El⁰ x)
+isSmallEl⁰ x = isℓSmallℓ (El⁰ x)
+
+isLocallySmallV∞ : {ℓ : Level} → isLocally[ ℓ ]Small (V∞ {ℓ})
+isLocallySmallV∞ {ℓ} = WInd2 (Type ℓ) (λ A → A) (Type ℓ) (λ A → A) (λ x y → is[ ℓ ]Small (x ≡ y)) step
+  where
+    step : {A : Type ℓ} {α : A → V∞ {ℓ}} {B : Type ℓ} {β : B → V∞ {ℓ}}
+      → ((a : A) (b : B) → is[ ℓ ]Small (α a ≡ β b))
+      → is[ ℓ ]Small (sup-∞ A α ≡ sup-∞ B β)
+    step {A} {α} {B} {β} IH =
+      isSmall-≃-isSmall
+        (isSmallΣ (isℓSmallℓ (A ≃ B))
+          (λ e → isSmall-≃-isSmall
+            (isSmallΠ (isℓSmallℓ A) (λ a → IH a (e .fst a)))
+            funExtEquiv))
+        (invEquiv ≡V∞-≃-≡Equiv)
+
+isLocallySmallV : {ℓ : Level} → isLocally[ ℓ ]Small (V⁰ {ℓ})
+isLocallySmallV {ℓ} x y =
+  isSmall-≃-isSmall (isLocallySmallV∞ (x .fst) (y .fst)) (invEquiv ≡V⁰-≃-≡V∞)

--- a/Cubical/Data/IterativeSets/Union.agda
+++ b/Cubical/Data/IterativeSets/Union.agda
@@ -1,0 +1,148 @@
+-- from a set x we can build the set ∪ x.
+module Cubical.Data.IterativeSets.Union where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Functions.Image
+open import Cubical.Functions.FunExtEquiv
+open import Cubical.HITs.Replacement
+open import Cubical.HITs.PropositionalTruncation
+open import Cubical.Displayed.Base
+open import Cubical.Data.Sigma
+open import Cubical.Data.W.W
+open import Cubical.Data.IterativeSets.Base
+open import Cubical.Data.IterativeSets.UnorderedPair.Base
+open import Cubical.Data.IterativeMultisets.Base renaming (index to index∞ ; elements to elements∞)
+open import Cubical.Functions.Embedding
+
+-- TOOD move this notion of smallness somewhere else
+module Smallness where
+  is[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+  is[_]Small ℓ A = Σ (Type ℓ) λ B → B ≃ A
+
+  isLocally[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+  isLocally[_]Small ℓ A = (x y : A) → is[ ℓ ]Small (x ≡ y)
+
+  isSmall-≃-isSmall :  ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''} → is[ ℓ ]Small A → A ≃ A' → is[ ℓ ]Small A'
+  isSmall-≃-isSmall small equiv .fst = small .fst
+  isSmall-≃-isSmall small equiv .snd = compEquiv (small .snd) equiv
+
+  isSmall≃ : ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''}
+    → is[ ℓ ]Small A
+    → is[ ℓ ]Small A'
+    → is[ ℓ ]Small (A ≃ A')
+  isSmall≃ smallA smallA' .fst = smallA .fst ≃ smallA' .fst
+  isSmall≃ smallA smallA' .snd = equivComp (smallA .snd) (smallA' .snd)
+
+  isSmall≡ : ∀ {ℓ} {ℓ'} {A : Type ℓ'} {A' : Type ℓ'}
+    → is[ ℓ ]Small A
+    → is[ ℓ ]Small A'
+    → is[ ℓ ]Small (A ≡ A')
+  isSmall≡ smallA smallA' = isSmall-≃-isSmall (isSmall≃ smallA smallA') (invEquiv univalence)
+
+  isℓSmallℓ : ∀ {ℓ} (A : Type ℓ) → is[ ℓ ]Small A
+  isℓSmallℓ A .fst = A
+  isℓSmallℓ A .snd = idEquiv A
+
+  isSmallΣ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
+    → is[ ℓ ]Small A
+    → ((a : A) → is[ ℓ ]Small (B a))
+    → is[ ℓ ]Small (Σ A B)
+  isSmallΣ sA sB .fst = Σ[ a' ∈ sA .fst ] sB (sA .snd .fst a') .fst
+  isSmallΣ sA sB .snd = Σ-cong-equiv (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)
+
+  isSmallΠ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
+    → is[ ℓ ]Small A
+    → ((a : A) → is[ ℓ ]Small (B a))
+    → is[ ℓ ]Small ((a : A) → B a)
+  isSmallΠ sA sB .fst = (a' : sA .fst) → sB (sA .snd .fst a') .fst
+  isSmallΠ sA sB .snd = equivΠ (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)
+
+open Smallness
+
+-- Some results about smallness of iterative sets
+module V-Smallness where
+  isSmallEl : ∀ {ℓ} (x : V⁰ {ℓ}) → is[ ℓ ]Small (El⁰ x)
+  isSmallEl x = isℓSmallℓ (El⁰ x)
+
+  isLocallySmallV∞ : {ℓ : Level} → isLocally[ ℓ ]Small (V∞ {ℓ})
+  isLocallySmallV∞ {ℓ} = WInd2 (Type ℓ) (λ A → A) (Type ℓ) (λ A → A) (λ x y → is[ ℓ ]Small (x ≡ y)) step
+    where
+      step : {A : Type ℓ} {α : A → V∞ {ℓ}} {B : Type ℓ} {β : B → V∞ {ℓ}}
+        → ((a : A) (b : B) → is[ ℓ ]Small (α a ≡ β b))
+        → is[ ℓ ]Small (sup-∞ A α ≡ sup-∞ B β)
+      step {A} {α} {B} {β} IH =
+        isSmall-≃-isSmall
+          (isSmallΣ (isℓSmallℓ (A ≃ B))
+            (λ e → isSmall-≃-isSmall
+              (isSmallΠ (isℓSmallℓ A) (λ a → IH a (e .fst a)))
+              funExtEquiv))
+          (invEquiv ≡V∞-≃-≡Equiv)
+
+  isLocallySmallV : {ℓ : Level} → isLocally[ ℓ ]Small (V⁰ {ℓ})
+  isLocallySmallV {ℓ} x y =
+    isSmall-≃-isSmall (isLocallySmallV∞ (x .fst) (y .fst)) (invEquiv ≡V⁰-≃-≡V∞)
+
+-- Key result: the image of a map of levels ℓ → ℓ' is ℓ-small
+module Replacement' {ℓ ℓ' : Level} {A : Type ℓ} {B : Type ℓ'} (lsB : isLocally[ ℓ ]Small B) (f : A → B) where
+  locallySmall→UARel : UARel B ℓ
+  locallySmall→UARel .UARel._≅_ x y = lsB x y .fst
+  locallySmall→UARel .UARel.ua x y = lsB x y .snd
+
+  Replacement' : is[ ℓ ]Small (Image f)
+  Replacement' .fst = Replacement locallySmall→UARel f
+  Replacement' .snd = replacement≃Image locallySmall→UARel f
+
+-- I don't know if more things should be public? Should the replacement
+-- machinery be exposed?
+module _ {ℓ : Level} where
+  ∪⁰-index : (x : V⁰ {ℓ}) → Type ℓ
+  ∪⁰-index x = Σ (index x) λ a → index (elements x a)
+  ∪⁰-elements : (x : V⁰) → ∪⁰-index x → V⁰
+  ∪⁰-elements x (a , b) = elements (elements x a) b
+
+  open Replacement'
+  open V-Smallness
+  private
+    uar : (x : V⁰ {ℓ}) → UARel V⁰ ℓ
+    uar x = locallySmall→UARel isLocallySmallV (∪⁰-elements x)
+
+  -- Morally, ∪ x has for indexing set the (union of indices of the) image of
+  -- elements x. But this fails for level reasons, which is why we need the
+  -- notion of smallness and replacement.
+  ∪⁰ : V⁰ {ℓ} → V⁰ {ℓ}
+  ∪⁰ x = fromEmb (idx , elm)
+    where
+      idx : Type ℓ
+      idx = Replacement' isLocallySmallV (∪⁰-elements x) .fst
+      elm : idx ↪ V⁰
+      elm .fst = unrep (uar x) (∪⁰-elements x)
+      elm .snd = isEmbeddingUnrep (locallySmall→UARel isLocallySmallV (∪⁰-elements x)) (∪⁰-elements x)
+
+  -- This indeed satisfies the union axiom. Unfortunately, computationally, we
+  -- lose track of which original set each element of the union comes from.
+  ∈∪⁰-≃ : ∀ x z → (z ∈⁰ (∪⁰ x)) ≃ (∃[ a ∈ index x ] z ∈⁰ elements x a)
+  ∈∪⁰-≃ x z =
+      (z ∈⁰ ∪⁰ x)
+    ≃⟨ idEquiv _ ⟩
+      fiber (unrep _ _) z
+    ≃⟨ invEquiv (propTruncIdempotent≃ (isEmbedding→hasPropFibers (isEmbeddingUnrep (uar x) (∪⁰-elements x)) z)) ⟩
+      isInImage (unrep (uar x) (∪⁰-elements x)) z
+    ≃⟨ idEquiv _ ⟩
+      ∃[ x₁ ∈ Replacement (uar x) (∪⁰-elements x)] unrep (uar x) (∪⁰-elements x) x₁ ≡ z
+    ≃⟨ propBiimpl→Equiv squash₁ squash₁
+         (rec squash₁ λ (r , p) →
+           rec squash₁ (λ ((a , b) , q) →
+             ∣ a , ∣ b , cong (unrep (uar x) (∪⁰-elements x)) q ∙ p ∣₁ ∣₁)
+             (isSurjectiveRep (uar x) (∪⁰-elements x) r))
+         (rec squash₁ λ (a , h) →
+           rec squash₁ (λ (b , p) → ∣ rep (a , b) , p ∣₁) h)
+      ⟩
+      ∃[ a ∈ index x ] ∃[ b ∈ index (elements x a) ] elements (elements x a) b ≡ z
+    ≃⟨ propTrunc≃ (Σ-cong-equiv-snd (λ a → propTruncIdempotent≃ (isProp∈⁰ {x = elements x a} {z = z}))) ⟩
+      ∃[ a ∈ index x ] z ∈⁰ elements x a
+    ■

--- a/Cubical/Data/IterativeSets/Union.agda
+++ b/Cubical/Data/IterativeSets/Union.agda
@@ -8,39 +8,14 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Function
 open import Cubical.Functions.Image
-open import Cubical.Functions.FunExtEquiv
 open import Cubical.HITs.Replacement
 open import Cubical.HITs.PropositionalTruncation
 open import Cubical.Displayed.Base
 open import Cubical.Data.Sigma
-open import Cubical.Data.W.W
 open import Cubical.Data.IterativeSets.Base
 open import Cubical.Data.IterativeSets.UnorderedPair.Base
 open import Cubical.Data.IterativeMultisets.Base renaming (index to index∞ ; elements to elements∞)
 open import Cubical.Functions.Embedding
-
--- Some results about smallness of iterative sets
-module V-Smallness where
-  isSmallEl : ∀ {ℓ} (x : V⁰ {ℓ}) → is[ ℓ ]Small (El⁰ x)
-  isSmallEl x = isℓSmallℓ (El⁰ x)
-
-  isLocallySmallV∞ : {ℓ : Level} → isLocally[ ℓ ]Small (V∞ {ℓ})
-  isLocallySmallV∞ {ℓ} = WInd2 (Type ℓ) (λ A → A) (Type ℓ) (λ A → A) (λ x y → is[ ℓ ]Small (x ≡ y)) step
-    where
-      step : {A : Type ℓ} {α : A → V∞ {ℓ}} {B : Type ℓ} {β : B → V∞ {ℓ}}
-        → ((a : A) (b : B) → is[ ℓ ]Small (α a ≡ β b))
-        → is[ ℓ ]Small (sup-∞ A α ≡ sup-∞ B β)
-      step {A} {α} {B} {β} IH =
-        isSmall-≃-isSmall
-          (isSmallΣ (isℓSmallℓ (A ≃ B))
-            (λ e → isSmall-≃-isSmall
-              (isSmallΠ (isℓSmallℓ A) (λ a → IH a (e .fst a)))
-              funExtEquiv))
-          (invEquiv ≡V∞-≃-≡Equiv)
-
-  isLocallySmallV : {ℓ : Level} → isLocally[ ℓ ]Small (V⁰ {ℓ})
-  isLocallySmallV {ℓ} x y =
-    isSmall-≃-isSmall (isLocallySmallV∞ (x .fst) (y .fst)) (invEquiv ≡V⁰-≃-≡V∞)
 
 -- Key result: the image of a map of levels ℓ → ℓ' is ℓ-small
 module Replacement' {ℓ ℓ' : Level} {A : Type ℓ} {B : Type ℓ'} (lsB : isLocally[ ℓ ]Small B) (f : A → B) where
@@ -61,7 +36,6 @@ module _ {ℓ : Level} where
   ∪⁰-elements x (a , b) = elements (elements x a) b
 
   open Replacement'
-  open V-Smallness
   private
     uar : (x : V⁰ {ℓ}) → UARel V⁰ ℓ
     uar x = locallySmall→UARel isLocallySmallV (∪⁰-elements x)

--- a/Cubical/Data/IterativeSets/Union.agda
+++ b/Cubical/Data/IterativeSets/Union.agda
@@ -2,7 +2,7 @@
 module Cubical.Data.IterativeSets.Union where
 
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.Smallness
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.HLevels
@@ -18,51 +18,6 @@ open import Cubical.Data.IterativeSets.Base
 open import Cubical.Data.IterativeSets.UnorderedPair.Base
 open import Cubical.Data.IterativeMultisets.Base renaming (index to index∞ ; elements to elements∞)
 open import Cubical.Functions.Embedding
-
--- TOOD move this notion of smallness somewhere else
-module Smallness where
-  is[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
-  is[_]Small ℓ A = Σ (Type ℓ) λ B → B ≃ A
-
-  isLocally[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
-  isLocally[_]Small ℓ A = (x y : A) → is[ ℓ ]Small (x ≡ y)
-
-  isSmall-≃-isSmall :  ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''} → is[ ℓ ]Small A → A ≃ A' → is[ ℓ ]Small A'
-  isSmall-≃-isSmall small equiv .fst = small .fst
-  isSmall-≃-isSmall small equiv .snd = compEquiv (small .snd) equiv
-
-  isSmall≃ : ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''}
-    → is[ ℓ ]Small A
-    → is[ ℓ ]Small A'
-    → is[ ℓ ]Small (A ≃ A')
-  isSmall≃ smallA smallA' .fst = smallA .fst ≃ smallA' .fst
-  isSmall≃ smallA smallA' .snd = equivComp (smallA .snd) (smallA' .snd)
-
-  isSmall≡ : ∀ {ℓ} {ℓ'} {A : Type ℓ'} {A' : Type ℓ'}
-    → is[ ℓ ]Small A
-    → is[ ℓ ]Small A'
-    → is[ ℓ ]Small (A ≡ A')
-  isSmall≡ smallA smallA' = isSmall-≃-isSmall (isSmall≃ smallA smallA') (invEquiv univalence)
-
-  isℓSmallℓ : ∀ {ℓ} (A : Type ℓ) → is[ ℓ ]Small A
-  isℓSmallℓ A .fst = A
-  isℓSmallℓ A .snd = idEquiv A
-
-  isSmallΣ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
-    → is[ ℓ ]Small A
-    → ((a : A) → is[ ℓ ]Small (B a))
-    → is[ ℓ ]Small (Σ A B)
-  isSmallΣ sA sB .fst = Σ[ a' ∈ sA .fst ] sB (sA .snd .fst a') .fst
-  isSmallΣ sA sB .snd = Σ-cong-equiv (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)
-
-  isSmallΠ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
-    → is[ ℓ ]Small A
-    → ((a : A) → is[ ℓ ]Small (B a))
-    → is[ ℓ ]Small ((a : A) → B a)
-  isSmallΠ sA sB .fst = (a' : sA .fst) → sB (sA .snd .fst a') .fst
-  isSmallΠ sA sB .snd = equivΠ (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)
-
-open Smallness
 
 -- Some results about smallness of iterative sets
 module V-Smallness where

--- a/Cubical/Data/IterativeSets/Union.agda
+++ b/Cubical/Data/IterativeSets/Union.agda
@@ -17,16 +17,6 @@ open import Cubical.Data.IterativeSets.UnorderedPair.Base
 open import Cubical.Data.IterativeMultisets.Base renaming (index to index∞ ; elements to elements∞)
 open import Cubical.Functions.Embedding
 
--- Key result: the image of a map of levels ℓ → ℓ' is ℓ-small
-module Replacement' {ℓ ℓ' : Level} {A : Type ℓ} {B : Type ℓ'} (lsB : isLocally[ ℓ ]Small B) (f : A → B) where
-  locallySmall→UARel : UARel B ℓ
-  locallySmall→UARel .UARel._≅_ x y = lsB x y .fst
-  locallySmall→UARel .UARel.ua x y = lsB x y .snd
-
-  Replacement' : is[ ℓ ]Small (Image f)
-  Replacement' .fst = Replacement locallySmall→UARel f
-  Replacement' .snd = replacement≃Image locallySmall→UARel f
-
 -- I don't know if more things should be public? Should the replacement
 -- machinery be exposed?
 module _ {ℓ : Level} where
@@ -35,7 +25,6 @@ module _ {ℓ : Level} where
   ∪⁰-elements : (x : V⁰) → ∪⁰-index x → V⁰
   ∪⁰-elements x (a , b) = elements (elements x a) b
 
-  open Replacement'
   private
     uar : (x : V⁰ {ℓ}) → UARel V⁰ ℓ
     uar x = locallySmall→UARel isLocallySmallV (∪⁰-elements x)

--- a/Cubical/Foundations/Smallness.agda
+++ b/Cubical/Foundations/Smallness.agda
@@ -1,0 +1,47 @@
+module Cubical.Foundations.Smallness where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Univalence
+open import Cubical.Data.Sigma
+
+is[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+is[_]Small ℓ A = Σ (Type ℓ) λ B → B ≃ A
+
+isLocally[_]Small : (ℓ : Level) {ℓ' : Level} (A : Type ℓ') → Type (ℓ-max (ℓ-suc ℓ) ℓ')
+isLocally[_]Small ℓ A = (x y : A) → is[ ℓ ]Small (x ≡ y)
+
+isSmall-≃-isSmall :  ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''} → is[ ℓ ]Small A → A ≃ A' → is[ ℓ ]Small A'
+isSmall-≃-isSmall small equiv .fst = small .fst
+isSmall-≃-isSmall small equiv .snd = compEquiv (small .snd) equiv
+
+isSmall≃ : ∀ {ℓ} {ℓ'} {ℓ''} {A : Type ℓ'} {A' : Type ℓ''}
+  → is[ ℓ ]Small A
+  → is[ ℓ ]Small A'
+  → is[ ℓ ]Small (A ≃ A')
+isSmall≃ smallA smallA' .fst = smallA .fst ≃ smallA' .fst
+isSmall≃ smallA smallA' .snd = equivComp (smallA .snd) (smallA' .snd)
+
+isSmall≡ : ∀ {ℓ} {ℓ'} {A : Type ℓ'} {A' : Type ℓ'}
+  → is[ ℓ ]Small A
+  → is[ ℓ ]Small A'
+  → is[ ℓ ]Small (A ≡ A')
+isSmall≡ smallA smallA' = isSmall-≃-isSmall (isSmall≃ smallA smallA') (invEquiv univalence)
+
+isℓSmallℓ : ∀ {ℓ} (A : Type ℓ) → is[ ℓ ]Small A
+isℓSmallℓ A .fst = A
+isℓSmallℓ A .snd = idEquiv A
+
+isSmallΣ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
+  → is[ ℓ ]Small A
+  → ((a : A) → is[ ℓ ]Small (B a))
+  → is[ ℓ ]Small (Σ A B)
+isSmallΣ sA sB .fst = Σ[ a' ∈ sA .fst ] sB (sA .snd .fst a') .fst
+isSmallΣ sA sB .snd = Σ-cong-equiv (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)
+
+isSmallΠ : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ'} {B : A → Type ℓ''}
+  → is[ ℓ ]Small A
+  → ((a : A) → is[ ℓ ]Small (B a))
+  → is[ ℓ ]Small ((a : A) → B a)
+isSmallΠ sA sB .fst = (a' : sA .fst) → sB (sA .snd .fst a') .fst
+isSmallΠ sA sB .snd = equivΠ (sA .snd) (λ a' → sB (sA .snd .fst a') .snd)

--- a/Cubical/HITs/Replacement/Base.agda
+++ b/Cubical/HITs/Replacement/Base.agda
@@ -35,6 +35,7 @@ module Cubical.HITs.Replacement.Base where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Smallness
 open import Cubical.Functions.Embedding
 open import Cubical.Functions.Image
 open import Cubical.HITs.PropositionalTruncation as Prop
@@ -112,3 +113,12 @@ module _ {ℓA ℓB ℓ≅B} {A : Type ℓA} {B : Type ℓB} (𝒮-B : UARel B �
       (restrictToImage f , isSurjectionImageRestriction f)
       (imageInclusion f)
       refl
+
+module _ {ℓ ℓ' : Level} {A : Type ℓ} {B : Type ℓ'} (lsB : isLocally[ ℓ ]Small B) (f : A → B) where
+  locallySmall→UARel : UARel B ℓ
+  locallySmall→UARel .UARel._≅_ x y = lsB x y .fst
+  locallySmall→UARel .UARel.ua x y = lsB x y .snd
+
+  Replacement' : is[ ℓ ]Small (Image f)
+  Replacement' .fst = Replacement locallySmall→UARel f
+  Replacement' .snd = replacement≃Image locallySmall→UARel f


### PR DESCRIPTION
This pull request adds a construction of unions of iterative sets: from a set x, we can build a set `∪ x` such that `z ∈ ∪ x ≃ ∃[ a ∈ index x ] z ∈ elements x a`.

The main difficulty is related to universe levels. We need to consider the image of a `elements x`, but this is a subset of V⁰, at level ℓ-suc ℓ instead of ℓ. Therefore I introduce machinery to show that this type is actually equivalent to one at level ℓ. This notion of smallness is more general and should maybe be separated from this particular construction.