### PR TITLE
remove `UsingEq`

### DIFF
--- a/Cubical/Data/Bool/Base.agda
+++ b/Cubical/Data/Bool/Base.agda
@@ -60,6 +60,15 @@ Bool→Type* : Bool → Type ℓ
 Bool→Type* true = Unit*
 Bool→Type* false = ⊥*
 
+-- this is proved here to avoid cyclic dependency, as it is needed in `Nat.Properties`
+DecBool→Type : {a : Bool} → Dec (Bool→Type a)
+DecBool→Type {a = true} = yes tt
+DecBool→Type {a = false} = no (λ x → x)
+
+DecBool→Type* : {a : Bool} → Dec (Bool→Type* {ℓ} a)
+DecBool→Type* {a = true} = yes tt*
+DecBool→Type* {a = false} = no (λ (lift x) → x)
+
 True : Dec A → Type₀
 True Q = Bool→Type (Dec→Bool Q)
 

--- a/Cubical/Data/Bool/Properties.agda
+++ b/Cubical/Data/Bool/Properties.agda
@@ -317,14 +317,6 @@ isPropBool→Type* : {a : Bool} → isProp (Bool→Type* {ℓ} a)
 isPropBool→Type* {a = true} = isPropUnit*
 isPropBool→Type* {a = false} = isProp⊥*
 
-DecBool→Type : {a : Bool} → Dec (Bool→Type a)
-DecBool→Type {a = true} = yes tt
-DecBool→Type {a = false} = no (λ x → x)
-
-DecBool→Type* : {a : Bool} → Dec (Bool→Type* {ℓ} a)
-DecBool→Type* {a = true} = yes tt*
-DecBool→Type* {a = false} = no (λ (lift x) → x)
-
 Dec→DecBool : {P : Type ℓ} → (dec : Dec P) → P → Bool→Type (Dec→Bool dec)
 Dec→DecBool (yes p) _ = tt
 Dec→DecBool (no ¬p) q = Empty.rec (¬p q)

--- a/Cubical/Data/Fast/Int/Order.agda
+++ b/Cubical/Data/Fast/Int/Order.agda
@@ -560,58 +560,56 @@ isAsym'< = recompute≤ ∘ proof _ _ where
 ≤max : m ≤ ℤ.max m n
 ≤max {pos zero}       {pos n}          = zero-≤pos
 ≤max {pos (suc m)}    {pos zero}       = isRefl≤
-≤max {pos (suc m)}    {pos (suc n)} with m ℕ.<ᵇ n UsingEq
-... | false , p = isRefl≤
-... | true  , p = <-weaken (pos<pos (subst Bool→Type (sym p) tt))
+≤max {pos (suc m)}    {pos (suc n)} with m ℕ.<ᵇ? n
+... | no ¬p = isRefl≤
+... | yes p = <-weaken (pos<pos p)
 ≤max {pos m}          {negsuc n}       = isRefl≤
 ≤max {negsuc m}       {pos n}          = negsuc≤pos
 ≤max {negsuc zero}    {negsuc n}       = isRefl≤
 ≤max {negsuc (suc m)} {negsuc zero}    = negsuc≤negsuc tt
-≤max {negsuc (suc m)} {negsuc (suc n)} with m ℕ.<ᵇ n UsingEq
-... | false , p = isAsym'< (¬>ℕ→¬negsuc<negsuc (subst Bool→Type p))
-... | true  , p = isRefl≤
+≤max {negsuc (suc m)} {negsuc (suc n)} with m ℕ.<ᵇ? n
+... | no ¬p = isAsym'< (¬>ℕ→¬negsuc<negsuc ¬p)
+... | yes p = isRefl≤
 
 -- this proof will not normalize quickly when m and n are the same large number
 ≤→max : m ≤ n → ℤ.max m n ≡ n
 ≤→max {pos zero}       {pos n}           p                = refl
