### PR TITLE
Faster operations over `Rationals`

### DIFF
--- a/Cubical/Algebra/Field/Instances/Rationals.agda
+++ b/Cubical/Algebra/Field/Instances/Rationals.agda
@@ -14,7 +14,7 @@ open import Cubical.Algebra.CommRing.Instances.Rationals
 open import Cubical.Algebra.Field
 
 open import Cubical.Data.Empty as Empty
-open import Cubical.Data.Int as ℤ
+open import Cubical.Data.Fast.Int as ℤ
 open import Cubical.Data.Nat as ℕ using (ℕ ; zero ; suc)
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Rationals as ℚ

--- a/Cubical/Algebra/OrderedCommRing/Instances/Rationals.agda
+++ b/Cubical/Algebra/OrderedCommRing/Instances/Rationals.agda
@@ -1,0 +1,59 @@
+module Cubical.Algebra.OrderedCommRing.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+
+open import Cubical.HITs.PropositionalTruncation as PT
+
+open import Cubical.Data.Rationals as ℚ
+  renaming (_+_ to _+ℚ_ ; _-_ to _-ℚ_; -_ to -ℚ_ ; _·_ to _·ℚ_)
+open import Cubical.Data.Rationals.Order as ℚ
+  renaming (_<_ to _<ℚ_ ; _≤_ to _≤ℚ_)
+
+open import Cubical.Algebra.CommRing
+open import Cubical.Algebra.CommRing.Instances.Rationals
+
+open import Cubical.Algebra.OrderedCommRing.Base
+
+open import Cubical.Relation.Nullary
+
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Rationals
+
+open import Cubical.Relation.Binary.Order.Pseudolattice
+open import Cubical.Relation.Binary.Order.Pseudolattice.Instances.Rationals
+
+open CommRingStr
+open OrderedCommRingStr
+open PseudolatticeStr
+open StrictOrderStr
+
+ℚOrderedCommRing : OrderedCommRing ℓ-zero ℓ-zero
+fst ℚOrderedCommRing = ℚ
+0r  (snd ℚOrderedCommRing) = 0
+1r  (snd ℚOrderedCommRing) = 1
+_+_ (snd ℚOrderedCommRing) = _+ℚ_
+_·_ (snd ℚOrderedCommRing) = _·ℚ_
+-_  (snd ℚOrderedCommRing) = -ℚ_
+_<_ (snd ℚOrderedCommRing) = _<ℚ_
+_≤_ (snd ℚOrderedCommRing) = _≤ℚ_
+isOrderedCommRing (snd ℚOrderedCommRing) = isOrderedCommRingℚ
+  where
+  open IsOrderedCommRing
+
+  isOrderedCommRingℚ : IsOrderedCommRing 0 1 _+ℚ_ _·ℚ_ -ℚ_ _<ℚ_ _≤ℚ_
+  isOrderedCommRingℚ .isCommRing      = ℚCommRing .snd .isCommRing
+  isOrderedCommRingℚ .isPseudolattice = ℚ≤Pseudolattice .snd .is-pseudolattice
+  isOrderedCommRingℚ .isStrictOrder   = ℚ<StrictOrder .snd .isStrictOrder
+  isOrderedCommRingℚ .<-≤-weaken      = <Weaken≤
+  isOrderedCommRingℚ .≤≃¬>            = λ x y →
+    propBiimpl→Equiv (isProp≤ x y) (isProp¬ (y <ℚ x)) (≤→≯  x y) (≮→≥ y x)
+  isOrderedCommRingℚ .+MonoR≤         = ≤-+o
+  isOrderedCommRingℚ .+MonoR<         = <-+o
+  isOrderedCommRingℚ .posSum→pos∨pos  = λ x y → ∣_∣₁ ∘ 0<+ x y
+  isOrderedCommRingℚ .<-≤-trans       = isTrans<≤
+  isOrderedCommRingℚ .≤-<-trans       = isTrans≤<
+  isOrderedCommRingℚ .·MonoR≤         = ≤-·o
+  isOrderedCommRingℚ .·MonoR<         = <-·o
+  isOrderedCommRingℚ .0<1             = pos<pos tt

--- a/Cubical/Data/Rationals/Base.agda
+++ b/Cubical/Data/Rationals/Base.agda
@@ -8,7 +8,7 @@ open import Cubical.Foundations.Isomorphism
 open import Cubical.Data.Nat as ℕ using (discreteℕ)
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Sigma
-open import Cubical.Data.Int as ℤ
+open import Cubical.Data.Fast.Int as ℤ
 
 open import Cubical.HITs.SetQuotients as SetQuotient
   using ([_]; eq/; discreteSetQuotients) renaming (_/_ to _//_) public
@@ -38,6 +38,9 @@ isSetℚ = SetQuotient.squash/
 [_/_] : ℤ → ℕ₊₁ → ℚ
 [ a / b ] = [ a , b ]
 
+{-# DISPLAY [_] (a        , 1+ b) = [ a / ℕ.suc b ] #-}
+{-# DISPLAY [_] (pos a    , 1+ b) = [ a / ℕ.suc b ] #-}
+{-# DISPLAY [_] (negsuc a , 1+ b) = [ - (ℕ.suc a) / ℕ.suc b ] #-}
 
 isEquivRel∼ : isEquivRel _∼_
 isEquivRel.reflexive isEquivRel∼ (a , b) = refl

--- a/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
+++ b/Cubical/Data/Rationals/MoreRationals/QuoQ/Extras.agda
@@ -3,7 +3,7 @@ module Cubical.Data.Rationals.MoreRationals.QuoQ.Extras where
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Sigma
 open import Cubical.Data.Int.MoreInts.QuoInt renaming (_·_ to _ℤ·_)
-open import Cubical.Data.Int as Int renaming (ℤ to Int)
+open import Cubical.Data.Fast.Int as Int renaming (ℤ to Int)
 open import Cubical.Foundations.Prelude
 
 open import Cubical.HITs.SetQuotients
@@ -20,8 +20,10 @@ iso/rHlp (z , n) = ∼≡-lemma (Int→ℤ (ℤ→Int z)) z n (ℤ→Int→ℤ z
     ∼≡-lemma a a' b aa' i = (Quo.isEquivRel∼ .isEquivRel.reflexive) ((aa' i) , b) i
 
 Int≡Int→ℤ·≡ℤ· : ∀ x y → x Int.· (Rationals.ℕ₊₁→ℤ y) ≡ ℤ→Int ((Int→ℤ x) ℤ· (Quo.ℕ₊₁→ℤ y))
-Int≡Int→ℤ·≡ℤ· x y = (cong₂ (λ u v → u Int.· v) (sym (Int→ℤ→Int x)) refl) ∙
-                     sym (ℤ→IntIsHom· (Int→ℤ x) (Quo.ℕ₊₁→ℤ y))
+Int≡Int→ℤ·≡ℤ· x y = sym (
+     ℤ→IntIsHom· (Int→ℤ x) (Quo.ℕ₊₁→ℤ y)
+  ∙∙ Int.·≡·f (ℤ→Int (Int→ℤ x)) (Rationals.ℕ₊₁→ℤ y)
+  ∙∙ congL Int._·_ (Int→ℤ→Int x))
 
 ∼'→R* : ∀ u v → (u Rationals∼ v) → R* {ER = Quo.isEquivRel∼}
                                 {iso/r = iso/R (λ x → ℤ→Int (fst x) , (snd x))

--- a/Cubical/Data/Rationals/Order.agda
+++ b/Cubical/Data/Rationals/Order.agda
@@ -9,9 +9,9 @@ open import Cubical.Foundations.Univalence
 open import Cubical.Functions.Logic using (_⊔′_)
 
 open import Cubical.Data.Empty as ⊥
-open import Cubical.Data.Int.Base as ℤ using (ℤ)
-open import Cubical.Data.Int.Properties as ℤ using ()
-open import Cubical.Data.Int.Order as ℤ using ()
+open import Cubical.Data.Fast.Int.Base as ℤ using (ℤ)
+open import Cubical.Data.Fast.Int.Properties as ℤ using ()
+open import Cubical.Data.Fast.Int.Order as ℤ using ()
 open import Cubical.Data.Rationals.Base as ℚ
 open import Cubical.Data.Rationals.Properties as ℚ
 open import Cubical.Data.Nat as ℕ
@@ -20,7 +20,7 @@ open import Cubical.Data.Sigma
 open import Cubical.Data.Sum as ⊎ using (_⊎_; inl; inr; isProp⊎)
 
 open import Cubical.HITs.PropositionalTruncation as ∥₁ using (isPropPropTrunc; ∣_∣₁)
-open import Cubical.HITs.SetQuotients
+open import Cubical.HITs.SetQuotients renaming (_/_ to _//_)
 
 open import Cubical.Relation.Nullary
 open import Cubical.Relation.Binary.Base
@@ -32,122 +32,61 @@ private
   ·CommR a b c = sym (ℤ.·Assoc a b c) ∙ cong (a ℤ.·_) (ℤ.·Comm b c) ∙ ℤ.·Assoc a c b
 
   _≤'_ : ℚ → ℚ → hProp ℓ-zero
-  _≤'_ = fun
-    where
-        lemma≤ : ((a , b) (c , d) (e , f) : (ℤ × ℕ₊₁))
-                → (c ℤ.· ℕ₊₁→ℤ f ) ≡ (e ℤ.· ℕ₊₁→ℤ d)
-                → ((a ℤ.· ℕ₊₁→ℤ d) ℤ.≤ (c ℤ.· ℕ₊₁→ℤ b))
-                ≡ ((a ℤ.· ℕ₊₁→ℤ f) ℤ.≤ (e ℤ.· ℕ₊₁→ℤ b))
-        lemma≤ (a , b) (c , d) (e , f) cf≡ed = (ua (propBiimpl→Equiv ℤ.isProp≤ ℤ.isProp≤
-                (ℤ.≤-·o-cancel {k = -1+ d} ∘
-                  subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                               (·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f) ∙
-                                cong (ℤ._· ℕ₊₁→ℤ b) cf≡ed ∙
-                                ·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.≤-·o {k = ℕ₊₁→ℕ f})
-                (ℤ.≤-·o-cancel {k = -1+ f} ∘
-                  subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ d))
-                                (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d) ∙
-                                 cong (ℤ._· ℕ₊₁→ℤ b) (sym cf≡ed) ∙
-                                 ·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.≤-·o {k = ℕ₊₁→ℕ d})))
-
-        fun₀ : ℤ × ℕ₊₁ → ℚ → hProp ℓ-zero
-        fst (fun₀ (a , b) [ c , d ]) = a ℤ.· ℕ₊₁→ℤ d ℤ.≤ c ℤ.· ℕ₊₁→ℤ b
-        snd (fun₀ _ [ _ ]) = ℤ.isProp≤
-        fun₀ a/b (eq/ c/d e/f cf≡ed i) = record
-          { fst = lemma≤ a/b c/d e/f cf≡ed i
-          ; snd = isProp→PathP (λ i → isPropIsProp {A = lemma≤ a/b c/d e/f cf≡ed i}) ℤ.isProp≤ ℤ.isProp≤ i
-          }
-        fun₀ a/b (squash/ x y p q i j) = isSet→SquareP (λ _ _ → isSetHProp)
-          (λ _ → fun₀ a/b x)
-          (λ _ → fun₀ a/b y)
-          (λ i → fun₀ a/b (p i))
-          (λ i → fun₀ a/b (q i)) j i
-
-        toPath : ∀ a/b c/d (x : a/b ∼ c/d) (y : ℚ) → fun₀ a/b y ≡ fun₀ c/d y
-        toPath (a , b) (c , d) ad≡cb = elimProp (λ _ → isSetHProp _ _) λ (e , f) →
-          Σ≡Prop (λ _ → isPropIsProp) (ua (propBiimpl→Equiv ℤ.isProp≤ ℤ.isProp≤
-                (ℤ.≤-·o-cancel {k = -1+ b} ∘
-                  subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ d) ∙
-                                 cong (ℤ._· ℕ₊₁→ℤ f) ad≡cb ∙
-                                 ·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
-                               (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d)) ∘
-                 ℤ.≤-·o {k = ℕ₊₁→ℕ d})
-                (ℤ.≤-·o-cancel {k = -1+ d} ∘
-                  subst2 ℤ._≤_ (·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b) ∙
-                                 cong (ℤ._· ℕ₊₁→ℤ f) (sym ad≡cb) ∙
-                                 ·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                               (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.≤-·o {k = ℕ₊₁→ℕ b})))
-
-        fun : ℚ → ℚ → hProp ℓ-zero
-        fun [ a/b ] y = fun₀ a/b y
-        fun (eq/ a/b c/d ad≡cb i) y = toPath a/b c/d ad≡cb y i
-        fun (squash/ x y p q i j) z = isSet→SquareP (λ _ _ → isSetHProp)
-          (λ _ → fun x z) (λ _ → fun y z) (λ i → fun (p i) z) (λ i → fun (q i) z) j i
+  _≤'_ = Rec2SymHProp.go onFrac module ≤ where
+    onFrac : Rec2SymHProp ℓ-zero
+    onFrac .Rec2SymHProp.rel  (a , b) (c , d) = a ℤ.· ℕ₊₁→ℤ d ℤ.≤ c ℤ.· ℕ₊₁→ℤ b
+    onFrac .Rec2SymHProp.prop (a , b) (c , d) = ℤ.isProp≤
+    onFrac .Rec2SymHProp.symL (a , b) (c , d) = sym
+    onFrac .Rec2SymHProp.symR (a , b) (c , d) = sym
+    onFrac .Rec2SymHProp.eql  (a , b) (c , d) (e , f) ad≡cb =
+        ℤ.≤-·o-cancel
+      ∘ subst2 ℤ._≤_ (·CommR a _ _ ∙∙ cong (ℤ._· _) ad≡cb ∙∙ ·CommR c _ _)
+                     (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d))
+      ∘ ℤ.≤-·o
+    onFrac .Rec2SymHProp.eqr  (a , b) (c , d) (e , f) cf≡ed =
+        ℤ.≤-·o-cancel
+      ∘ subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+                     (·CommR c _ _ ∙∙ cong (ℤ._· _) cf≡ed ∙∙ ·CommR e _ _)
+      ∘ ℤ.≤-·o
 
   _<'_ : ℚ → ℚ → hProp ℓ-zero
-  _<'_ = fun
-    where
-        lemma< : ((a , b) (c , d) (e , f) : (ℤ × ℕ₊₁))
-                → (c ℤ.· ℕ₊₁→ℤ f ) ≡ (e ℤ.· ℕ₊₁→ℤ d)
-                → ((a ℤ.· ℕ₊₁→ℤ d) ℤ.< (c ℤ.· ℕ₊₁→ℤ b))
-                ≡ ((a ℤ.· ℕ₊₁→ℤ f) ℤ.< (e ℤ.· ℕ₊₁→ℤ b))
-        lemma< (a , b) (c , d) (e , f) cf≡ed = (ua (propBiimpl→Equiv ℤ.isProp< ℤ.isProp<
-                (ℤ.<-·o-cancel {k = -1+ d} ∘
-                  subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                               (·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f) ∙
-                                cong (ℤ._· ℕ₊₁→ℤ b) cf≡ed ∙
-                                ·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.<-·o {k = -1+ f})
-                (ℤ.<-·o-cancel {k = -1+ f} ∘
-                  subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ d))
-                               (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d) ∙
-                                cong (ℤ._· ℕ₊₁→ℤ b) (sym cf≡ed) ∙
-                                ·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.<-·o {k = -1+ d})))
+  _<'_ = Rec2SymHProp.go onFrac module < where
+    onFrac : Rec2SymHProp ℓ-zero
+    onFrac .Rec2SymHProp.rel  (a , b) (c , d) = a ℤ.· ℕ₊₁→ℤ d ℤ.< c ℤ.· ℕ₊₁→ℤ b
+    onFrac .Rec2SymHProp.prop (a , b) (c , d) = ℤ.isProp<
+    onFrac .Rec2SymHProp.symL (a , b) (c , d) = sym
+    onFrac .Rec2SymHProp.symR (a , b) (c , d) = sym
+    onFrac .Rec2SymHProp.eql  (a , b) (c , d) (e , f) ad≡cb =
+        ℤ.<-·o-cancel
+      ∘ subst2 ℤ._<_ (·CommR a _ _ ∙∙ cong (ℤ._· _) ad≡cb ∙∙ ·CommR c _ _)
+                     (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d))
+      ∘ ℤ.<-·o
+    onFrac .Rec2SymHProp.eqr  (a , b) (c , d) (e , f) cf≡ed =
+        ℤ.<-·o-cancel
+      ∘ subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+                     (·CommR c _ _ ∙∙ cong (ℤ._· _) cf≡ed ∙∙ ·CommR e _ _)
+      ∘ ℤ.<-·o
 
-        fun₀ : ℤ × ℕ₊₁ → ℚ → hProp ℓ-zero
-        fst (fun₀ (a , b) [ c , d ]) = a ℤ.· ℕ₊₁→ℤ d ℤ.< c ℤ.· ℕ₊₁→ℤ b
-        snd (fun₀ _ [ _ ]) = ℤ.isProp<
-        fun₀ a/b (eq/ c/d e/f cf≡ed i) = record
-          { fst = lemma< a/b c/d e/f cf≡ed i
-          ; snd = isProp→PathP (λ i → isPropIsProp {A = lemma< a/b c/d e/f cf≡ed i}) ℤ.isProp< ℤ.isProp< i
-          }
-        fun₀ a/b (squash/ x y p q i j) = isSet→SquareP (λ _ _ → isSetHProp)
-          (λ _ → fun₀ a/b x)
-          (λ _ → fun₀ a/b y)
-          (λ i → fun₀ a/b (p i))
-          (λ i → fun₀ a/b (q i)) j i
+{-# DISPLAY <.onFrac = _<'_ #-}
+{-# DISPLAY ≤.onFrac = _≤'_ #-}
 
-        toPath : ∀ a/b c/d (x : a/b ∼ c/d) (y : ℚ) → fun₀ a/b y ≡ fun₀ c/d y
-        toPath (a , b) (c , d) ad≡cb = elimProp (λ _ → isSetHProp _ _) λ (e , f) →
-          Σ≡Prop (λ _ → isPropIsProp) (ua (propBiimpl→Equiv ℤ.isProp< ℤ.isProp<
-                (ℤ.<-·o-cancel {k = -1+ b} ∘
-                  subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ d) ∙
-                                cong (ℤ._· ℕ₊₁→ℤ f) ad≡cb ∙
-                                ·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
-                               (·CommR e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d)) ∘
-                 ℤ.<-·o {k = -1+ d})
-                (ℤ.<-·o-cancel {k = -1+ d} ∘
-                  subst2 ℤ._<_ (·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b) ∙
-                                cong (ℤ._· ℕ₊₁→ℤ f) (sym ad≡cb) ∙
-                                ·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                               (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∘
-                 ℤ.<-·o {k = -1+ b})))
+record _≤_ (m n : ℚ ) : Type₀ where
+  constructor inj
+  field
+    prf : fst (m ≤' n)
 
-        fun : ℚ → ℚ → hProp ℓ-zero
-        fun [ a/b ] y = fun₀ a/b y
-        fun (eq/ a/b c/d ad≡cb i) y = toPath a/b c/d ad≡cb y i
-        fun (squash/ x y p q i j) z = isSet→SquareP (λ _ _ → isSetHProp)
-          (λ _ → fun x z) (λ _ → fun y z) (λ i → fun (p i) z) (λ i → fun (q i) z) j i
+record _<_ (m n : ℚ ) : Type₀ where
+  constructor inj
+  field
+    prf : fst (m <' n)
 
-_≤_ : ℚ → ℚ → Type₀
-m ≤ n = fst (m ≤' n)
+pattern pos≤pos p       = inj (ℤ.pos≤pos p)
+pattern negsuc≤pos      = inj ℤ.negsuc≤pos
+pattern negsuc≤negsuc p = inj (ℤ.negsuc≤negsuc p)
 
-_<_ : ℚ → ℚ → Type₀
-m < n = fst (m <' n)
+pattern pos<pos p       = inj (ℤ.pos<pos p)
+pattern negsuc<pos      = inj ℤ.negsuc<pos
+pattern negsuc<negsuc p = inj (ℤ.negsuc<negsuc p)
 
 _≥_ : ℚ → ℚ → Type₀
 m ≥ n = n ≤ m
@@ -167,53 +106,114 @@ module _ where
   open BinaryRelation
 
   isProp≤ : isPropValued _≤_
-  isProp≤ m n = snd (m ≤' n)
+  isProp≤ m n (inj p) (inj q) = cong inj (snd (m ≤' n) p q)
 
   isProp< : isPropValued _<_
-  isProp< m n = snd (m <' n)
+  isProp< m n (inj p) (inj q) = cong inj (snd (m <' n) p q)
+
+  recompute≤ : ∀ {a b} → a ≤ b → a ≤ b
+  recompute≤ = elimProp2 {P = λ a b → a ≤ b → a ≤ b}
+                         (λ _ _ → isProp→ (isProp≤ _ _))
+                         (λ _ _ → inj ∘ ℤ.recompute≤ ∘ _≤_.prf) _ _
+
+  recompute< : ∀ {a b} → a < b → a < b
+  recompute< = elimProp2 {P = λ a b → a < b → a < b}
+                         (λ _ _ → isProp→ (isProp< _ _))
+                         (λ _ _ → inj ∘ ℤ.recompute< ∘ _<_.prf) _ _
+
+  recompute¬≤ : ∀ {a b} → ¬ (a ≤ b) → ¬ (a ≤ b)
+  recompute¬≤ = elimProp2 {P = λ a b → ¬ (a ≤ b) → ¬ (a ≤ b)}
+                          (λ _ _ → isProp→ (isProp¬ _))
+                          (λ _ _ ¬a≤b → ℤ.recompute¬≤ (¬a≤b ∘ inj) ∘ _≤_.prf) _ _
+
+  recompute¬< : ∀ {a b} → ¬ (a < b) → ¬ (a < b)
+  recompute¬< = elimProp2 {P = λ a b → ¬ (a < b) → ¬ (a < b)}
+                          (λ _ _ → isProp→ (isProp¬ _))
+                          (λ _ _ ¬a<b → ℤ.recompute¬< (¬a<b ∘ inj) ∘ _<_.prf) _ _
+
+  recompute# : ∀ {a b} → a # b → a # b
+  recompute# = ⊎.map recompute< recompute<
+
+  recompute¬# : ∀ {a b} → ¬ (a # b) → ¬ (a # b)
+  recompute¬# r = ⊎.rec (recompute¬< (r ∘ inl)) (recompute¬< (r ∘ inr))
+
+  -- if the proof p : x ≡ x' is computationaly heavy, then
+  -- subst (_≤ _) p q will normalize slowly for concrete rationals,
+  -- and the situation applies as well for < and # in place of ≤.
+  -- However, we can always recompute and avoid the actual transports, and since
+  -- this pattern is quite common, here below we introduce the following helpers:
+
+  subst≤ : ∀ {x x' y y'} → x ≡ x' → y ≡ y' → x ≤ y → x' ≤ y'
+  subst≤ = ((recompute≤ ∘_) ∘_) ∘ subst2 _≤_
+
+  subst≤L : ∀ {x x' y} → x ≡ x' → x ≤ y → x' ≤ y
+  subst≤L = (recompute≤ ∘_) ∘ subst (_≤ _)
+
+  subst≤R : ∀ {x y y'} → y ≡ y' → x ≤ y → x ≤ y'
+  subst≤R = (recompute≤ ∘_) ∘ subst (_ ≤_)
+
+  subst< : ∀ {x x' y y'} → x ≡ x' → y ≡ y' → x < y → x' < y'
+  subst< = ((recompute< ∘_) ∘_) ∘ subst2 _<_
+
+  subst<L : ∀ {x x' y} → x ≡ x' → x < y → x' < y
+  subst<L = (recompute< ∘_) ∘ subst (_< _)
+
+  subst<R : ∀ {x y y'} → y ≡ y' → x < y → x < y'
+  subst<R = (recompute< ∘_) ∘ subst (_ <_)
+
+  subst# : ∀ {x x' y y'} → x ≡ x' → y ≡ y' → x # y → x' # y'
+  subst# = ((recompute# ∘_) ∘_) ∘ subst2 _#_
+
+  subst#L : ∀ {x x' y} → x ≡ x' → x # y → x' # y
+  subst#L = (recompute# ∘_) ∘ subst (_# _)
+
+  subst#R : ∀ {x y y'} → y ≡ y' → x # y → x # y'
+  subst#R = (recompute# ∘_) ∘ subst (_ #_)
+
+  -- properties of ≤ , < , and #
 
   isRefl≤ : isRefl _≤_
-  isRefl≤ = elimProp {P = λ x → x ≤ x} (λ x → isProp≤ x x) λ _ → ℤ.isRefl≤
+  isRefl≤ = elimProp {P = λ x → x ≤ x} (λ x → isProp≤ x x) λ _ → inj ℤ.isRefl≤
 
   isIrrefl< : isIrrefl _<_
-  isIrrefl< = elimProp {P = λ x → ¬ x < x} (λ _ → isProp¬ _) λ _ → ℤ.isIrrefl<
+  isIrrefl< = elimProp {P = λ x → ¬ x < x} (λ _ → isProp¬ _) λ _ → ℤ.isIrrefl< ∘ _<_.prf
 
   isAntisym≤ : isAntisym _≤_
   isAntisym≤ =
     elimProp2 {P = λ a b → a ≤ b → b ≤ a → a ≡ b}
               (λ x y → isPropΠ2 λ _ _ → isSetℚ x y)
-              λ a b a≤b b≤a → eq/ a b (ℤ.isAntisym≤ a≤b b≤a)
+              λ a b (inj a≤b) (inj b≤a) → eq/ a b (ℤ.isAntisym≤ a≤b b≤a)
 
   isTrans≤ : isTrans _≤_
   isTrans≤ =
     elimProp3 {P = λ a b c → a ≤ b → b ≤ c → a ≤ c}
               (λ x _ z → isPropΠ2 λ _ _ → isProp≤ x z)
-              λ { (a , b) (c , d) (e , f) ad≤cb cf≤ed →
-                ℤ.≤-·o-cancel {k = -1+ d}
+              λ { (a , b) (c , d) (e , f) (inj ad≤cb) (inj cf≤ed) →
+                inj (ℤ.≤-·o-cancel
                   (subst (ℤ._≤ e ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ d)
                     (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                  (ℤ.isTrans≤ (ℤ.≤-·o {k = ℕ₊₁→ℕ f} ad≤cb)
+                  (ℤ.isTrans≤ (ℤ.≤-·o ad≤cb)
                     (subst2 ℤ._≤_
                       (·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b))
                       (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                      (ℤ.≤-·o {k = ℕ₊₁→ℕ b} cf≤ed)))) }
+                      (ℤ.≤-·o cf≤ed))))) }
 
   isTrans< : isTrans _<_
   isTrans< =
     elimProp3 {P = λ a b c → a < b → b < c → a < c}
               (λ x _ z → isPropΠ2 λ _ _ → isProp< x z)
-              λ { (a , b) (c , d) (e , f) ad<cb cf<ed →
-                ℤ.<-·o-cancel {k = -1+ d}
+              λ { (a , b) (c , d) (e , f) (inj ad<cb) (inj cf<ed) →
+                inj (ℤ.<-·o-cancel
                   (subst (ℤ._< e ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ d)
                     (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                  (ℤ.isTrans< (ℤ.<-·o {k = -1+ f} ad<cb)
+                  (ℤ.isTrans< (ℤ.<-·o ad<cb)
                     (subst2 ℤ._<_
                       (·CommR c (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b))
                       (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                      (ℤ.<-·o {k = -1+ b} cf<ed)))) }
+                      (ℤ.<-·o cf<ed))))) }
 
   isAsym< : isAsym _<_
-  isAsym< = isIrrefl×isTrans→isAsym _<_ (isIrrefl< , isTrans<)
+  isAsym< = ((recompute¬< ∘_) ∘_) ∘ isIrrefl×isTrans→isAsym _<_ (isIrrefl< , isTrans<)
 
   isTotal≤ : isTotal _≤_
   isTotal≤ =
@@ -223,9 +223,9 @@ module _ where
     where
       lem : (a b : ℤ.ℤ × ℕ₊₁) → ([ a ] ≤ [ b ]) ⊎ ([ b ] ≤ [ a ])
       lem (a , b) (c , d) with (a ℤ.· ℕ₊₁→ℤ d) ℤ.≟ (c ℤ.· ℕ₊₁→ℤ b)
-      ... | ℤ.lt ad<cb = inl (ℤ.<-weaken ad<cb)
-      ... | ℤ.eq ad≡cb = inl (0 , ad≡cb)
-      ... | ℤ.gt cb<ad = inr (ℤ.<-weaken cb<ad)
+      ... | ℤ.lt ad<cb = inl (inj (ℤ.<-weaken ad<cb))
+      ... | ℤ.eq ad≡cb = inl (inj (ℤ.recompute≤ $ subst (_ ℤ.≤_) ad≡cb ℤ.isRefl≤))
+      ... | ℤ.gt cb<ad = inr (inj (ℤ.<-weaken cb<ad))
 
   isConnected< : isConnected _<_
   isConnected< =
@@ -235,9 +235,9 @@ module _ where
     where
       lem : (a b : ℤ.ℤ × ℕ₊₁) → (¬ [ a ] < [ b ]) × (¬ [ b ] < [ a ]) → [ a ] ≡ [ b ]
       lem (a , b) (c , d) (¬ad<cb , ¬cb<ad) with (a ℤ.· ℕ₊₁→ℤ d) ℤ.≟ (c ℤ.· ℕ₊₁→ℤ b)
-      ... | ℤ.lt ad<cb = ⊥.rec (¬ad<cb ad<cb)
+      ... | ℤ.lt ad<cb = ⊥.rec (¬ad<cb (inj ad<cb))
       ... | ℤ.eq ad≡cb = eq/ (a , b) (c , d) ad≡cb
-      ... | ℤ.gt cb<ad = ⊥.rec (¬cb<ad cb<ad)
+      ... | ℤ.gt cb<ad = ⊥.rec (¬cb<ad (inj cb<ad))
 
   isProp# : isPropValued _#_
   isProp# x y = isProp⊎ (isProp< x y) (isProp< y x) (isAsym< x y)
@@ -258,9 +258,9 @@ module _ where
     where
       lem : (a b : ℤ.ℤ × ℕ₊₁) → ¬ [_] {R = _∼_} a ≡ [ b ] → [ a ] # [ b ]
       lem (a , b) (c , d) ¬a≡b with (a ℤ.· ℕ₊₁→ℤ d) ℤ.≟ (c ℤ.· ℕ₊₁→ℤ b)
-      ... | ℤ.lt ad<cb = inl ad<cb
+      ... | ℤ.lt ad<cb = inl (inj ad<cb)
       ... | ℤ.eq ad≡cb = ⊥.rec (¬a≡b (eq/ (a , b) (c , d) ad≡cb))
-      ... | ℤ.gt cb<ad = inr cb<ad
+      ... | ℤ.gt cb<ad = inr (inj cb<ad)
 
   isWeaklyLinear< : isWeaklyLinear _<_
   isWeaklyLinear< =
@@ -270,7 +270,7 @@ module _ where
     where
       lem : (a b c : ℤ.ℤ × ℕ₊₁) → [ a ] < [ b ] → ([ a ] < [ c ]) ⊔′ ([ c ] < [ b ])
       lem a b c a<b with discreteℚ [ a ] [ c ]
-      ... | yes a≡c = ∣ inr (subst (_< [ b ]) a≡c a<b) ∣₁
+      ... | yes a≡c = ∣ inr (subst<L a≡c a<b) ∣₁
       ... | no a≢c = ∣ ⊎.map (λ a<c → a<c)
                              (λ c<a → isTrans< [ c ] [ a ] [ b ] c<a a<b)
                              (inequalityImplies# [ a ] [ c ] a≢c) ∣₁
@@ -283,15 +283,15 @@ module _ where
       where
         lem : (a b c : ℤ.ℤ × ℕ₊₁) → [ a ] # [ b ] → ([ a ] # [ c ]) ⊔′ ([ b ] # [ c ])
         lem a b c a#b with discreteℚ [ b ] [ c ]
-        ... | yes b≡c = ∣ inl (subst ([ a ] #_) b≡c a#b) ∣₁
+        ... | yes b≡c = ∣ inl (subst#R b≡c a#b) ∣₁
         ... | no  b≢c = ∣ inr (inequalityImplies# [ b ] [ c ] b≢c) ∣₁
 
 ≤-+o : ∀ m n o → m ≤ n → m ℚ.+ o ≤ n ℚ.+ o
 ≤-+o =
   elimProp3 {P = λ a b c → a ≤ b → a ℚ.+ c ≤ b ℚ.+ c}
             (λ x y z → isProp→ (isProp≤ (x ℚ.+ z) (y ℚ.+ z)))
-             λ { (a , b) (c , d) (e , f) ad≤cb →
-               subst2 ℤ._≤_
+             λ { (a , b) (c , d) (e , f) (inj ad≤cb) →
+                inj $ ℤ.recompute≤ $ subst2 ℤ._≤_
                        (cong₂ ℤ._+_
                               (cong (λ x → a ℤ.· ℕ₊₁→ℤ d ℤ.· x)
                                     (ℤ.pos·pos (ℕ₊₁→ℕ f) (ℕ₊₁→ℕ f)) ∙
@@ -324,13 +324,10 @@ module _ where
                                     cong (λ x → e ℤ.· ℕ₊₁→ℤ d ℤ.· x)
                                          (sym (ℤ.pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ f)))) ∙
                        sym (ℤ.·DistL+ (c ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ d) (ℕ₊₁→ℤ (b ·₊₁ f))))
-                       (ℤ.≤-+o {o = e ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ f}
-                               (ℤ.≤-·o {k = ℕ₊₁→ℕ (f ·₊₁ f)} ad≤cb)) }
+                       (ℤ.≤-+o (ℤ.≤-·o ad≤cb)) }
 
 ≤-o+ : ∀ m n o →  m ≤ n → o ℚ.+ m ≤ o ℚ.+ n
-≤-o+ m n o = subst2 _≤_ (+Comm m o)
-                         (+Comm n o) ∘
-             ≤-+o m n o
+≤-o+ m n o = subst≤ (+Comm m o) (+Comm n o) ∘ ≤-+o m n o
 
 ≤Monotone+ : ∀ m n o s → m ≤ n → o ≤ s → m ℚ.+ o ≤ n ℚ.+ s
 ≤Monotone+ m n o s m≤n o≤s
@@ -341,23 +338,23 @@ module _ where
               (≤-o+ o s n o≤s)
 
 ≤-o+-cancel : ∀ m n o →  o ℚ.+ m ≤ o ℚ.+ n → m ≤ n
-≤-o+-cancel m n o
-  = subst2 _≤_ (+Assoc (- o) o m ∙ cong (ℚ._+ m) (+InvL o) ∙ +IdL m)
-                (+Assoc (- o) o n ∙ cong (ℚ._+ n) (+InvL o) ∙ +IdL n) ∘
-           ≤-o+ (o ℚ.+ m) (o ℚ.+ n) (- o)
+≤-o+-cancel m n o = subst≤
+  (+Assoc (- o) o m ∙ cong (ℚ._+ m) (+InvL o) ∙ +IdL m)
+  (+Assoc (- o) o n ∙ cong (ℚ._+ n) (+InvL o) ∙ +IdL n) ∘
+  ≤-o+ (o ℚ.+ m) (o ℚ.+ n) (- o)
 
 ≤-+o-cancel : ∀ m n o → m ℚ.+ o ≤ n ℚ.+ o → m ≤ n
-≤-+o-cancel m n o
-  = subst2 _≤_ (sym (+Assoc m o (- o)) ∙ cong (λ x → m ℚ.+ x) (+InvR o) ∙ +IdR m)
-                (sym (+Assoc n o (- o)) ∙ cong (λ x → n ℚ.+ x) (+InvR o) ∙ +IdR n) ∘
-           ≤-+o (m ℚ.+ o) (n ℚ.+ o) (- o)
+≤-+o-cancel m n o = subst≤
+  (sym (+Assoc m o (- o)) ∙ cong (λ x → m ℚ.+ x) (+InvR o) ∙ +IdR m)
+  (sym (+Assoc n o (- o)) ∙ cong (λ x → n ℚ.+ x) (+InvR o) ∙ +IdR n) ∘
+  ≤-+o (m ℚ.+ o) (n ℚ.+ o) (- o)
 
 <-+o : ∀ m n o → m < n → m ℚ.+ o < n ℚ.+ o
 <-+o =
   elimProp3 {P = λ a b c → a < b → a ℚ.+ c < b ℚ.+ c}
             (λ x y z → isProp→ (isProp< (x ℚ.+ z) (y ℚ.+ z)))
-             λ { (a , b) (c , d) (e , f) ad<cb →
-               subst2 ℤ._<_
+             λ { (a , b) (c , d) (e , f) (inj ad<cb) →
+               inj $ ℤ.recompute< $ subst2 ℤ._<_
                        (cong₂ ℤ._+_
                               (cong (λ x → a ℤ.· ℕ₊₁→ℤ d ℤ.· x)
                                     (ℤ.pos·pos (ℕ₊₁→ℕ f) (ℕ₊₁→ℕ f)) ∙
@@ -390,81 +387,78 @@ module _ where
                                     cong (λ x → e ℤ.· ℕ₊₁→ℤ d ℤ.· x)
                                          (sym (ℤ.pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ f)))) ∙
                        sym (ℤ.·DistL+ (c ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ d) (ℕ₊₁→ℤ (b ·₊₁ f))))
-                       (ℤ.<-+o {o = e ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ f}
-                               (ℤ.<-·o {k = -1+ (f ·₊₁ f)} ad<cb)) }
+                       (ℤ.<-+o (ℤ.<-·o ad<cb)) }
 
 <-o+ : ∀ m n o → m < n → o ℚ.+ m < o ℚ.+ n
-<-o+ m n o = subst2 _<_ (+Comm m o) (+Comm n o) ∘ <-+o m n o
+<-o+ m n o = subst< (+Comm m o) (+Comm n o) ∘ <-+o m n o
 
 <Monotone+ : ∀ m n o s → m < n → o < s → m ℚ.+ o < n ℚ.+ s
 <Monotone+ m n o s m<n o<s
   = isTrans< (m ℚ.+ o) (n ℚ.+ o) (n ℚ.+ s) (<-+o m n o m<n) (<-o+ o s n o<s)
 
 <-o+-cancel : ∀ m n o → o ℚ.+ m < o ℚ.+ n → m < n
-<-o+-cancel m n o
-  = subst2 _<_ (+Assoc (- o) o m ∙ cong (ℚ._+ m) (+InvL o) ∙ +IdL m)
-               (+Assoc (- o) o n ∙ cong (ℚ._+ n) (+InvL o) ∙ +IdL n) ∘
-           <-o+ (o ℚ.+ m) (o ℚ.+ n) (- o)
+<-o+-cancel m n o = subst<
+  (+Assoc (- o) o m ∙ cong (ℚ._+ m) (+InvL o) ∙ +IdL m)
+  (+Assoc (- o) o n ∙ cong (ℚ._+ n) (+InvL o) ∙ +IdL n) ∘
+  <-o+ (o ℚ.+ m) (o ℚ.+ n) (- o)
 
 <-+o-cancel : ∀ m n o → m ℚ.+ o < n ℚ.+ o → m < n
-<-+o-cancel m n o
-  = subst2 _<_ (sym (+Assoc m o (- o)) ∙ cong (λ x → m ℚ.+ x) (+InvR o) ∙ +IdR m)
-               (sym (+Assoc n o (- o)) ∙ cong (λ x → n ℚ.+ x) (+InvR o) ∙ +IdR n) ∘
-           <-+o (m ℚ.+ o) (n ℚ.+ o) (- o)
+<-+o-cancel m n o = subst<
+  (sym (+Assoc m o (- o)) ∙ cong (λ x → m ℚ.+ x) (+InvR o) ∙ +IdR m)
+  (sym (+Assoc n o (- o)) ∙ cong (λ x → n ℚ.+ x) (+InvR o) ∙ +IdR n) ∘
+  <-+o (m ℚ.+ o) (n ℚ.+ o) (- o)
 
 <Weaken≤ : ∀ m n → m < n → m ≤ n
 <Weaken≤ m n = elimProp2 {P = λ x y → x < y → x ≤ y}
                              (λ x y → isProp→ (isProp≤ x y))
-                             (λ { (a , b) (c , d) → ℤ.<-weaken }) m n
+                             (λ { (a , b) (c , d) → inj ∘ ℤ.<-weaken ∘ _<_.prf }) m n
 
 isTrans<≤ : ∀ m n o → m < n → n ≤ o → m < o
 isTrans<≤ =
     elimProp3 {P = λ a b c → a < b → b ≤ c → a < c}
               (λ x _ z → isPropΠ2 λ _ _ → isProp< x z)
-               λ { (a , b) (c , d) (e , f) ad<cb cf≤ed
-                → ℤ.<-·o-cancel {k = -1+ d}
-                 (ℤ.<≤-trans {m = c ℤ.· ℕ₊₁→ℤ f ℤ.· ℕ₊₁→ℤ b}
-                              (subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+               λ { (a , b) (c , d) (e , f) (inj ad<cb) (inj cf≤ed)
+                → inj $ ℤ.<-·o-cancel
+                 (ℤ.<≤-trans (subst2 ℤ._<_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
                                             (·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
-                                            (ℤ.<-·o {k = -1+ f} ad<cb))
-                              (subst (_ ℤ.≤_) (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                                     (ℤ.≤-·o {k = ℕ₊₁→ℕ b} cf≤ed)) )}
+                                            (ℤ.<-·o ad<cb))
+                             (subst (_ ℤ.≤_) (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
+                                    (ℤ.≤-·o cf≤ed)) )}
 
 isTrans≤< : ∀ m n o → m ≤ n → n < o → m < o
 isTrans≤< =
     elimProp3 {P = λ a b c → a ≤ b → b < c → a < c}
               (λ x _ z → isPropΠ2 λ _ _ → isProp< x z)
-               λ { (a , b) (c , d) (e , f) ad≤cb cf<ed
-                → ℤ.<-·o-cancel {k = -1+ d}
-                 (ℤ.≤<-trans {m = c ℤ.· ℕ₊₁→ℤ f ℤ.· ℕ₊₁→ℤ b}
-                              (subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
-                                             (·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
-                                             (ℤ.≤-·o {k = ℕ₊₁→ℕ f} ad≤cb))
-                              (subst (_ ℤ.<_) (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                                     (ℤ.<-·o {k = -1+ b} cf<ed)) )}
+               λ { (a , b) (c , d) (e , f) (inj ad≤cb) (inj cf<ed)
+                → inj $ ℤ.<-·o-cancel
+                 (ℤ.≤<-trans (subst2 ℤ._≤_ (·CommR a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+                                            (·CommR c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
+                                            (ℤ.≤-·o ad≤cb))
+                             (subst (_ ℤ.<_) (·CommR e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
+                                    (ℤ.<-·o cf<ed)) )}
 
 ≤-·o : ∀ m n o → 0 ≤ o → m ≤ n → m ℚ.· o ≤ n ℚ.· o
 ≤-·o =
   elimProp3 {P = λ a b c → 0 ≤ c → a ≤ b → a ℚ.· c ≤ b ℚ.· c}
             (λ x y z → isPropΠ2 λ _ _ → isProp≤ (x ℚ.· z) (y ℚ.· z))
-             λ { (a , b) (c , d) (e , f) 0≤e ad≤cb
-             → subst2 ℤ._≤_ (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR a (ℕ₊₁→ℤ d) e) ∙
+             λ { (a , b) (c , d) (e , f) (inj 0≤e) (inj ad≤cb)
+             → inj $ ℤ.recompute≤ $
+               subst2 ℤ._≤_ (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR a (ℕ₊₁→ℤ d) e) ∙
                               sym (ℤ.·Assoc (a ℤ.· e) (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f)) ∙
                               cong (a ℤ.· e ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f))))
                              (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR c (ℕ₊₁→ℤ b) e) ∙
                               sym (ℤ.·Assoc (c ℤ.· e) (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f)) ∙
                               cong (c ℤ.· e ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ f))))
-                             (ℤ.≤-·o {k = ℕ₊₁→ℕ f}
-                                      (ℤ.0≤o→≤-·o (subst (0 ℤ.≤_) (ℤ.·IdR e) 0≤e) ad≤cb)) }
+                             (ℤ.≤-·o (ℤ.0≤o→≤-·o (subst (0 ℤ.≤_) (ℤ.·IdR e) 0≤e) ad≤cb)) }
 
 ≤-·o-cancel : ∀ m n o → 0 < o → m ℚ.· o ≤ n ℚ.· o → m ≤ n
 ≤-·o-cancel =
   elimProp3 {P = λ a b c → 0 < c → a ℚ.· c ≤ b ℚ.· c → a ≤ b}
             (λ x y _ → isPropΠ2 λ _ _ → isProp≤ x y)
-             λ { (a , b) (c , d) (e , f) 0<e aedf≤cebf
-             → ℤ.0<o→≤-·o-cancel (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e)
+             λ { (a , b) (c , d) (e , f) (inj 0<e) (inj aedf≤cebf)
+             → inj $ ℤ.0<o→≤-·o-cancel (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e)
                (subst2 ℤ._≤_ (·CommR a e (ℕ₊₁→ℤ d)) (·CommR c e (ℕ₊₁→ℤ b))
-                      (ℤ.≤-·o-cancel {k = -1+ f}
+                      (ℤ.≤-·o-cancel
                         (subst2 ℤ._≤_ (sym (ℤ.·Assoc a e (ℕ₊₁→ℤ (d ·₊₁ f))) ∙
                                        cong (λ x → a ℤ.· (e ℤ.· x))
                                             (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f)) ∙
@@ -484,24 +478,24 @@ isTrans≤< =
 <-·o =
   elimProp3 {P = λ a b c → 0 < c → a < b → a ℚ.· c < b ℚ.· c}
             (λ x y z → isPropΠ2 λ _ _ → isProp< (x ℚ.· z) (y ℚ.· z))
-             λ { (a , b) (c , d) (e , f) 0<e ad<cb
-             → subst2 ℤ._<_ (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR a (ℕ₊₁→ℤ d) e) ∙
+             λ { (a , b) (c , d) (e , f) (inj 0<e) (inj ad<cb)
+             → inj $ ℤ.recompute< $
+               subst2 ℤ._<_ (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR a (ℕ₊₁→ℤ d) e) ∙
                              sym (ℤ.·Assoc (a ℤ.· e) (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f)) ∙
                              cong (a ℤ.· e ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f))))
                             (cong (ℤ._· ℕ₊₁→ℤ f) (·CommR c (ℕ₊₁→ℤ b) e) ∙
                              sym (ℤ.·Assoc (c ℤ.· e) (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f)) ∙
                              cong (c ℤ.· e ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ f))))
-                            (ℤ.<-·o {k = -1+ f}
-                                    (ℤ.0<o→<-·o (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e) ad<cb)) }
+                            (ℤ.<-·o (ℤ.0<o→<-·o (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e) ad<cb)) }
 
 <-·o-cancel : ∀ m n o → 0 < o → m ℚ.· o < n ℚ.· o → m < n
 <-·o-cancel =
   elimProp3 {P = λ a b c → 0 < c → a ℚ.· c < b ℚ.· c → a < b}
             (λ x y _ → isPropΠ2 λ _ _ → isProp< x y)
-             λ { (a , b) (c , d) (e , f) 0<e aedf<cebf
-             → ℤ.0<o→<-·o-cancel (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e)
+             λ { (a , b) (c , d) (e , f) (inj 0<e) (inj aedf<cebf)
+             → inj $ ℤ.0<o→<-·o-cancel (subst (0 ℤ.<_) (ℤ.·IdR e) 0<e)
                (subst2 ℤ._<_ (·CommR a e (ℕ₊₁→ℤ d)) (·CommR c e (ℕ₊₁→ℤ b))
-                      (ℤ.<-·o-cancel {k = -1+ f}
+                      (ℤ.<-·o-cancel
                         (subst2 ℤ._<_ (sym (ℤ.·Assoc a e (ℕ₊₁→ℤ (d ·₊₁ f))) ∙
                                        cong (λ x → a ℤ.· (e ℤ.· x))
                                             (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f)) ∙
@@ -522,20 +516,20 @@ min≤
     = elimProp2 {P = λ a b → ℚ.min a b ≤ a}
                 (λ x y → isProp≤ (ℚ.min x y) x)
                  λ { (a , b) (c , d)
-                  → subst2 ℤ._≤_ (sym (ℤ.·DistPosLMin (a ℤ.· ℕ₊₁→ℤ d)
+                  → inj (ℤ.recompute≤ (
+                    subst2 ℤ._≤_ (sym (ℤ.·DistPosLMin (a ℤ.· ℕ₊₁→ℤ d)
                                                        (c ℤ.· ℕ₊₁→ℤ b)
                                                        (ℕ₊₁→ℕ b)))
                                   (sym (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∙
                                    cong (a ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ b)) ∙
                                                   cong ℕ₊₁→ℤ (·₊₁-comm d b)))
-                                  (ℤ.min≤ {a ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ b}
-                                           {c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b}) }
+                                  ℤ.min≤)) }
 
 ≤→min : ∀ m n → m ≤ n → ℚ.min m n ≡ m
 ≤→min
     = elimProp2 {P = λ a b → a ≤ b → ℚ.min a b ≡ a}
                 (λ x y → isProp→ (isSetℚ (ℚ.min x y) x))
-                 λ { (a , b) (c , d) ad≤cb
+                 λ { (a , b) (c , d) (inj ad≤cb)
                   → eq/ (ℤ.min (a ℤ.· ℕ₊₁→ℤ d)
                                (c ℤ.· ℕ₊₁→ℤ b)
                          , b ·₊₁ d)
@@ -550,20 +544,20 @@ min≤
     = elimProp2 {P = λ a b → a ≤ ℚ.max a b}
                 (λ x y → isProp≤ x (ℚ.max x y))
                  λ { (a , b) (c , d)
-                  → subst2 ℤ._≤_ (sym (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∙
+                  → inj (ℤ.recompute≤ (
+                    subst2 ℤ._≤_ (sym (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∙
                                    cong (a ℤ.·_) (sym (ℤ.pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ b)) ∙
                                                   cong ℕ₊₁→ℤ (·₊₁-comm d b)))
                                   (sym (ℤ.·DistPosLMax (a ℤ.· ℕ₊₁→ℤ d)
                                                        (c ℤ.· ℕ₊₁→ℤ b)
                                                        (ℕ₊₁→ℕ b)))
-                                  (ℤ.≤max {a ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ b}
-                                           {c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b}) }
+                                  ℤ.≤max)) }
 
 ≤→max : ∀ m n →  m ≤ n → ℚ.max m n ≡ n
 ≤→max m n
     = elimProp2 {P = λ a b → a ≤ b → ℚ.max a b ≡ b}
                 (λ x y → isProp→ (isSetℚ (ℚ.max x y) y))
-                (λ { (a , b) (c , d) ad≤cb
+                (λ { (a , b) (c , d) (inj ad≤cb)
                   → eq/ (ℤ.max (a ℤ.· ℕ₊₁→ℤ d)
                                (c ℤ.· ℕ₊₁→ℤ b)
                          , b ·₊₁ d)
@@ -574,11 +568,14 @@ min≤
 
 ≤Dec : ∀ m n → Dec (m ≤ n)
 ≤Dec = elimProp2 (λ x y → isPropDec (isProp≤ x y))
-       λ { (a , b) (c , d) → ℤ.≤Dec (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) }
+       (λ (a , b) (c , d) → decRec (yes ∘ inj) (no ∘ _∘ _≤_.prf)
+        (ℤ.≤Dec (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b))  )
 
 <Dec : ∀ m n → Dec (m < n)
 <Dec = elimProp2 (λ x y → isPropDec (isProp< x y))
-       λ { (a , b) (c , d) → ℤ.<Dec (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) }
+       λ { (a , b) (c , d) → decRec (yes ∘ inj) (no ∘ _∘ _<_.prf)
+        (ℤ.<Dec (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b)) }
+
 
 _≟_ : (m n : ℚ) → Trichotomy m n
 m ≟ n with discreteℚ m n
@@ -588,33 +585,34 @@ m ≟ n with discreteℚ m n
 ...             | inr n<m = gt n<m
 
 ≤MonotoneMin : ∀ m n o s → m ≤ n → o ≤ s → ℚ.min m o ≤ ℚ.min n s
-≤MonotoneMin m n o s m≤n o≤s
-  = subst (_≤ ℚ.min n s)
-          (sym (ℚ.minAssoc n s (ℚ.min m o)) ∙
-           cong (ℚ.min n) (ℚ.minAssoc s m o ∙
-                           cong (λ a → ℚ.min a o) (ℚ.minComm s m) ∙
-                                 sym (ℚ.minAssoc m s o)) ∙
-                           ℚ.minAssoc n m (ℚ.min s o) ∙
-           cong₂ ℚ.min (ℚ.minComm n m ∙ ≤→min m n m≤n)
-                       (ℚ.minComm s o ∙ ≤→min o s o≤s))
-           (min≤ (ℚ.min n s) (ℚ.min m o))
+≤MonotoneMin m n o s m≤n o≤s = recompute≤ $
+  subst (_≤ ℚ.min n s)
+        (sym (ℚ.minAssoc n s (ℚ.min m o)) ∙
+         cong (ℚ.min n) (ℚ.minAssoc s m o ∙
+                         cong (λ a → ℚ.min a o) (ℚ.minComm s m) ∙
+                               sym (ℚ.minAssoc m s o)) ∙
+                         ℚ.minAssoc n m (ℚ.min s o) ∙
+         cong₂ ℚ.min (ℚ.minComm n m ∙ ≤→min m n m≤n)
+                     (ℚ.minComm s o ∙ ≤→min o s o≤s))
+         (min≤ (ℚ.min n s) (ℚ.min m o))
 
 ≤MonotoneMax : ∀ m n o s → m ≤ n → o ≤ s → ℚ.max m o ≤ ℚ.max n s
-≤MonotoneMax m n o s m≤n o≤s
-  = subst (ℚ.max m o ≤_)
-          (sym (ℚ.maxAssoc m o (ℚ.max n s)) ∙
-           cong (ℚ.max m) (ℚ.maxAssoc o n s ∙
-                           cong (λ a → ℚ.max a s) (ℚ.maxComm o n) ∙
-                                 sym (ℚ.maxAssoc n o s)) ∙
-                           ℚ.maxAssoc m n (ℚ.max o s) ∙
-           cong₂ ℚ.max (≤→max m n m≤n) (≤→max o s o≤s))
-          (≤max (ℚ.max m o) (ℚ.max n s))
+≤MonotoneMax m n o s m≤n o≤s = recompute≤ $
+  subst (ℚ.max m o ≤_)
+        (sym (ℚ.maxAssoc m o (ℚ.max n s)) ∙
+         cong (ℚ.max m) (ℚ.maxAssoc o n s ∙
+                         cong (λ a → ℚ.max a s) (ℚ.maxComm o n) ∙
+                               sym (ℚ.maxAssoc n o s)) ∙
+                         ℚ.maxAssoc m n (ℚ.max o s) ∙
+         cong₂ ℚ.max (≤→max m n m≤n) (≤→max o s o≤s))
+        (≤max (ℚ.max m o) (ℚ.max n s))
 
 ≡Weaken≤ : ∀ m n → m ≡ n → m ≤ n
-≡Weaken≤ m n m≡n = subst (m ≤_) m≡n (isRefl≤ m)
+≡Weaken≤ m n m≡n = subst≤R m≡n (isRefl≤ m)
 
 ≤→≯ : ∀ m n →  m ≤ n → ¬ (m > n)
-≤→≯ m n m≤n n<m = isIrrefl< n (subst (n <_) (isAntisym≤ m n m≤n (<Weaken≤ n m n<m)) n<m)
+≤→≯ m n m≤n = recompute¬< $
+  λ n<m → isIrrefl< n (subst (n <_) (isAntisym≤ m n m≤n (<Weaken≤ n m n<m)) n<m)
 
 ≮→≥ : ∀ m n → ¬ (m < n) → m ≥ n
 ≮→≥ m n m≮n with discreteℚ m n
@@ -628,3 +626,9 @@ m ≟ n with discreteℚ m n
 ... | no 0≮m | no 0≮n = ⊥.rec (≤→≯ (m ℚ.+ n) 0 (≤Monotone+ m 0 n 0 (≮→≥ 0 m 0≮m) (≮→≥ 0 n 0≮n)) 0<m+n)
 ... | no _    | yes 0<n = inr 0<n
 ... | yes 0<m | _ = inl 0<m
+
+≤ℤ→≤ℚ : ∀ m n k → m ℤ.≤ n → [ m / k ] ≤ [ n / k ]
+≤ℤ→≤ℚ m n (1+ k) m≤n = inj (ℤ.≤-·o {m} m≤n)
+
+<ℤ→<ℚ : ∀ m n k → m ℤ.< n → [ m / k ] < [ n / k ]
+<ℤ→<ℚ m n (1+ k) m<n = inj (ℤ.<-·o {m} m<n)

--- a/Cubical/Data/Rationals/Properties.agda
+++ b/Cubical/Data/Rationals/Properties.agda
@@ -1,15 +1,22 @@
 module Cubical.Data.Rationals.Properties where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.GroupoidLaws hiding (_⁻¹)
 open import Cubical.Foundations.Univalence
 
-open import Cubical.Data.Int as ℤ using (ℤ; pos·pos; pos0+)
-open import Cubical.HITs.SetQuotients as SetQuotient using () renaming (_/_ to _//_)
+open import Cubical.Data.Fast.Int as ℤ using (ℤ ; pos ; neg ; negsuc ; pos0+ ; sign)
+  renaming (_+_ to _+ℤ_ ; _·_ to _·ℤ_)
+open import Cubical.HITs.SetQuotients as SetQuotient using (ElimProp)
+  renaming (_/_ to _//_)
 
+open import Cubical.Data.Empty as ⊥
 open import Cubical.Data.Nat as ℕ using (ℕ; zero; suc)
+  renaming (_+_ to _+ℕ_ ; _·_ to _·ℕ_)
+open import Cubical.Data.Nat.Coprime
 open import Cubical.Data.NatPlusOne
 open import Cubical.Data.Sigma
 
@@ -18,84 +25,167 @@ open import Cubical.Relation.Nullary
 
 open import Cubical.Data.Rationals.Base
 
+∼→sign≡sign : ∀ a a' b b' → (a , b) ∼ (a' , b') → ℤ.sign a ≡ ℤ.sign a'
+∼→sign≡sign (pos zero)    (pos zero)    _ _ = λ _ → refl
+∼→sign≡sign (pos zero)    (pos (suc n)) _ _ = ⊥.rec ∘ ℕ.znots ∘ ℤ.injPos
+∼→sign≡sign (pos (suc m)) (pos zero)    _ _ = ⊥.rec ∘ ℕ.snotz ∘ ℤ.injPos
+∼→sign≡sign (pos (suc m)) (pos (suc n)) _ _ = λ _ → refl
+∼→sign≡sign (pos m)       (negsuc n)    _ _ = ⊥.rec ∘ ℤ.posNotnegsuc _ _
+∼→sign≡sign (negsuc m)    (pos n)       _ _ = ⊥.rec ∘ ℤ.negsucNotpos _ _
+∼→sign≡sign (negsuc m)    (negsuc n)    _ _ = λ _ → refl
+
 ·CancelL : ∀ {a b} (c : ℕ₊₁) → [ ℕ₊₁→ℤ c ℤ.· a / c ·₊₁ b ] ≡ [ a / b ]
 ·CancelL {a} {b} c = eq/ _ _
   ((ℕ₊₁→ℤ c ℤ.· a)   ℤ.· ℕ₊₁→ℤ b  ≡⟨ cong (ℤ._· ℕ₊₁→ℤ b) (ℤ.·Comm (ℕ₊₁→ℤ c) a) ⟩
    (a ℤ.· (ℕ₊₁→ℤ c)) ℤ.· ℕ₊₁→ℤ b  ≡⟨ sym (ℤ.·Assoc a (ℕ₊₁→ℤ c) (ℕ₊₁→ℤ b)) ⟩
-    a ℤ.· (ℕ₊₁→ℤ c   ℤ.· ℕ₊₁→ℤ b) ≡⟨ cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ c) (ℕ₊₁→ℕ b))) ⟩
-    a ℤ.·  ℕ₊₁→ℤ (c ·₊₁ b)         ∎)
+    a ℤ.· (ℕ₊₁→ℤ c   ℤ.· ℕ₊₁→ℤ b) ∎)
 
 ·CancelR : ∀ {a b} (c : ℕ₊₁) → [ a ℤ.· ℕ₊₁→ℤ c / b ·₊₁ c ] ≡ [ a / b ]
 ·CancelR {a} {b} c = eq/ _ _
   (a ℤ.·  ℕ₊₁→ℤ c ℤ.· ℕ₊₁→ℤ b   ≡⟨ sym (ℤ.·Assoc a (ℕ₊₁→ℤ c) (ℕ₊₁→ℤ b)) ⟩
    a ℤ.· (ℕ₊₁→ℤ c ℤ.· ℕ₊₁→ℤ b)  ≡⟨ cong (a ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ c) (ℕ₊₁→ℤ b)) ⟩
-   a ℤ.· (ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ c)  ≡⟨ cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ c))) ⟩
-   a ℤ.· ℕ₊₁→ℤ (b ·₊₁ c) ∎)
+   a ℤ.· (ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ c)  ∎)
+
+module Reduce where
+  reduced : ℚ → Type
+  reduced q = Σ[ (a , b) ∈ ℤ × ℕ₊₁ ] (areCoprime (ℤ.abs a , ℕ₊₁→ℕ b)) × ([ a / b ] ≡ q)
+
+  isPropReduced : ∀ q → isProp (reduced q)
+  isPropReduced q ((a , b) , cop , a/b≡q) ((c , d) , cop' , c/d≡q) = proof where
+    ad≡cb : (a , b) ∼ (c , d)
+    ad≡cb = eq/⁻¹ _ _ (a/b≡q ∙ sym c/d≡q)
+
+    ∣a∣d≡∣c∣b : ℤ.abs a ℕ.· ℕ₊₁→ℕ d ≡ ℤ.abs c ℕ.· ℕ₊₁→ℕ b
+    ∣a∣d≡∣c∣b = sym (ℤ.abs· a (ℕ₊₁→ℤ d)) ∙∙ cong ℤ.abs ad≡cb ∙∙ ℤ.abs· c (ℕ₊₁→ℤ b)
+
+    num≡num : a ≡ c
+    num≡num = sym (ℤ.sign·abs a)
+           ∙∙ cong₂ (flip ℤ._·_ ∘ pos)
+                (natDivisibility cop cop' ∣a∣d≡∣c∣b) (∼→sign≡sign a c _ _ ad≡cb)
+           ∙∙ (ℤ.sign·abs c)
+
+    den≡den : b ≡ d
+    den≡den = cong 1+_ $ natDivisibility' cop cop' ∣a∣d≡∣c∣b
+
+    proof : ((a , b) , cop , a/b≡q) ≡ ((c , d) , cop' , c/d≡q)
+    proof =
+      Σ≡Prop (λ (a , b) → isProp× (isPropAreCoprime (ℤ.abs a) (ℕ₊₁→ℕ b)) (isSetℚ _ q))
+      (ΣPathP (num≡num , den≡den))
+
+  reduceΣ : ∀ q → reduced q
+  reduceΣ = ElimProp.go onFrac module ReduceΣ where
+    onFrac : ElimProp reduced
+    onFrac .ElimProp.fun (a , b₊) = reduced[] where
+      open ToCoprime (ℤ.abs a , b₊) renaming (toCoprimeAreCoprime to tcac ; c₂ to c₂₊)
+      b = ℕ₊₁→ℕ b₊ ; +b = pos b ; +c₁ = pos c₁ ; c₂ = ℕ₊₁→ℕ c₂₊ ; +c₂ = pos c₂
+
+      lemma-cop : ∀ {c} {d-1} a → c ·ℕ suc d-1 ≡ ℤ.abs a → c ≡ ℤ.abs (sign a ·ℤ pos c)
+      lemma-cop {zero } (pos zero)    _ = refl
+      lemma-cop {suc _} (pos zero)    x = ⊥.rec (ℕ.snotz x)
+      lemma-cop {c    } (pos (suc n)) _ = sym $ ℕ.+-zero c
+      lemma-cop {zero } (negsuc n)    _ = refl
+      lemma-cop {suc c} (negsuc n)    _ = cong suc $ sym $ ℕ.+-zero c
+
+      reduced[] : reduced [ a / b₊ ]
+      reduced[] .fst      = sign a ·ℤ pos c₁ , c₂₊
+      reduced[] .snd .fst =
+        subst (areCoprime ∘ (_, c₂)) (lemma-cop a (cong (c₁ ·ℕ_) (sym q) ∙ p₁)) tcac
+      reduced[] .snd .snd = eq/ _ _ $
+        sign a ·ℤ   +c₁ ·ℤ +b            ≡⟨ sym $ ℤ.·Assoc (sign a) _ _ ⟩
+        sign a ·ℤ ( +c₁ ·ℤ +b)           ≡⟨ cong ((sign a ·ℤ_) ∘ pos) $
+                     c₁ ·ℕ b             ≡⟨ sym $ cong (c₁ ·ℕ_) p₂ ⟩
+                     c₁ ·ℕ (c₂ ·ℕ d )    ≡⟨ cong (c₁ ·ℕ_) (ℕ.·-comm c₂ d) ⟩
+                     c₁ ·ℕ (d  ·ℕ c₂)    ≡⟨ ℕ.·-assoc c₁ d c₂ ⟩ cong (_·ℕ c₂) p₁ ⟩
+        sign a ·ℤ  pos( ℤ.abs a ·ℕ c₂)   ≡⟨ ℤ.·Assoc (sign a) _ _ ⟩
+        sign a ·ℤ  pos( ℤ.abs a ) ·ℤ +c₂ ≡⟨ cong (_·ℤ +c₂) (ℤ.sign·abs a) ⟩
+        a ·ℤ +c₂                         ∎
+    onFrac .ElimProp.prop = isPropReduced
+
+reduce : ℚ → ℚ
+reduce = [_] ∘ fst ∘ Reduce.reduceΣ
+
+reduce≡ : ∀ x → reduce x ≡ x
+reduce≡ = snd ∘ snd ∘ Reduce.reduceΣ
 
 -- useful functions for defining operations on ℚ
 
-onCommonDenom :
-  (g : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → ℤ)
-  (g-eql : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
-           → ℕ₊₁→ℤ d ℤ.· (g (a , b) (e , f)) ≡ ℕ₊₁→ℤ b ℤ.· (g (c , d) (e , f)))
-  (g-eqr : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : c ℤ.· ℕ₊₁→ℤ f ≡ e ℤ.· ℕ₊₁→ℤ d)
-           → (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f ≡ (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d)
-  → ℚ → ℚ → ℚ
-onCommonDenom g g-eql g-eqr = SetQuotient.rec2 isSetℚ
-  (λ { (a , b) (c , d) → [ g (a , b) (c , d) / b ·₊₁ d ] })
-  (λ { (a , b) (c , d) (e , f) p → eql (a , b) (c , d) (e , f) p })
-  (λ { (a , b) (c , d) (e , f) p → eqr (a , b) (c , d) (e , f) p })
-  where abstract
-        eql : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
-              → [ g (a , b) (e , f) / b ·₊₁ f ] ≡ [ g (c , d) (e , f) / d ·₊₁ f ]
-        eql (a , b) (c , d) (e , f) p =
-          [ g (a , b) (e , f) / b ·₊₁ f ]
-            ≡⟨ sym (·CancelL d) ⟩
-          [ ℕ₊₁→ℤ d ℤ.· (g (a , b) (e , f)) / d ·₊₁ (b ·₊₁ f) ]
-            ≡[ i ]⟨ [ ℕ₊₁→ℤ d ℤ.· (g (a , b) (e , f)) / ·₊₁-assoc d b f i ] ⟩
-          [ ℕ₊₁→ℤ d ℤ.· (g (a , b) (e , f)) / (d ·₊₁ b) ·₊₁ f ]
-            ≡[ i ]⟨ [ g-eql (a , b) (c , d) (e , f) p i / ·₊₁-comm d b i ·₊₁ f ] ⟩
-          [ ℕ₊₁→ℤ b ℤ.· (g (c , d) (e , f)) / (b ·₊₁ d) ·₊₁ f ]
-            ≡[ i ]⟨ [ ℕ₊₁→ℤ b ℤ.· (g (c , d) (e , f)) / ·₊₁-assoc b d f (~ i) ] ⟩
-          [ ℕ₊₁→ℤ b ℤ.· (g (c , d) (e , f)) / b ·₊₁ (d ·₊₁ f) ]
-            ≡⟨ ·CancelL b ⟩
-          [ g (c , d) (e , f) / d ·₊₁ f ] ∎
-        eqr : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : c ℤ.· ℕ₊₁→ℤ f ≡ e ℤ.· ℕ₊₁→ℤ d)
-             → [ g (a , b) (c , d) / b ·₊₁ d ] ≡ [ g (a , b) (e , f) / b ·₊₁ f ]
-        eqr (a , b) (c , d) (e , f) p =
-          [ g (a , b) (c , d) / b ·₊₁ d ]
-            ≡⟨ sym (·CancelR f) ⟩
-          [ (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / (b ·₊₁ d) ·₊₁ f ]
-            ≡[ i ]⟨ [ (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / ·₊₁-assoc b d f (~ i) ] ⟩
-          [ (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / b ·₊₁ (d ·₊₁ f) ]
-            ≡[ i ]⟨ [ g-eqr (a , b) (c , d) (e , f) p i / b ·₊₁ ·₊₁-comm d f i ] ⟩
-          [ (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / b ·₊₁ (f ·₊₁ d) ]
-            ≡[ i ]⟨ [ (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / ·₊₁-assoc b f d i ] ⟩
-          [ (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / (b ·₊₁ f) ·₊₁ d ]
-            ≡⟨ ·CancelR d ⟩
-          [ g (a , b) (e , f) / b ·₊₁ f ] ∎
+record OnCommonDenom : Type₀ where
+  no-eta-equality
+  field
+    fun : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → ℤ
+    eql : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) → (a , b) ∼ (c , d)
+        → ℕ₊₁→ℤ d ℤ.· (fun (a , b) (e , f)) ≡ ℕ₊₁→ℤ b ℤ.· (fun (c , d) (e , f))
+    eqr : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) → (c , d) ∼ (e , f)
+        → (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f ≡ (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d
 
-onCommonDenomSym :
-  (g : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → ℤ)
-  (g-sym : ∀ x y → g x y ≡ g y x)
-  (g-eql : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
-           → ℕ₊₁→ℤ d ℤ.· (g (a , b) (e , f)) ≡ ℕ₊₁→ℤ b ℤ.· (g (c , d) (e , f)))
-  → ℚ → ℚ → ℚ
-onCommonDenomSym g g-sym g-eql = onCommonDenom g g-eql q-eqr
-  where abstract
-        q-eqr : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : c ℤ.· ℕ₊₁→ℤ f ≡ e ℤ.· ℕ₊₁→ℤ d)
-                → (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f ≡ (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d
-        q-eqr (a , b) (c , d) (e , f) p =
-          (g (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f ≡[ i ]⟨ ℤ.·Comm (g-sym (a , b) (c , d) i) (ℕ₊₁→ℤ f) i ⟩
-          ℕ₊₁→ℤ f ℤ.· (g (c , d) (a , b)) ≡⟨ g-eql (c , d) (e , f) (a , b) p ⟩
-          ℕ₊₁→ℤ d ℤ.· (g (e , f) (a , b)) ≡[ i ]⟨ ℤ.·Comm (ℕ₊₁→ℤ d) (g-sym (e , f) (a , b) i) i ⟩
-          (g (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d ∎
+  go : ℚ → ℚ → ℚ
+  go = SetQuotient.Rec2.go r module GO where
+    r : SetQuotient.Rec2 ℚ
+    r .SetQuotient.Rec2.fun = λ x y → [ fun x y / (snd x) ·₊₁ (snd y) ]
+    r .SetQuotient.Rec2.set = isSetℚ
+    r .SetQuotient.Rec2.eql = eql' where abstract
+      eql' : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
+           → [ fun (a , b) (e , f) / b ·₊₁ f ] ≡ [ fun (c , d) (e , f) / d ·₊₁ f ]
+      eql' (a , b) (c , d) (e , f) p =
+        [ fun (a , b) (e , f) / b ·₊₁ f ]
+          ≡⟨ sym (·CancelL d) ⟩
+        [ ℕ₊₁→ℤ d ℤ.· (fun (a , b) (e , f)) / d ·₊₁ (b ·₊₁ f) ]
+          ≡[ i ]⟨ [ ℕ₊₁→ℤ d ℤ.· (fun (a , b) (e , f)) / ·₊₁-assoc d b f i ] ⟩
+        [ ℕ₊₁→ℤ d ℤ.· (fun (a , b) (e , f)) / (d ·₊₁ b) ·₊₁ f ]
+          ≡[ i ]⟨ [ eql (a , b) (c , d) (e , f) p i / ·₊₁-comm d b i ·₊₁ f ] ⟩
+        [ ℕ₊₁→ℤ b ℤ.· (fun (c , d) (e , f)) / (b ·₊₁ d) ·₊₁ f ]
+          ≡[ i ]⟨ [ ℕ₊₁→ℤ b ℤ.· (fun (c , d) (e , f)) / ·₊₁-assoc b d f (~ i) ] ⟩
+        [ ℕ₊₁→ℤ b ℤ.· (fun (c , d) (e , f)) / b ·₊₁ (d ·₊₁ f) ]
+          ≡⟨ ·CancelL b ⟩
+        [ fun (c , d) (e , f) / d ·₊₁ f ] ∎
+    r .SetQuotient.Rec2.eqr = eqr' where abstract
+      eqr' : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : c ℤ.· ℕ₊₁→ℤ f ≡ e ℤ.· ℕ₊₁→ℤ d)
+           → [ fun (a , b) (c , d) / b ·₊₁ d ] ≡ [ fun (a , b) (e , f) / b ·₊₁ f ]
+      eqr' (a , b) (c , d) (e , f) p =
+        [ fun (a , b) (c , d) / b ·₊₁ d ]
+          ≡⟨ sym (·CancelR f) ⟩
+        [ (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / (b ·₊₁ d) ·₊₁ f ]
+          ≡[ i ]⟨ [ (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / ·₊₁-assoc b d f (~ i) ] ⟩
+        [ (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f / b ·₊₁ (d ·₊₁ f) ]
+          ≡[ i ]⟨ [ eqr (a , b) (c , d) (e , f) p i / b ·₊₁ ·₊₁-comm d f i ] ⟩
+        [ (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / b ·₊₁ (f ·₊₁ d) ]
+          ≡[ i ]⟨ [ (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / ·₊₁-assoc b f d i ] ⟩
+        [ (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d / (b ·₊₁ f) ·₊₁ d ]
+          ≡⟨ ·CancelR d ⟩
+        [ fun (a , b) (e , f) / b ·₊₁ f ] ∎
 
-onCommonDenomSym-comm : ∀ {g} g-sym {g-eql} (x y : ℚ)
-                        → onCommonDenomSym g g-sym g-eql x y ≡
-                          onCommonDenomSym g g-sym g-eql y x
-onCommonDenomSym-comm g-sym = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
-  (λ { (a , b) (c , d) i → [ g-sym (a , b) (c , d) i / ·₊₁-comm b d i ] })
+{-# DISPLAY OnCommonDenom.GO.r r = r #-}
+
+record OnCommonDenomSym : Type₀ where
+  no-eta-equality
+  field
+    fun  : ℤ × ℕ₊₁ → ℤ × ℕ₊₁ → ℤ
+    comm : ∀ x y → fun x y ≡ fun y x
+    eql  : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) → (a , b) ∼ (c , d)
+         → ℕ₊₁→ℤ d ℤ.· (fun (a , b) (e , f)) ≡ ℕ₊₁→ℤ b ℤ.· (fun (c , d) (e , f))
+
+  go : ℚ → ℚ → ℚ
+  go = OnCommonDenom.go r module GO where
+    r : OnCommonDenom
+    r .OnCommonDenom.fun = fun
+    r .OnCommonDenom.eql = eql
+    r .OnCommonDenom.eqr = eqr where abstract
+      eqr : ∀ ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : c ℤ.· ℕ₊₁→ℤ f ≡ e ℤ.· ℕ₊₁→ℤ d)
+          → (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f ≡ (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d
+      eqr (a , b) (c , d) (e , f) p =
+        (fun (a , b) (c , d)) ℤ.· ℕ₊₁→ℤ f
+          ≡[ i ]⟨ ℤ.·Comm (comm (a , b) (c , d) i) (ℕ₊₁→ℤ f) i ⟩
+        ℕ₊₁→ℤ f ℤ.· (fun (c , d) (a , b))
+          ≡⟨ eql (c , d) (e , f) (a , b) p ⟩
+        ℕ₊₁→ℤ d ℤ.· (fun (e , f) (a , b))
+          ≡[ i ]⟨ ℤ.·Comm (ℕ₊₁→ℤ d) (comm (e , f) (a , b) i) i ⟩
+        (fun (a , b) (e , f)) ℤ.· ℕ₊₁→ℤ d ∎
+
+  go-comm : ∀ x y → go x y ≡ go y x
+  go-comm = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
+    λ (a , b) (c , d) i → [ comm (a , b) (c , d) i / ·₊₁-comm b d i ]
+
+{-# DISPLAY OnCommonDenomSym.GO.r r = r #-}
 
 
 -- basic arithmetic operations on ℚ
@@ -115,11 +205,12 @@ private abstract
                ∙ cong (c ℤ.·_) (ℤ.·Comm a b)
 
 min : ℚ → ℚ → ℚ
-min = onCommonDenomSym
-  (λ { (a , b) (c , d) → ℤ.min (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
-  (λ { (a , b) (c , d) → ℤ.minComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
-   eq
-  where abstract
+min = OnCommonDenomSym.go onFrac module min where
+  open OnCommonDenomSym
+  onFrac : OnCommonDenomSym
+  onFrac .fun  (a , b) (c , d) = ℤ.min (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b)
+  onFrac .comm (a , b) (c , d) = ℤ.minComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b)
+  onFrac .eql  = eq where abstract
     eq : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
        → ℕ₊₁→ℤ d ℤ.· ℤ.min (a ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ b)
        ≡ ℕ₊₁→ℤ b ℤ.· ℤ.min (c ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ d)
@@ -152,11 +243,12 @@ min = onCommonDenomSym
                          (e ℤ.· ℕ₊₁→ℤ d) ∎
 
 max : ℚ → ℚ → ℚ
-max = onCommonDenomSym
-  (λ { (a , b) (c , d) → ℤ.max (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
-  (λ { (a , b) (c , d) → ℤ.maxComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
-   eq
-  where abstract
+max = OnCommonDenomSym.go onFrac module max where
+  open OnCommonDenomSym
+  onFrac : OnCommonDenomSym
+  onFrac .fun  (a , b) (c , d) = ℤ.max (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b)
+  onFrac .comm (a , b) (c , d) = ℤ.maxComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b)
+  onFrac .eql  = eq where abstract
     eq : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
        → ℕ₊₁→ℤ d ℤ.· ℤ.max (a ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ b)
        ≡ ℕ₊₁→ℤ b ℤ.· ℤ.max (c ℤ.· ℕ₊₁→ℤ f) (e ℤ.· ℕ₊₁→ℤ d)
@@ -189,33 +281,28 @@ max = onCommonDenomSym
                          (e ℤ.· ℕ₊₁→ℤ d) ∎
 
 minComm : ∀ x y → min x y ≡ min y x
-minComm = onCommonDenomSym-comm
-  (λ { (a , b) (c , d) → ℤ.minComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
+minComm = OnCommonDenomSym.go-comm min.onFrac
 
 maxComm : ∀ x y → max x y ≡ max y x
-maxComm = onCommonDenomSym-comm
-  (λ { (a , b) (c , d) → ℤ.maxComm (a ℤ.· ℕ₊₁→ℤ d) (c ℤ.· ℕ₊₁→ℤ b) })
+maxComm = OnCommonDenomSym.go-comm max.onFrac
 
 minIdem : ∀ x → min x x ≡ x
 minIdem = SetQuotient.elimProp (λ _ → isSetℚ _ _)
   λ { (a , b) → eq/ (ℤ.min (a ℤ.· ℕ₊₁→ℤ b) (a ℤ.· ℕ₊₁→ℤ b) , b ·₊₁ b) (a , b)
                     (cong (ℤ._· ℕ₊₁→ℤ b) (ℤ.minIdem (a ℤ.· ℕ₊₁→ℤ b)) ∙
-                     sym (ℤ.·Assoc a (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ b)) ∙
-                     cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ b)))) }
+                     sym (ℤ.·Assoc a (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ b))) }
 
 maxIdem : ∀ x → max x x ≡ x
 maxIdem = SetQuotient.elimProp (λ _ → isSetℚ _ _)
   λ { (a , b) → eq/ (ℤ.max (a ℤ.· ℕ₊₁→ℤ b) (a ℤ.· ℕ₊₁→ℤ b) , b ·₊₁ b) (a , b)
                     (cong (ℤ._· ℕ₊₁→ℤ b) (ℤ.maxIdem (a ℤ.· ℕ₊₁→ℤ b)) ∙
-                     sym (ℤ.·Assoc a (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ b)) ∙
-                     cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ b)))) }
+                     sym (ℤ.·Assoc a (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ b))) }
 
 minAssoc : ∀ x y z → min x (min y z) ≡ min (min x y) z
 minAssoc = SetQuotient.elimProp3 (λ _ _ _ → isSetℚ _ _)
   λ { (a , b) (c , d) (e , f) i
     → [ (cong₂ ℤ.min
-               (cong (a ℤ.·_) (pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f))
-               ∙ ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+               (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
                (ℤ.·DistPosLMin (c ℤ.· ℕ₊₁→ℤ f)
                                (e ℤ.· ℕ₊₁→ℤ d)
                                (ℕ₊₁→ℕ b)
@@ -223,8 +310,7 @@ minAssoc = SetQuotient.elimProp3 (λ _ _ _ → isSetℚ _ _)
                              ∙ cong (c ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b))
                              ∙ ℤ.·Assoc c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
                              (sym (ℤ.·Assoc e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                             ∙ cong (e ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)
-                                             ∙ sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ d)))))
+                             ∙ cong (e ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))))
         ∙ ℤ.minAssoc (a ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ f)
                      (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ f)
                      (e ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
@@ -237,8 +323,7 @@ maxAssoc : ∀ x y z → max x (max y z) ≡ max (max x y) z
 maxAssoc = SetQuotient.elimProp3 (λ _ _ _ → isSetℚ _ _)
   λ { (a , b) (c , d) (e , f) i
     → [ (cong₂ ℤ.max
-               (cong (a ℤ.·_) (pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f))
-               ∙ ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
+               (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ f))
                (ℤ.·DistPosLMax (c ℤ.· ℕ₊₁→ℤ f)
                                (e ℤ.· ℕ₊₁→ℤ d)
                                (ℕ₊₁→ℕ b)
@@ -246,8 +331,7 @@ maxAssoc = SetQuotient.elimProp3 (λ _ _ _ → isSetℚ _ _)
                              ∙ cong (c ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ f) (ℕ₊₁→ℤ b))
                              ∙ ℤ.·Assoc c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))
                              (sym (ℤ.·Assoc e (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))
-                             ∙ cong (e ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)
-                                             ∙ sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ d)))))
+                             ∙ cong (e ℤ.·_) (ℤ.·Comm (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b))))
         ∙ ℤ.maxAssoc (a ℤ.· ℕ₊₁→ℤ d ℤ.· ℕ₊₁→ℤ f)
                      (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ f)
                      (e ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
@@ -279,8 +363,7 @@ minAbsorbLMax = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
                                 (ℤ.max x (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b))
                                  ℤ.· ℕ₊₁→ℤ b)
                                 (sym (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∙
-                                 cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ b)) ∙
-                                                cong ℕ₊₁→ℤ (·₊₁-comm d b))) ⟩
+                                 cong (a ℤ.·_) (cong ℕ₊₁→ℤ (·₊₁-comm d b))) ⟩
            ℤ.min (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
           (ℤ.max (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
                  (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b))
@@ -288,8 +371,7 @@ minAbsorbLMax = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
                                 (ℤ.minAbsorbLMax (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d)) _) ⟩
            a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d) ℤ.· ℕ₊₁→ℤ b
                  ≡⟨ sym (ℤ.·Assoc a (ℕ₊₁→ℤ (b ·₊₁ d)) (ℕ₊₁→ℤ b)) ∙
-                    cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ (b ·₊₁ d)) (ℕ₊₁→ℕ b)) ∙
-                                   cong ℕ₊₁→ℤ (·₊₁-comm (b ·₊₁ d) b)) ⟩
+                    cong (a ℤ.·_) (cong ℕ₊₁→ℤ (·₊₁-comm (b ·₊₁ d) b)) ⟩
            a ℤ.· ℕ₊₁→ℤ (b ·₊₁ (b ·₊₁ d)) ∎) }
 
 maxAbsorbLMin : ∀ x y → max x (min x y) ≡ x
@@ -315,8 +397,7 @@ maxAbsorbLMin = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
                                              (ℤ.min x (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b))
                                        ℤ.· ℕ₊₁→ℤ b)
                                 (sym (ℤ.·Assoc a (ℕ₊₁→ℤ d) (ℕ₊₁→ℤ b)) ∙
-                                 cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ b)) ∙
-                                                cong ℕ₊₁→ℤ (·₊₁-comm d b))) ⟩
+                                 cong (a ℤ.·_) (cong ℕ₊₁→ℤ (·₊₁-comm d b))) ⟩
            ℤ.max (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
                  (ℤ.min (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d))
                         (c ℤ.· ℕ₊₁→ℤ b ℤ.· ℕ₊₁→ℤ b))
@@ -324,16 +405,16 @@ maxAbsorbLMin = SetQuotient.elimProp2 (λ _ _ → isSetℚ _ _)
                                 (ℤ.maxAbsorbLMin (a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d)) _) ⟩
            a ℤ.· ℕ₊₁→ℤ (b ·₊₁ d) ℤ.· ℕ₊₁→ℤ b
              ≡⟨ sym (ℤ.·Assoc a (ℕ₊₁→ℤ (b ·₊₁ d)) (ℕ₊₁→ℤ b)) ∙
-                cong (a ℤ.·_) (sym (pos·pos (ℕ₊₁→ℕ (b ·₊₁ d)) (ℕ₊₁→ℕ b)) ∙
-                               cong ℕ₊₁→ℤ (·₊₁-comm (b ·₊₁ d) b)) ⟩
+                cong (a ℤ.·_) (cong ℕ₊₁→ℤ (·₊₁-comm (b ·₊₁ d) b)) ⟩
            a ℤ.· ℕ₊₁→ℤ (b ·₊₁ (b ·₊₁ d)) ∎) }
 
 _+_ : ℚ → ℚ → ℚ
-_+_ = onCommonDenomSym
-  (λ { (a , b) (c , d) → a ℤ.· (ℕ₊₁→ℤ d) ℤ.+ c ℤ.· (ℕ₊₁→ℤ b) })
-  (λ { (a , b) (c , d) → ℤ.+Comm (a ℤ.· (ℕ₊₁→ℤ d)) (c ℤ.· (ℕ₊₁→ℤ b)) })
-   eq
-  where abstract
+_+_ = OnCommonDenomSym.go onFrac module _+_ where
+  open OnCommonDenomSym
+  onFrac : OnCommonDenomSym
+  onFrac .fun  (a , b) (c , d) = a ℤ.· (ℕ₊₁→ℤ d) ℤ.+ c ℤ.· (ℕ₊₁→ℤ b)
+  onFrac .comm (a , b) (c , d) = ℤ.+Comm (a ℤ.· (ℕ₊₁→ℤ d)) (c ℤ.· (ℕ₊₁→ℤ b))
+  onFrac .eql  = eq where abstract
     eq : ((a , b) (c , d) (e , f) : ℤ × ℕ₊₁) (p : a ℤ.· ℕ₊₁→ℤ d ≡ c ℤ.· ℕ₊₁→ℤ b)
        → ℕ₊₁→ℤ d ℤ.· (a ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· ℕ₊₁→ℤ b)
        ≡ ℕ₊₁→ℤ b ℤ.· (c ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· ℕ₊₁→ℤ d)
@@ -347,8 +428,7 @@ _+_ = onCommonDenomSym
       ℕ₊₁→ℤ b ℤ.· (c ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· ℕ₊₁→ℤ d) ∎
 
 +Comm : ∀ x y → x + y ≡ y + x
-+Comm = onCommonDenomSym-comm
-  (λ { (a , b) (c , d) → ℤ.+Comm (a ℤ.· (ℕ₊₁→ℤ d)) (c ℤ.· (ℕ₊₁→ℤ b)) })
++Comm = OnCommonDenomSym.go-comm _+_.onFrac
 
 +IdL : ∀ x → 0 + x ≡ x
 +IdL = SetQuotient.elimProp (λ _ → isSetℚ _ _)
@@ -362,11 +442,7 @@ _+_ = onCommonDenomSym
 +Assoc : ∀ x y z → x + (y + z) ≡ (x + y) + z
 +Assoc = SetQuotient.elimProp3 (λ _ _ _ → isSetℚ _ _)
   (λ { (a , b) (c , d) (e , f) i
-    → [ (cong (λ x → a ℤ.· x ℤ.+ (c ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· ℕ₊₁→ℤ d) ℤ.· ℕ₊₁→ℤ b)
-              (pos·pos (ℕ₊₁→ℕ d) (ℕ₊₁→ℕ f))
-       ∙ eq a (ℕ₊₁→ℤ b) c (ℕ₊₁→ℤ d) e (ℕ₊₁→ℤ f)
-       ∙ cong (λ x → (a ℤ.· ℕ₊₁→ℤ d ℤ.+ c ℤ.· ℕ₊₁→ℤ b) ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· x)
-              (sym (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ d)))) i / ·₊₁-assoc b d f i ] })
+    → [ eq a (ℕ₊₁→ℤ b) c (ℕ₊₁→ℤ d) e (ℕ₊₁→ℤ f) i / ·₊₁-assoc b d f i ] })
   where eq₁ : ∀ a b c → (a ℤ.· b) ℤ.· c ≡ a ℤ.· (c ℤ.· b)
         eq₁ a b c = sym (ℤ.·Assoc a b c) ∙ cong (a ℤ.·_) (ℤ.·Comm b c)
         eq₂ : ∀ a b c → (a ℤ.· b) ℤ.· c ≡ (a ℤ.· c) ℤ.· b
@@ -384,13 +460,15 @@ _+_ = onCommonDenomSym
 
 
 _·_ : ℚ → ℚ → ℚ
-_·_ = onCommonDenomSym
-  (λ { (a , _) (c , _) → a ℤ.· c })
-  (λ { (a , _) (c , _) → ℤ.·Comm a c })
-  (λ { (a , b) (c , d) (e , _) p → lem₁ a (ℕ₊₁→ℤ d) c (ℕ₊₁→ℤ b) e p })
+_·_ = OnCommonDenomSym.go onFrac module _·_ where
+  open OnCommonDenomSym
+  onFrac : OnCommonDenomSym
+  onFrac .fun  (a , _) (c , _) = a ℤ.· c
+  onFrac .comm (a , _) (c , _) = ℤ.·Comm a c
+  onFrac .eql  (a , b) (c , d) = lem₁ a (ℕ₊₁→ℤ d) c (ℕ₊₁→ℤ b) ∘ fst
 
 ·Comm : ∀ x y → x · y ≡ y · x
-·Comm = onCommonDenomSym-comm (λ { (a , _) (c , _) → ℤ.·Comm a c })
+·Comm = OnCommonDenomSym.go-comm _·_.onFrac
 
 ·IdL : ∀ x → 1 · x ≡ x
 ·IdL = SetQuotient.elimProp (λ _ → isSetℚ _ _)
@@ -439,11 +517,7 @@ _·_ = onCommonDenomSym
              ≡ [ a ℤ.· (c ℤ.· ℕ₊₁→ℤ f ℤ.+ e ℤ.· ℕ₊₁→ℤ d)
                 / b ·₊₁ (d ·₊₁ f) ]
         eq a b c d e f =
-          (λ i → [ (cong (a ℤ.· c ℤ.·_) (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ f))
-                 ∙ (lemℤ a c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f))) i
-                   ℤ.+
-                   (cong (a ℤ.· e ℤ.·_) (pos·pos (ℕ₊₁→ℕ b) (ℕ₊₁→ℕ d))
-                 ∙ (lemℤ a e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d))) i
+          (λ i → [ lemℤ a c (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ f) i ℤ.+ lemℤ a e (ℕ₊₁→ℤ b) (ℕ₊₁→ℤ d) i
                    / lemℕ₊₁ b d b f i ]) ∙
           (λ i → [ (sym (ℤ.·DistL+ (a ℤ.· (c ℤ.· ℕ₊₁→ℤ f)) (a ℤ.· (e ℤ.· ℕ₊₁→ℤ d)) (ℕ₊₁→ℤ b))) i
                    / (b ·₊₁ (d ·₊₁ f)) ·₊₁ b ]) ∙
@@ -485,14 +559,9 @@ x - y = x + (- y)
 +CancelR x y z p = +CancelL y x z (+Comm y x ∙ p ∙ +Comm z y)
 
 numerator0→0 : (u : ℤ × ℕ₊₁) → u .fst ≡ 0 → [ u ] ≡ 0
-numerator0→0 (a , b) p = eq/ ((a , b)) ((0 , 1)) q
-  where
-  q : a ℤ.· (ℕ₊₁→ℤ 1) ≡ 0 ℤ.· (ℕ₊₁→ℤ b)
-  q =
-    a ℤ.· (ℕ₊₁→ℤ 1)
-      ≡⟨ ℤ.·IdR a ⟩
-    a
-      ≡⟨ p ⟩
-    0
-      ≡⟨ sym (ℤ.·AnnihilL (ℕ₊₁→ℤ b)) ⟩
-    0 ℤ.· (ℕ₊₁→ℤ b) ∎
+numerator0→0 (a , b) p = eq/ (a , b) (0 , 1) (ℤ.·IdR a ∙ p)
+
+{-# DISPLAY min.onFrac = min #-}
+{-# DISPLAY max.onFrac = max #-}
+{-# DISPLAY _+_.onFrac = _+_ #-}
+{-# DISPLAY _·_.onFrac = _·_ #-}

--- a/Cubical/HITs/SetQuotients/Properties.agda
+++ b/Cubical/HITs/SetQuotients/Properties.agda
@@ -8,7 +8,7 @@ module Cubical.HITs.SetQuotients.Properties where
 
 open import Cubical.HITs.SetQuotients.Base
 
-open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Prelude renaming (ℓ-max to _⊔_)
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Transport
 open import Cubical.Foundations.Isomorphism
@@ -40,42 +40,129 @@ private
     A B C Q : Type ℓ
     R S T W : A → A → Type ℓ
 
+record ElimProp {A : Type ℓ} {R : A → A → Type ℓ'}
+  (P : A / R → Type ℓ'') : Type (ℓ ⊔ ℓ' ⊔ ℓ'') where
+  no-eta-equality
+  field
+    fun  : ∀ a → P [ a ]
+    prop : ∀ x → isProp (P x)
+
+  go : ∀ x → P x
+  go [ a ]                 = fun a
+  go (eq/ a b r i)         = isProp→PathP (λ i → prop (eq/ a b r i)) (fun a) (fun b) i
+  go (squash/ x y p q i j) = isOfHLevel→isOfHLevelDep 2 (λ x → isProp→isSet (prop x))
+    (go x) (go y) (cong go p) (cong go q) (squash/ x y p q) i j
+
+-- These DISPLAY pragmas, together with the use of "named where blocks" below, allows for
+-- cleaner and shorter normal forms
+{-# DISPLAY ElimProp.go r = r #-}
+
 elimProp : {P : A / R → Type ℓ}
   → (∀ x → isProp (P x))
   → (∀ a → P [ a ])
   → ∀ x → P x
-elimProp prop f [ x ] = f x
-elimProp prop f (squash/ x y p q i j) =
-  isOfHLevel→isOfHLevelDep 2 (λ x → isProp→isSet (prop x))
-    (g x) (g y) (cong g p) (cong g q) (squash/ x y p q) i j
-    where
-    g = elimProp prop f
-elimProp prop f (eq/ a b r i) =
-  isProp→PathP (λ i → prop (eq/ a b r i)) (f a) (f b) i
+elimProp prop f = ElimProp.go e module elimProp where
+  e : ElimProp _
+  e .ElimProp.fun  = f
+  e .ElimProp.prop = prop
+
+record ElimProp2 {ℓA ℓB ℓR ℓS ℓ : Level}
+  {A : Type ℓA} {B : Type ℓB}
+  {R : A → A → Type ℓR} {S : B → B → Type ℓS}
+  (P : A / R → B / S → Type ℓ)
+  : Type (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓR ⊔ ℓS) where
+  no-eta-equality
+  field
+    fun  : ∀ a b → P [ a ] [ b ]
+    prop : ∀ x y → isProp (P x y)
+
+  go : ∀ x y → P x y
+  go = ElimProp.go el module lGO where
+    el : ElimProp _
+    el .ElimProp.fun x = ElimProp.go er module rGO where
+      er : ElimProp _
+      er .ElimProp.fun  = fun x
+      er .ElimProp.prop = prop [ x ]
+    el .ElimProp.prop = isPropΠ ∘ prop
+
+{-# DISPLAY ElimProp2.lGO.el     r   = r #-}
+{-# DISPLAY ElimProp2.lGO.rGO.er r a = r [ a ] #-}
 
 elimProp2 : {P : A / R → B / S → Type ℓ}
   → (∀ x y → isProp (P x y))
   → (∀ a b → P [ a ] [ b ])
   → ∀ x y → P x y
-elimProp2 prop f =
-  elimProp (λ x → isPropΠ (prop x)) λ a →
-  elimProp (prop [ a ]) (f a)
+elimProp2 prop f = ElimProp2.go e module elimProp2 where
+  e : ElimProp2 _
+  e .ElimProp2.fun  = f
+  e .ElimProp2.prop = prop
+
+record ElimProp3 {ℓA ℓB ℓC ℓR ℓS ℓT ℓ : Level}
+  {A : Type ℓA} {B : Type ℓB} {C : Type ℓC}
+  {R : A → A → Type ℓR} {S : B → B → Type ℓS} {T : C → C → Type ℓT}
+  (P : A / R → B / S → C / T → Type ℓ)
+  : Type (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓC ⊔ ℓR ⊔ ℓS ⊔ ℓT) where
+  no-eta-equality
+  field
+    fun  : ∀ a b c → P [ a ] [ b ] [ c ]
+    prop : ∀ x y z → isProp (P x y z)
+
+  go : ∀ x y z → P x y z
+  go = ElimProp.go el module lGO where
+    el : ElimProp _
+    el .ElimProp.fun x = ElimProp2.go er module rGO where
+      er : ElimProp2 _
+      er .ElimProp2.fun  = fun x
+      er .ElimProp2.prop = prop [ x ]
+    el .ElimProp.prop = isPropΠ2 ∘ prop
+
+{-# DISPLAY ElimProp3.lGO.el     r   = r #-}
+{-# DISPLAY ElimProp3.lGO.rGO.er r a = r [ a ] #-}
 
 elimProp3 : {P : A / R → B / S → C / T → Type ℓ}
   → (∀ x y z → isProp (P x y z))
   → (∀ a b c → P [ a ] [ b ] [ c ])
   → ∀ x y z → P x y z
-elimProp3 prop f =
-  elimProp (λ x → isPropΠ2 (prop x)) λ a →
-  elimProp2 (prop [ a ]) (f a)
+elimProp3 prop f = ElimProp3.go e module elimProp3 where
+  e : ElimProp3 _
+  e .ElimProp3.fun  = f
+  e .ElimProp3.prop = prop
+
+record ElimProp4 {ℓA ℓB ℓC ℓQ ℓR ℓS ℓT ℓW ℓ : Level}
+  {A : Type ℓA} {B : Type ℓB} {C : Type ℓC} {Q : Type ℓQ}
+  {R : A → A → Type ℓR} {S : B → B → Type ℓS} {T : C → C → Type ℓT} {W : Q → Q → Type ℓW}
+  (P : A / R → B / S → C / T → Q / W → Type ℓ)
+  : Type (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓC ⊔ ℓQ ⊔ ℓR ⊔ ℓS ⊔ ℓT ⊔ ℓW) where
+  no-eta-equality
+  field
+    fun  : ∀ a b c d → P [ a ] [ b ] [ c ] [ d ]
+    prop : ∀ x y z t → isProp (P x y z t)
+
+  go : ∀ x y z t → P x y z t
+  go = ElimProp.go el module lGO where
+    el : ElimProp _
+    el .ElimProp.fun x = ElimProp3.go er module rGO where
+      er : ElimProp3 _
+      er .ElimProp3.fun  = fun x
+      er .ElimProp3.prop = prop [ x ]
+    el .ElimProp.prop = isPropΠ3 ∘ prop
+
+{-# DISPLAY ElimProp4.lGO.el     r   = r #-}
+{-# DISPLAY ElimProp4.lGO.rGO.er r a = r [ a ] #-}
 
 elimProp4 : {P : A / R → B / S → C / T → Q / W → Type ℓ}
   → (∀ x y z t → isProp (P x y z t))
   → (∀ a b c d → P [ a ] [ b ] [ c ] [ d ])
   → ∀ x y z t → P x y z t
-elimProp4 prop f =
-  elimProp (λ x → isPropΠ3 (prop x)) λ a →
-  elimProp3 (prop [ a ]) (f a)
+elimProp4 prop f = ElimProp4.go e module elimProp4 where
+  e : ElimProp4 _
+  e .ElimProp4.fun  = f
+  e .ElimProp4.prop = prop
+
+{-# DISPLAY elimProp.e  = elimProp #-}
+{-# DISPLAY elimProp2.e = elimProp2 #-}
+{-# DISPLAY elimProp3.e = elimProp3 #-}
+{-# DISPLAY elimProp4.e = elimProp4 #-}
 
 -- sometimes more convenient:
 elimContr : {P : A / R → Type ℓ}
@@ -96,56 +183,170 @@ elimContr2 contr =
 []surjective : (x : A / R) → ∃[ a ∈ A ] [ a ] ≡ x
 []surjective = elimProp (λ x → squash₁) (λ a → ∣ a , refl ∣₁)
 
+record Elim {A : Type ℓ} {R : A → A → Type ℓ'}
+  (P : A / R → Type ℓ'') : Type (ℓ ⊔ ℓ' ⊔ ℓ'') where
+  no-eta-equality
+  field
+    fun : ∀ a → P [ a ]
+    set : ∀ x → isSet (P x)
+    eq  : (a b : A) (r : R a b) → PathP (λ i → P (eq/ a b r i)) (fun a) (fun b)
+
+  go : ∀ x → P x
+  go [ a ]                 = fun a
+  go (eq/ a b r i)         = eq a b r i
+  go (squash/ x y p q i j) = isOfHLevel→isOfHLevelDep 2 set
+    (go x) (go y) (cong go p) (cong go q) (squash/ x y p q) i j
+
+{-# DISPLAY Elim.go r = r #-}
+
 elim : {P : A / R → Type ℓ}
   → (∀ x → isSet (P x))
   → (f : (a : A) → (P [ a ]))
   → ((a b : A) (r : R a b) → PathP (λ i → P (eq/ a b r i)) (f a) (f b))
   → ∀ x → P x
-elim set f feq [ a ] = f a
-elim set f feq (eq/ a b r i) = feq a b r i
-elim set f feq (squash/ x y p q i j) =
-  isOfHLevel→isOfHLevelDep 2 set
-    (g x) (g y) (cong g p) (cong g q) (squash/ x y p q) i j
-  where
-  g = elim set f feq
+elim set f feq = Elim.go e module elim where
+  e : Elim _
+  e .Elim.fun = f
+  e .Elim.set = set
+  e .Elim.eq  = feq
+
+record Rec {A : Type ℓ} {R : A → A → Type ℓ'} (B : Type ℓ'') : Type (ℓ ⊔ ℓ' ⊔ ℓ'') where
+  no-eta-equality
+  field
+    fun : A → B
+    set : isSet B
+    eq  : (a b : A) (r : R a b) → fun a ≡ fun b
+
+  go : A / R → B
+  go [ a ]                 = fun a
+  go (eq/ a b r i)         = eq a b r i
+  go (squash/ x y p q i j) = set (go x) (go y) (cong go p) (cong go q) i j
+
+{-# DISPLAY Rec.go r = r #-}
 
 rec : isSet B
   → (f : A → B)
   → ((a b : A) (r : R a b) → f a ≡ f b)
   → A / R → B
-rec set f feq [ a ] = f a
-rec set f feq (eq/ a b r i) = feq a b r i
-rec set f feq (squash/ x y p q i j) = set (g x) (g y) (cong g p) (cong g q) i j
-  where
-  g = rec set f feq
+rec set f feq = Rec.go r module rec where
+  r : Rec _
+  r .Rec.fun = f
+  r .Rec.set = set
+  r .Rec.eq  = feq
+
+record Rec2 {ℓA ℓB ℓR ℓS ℓ : Level}
+  {A : Type ℓA} {B : Type ℓB}
+  {R : A → A → Type ℓR} {S : B → B → Type ℓS}
+  (C : Type ℓ)
+  : Type (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓR ⊔ ℓS) where
+  no-eta-equality
+  field
+    fun : A → B → C
+    set : isSet C
+    eql : ∀ a b c → R a b → fun a c ≡ fun b c
+    eqr : ∀ a b c → S b c → fun a b ≡ fun a c
+
+  go : A / R → B / S → C
+  go = Rec.go el module lGO where
+    el : Rec _
+    el .Rec.fun x = Rec.go er module rGO where
+      er : Rec _
+      er .Rec.fun = fun x
+      er .Rec.set = set
+      er .Rec.eq  = eqr x
+    el .Rec.set = isSet→ set
+    el .Rec.eq a b r = funExt (ElimProp.go e) where
+      e : ElimProp _
+      e .ElimProp.fun  c = eql a b c r
+      e .ElimProp.prop _ = set _ _
+
+{-# DISPLAY Rec2.lGO.el     r   = r #-}
+{-# DISPLAY Rec2.lGO.rGO.er r a = r [ a ] #-}
 
 rec2 : isSet C
      → (f : A → B → C)
      → (∀ a b c → R a b → f a c ≡ f b c)
      → (∀ a b c → S b c → f a b ≡ f a c)
      → A / R → B / S → C
-rec2 {_} {C} {_} {A} {_} {B} {_} {R} {_} {S} set f feql feqr = fun
-  where
-    fun₀ : A → B / S → C
-    fun₀ a [ b ] = f a b
-    fun₀ a (eq/ b c r i) = feqr a b c r i
-    fun₀ a (squash/ x y p q i j) = isSet→SquareP (λ _ _ → set)
-      (λ _ → fun₀ a x)
-      (λ _ → fun₀ a y)
-      (λ i → fun₀ a (p i))
-      (λ i → fun₀ a (q i)) j i
+rec2 set f feql feqr = Rec2.go r module rec2 where
+  r : Rec2 _
+  r .Rec2.fun = f
+  r .Rec2.set = set
+  r .Rec2.eql = feql
+  r .Rec2.eqr = feqr
 
-    toPath : ∀ (a b : A) (x : R a b) (y : B / S) → fun₀ a y ≡ fun₀ b y
-    toPath a b rab = elimProp (λ _ → set _ _) λ c → feql a b c rab
+{-# DISPLAY elim.e = elim #-}
+{-# DISPLAY rec.r  = rec #-}
+{-# DISPLAY rec2.r = rec2 #-}
 
-    fun : A / R → B / S → C
-    fun [ a ] y = fun₀ a y
-    fun (eq/ a b r i) y = toPath a b r y i
-    fun (squash/ x y p q i j) z = isSet→SquareP (λ _ _ → set)
-      (λ _ → fun x z)
-      (λ _ → fun y z)
-      (λ i → fun (p i) z)
-      (λ i → fun (q i) z) j i
+record RecHProp {ℓA ℓR} (ℓ : Level) {A : Type ℓA} {R : A → A → Type ℓR}
+  : Type (ℓ-suc (ℓ ⊔ ℓA ⊔ ℓR)) where
+  no-eta-equality
+  field
+    rel  : A → Type ℓ
+    prop : ∀ x → isProp (rel x)
+    eq→  : (a b : A) (r : R a b) → rel a → rel b
+    eq←  : (a b : A) (r : R a b) → rel b → rel a
+
+  go : A / R → hProp ℓ
+  go = Rec.go e module GO where
+    e : Rec (hProp ℓ)
+    e .Rec.fun x .fst = rel x
+    e .Rec.fun x .snd = prop x
+    e .Rec.set        = isSetHProp
+    e .Rec.eq  a b r  =
+      Σ≡Prop (λ _ → isPropIsProp) (hPropExt (prop a) (prop b) (eq→ a b r) (eq← a b r))
+
+{-# DISPLAY RecHProp.GO.e r = r #-}
+
+record Rec2HProp {ℓA ℓB ℓR ℓS} (ℓ : Level)
+  {A : Type ℓA} {B : Type ℓB} {R : A → A → Type ℓR} {S : B → B → Type ℓS}
+  : Type (ℓ-suc (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓR ⊔ ℓS)) where
+  no-eta-equality
+  field
+    rel  : A → B → Type ℓ
+    prop : ∀ x y → isProp (rel x y)
+    eql→ : (a b : A) (c : B) (r : R a b) → rel a c → rel b c
+    eql← : (a b : A) (c : B) (r : R a b) → rel b c → rel a c
+    eqr→ : (a : A) (b c : B) (s : S b c) → rel a b → rel a c
+    eqr← : (a : A) (b c : B) (s : S b c) → rel a c → rel a b
+
+  go : A / R → B / S → hProp ℓ
+  go = Rec2.go e module GO where
+    e : Rec2 (hProp ℓ)
+    e .Rec2.fun x y .fst = rel x y
+    e .Rec2.fun x y .snd = prop x y
+    e .Rec2.set = isSetHProp
+    e .Rec2.eql a b c r = Σ≡Prop (λ _ → isPropIsProp)
+      (hPropExt (prop a c) (prop b c) (eql→ a b c r) (eql← a b c r))
+    e .Rec2.eqr a b c r = Σ≡Prop (λ _ → isPropIsProp)
+      (hPropExt (prop a b) (prop a c) (eqr→ a b c r) (eqr← a b c r))
+
+{-# DISPLAY Rec2HProp.GO.e r = r #-}
+
+record Rec2SymHProp {ℓA ℓB ℓR ℓS} (ℓ : Level)
+  {A : Type ℓA} {B : Type ℓB} {R : A → A → Type ℓR} {S : B → B → Type ℓS}
+  : Type (ℓ-suc (ℓ ⊔ ℓA ⊔ ℓB ⊔ ℓR ⊔ ℓS)) where
+  no-eta-equality
+  field
+    rel  : A → B → Type ℓ
+    prop : ∀ x y → isProp (rel x y)
+    symL : (a b : A) → R a b → R b a
+    symR : (b c : B) → S b c → S c b
+    eql  : (a b : A) (c : B) (r : R a b) → rel a c → rel b c
+    eqr  : (a : A) (b c : B) (S : S b c) → rel a b → rel a c
+
+  go : A / R → B / S → hProp ℓ
+  go = Rec2HProp.go e module GO where
+    e : Rec2HProp ℓ
+    e .Rec2HProp.rel  = rel
+    e .Rec2HProp.prop = prop
+    e .Rec2HProp.eql→ = eql
+    e .Rec2HProp.eql← = λ a b c → eql b a c ∘ symL a b
+    e .Rec2HProp.eqr→ = eqr
+    e .Rec2HProp.eqr← = λ a b c → eqr a c b ∘ symR b c
+
+{-# DISPLAY Rec2SymHProp.GO.e r = r #-}
 
 -- the recursor for maps into groupoids:
 -- i.e. for any type A with a binary relation R and groupoid B,

--- a/Cubical/Relation/Binary/Order/Loset/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Loset/Instances/Rationals.agda
@@ -1,0 +1,30 @@
+module Cubical.Relation.Binary.Order.Loset.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Empty as ⊥
+
+open import Cubical.Data.Rationals
+open import Cubical.Data.Rationals.Order renaming (_<_ to _<ℚ_)
+
+open import Cubical.Relation.Binary.Order.Loset
+
+open LosetStr
+
+ℚ<Loset : Loset ℓ-zero ℓ-zero
+fst ℚ<Loset = ℚ
+_<_ (snd ℚ<Loset) = _<ℚ_
+isLoset (snd ℚ<Loset) = isLosetℚ<
+  where
+    open IsLoset
+    isLosetℚ< : IsLoset _<ℚ_
+    isLosetℚ< .is-set           = isSetℚ
+    isLosetℚ< .is-prop-valued   = isProp<
+    isLosetℚ< .is-irrefl        = isIrrefl<
+    isLosetℚ< .is-trans         = isTrans<
+    isLosetℚ< .is-asym          = isAsym<
+    isLosetℚ< .is-weakly-linear = isWeaklyLinear<
+    isLosetℚ< .is-connected     = isConnected<

--- a/Cubical/Relation/Binary/Order/Poset/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Poset/Instances/Rationals.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Poset.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Toset
+
+open import Cubical.Relation.Binary.Order.Toset.Instances.Rationals
+
+ℚ≤Poset : Poset ℓ-zero ℓ-zero
+ℚ≤Poset = Toset→Poset ℚ≤Toset

--- a/Cubical/Relation/Binary/Order/Proset/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Proset/Instances/Rationals.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Proset.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Poset
+open import Cubical.Relation.Binary.Order.Proset
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Rationals
+
+ℚ≤Proset : Proset ℓ-zero ℓ-zero
+ℚ≤Proset = Poset→Proset ℚ≤Poset

--- a/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Pseudolattice/Instances/Rationals.agda
@@ -1,0 +1,19 @@
+module Cubical.Relation.Binary.Order.Pseudolattice.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Rationals
+open import Cubical.Data.Rationals.Order renaming (_≤_ to _≤ℚ_)
+
+open import Cubical.Relation.Binary.Order.Poset.Instances.Rationals
+open import Cubical.Relation.Binary.Order.Pseudolattice
+
+ℚ≤Pseudolattice : Pseudolattice ℓ-zero ℓ-zero
+ℚ≤Pseudolattice = makePseudolatticeFromPoset ℚ≤Poset min max
+  (λ {a b}   → min≤ a b)
+  (λ {a b}   → recompute≤ (subst (_≤ℚ b) (minComm b a) (min≤ b a)))
+  (λ {a b x} → ((recompute≤ ∘ subst (_≤ℚ min a b) (minIdem x)) ∘_) ∘ ≤MonotoneMin x a x b)
+  (λ {x} {y} → ≤max x y)
+  (λ {a b}   → recompute≤ (subst (b ≤ℚ_) (maxComm b a) (≤max b a)))
+  (λ {a b x} → ((recompute≤ ∘ subst (max a b ≤ℚ_) (maxIdem x)) ∘_) ∘ ≤MonotoneMax a x b x)

--- a/Cubical/Relation/Binary/Order/Quoset/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Quoset/Instances/Rationals.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.Quoset.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.Quoset
+open import Cubical.Relation.Binary.Order.StrictOrder
+
+open import Cubical.Relation.Binary.Order.StrictOrder.Instances.Rationals
+
+ℚ<Quoset : Quoset ℓ-zero ℓ-zero
+ℚ<Quoset = StrictOrder→Quoset ℚ<StrictOrder

--- a/Cubical/Relation/Binary/Order/StrictOrder/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/StrictOrder/Instances/Rationals.agda
@@ -1,0 +1,11 @@
+module Cubical.Relation.Binary.Order.StrictOrder.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Relation.Binary.Order.StrictOrder
+open import Cubical.Relation.Binary.Order.Loset
+
+open import Cubical.Relation.Binary.Order.Loset.Instances.Rationals
+
+ℚ<StrictOrder : StrictOrder ℓ-zero ℓ-zero
+ℚ<StrictOrder = Loset→StrictOrder ℚ<Loset

--- a/Cubical/Relation/Binary/Order/Toset/Instances/Rationals.agda
+++ b/Cubical/Relation/Binary/Order/Toset/Instances/Rationals.agda
@@ -1,0 +1,30 @@
+module Cubical.Relation.Binary.Order.Toset.Instances.Rationals where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sum
+open import Cubical.HITs.PropositionalTruncation
+
+open import Cubical.Data.Rationals
+open import Cubical.Data.Rationals.Order renaming (_≤_ to _≤ℚ_)
+
+open import Cubical.Relation.Binary.Order.Toset
+
+open import Cubical.Relation.Binary
+open BinaryRelation
+
+open TosetStr
+
+ℚ≤Toset : Toset ℓ-zero ℓ-zero
+fst ℚ≤Toset = ℚ
+_≤_ (snd ℚ≤Toset) = _≤ℚ_
+isToset (snd ℚ≤Toset) = isTosetℚ≤
+  where
+    open IsToset
+    isTosetℚ≤ : IsToset _≤ℚ_
+    isTosetℚ≤ .is-set         = isSetℚ
+    isTosetℚ≤ .is-prop-valued = isProp≤
+    isTosetℚ≤ .is-refl        = isRefl≤
+    isTosetℚ≤ .is-trans       = isTrans≤
+    isTosetℚ≤ .is-antisym     = isAntisym≤
+    isTosetℚ≤ .is-total       = isTotal≤


### PR DESCRIPTION
This PR redefines the operations and relations in `Data.Rationals`, making them rely on `Data.Fast.Int`; it also includes several changes in the `Rationals.Order` subdirectory.
I chose to edit the standard implementation of the rationals, instead of introducing yet another folder with a new encoding, for the following reasons:
- the type of integers is the same (only the implementation of the operations is changed), and other than the import with the keyword `Fast`, there are not many differences when using the fast integers
- Rational numbers are not used nearly as much in the library, compared to the integers, so it is possible to change the implementation without fixing a lot of proofs.

Other than that, this PR introduces records for set-quotient eliminators/recursors. The old eliminator/recursor functions have been redefined to call `go` from the associated record (for backward compatibility and to allow users to use functions instead of the new records, if they prefer). 
Multiple display pragmas have been used to print shorter names in goals.
Similarly, the functions `onCommonDenom` and `onCommonDenomSym` have been turned into records.
 
Other than the use of the orderings in fast rationals, the changes in `Rationals.Order` are:
- use the new record `Rec2SymHProp` to simplify the definitions of the order relations
- use of records wrapping the underlying type of `_<'_` and `_≤'_`, so that the arguments can be inferred more easily
- added `recompute<` and similar helper functions

This solves #1124, but I suggest to @onestruggler to define the operations on `ℚ[ω]` with some application of `reduce`: with this PR, their example will compute instantly, but the result is a huge unnormalized fraction.
For this reason, the `reduce` function has also been introduced, together with the proof that `reduce` is extensionally equal to the identity function

The choice of "redefinition with records" comes from @marcinjangrzybowski, and eventually, it will allow us to get more reliable solvers for rationals.