-≤→max {pos (suc m)}    {pos (suc n)}    (pos≤pos p) with m ℕ.<ᵇ n UsingEq
-... | false , q = isAntisym≤ (pos≤pos p) (isAsym'< (¬<ℕ→¬pos<pos (subst Bool→Type q)) )
-... | true  , q = refl
+≤→max {pos (suc m)}    {pos (suc n)}    (pos≤pos p) with m ℕ.<ᵇ? n
+... | no ¬q = isAntisym≤ (pos≤pos p) (isAsym'< (¬<ℕ→¬pos<pos ¬q))
+... | yes q = refl
 ≤→max {negsuc m}       {pos n}           _                = refl
 ≤→max {negsuc zero}    {negsuc zero}    (negsuc≤negsuc p) = refl
 ≤→max {negsuc (suc m)} {negsuc zero}    (negsuc≤negsuc p) = refl
-≤→max {negsuc (suc m)} {negsuc (suc n)} (negsuc≤negsuc p) with m ℕ.<ᵇ n UsingEq
-... | false , q = refl
-... | true  , q = isAntisym≤ (negsuc≤negsuc p)
-                             (<-weaken (negsuc<negsuc (subst Bool→Type (sym q) tt)))
+≤→max {negsuc (suc m)} {negsuc (suc n)} (negsuc≤negsuc p) with m ℕ.<ᵇ? n
+... | no ¬q = refl
+... | yes q = isAntisym≤ (negsuc≤negsuc p) (<-weaken (negsuc<negsuc q))
 
 min≤ : ℤ.min m n ≤ m
 min≤ {pos zero}       {pos n}          = zero-≤pos
 min≤ {pos (suc m)}    {pos zero}       = zero-≤pos
-min≤ {pos (suc m)}    {pos (suc n)} with m ℕ.<ᵇ n UsingEq
-... | false , p = isAsym'< (¬<ℕ→¬pos<pos (subst Bool→Type p))
-... | true  , p = isRefl≤
+min≤ {pos (suc m)}    {pos (suc n)} with m ℕ.<ᵇ? n
+... | no ¬p = isAsym'< (¬<ℕ→¬pos<pos ¬p)
+... | yes p = isRefl≤
 min≤ {pos m}          {negsuc n}       = negsuc≤pos
 min≤ {negsuc m}       {pos n}          = isRefl≤
 min≤ {negsuc zero}    {negsuc n}       = negsuc≤negsuc tt
 min≤ {negsuc (suc m)} {negsuc zero}    = isRefl≤
-min≤ {negsuc (suc m)} {negsuc (suc n)} with m ℕ.<ᵇ n UsingEq
-... | false , p = isRefl≤
-... | true  , p = <-weaken (negsuc<negsuc (subst Bool→Type (sym p) tt))
+min≤ {negsuc (suc m)} {negsuc (suc n)} with m ℕ.<ᵇ? n
+... | no ¬p = isRefl≤
+... | yes p = <-weaken (negsuc<negsuc p)
 
 -- this proof will not normalize quickly when m and n are the same large number
 ≤→min : m ≤ n → ℤ.min m n ≡ m
 ≤→min {pos zero}       {pos n}           _                = refl
-≤→min {pos (suc m)}    {pos (suc n)}    (pos≤pos p) with m ℕ.<ᵇ n UsingEq
-... | false , q = isAntisym≤ (isAsym'< (¬<ℕ→¬pos<pos (subst Bool→Type q))) (pos≤pos p)
-... | true  , q = refl
+≤→min {pos (suc m)}    {pos (suc n)}    (pos≤pos p) with m ℕ.<ᵇ? n
+... | no ¬q = isAntisym≤ (isAsym'< (¬<ℕ→¬pos<pos ¬q)) (pos≤pos p)
+... | yes q = refl
 ≤→min {negsuc m}       {pos n}           _                = refl
 ≤→min {negsuc zero}    {negsuc zero}    (negsuc≤negsuc p) = refl
 ≤→min {negsuc (suc m)} {negsuc zero}    (negsuc≤negsuc p) = refl
-≤→min {negsuc (suc m)} {negsuc (suc n)} (negsuc≤negsuc p) with m ℕ.<ᵇ n UsingEq
-... | false , q = refl
-... | true  , q = isAntisym≤ (<-weaken (negsuc<negsuc (subst Bool→Type (sym q) tt)))
-                             (negsuc≤negsuc p)
+≤→min {negsuc (suc m)} {negsuc (suc n)} (negsuc≤negsuc p) with m ℕ.<ᵇ? n
+... | no ¬q = refl
+... | yes q = isAntisym≤ (<-weaken (negsuc<negsuc q)) (negsuc≤negsuc p)
 
 ≤MonotoneMin : m ≤ n → o ≤ s → ℤ.min m o ≤ ℤ.min n s
 ≤MonotoneMin {m} {n} {o} {s} p q = recompute≤ $

--- a/Cubical/Data/Fast/Int/Properties.agda
+++ b/Cubical/Data/Fast/Int/Properties.agda
@@ -214,38 +214,38 @@ maxAssoc (negsuc m) (negsuc n) (negsuc k) = cong negsuc $ ∧Assoc {m} {n} {k}
 minAbsorbLMax : ∀ x y → min x (max x y) ≡ x
 minAbsorbLMax (pos zero) (pos n) = refl
 minAbsorbLMax (pos (suc m)) (pos zero) = cong pos ∧Idem
-minAbsorbLMax (pos (suc m)) (pos (suc n)) with m <ᵇ n UsingEq
-... | false , _ = cong pos ∧Idem
-... | true  , p  with m <ᵇ n UsingEq
-... | false , ¬p = ⊥.rec (true≢false (sym p ∙ ¬p))
-... | true  , _  = refl
+minAbsorbLMax (pos (suc m)) (pos (suc n)) with m <ᵇ? n
+... | no  _ = cong pos ∧Idem
+... | yes p with m <ᵇ? n
+... | no ¬p = ⊥.rec (¬p p)
+... | yes _ = refl
 minAbsorbLMax (pos m)    (negsuc n) = cong pos ∧Idem
 minAbsorbLMax (negsuc m) (pos n)    = refl
 minAbsorbLMax (negsuc zero) (negsuc n) = refl
 minAbsorbLMax (negsuc (suc m)) (negsuc zero) = refl
-minAbsorbLMax (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ n UsingEq
-... | true  , _ = cong negsuc ∨Idem
-... | false , ¬p with m <ᵇ n UsingEq
-... | false , _ = refl
-... | true  , p = ⊥.rec (true≢false (sym p ∙ ¬p))
+minAbsorbLMax (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ? n
+... | yes _ = cong negsuc ∨Idem
+... | no ¬p with m <ᵇ? n
+... | no  _ = refl
+... | yes p = ⊥.rec (¬p p)
 
 maxAbsorbLMin : ∀ x y → max x (min x y) ≡ x
 maxAbsorbLMin (pos zero) (pos n) = refl
 maxAbsorbLMin (pos (suc m)) (pos zero) = refl
-maxAbsorbLMin (pos (suc m)) (pos (suc n)) with m <ᵇ n UsingEq
-... | true  , _ = cong pos ∨Idem
-... | false , ¬p with m <ᵇ n UsingEq
-... | false , _ = refl
-... | true  , p = ⊥.rec (true≢false (sym p ∙ ¬p))
+maxAbsorbLMin (pos (suc m)) (pos (suc n)) with m <ᵇ? n
+... | yes _ = cong pos ∨Idem
+... | no ¬p with m <ᵇ? n
+... | no  _ = refl
+... | yes p = ⊥.rec (¬p p)
 maxAbsorbLMin (pos m) (negsuc n) = refl
 maxAbsorbLMin (negsuc m) (pos n) = cong negsuc ∧Idem
 maxAbsorbLMin (negsuc zero) (negsuc n) = refl
 maxAbsorbLMin (negsuc (suc m)) (negsuc zero) = cong negsuc ∧Idem
-maxAbsorbLMin (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ n UsingEq
-... | false , _ = cong negsuc ∧Idem
-... | true  , p  with m <ᵇ n UsingEq
-... | false , ¬p = ⊥.rec (true≢false (sym p ∙ ¬p))
-... | true  , _  = refl
+maxAbsorbLMin (negsuc (suc m)) (negsuc (suc n)) with m <ᵇ? n
+... | no  _ = cong negsuc ∧Idem
+... | yes p with m <ᵇ? n
+... | no ¬p = ⊥.rec (¬p p)
+... | yes _ = refl
 
 predℤ+pos : ∀ n m → predℤ (m +pos n) ≡ (predℤ m) +pos n
 predℤ+pos zero m = refl

--- a/Cubical/Data/Nat/Order.agda
+++ b/Cubical/Data/Nat/Order.agda
@@ -305,16 +305,16 @@ min-≤-right {suc m} {suc n} = subst (_≤ _) (sym minSuc) $ suc-≤-suc $ min-
 maxLUB : ∀ {x} → m ≤ x → n ≤ x → max m n ≤ x
 maxLUB {zero}  {n}     _    n≤x  = n≤x
 maxLUB {suc m} {zero}  sm≤x _    = sm≤x
-maxLUB {suc m} {suc n} sm≤x sn≤x with m <ᵇ n
-... | false = sm≤x
-... | true  = sn≤x
+maxLUB {suc m} {suc n} sm≤x sn≤x with m <ᵇ? n
+... | no  _ = sm≤x
+... | yes _ = sn≤x
 
 minGLB : ∀ {x} → x ≤ m → x ≤ n → x ≤ min m n
 minGLB {zero}  {n}     x≤0 _     = x≤0
 minGLB {suc m} {zero}  _   x≤0   = x≤0
-minGLB {suc m} {suc n} x≤sm x≤sn with m <ᵇ n
-... | false = x≤sn
-... | true  = x≤sm
+minGLB {suc m} {suc n} x≤sm x≤sn with m <ᵇ? n
+... | no  _ = x≤sn
+... | yes _ = x≤sm
 
 0<^ : ∀ n → 0 < (suc m) ^ n
 0<^ {m} (zero ) = <-suc
@@ -381,6 +381,16 @@ private
 ≤→≤ᵇ {zero}  {n} 0≤n  = tt
 ≤→≤ᵇ {suc m} {n} sm≤n = <→<ᵇ sm≤n
 
+¬<ᵇ→≥ᵇ : ∀ m n → ¬ Bool→Type (m <ᵇ n) → Bool→Type (n ≤ᵇ m)
+¬<ᵇ→≥ᵇ m       zero    = λ _ → tt
+¬<ᵇ→≥ᵇ zero    (suc n) = ⊥.rec ∘ (_$ tt)
+¬<ᵇ→≥ᵇ (suc m) (suc n) = ¬<ᵇ→≥ᵇ m n
+
+¬≤ᵇ→>ᵇ : ∀ m n → ¬ Bool→Type (m ≤ᵇ n) → Bool→Type (n <ᵇ m)
+¬≤ᵇ→>ᵇ zero    n       = ⊥.rec ∘ (_$ tt)
+¬≤ᵇ→>ᵇ (suc m) zero    = λ _ → tt
+¬≤ᵇ→>ᵇ (suc m) (suc n) = ¬≤ᵇ→>ᵇ m n
+
 ≤Dec : ∀ m n → Dec (m ≤ n)
 ≤Dec zero n = yes (n , +-zero _)
 ≤Dec (suc m) zero = no ¬-<-zero
@@ -402,19 +412,12 @@ Trichotomy-suc (lt m<n) = lt (suc-≤-suc m<n)
 Trichotomy-suc (eq m=n) = eq (cong suc m=n)
 Trichotomy-suc (gt n<m) = gt (suc-≤-suc n<m)
 
-private
-  ∸→>ᵇ : ∀ m n → caseNat ⊥.⊥ Unit (m ∸ n) → Bool→Type (m >ᵇ n)
-  ∸→>ᵇ (suc m) zero    t = tt
-  ∸→>ᵇ (suc m) (suc n) t = ∸→>ᵇ m n t
-
 _≟_ : ∀ m n → Trichotomy m n
-m ≟ n with m ∸ n UsingEq | n ∸ m UsingEq
-... | zero  , p | zero  , q = eq (∸≡0→≡ p q)
-... | zero  , p | suc _ , q = lt (<ᵇ→< $ ∸→>ᵇ n m $ subst (caseNat ⊥.⊥ Unit) (sym q) tt)
-... | suc _ , p | zero  , q = gt (<ᵇ→< $ ∸→>ᵇ m n $ subst (caseNat ⊥.⊥ Unit) (sym p) tt)
-... | suc _ , p | suc _ , q = ⊥.rec $ <-irrefl {m} $ <-trans
-  (<ᵇ→< $ ∸→>ᵇ n m $ subst (caseNat ⊥.⊥ Unit) (sym q) tt)
-  (<ᵇ→< $ ∸→>ᵇ m n $ subst (caseNat ⊥.⊥ Unit) (sym p) tt)
+m ≟ n with m <ᵇ? n | n <ᵇ? m
+... | yes p | yes q = ⊥.rec $ <-irrefl {m} $ <-trans (<ᵇ→< p) (<ᵇ→< q)
+... | yes p | no ¬q = lt (<ᵇ→< p)
+... | no ¬p | yes q = gt (<ᵇ→< q)
+... | no ¬p | no ¬q = eq (≤-antisym (≤ᵇ→≤ (¬<ᵇ→≥ᵇ n m ¬q)) (≤ᵇ→≤ (¬<ᵇ→≥ᵇ m n ¬p)))
 
 --  Alternative version of ≟, defined without builtin primitives
 

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -20,20 +20,27 @@ private
   variable
     l m n : ℕ
 
+-- decidability of boolean builtins
+_<ᵇ?_ : ∀ m n → Dec (Bool→Type (m <ᵇ n))
+m <ᵇ? n = DecBool→Type {m <ᵇ n}
+
+_≡ᵇ?_ : ∀ m n → Dec (Bool→Type (m ≡ᵇ n))
+m ≡ᵇ? n = DecBool→Type {m ≡ᵇ n}
+
 min : ℕ → ℕ → ℕ
 min zero m = zero
 min (suc n) zero = zero
-min (suc n) (suc m) with n <ᵇ m UsingEq
-... | false , _ = suc m
-... | true  , _ = suc n
+min (suc n) (suc m) with n <ᵇ? m
+... | no  _ = suc m
+... | yes _ = suc n
 
 minSuc : min (suc n) (suc m) ≡ suc (min n m)
 minSuc {zero} {zero} = refl
 minSuc {zero} {suc m} = refl
 minSuc {suc n} {zero} = refl
-minSuc {suc n} {suc m} with suc n <ᵇ suc m
-... | false = refl
-... | true  = refl
+minSuc {suc n} {suc m} with suc n <ᵇ? suc m
+... | yes p = refl
+... | no ¬p = refl
 
 minComm : (n m : ℕ) → min n m ≡ min m n
 minComm zero zero = refl
@@ -44,17 +51,17 @@ minComm (suc n) (suc m) = minSuc ∙∙ cong suc (minComm n m) ∙∙ sym minSuc
 max : ℕ → ℕ → ℕ
 max zero m = m
 max (suc n) zero = suc n
-max (suc n) (suc m) with n <ᵇ m UsingEq
-... | false , _ = suc n
-... | true  , _ = suc m
+max (suc n) (suc m) with n <ᵇ? m
+... | no  _ = suc n
+... | yes _ = suc m
 
 maxSuc : max (suc n) (suc m) ≡ suc (max n m)
 maxSuc {zero} {zero} = refl
 maxSuc {zero} {suc m} = refl
 maxSuc {suc n} {zero} = refl
-maxSuc {suc n} {suc m} with suc n <ᵇ suc m
-... | false = refl
-... | true  = refl
+maxSuc {suc n} {suc m} with suc n <ᵇ? suc m
+... | no  _ = refl
+... | yes _ = refl
 
 maxComm : (n m : ℕ) → max n m ≡ max m n
 maxComm zero zero = refl
@@ -157,9 +164,9 @@ decodeℕ (suc n) (suc m) = λ r → cong suc (decodeℕ n m r)
 ≡→≡ᵇ {suc m} {suc n} p = ≡→≡ᵇ {m} {n} (cong predℕ p)
 
 discreteℕ : Discrete ℕ
-discreteℕ m n with m ≡ᵇ n UsingEq
-... | false , p = no  (subst Bool→Type p ∘ ≡→≡ᵇ)
-... | true  , p = yes (≡ᵇ→≡ (subst Bool→Type (sym p) tt))
+discreteℕ m n with m ≡ᵇ? n
+... | no ¬p = no  (¬p ∘ ≡→≡ᵇ)
+... | yes p = yes (≡ᵇ→≡ p)
 
 separatedℕ : Separated ℕ
 separatedℕ = Discrete→Separated discreteℕ

--- a/Cubical/Data/Nat/Properties.agda
+++ b/Cubical/Data/Nat/Properties.agda
@@ -39,8 +39,8 @@ minSuc {zero} {zero} = refl
 minSuc {zero} {suc m} = refl
 minSuc {suc n} {zero} = refl
 minSuc {suc n} {suc m} with suc n <ᵇ? suc m
-... | yes p = refl
-... | no ¬p = refl
+... | yes _ = refl
+... | no  _ = refl
 
 minComm : (n m : ℕ) → min n m ≡ min m n
 minComm zero zero = refl

--- a/Cubical/Foundations/Prelude.agda
+++ b/Cubical/Foundations/Prelude.agda
@@ -498,23 +498,6 @@ isContrSinglP A a .fst = _ , transport-filler (λ i → A i) a
 isContrSinglP A a .snd (x , p) i =
   _ , λ j → fill A (λ j → λ {(i = i0) → transport-filler (λ i → A i) a j; (i = i1) → p j}) (inS a) j
 
--- Helpers for carrying equalities into with-abstractions
--- see `discreteℕ` in Data.Nat.Properties for an example of usage
-
-infixl 0 _UsingEq
-infixl 0 _i0:>_UsingEqP
-
--- Similar to `inspect`, but more convenient when `a` is not a function
--- application, or when the applied function is not relevant
--- Note: when defining a term with `UsingEq`, it's still possible to prove its properties
--- using a with-abstraction without `UsingEq`, but not the other way around.
--- See `min`/`max` and their properties in Data.Nat.Properties for examples of this.
-_UsingEq : (a : A) → singl a
-a UsingEq = isContrSingl a .fst
-
-_i0:>_UsingEqP : (A : I → Type ℓ) (a : A i0) → singlP A a
-A i0:> a UsingEqP = isContrSinglP A a .fst
-
 -- Higher cube types
 
 SquareP :


### PR DESCRIPTION
This PR closes #1321 by introducing the decision procedures `_<ᵇ?_` and `_≡ᵇ?_`, and using them instead of `UsingEq` in with-abstractions.

To achieve this, `DecBool→Type` was moved from `Data.Bool.Properties` to `Data.Bool.Base`, as otherwise there would be a cyclic dependency; the alternative would be to define a copy of it locally, but I prefer to avoid code duplication.
Since `_≟_`  was also defined with `UsingEq`, I took this opportunity to rewrite it more easily, but with comparable performance, by introducing `¬<ᵇ→≥ᵇ`.

Finally, `_UsingEq` and `_i0:>_UsingEqP` has been removed from `Foundations.Prelude`.